### PR TITLE
feat: auto-update harness on session start

### DIFF
--- a/hooks/on-start.sh
+++ b/hooks/on-start.sh
@@ -2,6 +2,13 @@
 # SessionStart hook: set agent identity and activate git hooks.
 # Runs at the beginning of every Claude Code session.
 
+# Auto-update harness from ImperialDragonHarness repo (once per day)
+_harness_stamp="$HOME/.claude/.last-pull"
+_today=$(date +%Y-%m-%d)
+if [ ! -f "$_harness_stamp" ] || [ "$(cat "$_harness_stamp")" != "$_today" ]; then
+    git -C "$HOME/.claude" pull --ff-only --quiet 2>/dev/null && echo "$_today" > "$_harness_stamp"
+fi
+
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
 # Load .env if present


### PR DESCRIPTION
## Summary
- Adds daily auto-pull from ImperialDragonHarness repo in `on-start.sh`
- Uses a date stamp file (`.last-pull`) so it only pulls once per day, avoiding redundant pulls from subagents

## Test plan
- [ ] Start a new Claude Code session, verify `~/.claude/.last-pull` is created with today's date
- [ ] Start a second session, verify no git pull is attempted
- [ ] Test offline: disconnect network, start session, verify hook doesn't block

🤖 Generated with [Claude Code](https://claude.com/claude-code)