### PR TITLE
bootstrap: install git-erg + file 10 verify-improvement tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 !commands/**
 !docs/
 !docs/**
+!tickets/
+!tickets/**
 
 # settings.json: universal config (hooks, effortLevel, universal permissions) — tracked
 # settings.local.json: machine-specific permissions — gitignored

--- a/tickets/0001-verify-concurrency-guard.erg
+++ b/tickets/0001-verify-concurrency-guard.erg
@@ -1,0 +1,90 @@
+%erg v1
+Title: /verify three-layer concurrency guard (file + label + counter)
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created
+2026-04-17T10:00Z claude note migrated from Climate_finance ticket 0079 (misfiled) and IDH issue #34
+
+--- body ---
+## Context
+
+`/verify` has no concurrency control. Two parallel `/verify <same-pr>`
+invocations across chats or machines would double-comment, race on
+fix-agent commits, and defeat the two-round cap. Surfaced 2026-04-17
+when tickets 0067–0070 were each verified in separate chats.
+
+## Threat model
+
+| Failure mode | Consequence |
+|-------------|-------------|
+| Double comment posts | PR conversation cluttered, reviewers confused |
+| Double fix-agent commits | force-push collision or merge conflict; lost work |
+| Double gate verdicts | round counter defeated; ambiguous state |
+| Idempotency break | re-running a "stuck" round re-executes fix logic |
+
+## Design: three-layer coordination
+
+**L1 — Local file lock `.git/verify-wip/<pr>.wip`.** Cheap, matches existing
+`.git/ticket-wip/<ID>.wip` convention. Atomic `O_EXCL` create; 30-min staleness
+check; JSON contents `{pr, round, session_id, started_at, skill_sha}`.
+Prevents same-machine same-user race (most likely case).
+
+**L2 — GitHub label + claim comment.** Cross-machine authority.
+- Label `verify:round-<n>`.
+- Claim comment `"/verify: round=<n> started by <session_id>, skill sha: <idh-head>, expected completion: <+30 min>"`.
+- Check labels on start; if present and last claim-comment < 30 min → abort with URL; else force-take.
+- Release label on verdict.
+
+**L3 — Monotonic round counter in `/verify-gate`.** Before emitting round-N
+verdict, scan PR comments for highest `round=<k>` seen. If N ≤ k → escalate.
+Catches timing-window leaks where L1+L2 briefly disagreed.
+
+**Idempotency (design goal, not a layer).** Damage containment if L1+L2+L3 all
+race. Fix-agent commits should be content-addressed; gate verdicts should be
+commutative.
+
+## Actions
+
+1. Patch `skills/verify/SKILL.md`: add phase 0.5 (L1) + 0.6 (L2), phase 6.5 release.
+2. Patch `skills/verify-gate/SKILL.md`: L3 check + standalone mode uses
+   `verify:gate-only` label.
+3. Update `skills/orchestrator/SKILL.md` Phase 6 to surface claim-URL on abort.
+4. Register labels `verify:round-1`, `verify:round-2`, `verify:gate-only` on
+   target repos (or document the convention).
+
+## Edge cases
+
+- `--force-approve` clears L1 file + L2 label.
+- Round 2 re-entry: transition `verify:round-1` → `verify:round-2`.
+- Clock skew: use `gh api` server timestamps for staleness, not local clock.
+
+## Rejected alternatives
+
+comment-only lock (no clean release), PR draft toggle (overloads semantics),
+review-state mutex (noise), PR body append (edit race), git notes (invisible),
+redis (infra), orchestrator-only enforcement (kills common case).
+
+## Test plan (manual)
+
+1. L1 smoke: two chats same machine → second aborts with file path.
+2. L2 smoke: delete L1 file, retry elsewhere → second aborts with URL.
+3. Stale recovery: 35-min-old lock → force-take with warning comment.
+4. L3 race: two concurrent round=1 → `/verify-gate` escalates on second.
+5. `--force-approve` with active lock: L1 + L2 both cleared.
+6. Round 2 transition clean.
+
+## Exit criteria
+
+- Two parallel `/verify` on same PR: second aborts with clear reference.
+- Round 2 re-entry transitions cleanly.
+- `--force-approve` clears all locks.
+- Stale locks (≥ 30 min) force-take with audit trail.
+- L3 counter prevents round 3 even when L1+L2 race.
+
+## Priority
+
+Not blocking any specific work, but should land before the next
+multi-chat `/verify` batch.

--- a/tickets/0002-verify-adherence-ratchet-statistical.erg
+++ b/tickets/0002-verify-adherence-ratchet-statistical.erg
@@ -1,0 +1,55 @@
+%erg v1
+Title: verify-adherence ratchet for statistical antipatterns
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+
+--- body ---
+## Context
+
+The ticket-0069 blocker (Climate_finance PR 691) was a textbook
+"with-replacement sample collapsed by `set()`" bug:
+`rng.choice(n, k, replace=True)` followed by `set(...)` drops
+multiplicities and yields a ~63% (1 − 1/e) subsample. Passed all 122
+unit + smoke tests because tests asserted schema, not sampling semantics.
+
+`/verify-adherence`'s ratchet did not catch it. The LLM portion did.
+That means each future similar bug pays the LLM tax instead of getting
+cheap mechanical detection.
+
+## Actions
+
+Add to `skills/verify-adherence/SKILL.md` ratchet bank:
+
+1. `rng\.choice\([^)]*replace\s*=\s*True\)` followed within ±5 lines by
+   `set\(|unique\(|drop_duplicates\(`.
+   Flag: *"with-replacement sampling collapsed — drops multiplicities;
+   verify intent"*.
+2. `np\.random\.RandomState\(\)` (no seed argument).
+   Flag: *"unseeded RNG — not reproducible"*.
+3. A function named `*bootstrap*` whose body does NOT contain
+   `replace\s*=\s*True`.
+   Flag: *"function named `bootstrap` but does not appear to resample
+   with replacement"*.
+
+Each finding emits a suggested test
+(`@pytest.mark.skip("verify-adherence: ratchet scaffold")`) asserting
+the corrective invariant.
+
+## Test
+
+Run `verify-adherence` against pre-fix
+`scripts/compute_divergence_bootstrap.py:_run_citation_bootstrap` in
+Climate_finance commit before `20b1117`. Expect the with-replacement+set
+rule to fire.
+
+## Exit criteria
+
+- Three new rules in the ratchet bank with rule references.
+- Each rule includes a `suggested_test` template.
+- Documented in a test-style regression (on a fixture) so the rules
+  themselves are covered.
+- The old memo-1 "ticket A" is addressed.

--- a/tickets/0003-verify-emit-failing-test-scaffolds.erg
+++ b/tickets/0003-verify-emit-failing-test-scaffolds.erg
@@ -1,0 +1,44 @@
+%erg v1
+Title: /verify emits failing-test scaffolds for blockers
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+
+--- body ---
+## Context
+
+The PR-691 verify report told the author to "add a sampling-semantics
+assertion so the blocker can't regress silently". The author had to
+reverse-engineer what that meant.
+
+A stub test in the diff converts review prose to executable expectations.
+Same pattern as `verify-adherence`'s `suggested_test` for semantic
+findings, but broader — applies to every blocker, not just adherence
+ones.
+
+## Actions
+
+1. Patch `skills/verify/SKILL.md`: on REROLL, the gate's
+   `unresolved_review_comments` and `unresolved_simplify_findings`
+   lists each get an attached test stub (best-effort, may be
+   `pytest.skip`'d).
+2. Stubs land via the fix agent on the PR branch with a
+   `verify: regression scaffold` marker so the human sees them in the
+   diff and can either implement or delete.
+3. Stubs include: imports, the assertion's correct shape, and a
+   pointer back to the verify comment that generated them.
+
+## Test
+
+Re-run on Climate_finance PR 691 pre-fix. Expect a stub like
+`test_citation_bootstrap_is_proper_subsampling` to be appended.
+
+## Exit criteria
+
+- REROLL blockers each yield a matching stub test on the PR branch.
+- Stubs are syntactically valid but allowed to `pytest.skip`.
+- Stubs carry a cross-ref comment pointing at the verify finding.
+- Memo-1 "ticket B" addressed.

--- a/tickets/0004-wire-verify-adherence-pre-pr.erg
+++ b/tickets/0004-wire-verify-adherence-pre-pr.erg
@@ -1,0 +1,38 @@
+%erg v1
+Title: Wire /verify-adherence into Execute (pre-PR self-gate)
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+
+--- body ---
+## Context
+
+Execute currently does Red → Green → Refactor → `make check` →
+`gh pr create`. The PR description claims completeness; a verify bounce
+afterward looks bad and adds latency. A pre-PR mechanical adherence
+check (no LLM rounds, just the ratchet) would let Execute self-gate
+cheaply.
+
+## Actions
+
+1. Update `skills/start-ticket/SKILL.md` (or its Execute sub-step) to
+   run `/verify-adherence` after `make check` and before `gh pr create`.
+2. If adherence finds blockers, Execute fixes them or stops with a
+   clear escalation; PR is not opened.
+3. Adherence-clean PRs get a `verify:adherence-passed` label so the
+   later `/verify` merge gate can skip the mechanical phase.
+
+## Test
+
+Drop a `np.random.RandomState()` (no seed) into a Phase 2 script and
+verify Execute refuses to open a PR.
+
+## Exit criteria
+
+- `/start-ticket` invokes `/verify-adherence` before `gh pr create`.
+- Blockers in pre-PR check halt PR creation.
+- `verify:adherence-passed` label propagates to the PR.
+- Memo-1 "ticket C" addressed.

--- a/tickets/0005-verify-auto-round-2-on-push.erg
+++ b/tickets/0005-verify-auto-round-2-on-push.erg
@@ -1,0 +1,53 @@
+%erg v1
+Title: /verify round 2 auto-triggers on fix-agent push
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+
+--- body ---
+## Context
+
+`skills/verify/SKILL.md` documents round 2, but in practice the human
+has to re-invoke. For autonomous flows this defeats the anti-rubber-
+stamp guarantee — round 2 becomes "sometimes happens."
+
+## Actions
+
+1. After the fix agent pushes to the PR branch on REROLL, the verify
+   skill (still in scope of round 1) re-enters phase 6 directly
+   without needing a new invocation.
+2. Add a per-PR state file (`/tmp/verify-rounds/<pr>.txt` or the L1
+   file from ticket 0001) so push events trigger re-entry only when
+   the previous round was REROLL, not on every push during initial
+   author work.
+3. Hard cap at round 2 → ESCALATE (existing invariant).
+
+## Dependency
+
+Couples with ticket 0001 (concurrency guard). The L1 file format
+from 0001 is the natural place to store round state.
+
+## Open question
+
+Skills are invoked, they don't subscribe to push events. So "auto-
+trigger on push" has to happen INSIDE the still-running `/verify`
+invocation that spawned the fix agent — it polls for the agent's push
+and then re-enters. OK if the skill runtime is a long-running process;
+needs rework if skills are request/response.
+
+## Test
+
+Drive Climate_finance PR 691 through verify with the buggy bootstrap.
+Expect REROLL → fix agent push → automatic round 2 → APPROVED, all
+from a single `/verify 691` invocation.
+
+## Exit criteria
+
+- One `/verify <pr>` invocation triggers round 2 automatically after
+  fix agent push.
+- No human re-invocation needed for the bounce-back loop.
+- Round 2 → round 3 still forbidden.
+- Memo-1 "ticket D" addressed.

--- a/tickets/0006-verify-surface-ci-and-preexisting.erg
+++ b/tickets/0006-verify-surface-ci-and-preexisting.erg
@@ -1,0 +1,56 @@
+%erg v1
+Title: /verify surfaces CI absence + pre-existing main failures + audits body claims
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from two reflection memos (PR 691 + PR 692)
+
+--- body ---
+## Context
+
+Two related gaps, both surfaced on first use:
+
+1. PR 691 had `no checks reported` and pre-existing `test_golden_values`
+   failures from ticket 0067. Verify said nothing about either.
+2. PR 692's author wrote "check-fast clean" and "G9 failure
+   pre-existing" in the body. Neither claim was cross-checked by verify.
+
+Both mean the verify skill treats the PR body as narrative rather than
+a self-validating report.
+
+## Actions
+
+1. Setup phase of `/verify`: query `gh pr checks <pr>`. If empty, post
+   a `verify: CI gap` informational comment (not a bounce — just visible).
+2. Setup also runs
+   `git checkout <merge-base> && uv run pytest tests/ -q --tb=no` in the
+   isolated worktree to capture the pre-existing failure set, diffs
+   against the PR-branch failure set. Report *introduced* and
+   *pre-existing* separately.
+3. Pre-existing failures are reported, never bounce the PR.
+4. Body-claim audit: if the PR body contains patterns like
+   `*passes*`, `*clean*`, `*pre-existing*`, the gate extracts the
+   subject and cross-checks:
+   - "tests pass" → run them
+   - "failure X pre-existing" → check if X appears in the merge-base
+     failure set
+   - "no regression" → diff the failure sets
+5. Audited claims are annotated in the verify comment:
+   ✓ verified / ✗ contradicted / ? could not be verified.
+
+## Test
+
+1. Run on a PR over a branch with known pre-existing failures; expect
+   them listed under "pre-existing on main, not introduced".
+2. Open a PR with body `"tests pass; failure X pre-existing"` where X
+   does not appear on main; verify should annotate X as ✗ contradicted.
+
+## Exit criteria
+
+- CI absence produces a visible `verify: CI gap` note.
+- Pre-existing failures are surfaced separately from introduced ones.
+- Body claims about pass/clean/pre-existing are audited and annotated.
+- Memo-1 "ticket E" and memo-2 "audit PR-body evidence claims" both
+  addressed.

--- a/tickets/0007-verify-minors-language-discipline.erg
+++ b/tickets/0007-verify-minors-language-discipline.erg
@@ -1,0 +1,44 @@
+%erg v1
+Title: /verify minors — verifiable / consider / nofollow language discipline
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+
+--- body ---
+## Context
+
+Review prose like "Asymmetric NaN handling — Wave C joins on
+(year, window) will mismatch" is either testable now (then it's
+blocker-grade with evidence) or a hypothesis (then it should be
+marked as such). The current ambiguous middle ground encourages
+cosmetic fixes that don't touch the underlying claim, defeating the
+gate's purpose.
+
+## Actions
+
+1. `/review-pr` and `/review-pr-prose` tag minor findings as one of:
+   - `verifiable:` has a current failing assertion attached
+   - `consider:` hypothesis worth a comment but not enforced
+   - `nofollow:` intentionally not pursued
+2. `/verify-gate` refuses to use ambiguous "this might break X"
+   language. Either tag it `verifiable:` and attach the failing test,
+   or downgrade to `consider:`.
+3. Gate's decision rules treat `verifiable:` as blocker-adjacent (must
+   address), `consider:` as informational (does not bounce), `nofollow:`
+   as mute.
+
+## Test
+
+A minor finding without a reproducible assertion should not bounce the
+PR but should appear in the verify comment as `consider:` rather than
+as a numbered concern.
+
+## Exit criteria
+
+- `/review-pr` and `/review-pr-prose` emit tagged minors.
+- `/verify-gate` enforces tagging (rejects ungrounded "X will break").
+- Verify comment visibly uses the three prefixes.
+- Memo-1 "ticket F" addressed.

--- a/tickets/0008-verify-cheap-static-checks-first.erg
+++ b/tickets/0008-verify-cheap-static-checks-first.erg
@@ -1,0 +1,50 @@
+%erg v1
+Title: /verify — cheap static checks before deep review
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 692)
+
+--- body ---
+## Context
+
+On PR 692, verify read source rather than running `make check-fast` or
+`python -c` first. The cheapest possible check — import resolution —
+should precede deep review. Formatter-strip-import bugs (the exact
+class the author's memory warned about) would be caught in seconds
+instead of minutes of LLM reasoning.
+
+The concrete incident: `C2STDivergenceSchema` import was stripped by
+the auto-formatter; all 17 local tests were green yet the first run
+would have `NameError`'d. Verify caught it but via LLM, not a cheap
+probe.
+
+## Actions
+
+1. At the start of `/verify-adherence`'s mechanical phase (before the
+   grep ratchet):
+   a. Parse the diff for every symbol referenced in touched modules.
+   b. For each `(module, name)` pair, run a one-line check:
+      ```
+      uv run python -c "import sys; sys.path.insert(0, 'scripts'); import M; getattr(M, 'name')"
+      ```
+   c. Fail with rule ref `verify-adherence#import-resolution` if any
+      symbol can't be resolved.
+2. Also run `uv run python -m pytest <touched-modules-test-files> -q`
+   to catch per-module test regressions before the full suite.
+3. Both checks are BLOCKING and fast (<10 s combined).
+
+## Test
+
+Introduce a formatter-style "import of a just-used symbol stripped"
+regression; verify-adherence should flag it at the cheap-check layer,
+not at the LLM layer.
+
+## Exit criteria
+
+- Import-resolution check runs before the grep ratchet.
+- Per-module test run precedes full-depth review.
+- Both are documented as the "phase 1.0" in verify-adherence.
+- Memo-2 "cheap checks before deep review" addressed.

--- a/tickets/0009-verify-telemetry.erg
+++ b/tickets/0009-verify-telemetry.erg
@@ -1,0 +1,41 @@
+%erg v1
+Title: /verify emits runtime + cost telemetry
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:00Z claude created from verify reflection memo (PR 692)
+
+--- body ---
+## Context
+
+PR 692's `/verify` run took ~3 min wall time with no progress signal.
+A runaway run would look identical to a healthy one. Users need
+calibration data to distinguish.
+
+## Actions
+
+1. `/verify` emits a single footer line on its verdict comment:
+   ```
+   telemetry: wall=<seconds>s agents=<n> tokens=<in+out> cost≈$<usd>
+   ```
+2. Per-phase timing logged to stderr during the run (not posted to PR).
+3. Abort thresholds:
+   - Wall > 15 min → post `verify: slow run` warning, continue.
+   - Wall > 30 min → ESCALATE (likely runaway).
+   - Token usage > 500k → post `verify: token-heavy run` warning, continue.
+   - Token usage > 1M → ESCALATE.
+4. Thresholds are config, not hardcoded.
+
+## Test
+
+Run verify on a small PR and confirm the telemetry line appears.
+Inject an artificial delay and confirm the slow-run threshold triggers.
+
+## Exit criteria
+
+- Every verdict comment includes a telemetry footer.
+- Slow/token-heavy runs produce warnings without aborting.
+- Runaway runs ESCALATE cleanly.
+- Memo-2 "runtime + cost telemetry" addressed.

--- a/tickets/0010-verify-final-report-structure.erg
+++ b/tickets/0010-verify-final-report-structure.erg
@@ -1,0 +1,84 @@
+%erg v1
+Title: /verify ends with a structured report of actions taken + gate verdict
+Status: open
+Created: 2026-04-17
+Author: user
+
+--- log ---
+2026-04-17T10:30Z claude created from explicit user ask mid-ticket-batch
+
+--- body ---
+## Context
+
+The `/verify` skill should terminate with an unambiguous report: both
+(a) what phases ran and what they changed, and (b) the `/verify-gate`
+verdict. Today `SKILL.md` documents a verdict-comment template, but
+leaves the "what happened before the verdict" implicit.
+
+The user's explicit framing: *"I want the skill to end with a report
+of what was done, and what the verify-gate agent says."*
+
+## Actions
+
+1. Update `skills/verify/SKILL.md` "Output shape" section to two
+   top-level sections, always both present:
+
+   **Part A — Actions taken** (skill own-report):
+   ```
+   ## /verify actions
+
+   round: <n>
+   adherence: <PASS|FAIL> — <n_blocking> blocking, <n_nit> nits
+     new grep matches: [<rule-refs>]
+     tests run: <n_pass> pass, <n_fail> fail
+     pre-existing failures on main: <n>
+   review-pr: <n_comments_posted>
+   review: <posted|skipped>
+   simplify: <n_fixes_applied>
+     files touched: [<paths>]
+   fix agent (if round 2): <n_commits> commits, <last sha>
+   wall time: <s>s
+   ```
+
+   **Part B — Gate verdict** (verbatim from `/verify-gate`):
+   ```
+   ## /verify-gate verdict
+
+   verdict: <APPROVED|REROLL|ESCALATE>
+   <rest of the verify-gate YAML-ish output>
+   ```
+
+2. The two sections are always posted to the PR as a single top-level
+   comment, even on ESCALATE. On APPROVED the comment is the
+   "ship it" signal. On REROLL the comment says exactly why the
+   bounce happened.
+
+3. `--force-approve` still posts the same two-section report, with
+   Part A annotated `FORCE-APPROVED by <reason>` and Part B showing
+   the gate's *would-have-been* verdict before override.
+
+## Relationship to 0009
+
+Ticket 0009 (telemetry) adds a single-line footer to the verdict
+comment. This ticket defines the *shape* of the comment itself.
+0009 fits inside 0010's Part A as a `wall time: ...` and
+`tokens: ...` line.
+
+## Test
+
+Run `/verify` on a known PR. Assert:
+- Comment has both `## /verify actions` and `## /verify-gate verdict`
+  headers.
+- Part A lists every phase that ran (or was skipped) with an explicit
+  counter.
+- Part B is a copy of the gate's structured output, no paraphrase.
+
+## Exit criteria
+
+- `skills/verify/SKILL.md` "Output shape" documents both sections.
+- The two sections are always posted together.
+- The report is the only top-level PR comment posted by `/verify` in
+  a round (no interim "started" / "finished" chatter — the final
+  report is the signal).
+- L2 claim comment from 0001 still posted at start, but it's a
+  lock announcement, not a report.

--- a/tickets/FORMAT.md
+++ b/tickets/FORMAT.md
@@ -1,0 +1,200 @@
+# Ticket format spec — %erg v1
+
+## Overview
+
+Local ticket system for agent coordination across worktrees on one machine.
+Not a replacement for GitHub Issues — those handle inter-agent and human coordination.
+Tickets are committed to git and travel with the repo.
+
+## File format
+
+Extension: `.erg`
+Location: `tickets/` (active), `tickets/archive/` (closed, old)
+Encoding: UTF-8, LF line endings.
+
+### Magic first line
+
+```
+%erg v1
+```
+
+Every `.erg` file starts with this line. It declares the format version
+and enables file-type detection without relying on the extension. A future
+`%ticket v2` adds headers without breaking v1 validators (they reject
+unknown versions rather than silently misparsing).
+
+### Structure
+
+```
+%erg v1
+Title: Short imperative description
+Status: open
+Created: 2026-03-27
+Author: claude
+
+--- log ---
+2026-03-27T10:00Z claude created
+
+--- body ---
+Free-form markdown body.
+```
+
+Three sections, in order:
+1. **Headers** — RFC 822 style, one per line, immediately after magic line.
+2. **Log** — append-only ledger, after `--- log ---` separator.
+3. **Body** — free-form markdown, after `--- body ---` separator.
+
+A blank line ends the header block. Both separators are required (the
+validator rejects files missing either one).
+
+### Headers (closed set, v1)
+
+| Header | Required | Type | Values |
+|--------|----------|------|--------|
+| `Title` | yes | string | Short imperative sentence |
+| `Status` | yes | enum | `open`, `doing`, `closed`, `pending` |
+| `Created` | yes | date | `YYYY-MM-DD` |
+| `Author` | yes | string | Agent or human identifier |
+| `Blocked-by` | no | ref | Ticket ID or `gh#N` (repeatable) |
+
+No other headers are valid in v1. No `X-` extensions. If v2 needs new
+headers, it declares `%ticket v2` and extends the set.
+
+**Status values:**
+- `open` — available for work.
+- `doing` — claimed, in progress.
+- `closed` — completed or cancelled.
+- `pending` — awaiting external input (e.g., review). Excluded from ready query.
+
+**`Blocked-by` references:**
+- A 4-digit ID (e.g., `0041`) refers to a local ticket.
+- `gh#N` refers to a GitHub issue. Resolved via API when online, treated as
+  satisfied (non-blocking) when offline.
+- Repeatable: one `Blocked-by:` line per dependency.
+- A blocker must be `closed` to unblock. `doing` and `pending` still block.
+
+### ID assignment
+
+The ticket ID is derived from the filename, not a header.
+
+Filename pattern: `{ID}-{slug}.erg`
+- ID: zero-padded sequential number, 4 digits. `0001`, `0002`, ...
+- Slug: lowercase kebab-case, ASCII only (`[a-z0-9-]`).
+
+To assign the next ID: read filenames in `tickets/` and `tickets/archive/`,
+extract the numeric prefix from each, take the maximum, increment by 1,
+zero-pad to 4 digits. If no tickets exist, start at `0001`.
+
+**Collision handling:** optimistic. Two worktrees may pick the same number.
+The pre-commit validator catches duplicate IDs. The agent that loses renames
+its ticket (increment again). This matches git's own optimistic concurrency.
+
+### Log section
+
+Append-only. Each line records one event:
+
+```
+{ISO-8601-timestamp} {actor} {verb} [{detail}]
+```
+
+**Timestamp:** `YYYY-MM-DDThh:mmZ` (UTC, minute precision).
+**Actor:** agent or human identifier (e.g., `claude`, `user`).
+**Verbs (closed set, v1):**
+
+| Verb | Meaning |
+|------|---------|
+| `created` | Ticket created |
+| `status` | Status changed. Detail: new status + reason |
+| `claimed` | Agent is starting work (also writes `.wip` file) |
+| `released` | Agent released claim without completing |
+| `note` | Free-form annotation |
+
+Lines are never edited or deleted. To correct an error, append a new line.
+
+### Body section
+
+Free-form markdown. Convention for actionable tickets:
+
+```
+## Context
+Why this work exists.
+
+## Actions
+1. Concrete steps.
+
+## Test
+First test to write (TDD red step).
+
+## Exit criteria
+Definition of done.
+```
+
+Not enforced by the validator. Agents are encouraged to follow the convention
+but the body is structurally unconstrained.
+
+## Cross-worktree coordination
+
+### Claim protocol
+
+Claims prevent two worktrees on the same machine from working on the same ticket.
+
+Claims use `.git/ticket-wip/` (shared across worktrees via `git-common-dir`):
+
+1. **Check:** read `.git/ticket-wip/{ID}.wip`. If it exists, ticket is claimed.
+2. **Claim:** write the file with content `{timestamp} {actor} {worktree-path}`.
+3. **Release:** delete the file (on close, abandon, or session end).
+
+`.wip` files are local-only (inside `.git/`, never committed). They survive
+across sessions but not across clones.
+
+### Ready query
+
+A ticket is **ready** when:
+- `Status: open` (not `doing`, not `closed`, not `pending`)
+- Every `Blocked-by` local ref points to a `Status: closed` ticket
+- Every `Blocked-by: gh#N` is either resolved via API or treated as satisfied (offline)
+- No `.wip` file exists for its ID
+
+### Archive criteria
+
+A ticket is **archivable** when:
+- `Status: closed`
+- Last log entry older than 90 days
+- Not referenced by any live ticket's `Blocked-by` header (DAG safety)
+
+Archive moves the file to `tickets/archive/` via `git mv`.
+
+## Validator rules (pre-commit)
+
+The Go validator enforces:
+1. Magic first line is `%erg v1` (reject unknown versions)
+2. All required headers present
+3. No unknown headers
+4. `Status` value is in the enum (`open`, `doing`, `closed`, `pending`)
+5. `Created` is a valid ISO date (`YYYY-MM-DD`)
+6. Filename matches `NNNN-{slug}.erg` pattern (4-digit ID, ASCII slug)
+7. No duplicate IDs across `tickets/` and `tickets/archive/`
+8. `Blocked-by` local refs point to existing ticket IDs
+9. No dependency cycles
+10. Log lines match `{timestamp} {actor} {verb}` format
+11. Both `--- log ---` and `--- body ---` separators present
+
+## Relationship to GitHub Issues
+
+| Concern | Tool |
+|---------|------|
+| Local work organization | `.erg` files |
+| Cross-worktree deconfliction | `.git/ticket-wip/` |
+| Multi-agent coordination | GitHub Issues |
+| Public visibility, review | GitHub Issues + PRs |
+
+A ticket may reference a GitHub issue (`Blocked-by: gh#435`) but never
+caches it. The two systems are independent.
+
+## Postel's Law
+
+**Strict on write, tolerant on read.** The validator enforces `%erg v1`
+on commit. But you — the agent — are the parser for arbitrary input. If you
+receive ticket-like information in any form (raw JSON from `gh`, a sentence,
+a markdown sketch), understand the intent and write clean `%erg v1`. The
+pre-commit hook catches mistakes. The tolerance is in you, not the tooling.

--- a/tickets/tools/go/go.mod
+++ b/tickets/tools/go/go.mod
@@ -1,0 +1,3 @@
+module git-erg
+
+go 1.21

--- a/tickets/tools/go/main.go
+++ b/tickets/tools/go/main.go
@@ -1,0 +1,1086 @@
+// erg — validate, ready, archive, graph %erg v1 files.
+// No external dependencies (stdlib only).
+//
+// Usage:
+//
+//	erg validate [dir|file ...]
+//	erg ready    [dir] [--json]
+//	erg archive  [dir] [--days N] [--execute]
+//	erg graph    [dir] [--json]
+//	erg next-id  [dir]
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Erg parser — %erg v1 format
+// ---------------------------------------------------------------------------
+
+const magicLine = "%erg v1"
+
+type Erg struct {
+	Path     string
+	Headers  map[string][]string // repeatable headers
+	LogLines []string
+	Body     string
+	HasMagic bool
+	HasLog   bool
+	HasBody  bool
+}
+
+func (t *Erg) Title() string {
+	if vs, ok := t.Headers["Title"]; ok && len(vs) > 0 {
+		return vs[0]
+	}
+	return ""
+}
+
+func (t *Erg) Status() string {
+	if vs, ok := t.Headers["Status"]; ok && len(vs) > 0 {
+		return vs[0]
+	}
+	return ""
+}
+
+func (t *Erg) BlockedBy() []string {
+	if vs, ok := t.Headers["Blocked-by"]; ok {
+		return vs
+	}
+	return nil
+}
+
+func (t *Erg) Filename() string {
+	return filepath.Base(t.Path)
+}
+
+// FilenameID extracts the numeric prefix from the filename (e.g., "0042" from "0042-add-auth.erg").
+func (t *Erg) FilenameID() string {
+	stem := strings.TrimSuffix(t.Filename(), ".erg")
+	if idx := strings.Index(stem, "-"); idx > 0 {
+		return stem[:idx]
+	}
+	return stem
+}
+
+func isLetter(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func isAlphanumeric(c byte) bool {
+	return isLetter(c) || (c >= '0' && c <= '9')
+}
+
+// parseHeaderLine extracts "Key: value" from a line.
+func parseHeaderLine(line string) (string, string, bool) {
+	if len(line) == 0 || !isLetter(line[0]) {
+		return "", "", false
+	}
+	colonPos := -1
+	for i := 1; i < len(line); i++ {
+		c := line[i]
+		if c == ':' {
+			colonPos = i
+			break
+		}
+		if isAlphanumeric(c) || c == '_' || c == '-' {
+			continue
+		}
+		if c == ' ' || c == '\t' {
+			for j := i; j < len(line); j++ {
+				if line[j] == ':' {
+					colonPos = j
+					break
+				}
+				if line[j] != ' ' && line[j] != '\t' {
+					return "", "", false
+				}
+			}
+			break
+		}
+		return "", "", false
+	}
+	if colonPos < 0 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(line[:colonPos])
+	val := strings.TrimSpace(line[colonPos+1:])
+	return key, val, true
+}
+
+func parseErg(path string) Erg {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Erg{Path: path, Headers: make(map[string][]string)}
+	}
+	lines := strings.Split(string(data), "\n")
+
+	headers := make(map[string][]string)
+	var logLines, bodyLines []string
+	section := "magic" // magic | headers | gap | log | body
+	hasMagic := false
+	hasLog := false
+	hasBody := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// First non-empty line must be the magic line
+		if section == "magic" {
+			if trimmed == "" {
+				continue
+			}
+			if trimmed == magicLine {
+				hasMagic = true
+				section = "headers"
+				continue
+			}
+			// No magic line — try to parse as old format
+			section = "headers"
+			// Fall through to header parsing
+		}
+
+		if !hasBody && trimmed == "--- log ---" {
+			section = "log"
+			hasLog = true
+			continue
+		}
+		if !hasBody && trimmed == "--- body ---" {
+			section = "body"
+			hasBody = true
+			continue
+		}
+
+		switch section {
+		case "headers":
+			if trimmed == "" {
+				section = "gap"
+				continue
+			}
+			if key, val, ok := parseHeaderLine(line); ok {
+				headers[key] = append(headers[key], val)
+			}
+		case "gap":
+			// ignore lines between header block and log separator
+		case "log":
+			if trimmed != "" {
+				logLines = append(logLines, line)
+			}
+		case "body":
+			bodyLines = append(bodyLines, line)
+		}
+	}
+
+	return Erg{
+		Path:     path,
+		Headers:  headers,
+		LogLines: logLines,
+		Body:     strings.Join(bodyLines, "\n"),
+		HasMagic: hasMagic,
+		HasLog:   hasLog,
+		HasBody:  hasBody,
+	}
+}
+
+func loadErgs(dir string) []Erg {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var tickets []Erg
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".erg") {
+			tickets = append(tickets, parseErg(filepath.Join(dir, e.Name())))
+		}
+	}
+	sort.Slice(tickets, func(i, j int) bool {
+		return tickets[i].Filename() < tickets[j].Filename()
+	})
+	return tickets
+}
+
+// ---------------------------------------------------------------------------
+// Validate — %erg v1 rules
+// ---------------------------------------------------------------------------
+
+var (
+	requiredHeaders = []string{"Title", "Status", "Created", "Author"}
+	validHeaders    = map[string]bool{
+		"Title": true, "Status": true, "Created": true,
+		"Author": true, "Blocked-by": true,
+	}
+	validStatuses = map[string]bool{
+		"open": true, "doing": true, "closed": true, "pending": true,
+	}
+	isoDateRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	// Filename: 4-digit ID, dash, lowercase kebab slug
+	filenameRE = regexp.MustCompile(`^\d{4}-[a-z0-9]+(-[a-z0-9]+)*\.erg$`)
+	// Log line: ISO timestamp, space, actor, space, verb [detail]
+	logLineRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\s+\S+\s+\S+`)
+)
+
+func validateErg(t *Erg, allIDs map[string]bool) []string {
+	var errors []string
+	name := t.Filename()
+
+	// Rule 1: magic first line
+	if !t.HasMagic {
+		errors = append(errors, fmt.Sprintf("%s: missing magic first line '%%erg v1'", name))
+	}
+
+	// Rule 2: required headers
+	for _, hdr := range requiredHeaders {
+		if _, ok := t.Headers[hdr]; !ok {
+			errors = append(errors, fmt.Sprintf("%s: missing required header '%s'", name, hdr))
+		}
+	}
+
+	// Rule 3: no unknown headers
+	for key := range t.Headers {
+		if !validHeaders[key] {
+			errors = append(errors, fmt.Sprintf("%s: unknown header '%s' (not in v1 closed set)", name, key))
+		}
+	}
+
+	// Rule 4: valid Status
+	status := t.Status()
+	if status != "" && !validStatuses[status] {
+		keys := sortedKeys(validStatuses)
+		errors = append(errors, fmt.Sprintf(
+			"%s: invalid Status '%s' (expected one of: %s)", name, status, strings.Join(keys, ", ")))
+	}
+
+	// Rule 5: Created is ISO date
+	if created, ok := t.Headers["Created"]; ok && len(created) > 0 {
+		if created[0] != "" && !isoDateRE.MatchString(created[0]) {
+			errors = append(errors, fmt.Sprintf(
+				"%s: Created '%s' is not a valid ISO date (YYYY-MM-DD)", name, created[0]))
+		}
+	}
+
+	// Rule 6: filename matches NNNN-slug.erg
+	if !filenameRE.MatchString(name) {
+		errors = append(errors, fmt.Sprintf(
+			"%s: filename does not match NNNN-slug.erg pattern", name))
+	}
+
+	// Rule 8: Blocked-by refs exist
+	for _, refID := range t.BlockedBy() {
+		if strings.HasPrefix(refID, "gh#") {
+			continue // GitHub issue reference — not validated locally
+		}
+		if !allIDs[refID] {
+			errors = append(errors, fmt.Sprintf(
+				"%s: Blocked-by '%s' references unknown ticket ID", name, refID))
+		}
+	}
+
+	// Rule 10: log lines match format
+	for _, line := range t.LogLines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !logLineRE.MatchString(trimmed) {
+			errors = append(errors, fmt.Sprintf(
+				"%s: malformed log line: %s", name, trimmed))
+		}
+	}
+
+	// Rule 11: both separators present
+	if !t.HasLog {
+		errors = append(errors, fmt.Sprintf("%s: missing '--- log ---' separator", name))
+	}
+	if !t.HasBody {
+		errors = append(errors, fmt.Sprintf("%s: missing '--- body ---' separator", name))
+	}
+
+	return errors
+}
+
+func detectCycles(tickets []Erg) []string {
+	var errors []string
+
+	adj := make(map[string][]string)
+	for i := range tickets {
+		id := tickets[i].FilenameID()
+		if id != "" {
+			var localRefs []string
+			for _, ref := range tickets[i].BlockedBy() {
+				if !strings.HasPrefix(ref, "gh#") {
+					localRefs = append(localRefs, ref)
+				}
+			}
+			adj[id] = localRefs
+		}
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int)
+	for id := range adj {
+		color[id] = white
+	}
+
+	// Use a shared stack with explicit push/pop to avoid Go slice aliasing bugs.
+	var stack []string
+
+	var dfs func(node string)
+	dfs = func(node string) {
+		color[node] = gray
+		stack = append(stack, node) // push
+		for _, neighbor := range adj[node] {
+			c, exists := color[neighbor]
+			if !exists {
+				continue
+			}
+			if c == gray {
+				start := 0
+				for i, n := range stack {
+					if n == neighbor {
+						start = i
+						break
+					}
+				}
+				cycle := append([]string{}, stack[start:]...)
+				cycle = append(cycle, neighbor)
+				errors = append(errors, "dependency cycle: "+strings.Join(cycle, " -> "))
+			} else if c == white {
+				dfs(neighbor)
+			}
+		}
+		stack = stack[:len(stack)-1] // pop
+		color[node] = black
+	}
+
+	ids := sortedKeys2(adj)
+	for _, id := range ids {
+		if color[id] == white {
+			dfs(id)
+		}
+	}
+	return errors
+}
+
+func validateAll(tickets []Erg, extraIDs map[string]bool) []string {
+	var errors []string
+
+	// Rule 7: no duplicate IDs
+	idToFiles := make(map[string][]string)
+	for i := range tickets {
+		id := tickets[i].FilenameID()
+		if id != "" {
+			idToFiles[id] = append(idToFiles[id], tickets[i].Filename())
+		}
+	}
+
+	dupIDs := sortedKeys2(idToFiles)
+	for _, tid := range dupIDs {
+		files := idToFiles[tid]
+		if len(files) > 1 {
+			errors = append(errors, fmt.Sprintf(
+				"duplicate ID '%s' in: %s", tid, strings.Join(files, ", ")))
+		}
+	}
+
+	// Check collisions with archived ticket IDs
+	if extraIDs != nil {
+		for tid := range idToFiles {
+			if extraIDs[tid] {
+				errors = append(errors, fmt.Sprintf(
+					"ID '%s' in %s collides with an archived ticket",
+					tid, strings.Join(idToFiles[tid], ", ")))
+			}
+		}
+	}
+
+	// Build allIDs for reference checking
+	allIDs := make(map[string]bool)
+	for id := range idToFiles {
+		allIDs[id] = true
+	}
+	for id := range extraIDs {
+		allIDs[id] = true
+	}
+
+	// Per-ticket validation
+	for i := range tickets {
+		errors = append(errors, validateErg(&tickets[i], allIDs)...)
+	}
+
+	// Rule 9: dependency cycles
+	errors = append(errors, detectCycles(tickets)...)
+	return errors
+}
+
+func cmdValidate(args []string) int {
+	if len(args) == 0 {
+		args = []string{"tickets/"}
+	}
+
+	var tickets []Erg
+	for _, arg := range args {
+		info, err := os.Stat(arg)
+		if err != nil {
+			fmt.Printf("WARNING: skipping %s (%v)\n", arg, err)
+			continue
+		}
+		if info.IsDir() {
+			tickets = append(tickets, loadErgs(arg)...)
+		} else if strings.HasSuffix(arg, ".erg") {
+			tickets = append(tickets, parseErg(arg))
+		} else {
+			fmt.Printf("WARNING: skipping %s (not a .erg file or directory)\n", arg)
+		}
+	}
+
+	if len(tickets) == 0 {
+		fmt.Println("No .erg files found.")
+		return 0
+	}
+
+	// Load archived ticket IDs as valid Blocked-by targets
+	extraIDs := make(map[string]bool)
+	for _, arg := range args {
+		info, err := os.Stat(arg)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		archiveDir := filepath.Join(arg, "archive")
+		if info, err := os.Stat(archiveDir); err == nil && info.IsDir() {
+			for _, at := range loadErgs(archiveDir) {
+				id := at.FilenameID()
+				if id != "" {
+					extraIDs[id] = true
+				}
+			}
+		}
+	}
+
+	errors := validateAll(tickets, extraIDs)
+	if len(errors) > 0 {
+		fmt.Printf("ERG VALIDATION FAILED (%d error(s)):\n", len(errors))
+		for _, e := range errors {
+			fmt.Printf("  %s\n", e)
+		}
+		return 1
+	}
+
+	fmt.Printf("ERG VALIDATION: PASS (%d tickets)\n", len(tickets))
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// Ready — find unblocked open tickets
+// ---------------------------------------------------------------------------
+
+type readyEntry struct {
+	id, title, file string
+}
+
+func loadWip() map[string]string {
+	wip := make(map[string]string)
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	out, err := cmd.Output()
+	if err != nil {
+		return wip
+	}
+	wipDir := filepath.Join(strings.TrimSpace(string(out)), "ticket-wip")
+	entries, err := os.ReadDir(wipDir)
+	if err != nil {
+		return wip
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".wip" {
+			continue
+		}
+		tid := strings.TrimSuffix(e.Name(), ".wip")
+		data, err := os.ReadFile(filepath.Join(wipDir, e.Name()))
+		if err == nil {
+			wip[tid] = strings.TrimSpace(string(data))
+		}
+	}
+	return wip
+}
+
+func cmdReady(args []string) int {
+	useJSON := false
+	var rest []string
+	for _, a := range args {
+		if a == "--json" {
+			useJSON = true
+		} else {
+			rest = append(rest, a)
+		}
+	}
+
+	ticketDir := "tickets"
+	if len(rest) > 0 {
+		ticketDir = rest[0]
+	}
+
+	info, err := os.Stat(ticketDir)
+	if err != nil || !info.IsDir() {
+		fmt.Printf("Directory not found: %s\n", ticketDir)
+		return 1
+	}
+
+	tickets := loadErgs(ticketDir)
+	statusByID := make(map[string]string)
+	for i := range tickets {
+		id := tickets[i].FilenameID()
+		if id != "" {
+			statusByID[id] = tickets[i].Status()
+		}
+	}
+
+	wip := loadWip()
+
+	var warnings []string
+	var ready []readyEntry
+	openCount := 0
+
+	for i := range tickets {
+		t := &tickets[i]
+		if t.Status() != "open" {
+			continue
+		}
+		openCount++
+
+		// Exclude WIP-claimed tickets
+		tid := t.FilenameID()
+		if _, claimed := wip[tid]; claimed {
+			continue
+		}
+
+		blocked := false
+		for _, refID := range t.BlockedBy() {
+			if strings.HasPrefix(refID, "gh#") {
+				continue // GitHub refs treated as satisfied offline
+			}
+			refStatus, found := statusByID[refID]
+			if !found {
+				warnings = append(warnings, fmt.Sprintf(
+					"%s: Blocked-by '%s' not found (treating as satisfied)", t.Filename(), refID))
+			} else if refStatus != "closed" {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			ready = append(ready, readyEntry{tid, t.Title(), t.Filename()})
+		}
+	}
+
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "WARNING: %s\n", w)
+	}
+
+	if useJSON {
+		if len(ready) == 0 {
+			fmt.Println("[]")
+		} else {
+			fmt.Println("[")
+			for i, r := range ready {
+				comma := ","
+				if i == len(ready)-1 {
+					comma = ""
+				}
+				wipField := ""
+				if w, ok := wip[r.id]; ok {
+					wipField = fmt.Sprintf(",\n    \"wip\": \"%s\"", jsonEscape(w))
+				}
+				fmt.Printf("  {\n    \"id\": \"%s\",\n    \"title\": \"%s\",\n    \"file\": \"%s\"%s\n  }%s\n",
+					jsonEscape(r.id), jsonEscape(r.title), jsonEscape(r.file), wipField, comma)
+			}
+			fmt.Println("]")
+		}
+	} else {
+		if len(ready) == 0 {
+			if len(tickets) == 0 {
+				fmt.Println("No tickets found.")
+			} else if openCount == 0 {
+				fmt.Printf("All %d tickets are closed.\n", len(tickets))
+			} else {
+				fmt.Printf("%d open tickets, all blocked.\n", openCount)
+			}
+		} else {
+			fmt.Printf("Ready tickets (%d):\n", len(ready))
+			for _, r := range ready {
+				suffix := ""
+				if w, ok := wip[r.id]; ok {
+					suffix = "  (wip: " + w + ")"
+				}
+				fmt.Printf("  %-8s %-40s %s%s\n", r.id, r.file, r.title, suffix)
+			}
+		}
+	}
+	return 0
+}
+
+func jsonEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Archive — DAG-safe archival of old closed tickets
+// ---------------------------------------------------------------------------
+
+// parseLogTimestamp extracts a time from a log line's ISO-8601 prefix.
+func parseLogTimestamp(line string) (time.Time, bool) {
+	line = strings.TrimSpace(line)
+	if len(line) < 16 {
+		return time.Time{}, false
+	}
+	tsStr := line
+	if idx := strings.IndexByte(line[16:], ' '); idx >= 0 {
+		tsStr = line[:16+idx]
+	}
+	tsStr = strings.TrimRight(tsStr, "Z")
+
+	if t, err := time.Parse("2006-01-02T15:04:05", tsStr); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02T15:04", tsStr); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+func cmdArchive(args []string) int {
+	execute := false
+	days := 90
+	ticketDir := "tickets"
+
+	var filtered []string
+	for _, a := range args {
+		if a == "--execute" {
+			execute = true
+		} else {
+			filtered = append(filtered, a)
+		}
+	}
+
+	for i := 0; i < len(filtered); i++ {
+		a := filtered[i]
+		if strings.HasPrefix(a, "--days=") {
+			if n, err := strconv.Atoi(a[7:]); err == nil {
+				days = n
+			}
+		} else if a == "--days" && i+1 < len(filtered) {
+			if n, err := strconv.Atoi(filtered[i+1]); err == nil {
+				days = n
+			}
+			i++
+		} else if !strings.HasPrefix(a, "--") {
+			ticketDir = a
+		}
+	}
+
+	info, err := os.Stat(ticketDir)
+	if err != nil || !info.IsDir() {
+		fmt.Printf("Directory not found: %s\n", ticketDir)
+		return 1
+	}
+
+	tickets := loadErgs(ticketDir)
+	cutoff := time.Now().UTC().AddDate(0, 0, -days)
+
+	// Collect all IDs referenced by Blocked-by in live tickets
+	referencedIDs := make(map[string]bool)
+	allErgs := append([]Erg{}, tickets...)
+	archiveDir := filepath.Join(ticketDir, "archive")
+	if info, err := os.Stat(archiveDir); err == nil && info.IsDir() {
+		allErgs = append(allErgs, loadErgs(archiveDir)...)
+	}
+	for i := range allErgs {
+		for _, ref := range allErgs[i].BlockedBy() {
+			if !strings.HasPrefix(ref, "gh#") {
+				referencedIDs[ref] = true
+			}
+		}
+	}
+
+	var archivable, dagProtected []Erg
+	for i := range tickets {
+		t := &tickets[i]
+		if t.Status() != "closed" {
+			continue
+		}
+
+		// Determine age from last log line or Created header
+		var lastTime time.Time
+		var hasTime bool
+		if len(t.LogLines) > 0 {
+			lastTime, hasTime = parseLogTimestamp(t.LogLines[len(t.LogLines)-1])
+		}
+		if !hasTime {
+			if created, ok := t.Headers["Created"]; ok && len(created) > 0 {
+				if ct, err := time.Parse("2006-01-02", created[0]); err == nil {
+					lastTime = ct
+					hasTime = true
+				}
+			}
+		}
+		if !hasTime || !lastTime.Before(cutoff) {
+			continue
+		}
+
+		id := t.FilenameID()
+		if referencedIDs[id] {
+			dagProtected = append(dagProtected, *t)
+		} else {
+			archivable = append(archivable, *t)
+		}
+	}
+
+	if len(dagProtected) > 0 {
+		var ids []string
+		for _, t := range dagProtected {
+			ids = append(ids, t.FilenameID())
+		}
+		fmt.Printf("DAG-protected (skipping %d): %s\n", len(dagProtected), strings.Join(ids, ", "))
+	}
+
+	if len(archivable) == 0 {
+		fmt.Printf("Nothing to archive (threshold: %d days).\n", days)
+		return 0
+	}
+
+	var ids []string
+	for _, t := range archivable {
+		ids = append(ids, t.FilenameID())
+	}
+	fmt.Printf("Will archive %d ticket(s): %s\n", len(archivable), strings.Join(ids, ", "))
+
+	if !execute {
+		fmt.Println("Dry run. Pass --execute to proceed.")
+		return 0
+	}
+
+	os.MkdirAll(archiveDir, 0755)
+
+	for _, t := range archivable {
+		dest := filepath.Join(archiveDir, t.Filename())
+		cmd := exec.Command("git", "mv", t.Path, dest)
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "git mv failed for %s\n", t.Filename())
+			return 1
+		}
+		fmt.Printf("  moved %s\n", t.Filename())
+	}
+
+	msg := fmt.Sprintf("archive %d closed tickets (>%d days, DAG-safe)", len(archivable), days)
+	cmd := exec.Command("git", "commit", "-m", msg)
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "git commit failed")
+		return 1
+	}
+	fmt.Printf("Committed: %s\n", msg)
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// Graph — visualize the ticket dependency DAG
+// ---------------------------------------------------------------------------
+
+func cmdGraph(args []string) int {
+	useJSON := false
+	var rest []string
+	for _, a := range args {
+		if a == "--json" {
+			useJSON = true
+		} else {
+			rest = append(rest, a)
+		}
+	}
+
+	ticketDir := "tickets"
+	if len(rest) > 0 {
+		ticketDir = rest[0]
+	}
+
+	info, err := os.Stat(ticketDir)
+	if err != nil || !info.IsDir() {
+		fmt.Printf("Directory not found: %s\n", ticketDir)
+		return 1
+	}
+
+	tickets := loadErgs(ticketDir)
+	if len(tickets) == 0 {
+		fmt.Println("No tickets found.")
+		return 0
+	}
+
+	// Build lookup maps
+	byID := make(map[string]*Erg)
+	statusByID := make(map[string]string)
+	for i := range tickets {
+		id := tickets[i].FilenameID()
+		if id != "" {
+			byID[id] = &tickets[i]
+			statusByID[id] = tickets[i].Status()
+		}
+	}
+
+	wip := loadWip()
+
+	// Build children map (reverse of Blocked-by): if B is blocked by A, then A -> B
+	children := make(map[string][]string)
+	hasParent := make(map[string]bool)
+	for i := range tickets {
+		id := tickets[i].FilenameID()
+		for _, ref := range tickets[i].BlockedBy() {
+			if strings.HasPrefix(ref, "gh#") {
+				continue
+			}
+			if _, exists := byID[ref]; exists {
+				children[ref] = append(children[ref], id)
+				hasParent[id] = true
+			}
+		}
+	}
+
+	// Sort children for deterministic output
+	for k := range children {
+		sort.Strings(children[k])
+	}
+
+	// Determine annotation for a ticket
+	annotate := func(id string) string {
+		status := statusByID[id]
+		if _, claimed := wip[id]; claimed {
+			return status + ", claimed"
+		}
+		if status == "open" {
+			// Check if blocked
+			t := byID[id]
+			for _, ref := range t.BlockedBy() {
+				if strings.HasPrefix(ref, "gh#") {
+					continue
+				}
+				if s, ok := statusByID[ref]; ok && s != "closed" {
+					return "open, blocked"
+				}
+			}
+			return "open, READY"
+		}
+		return status
+	}
+
+	// Find root nodes (no parent in the DAG)
+	var roots []string
+	for i := range tickets {
+		id := tickets[i].FilenameID()
+		if id != "" && !hasParent[id] {
+			roots = append(roots, id)
+		}
+	}
+	sort.Strings(roots)
+
+	if useJSON {
+		type jsonNode struct {
+			id, title, status, annotation string
+			blockedBy                     []string
+			deps                          []string
+		}
+		var nodes []jsonNode
+		for i := range tickets {
+			id := tickets[i].FilenameID()
+			n := jsonNode{
+				id:         id,
+				title:      tickets[i].Title(),
+				status:     tickets[i].Status(),
+				annotation: annotate(id),
+				blockedBy:  tickets[i].BlockedBy(),
+				deps:       children[id],
+			}
+			nodes = append(nodes, n)
+		}
+		fmt.Println("[")
+		for i, n := range nodes {
+			comma := ","
+			if i == len(nodes)-1 {
+				comma = ""
+			}
+			blockedByJSON := "[]"
+			if len(n.blockedBy) > 0 {
+				var parts []string
+				for _, b := range n.blockedBy {
+					parts = append(parts, fmt.Sprintf("\"%s\"", jsonEscape(b)))
+				}
+				blockedByJSON = "[" + strings.Join(parts, ", ") + "]"
+			}
+			depsJSON := "[]"
+			if len(n.deps) > 0 {
+				var parts []string
+				for _, d := range n.deps {
+					parts = append(parts, fmt.Sprintf("\"%s\"", jsonEscape(d)))
+				}
+				depsJSON = "[" + strings.Join(parts, ", ") + "]"
+			}
+			fmt.Printf("  {\n    \"id\": \"%s\",\n    \"title\": \"%s\",\n    \"status\": \"%s\",\n    \"annotation\": \"%s\",\n    \"blocked_by\": %s,\n    \"unblocks\": %s\n  }%s\n",
+				jsonEscape(n.id), jsonEscape(n.title), jsonEscape(n.status), jsonEscape(n.annotation), blockedByJSON, depsJSON, comma)
+		}
+		fmt.Println("]")
+		return 0
+	}
+
+	// ASCII tree output
+	var printTree func(id string, prefix string, isLast bool)
+	printTree = func(id string, prefix string, isLast bool) {
+		t := byID[id]
+		if t == nil {
+			return
+		}
+		ann := annotate(id)
+		connector := "-> "
+		if prefix == "" {
+			connector = ""
+		}
+		fmt.Printf("%s%s%s %s [%s]\n", prefix, connector, id, t.Title(), ann)
+
+		kids := children[id]
+		childPrefix := prefix
+		if prefix != "" {
+			if isLast {
+				childPrefix = prefix[:len(prefix)-3] + "   "
+			} else {
+				childPrefix = prefix[:len(prefix)-3] + "|  "
+			}
+		}
+		for i, kid := range kids {
+			last := i == len(kids)-1
+			if childPrefix == "" {
+				printTree(kid, "   ", last)
+			} else {
+				printTree(kid, childPrefix+"   ", last)
+			}
+		}
+	}
+
+	for _, root := range roots {
+		printTree(root, "", true)
+	}
+
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// Next-ID — print the next available ticket ID
+// ---------------------------------------------------------------------------
+
+func cmdNextID(args []string) int {
+	ticketDir := "tickets"
+	if len(args) > 0 {
+		ticketDir = args[0]
+	}
+
+	maxID := 0
+
+	// Scan both tickets/ and tickets/archive/
+	for _, dir := range []string{ticketDir, filepath.Join(ticketDir, "archive")} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".erg") {
+				continue
+			}
+			stem := strings.TrimSuffix(e.Name(), ".erg")
+			if idx := strings.Index(stem, "-"); idx > 0 {
+				stem = stem[:idx]
+			}
+			if n, err := strconv.Atoi(stem); err == nil && n > maxID {
+				maxID = n
+			}
+		}
+	}
+
+	fmt.Printf("%04d\n", maxID+1)
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedKeys2[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ---------------------------------------------------------------------------
+// Main dispatch
+// ---------------------------------------------------------------------------
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: erg <command> [args...]")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  validate [dir|files...]   Validate %erg v1 files")
+	fmt.Fprintln(os.Stderr, "  ready [dir] [--json]      Show tickets ready for work")
+	fmt.Fprintln(os.Stderr, "  archive [dir] [--days N] [--execute]  Archive old closed tickets")
+	fmt.Fprintln(os.Stderr, "  graph [dir] [--json]      Show ticket dependency DAG")
+	fmt.Fprintln(os.Stderr, "  next-id [dir]             Print the next available ticket ID")
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	rest := os.Args[2:]
+
+	var exitCode int
+	switch cmd {
+	case "validate":
+		exitCode = cmdValidate(rest)
+	case "ready":
+		exitCode = cmdReady(rest)
+	case "archive":
+		exitCode = cmdArchive(rest)
+	case "graph":
+		exitCode = cmdGraph(rest)
+	case "next-id":
+		exitCode = cmdNextID(rest)
+	case "-h", "--help", "help":
+		printUsage()
+		exitCode = 0
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", cmd)
+		printUsage()
+		exitCode = 1
+	}
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
## Summary
Dogfood principle: harness tickets belong on the harness repo.

**Bootstrap:** installs the %erg v1 ticket system in IDH (spec + Go validator). Harness-internal tickets now live in `tickets/`, validated by `go run ./tickets/tools/go validate tickets`.

**Tickets filed (10):** all from the two 2026-04-17 `/verify` first-use reflection memos on Climate_finance PR 691 (`0069`) and PR 692 (`0068`). Plus the migration of prior Climate_finance ticket 0079 (misfiled — closed as PR #694) as ticket 0001 here.

| ID | Title | Source |
|----|-------|--------|
| 0001 | Concurrency guard (three-layer: file + label + counter) | migrated from Climate_finance 0079 |
| 0002 | verify-adherence ratchet for statistical antipatterns | memo 1 / A |
| 0003 | Emit failing-test scaffolds for blockers | memo 1 / B |
| 0004 | Wire verify-adherence pre-PR self-gate | memo 1 / C |
| 0005 | Auto-round-2 on fix-agent push | memo 1 / D |
| 0006 | Surface CI absence + pre-existing failures + audit body claims | memo 1 / E + memo 2 / #2 |
| 0007 | Minors language discipline (verifiable/consider/nofollow) | memo 1 / F |
| 0008 | Cheap static checks before deep review | memo 2 / #1 |
| 0009 | Runtime + cost telemetry | memo 2 / #3 |
| 0010 | Structured final report (actions + gate verdict) | explicit user ask 2026-04-17 |

### Relationships
- 0006 merges two memo items: CI-gap visibility + body-claim auditing.
- 0009 is subsumed by 0010's Part A as a telemetry line.
- 0001 and 0005 couple: the L1 file format in 0001 is the natural state store for 0005's round-aware re-entry.
- 0008 is a narrower, higher-priority form of 0004's "cheap before deep" principle.

## Test plan
- [x] `go run ./tickets/tools/go validate tickets` — 10 tickets PASS
- [ ] Reviewer scan of ticket bodies for clarity and scope
- [ ] (Future) each ticket has its own implementation PR

## Supersedes
- `MinhHaDuong/ImperialDragonHarness#34` (issue) — same content now tracked as ticket 0001 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)