### PR TITLE
/review-pr + /verify-gate: tagged minors discipline (ticket 0007)

### DIFF
--- a/skills/review-pr-prose/SKILL.md
+++ b/skills/review-pr-prose/SKILL.md
@@ -37,6 +37,20 @@ One agent is always the **AI-tells auditor**. It reads `config/ai-tells.yml` for
 4. Build the manuscript. Check consistency between prose and data.
 5. Post a single review on the merge request.
 
+## Minor/suggestion tags (mandatory)
+
+Every minor or suggestion item in the posted review carries exactly one prefix:
+
+| Prefix | Meaning |
+|---|---|
+| `verifiable:` | A reproducible check is attached (line-number citation against the text, numeric recheck, lint rule violation). Reviewer can confirm without re-reading the paragraph. |
+| `consider:` | Hypothesis or taste call. No enforcement. Author may dismiss. |
+| `nofollow:` | Noted but not pursued (out of venue, already handled elsewhere, deliberate stylistic choice). No action expected. |
+
+Rules:
+- Hedged prose like "readers may find X confusing" without a concrete pointer is forbidden. Either cite the line and the confusable construction (`verifiable:`) or downgrade to `consider:`.
+- Majors are not tagged; tags are for the minor/suggestion tier only.
+
 ## Proportional depth
 
 | Text change | Panel size |

--- a/skills/review-pr-prose/SKILL.md
+++ b/skills/review-pr-prose/SKILL.md
@@ -50,6 +50,7 @@ Every minor or suggestion item in the posted review carries exactly one prefix:
 Rules:
 - Hedged prose like "readers may find X confusing" without a concrete pointer is forbidden. Either cite the line and the confusable construction (`verifiable:`) or downgrade to `consider:`.
 - Majors are not tagged; tags are for the minor/suggestion tier only.
+- The tag set is shared with `/review-pr` and `/verify-gate`. Keep all three in sync.
 
 ## Proportional depth
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -52,6 +52,21 @@ Spin multiple agents in parallel, each with a distinct perspective. Run all agen
 4. **Run tests**: `make check`
 5. **Post a single review** on the merge request, attributing each finding to its perspective.
 
+## Minor finding tags (mandatory)
+
+Every non-blocker finding posted in the review carries exactly one prefix:
+
+| Prefix | Meaning |
+|---|---|
+| `verifiable:` | A current failing assertion is attached (test_id, command output, or commit SHA:file:line). The claim is reproducible now. |
+| `consider:` | Hypothesis worth flagging, no enforcement. No test exists and none is required. Author may dismiss. |
+| `nofollow:` | Intentionally not pursued (out of scope, duplicate, stylistic preference). Recorded for the audit trail; no action expected. |
+
+Rules:
+- Ambiguous "this might break X" / "could cause Y" language is forbidden. Either produce the failing assertion (`verifiable:`) or downgrade to `consider:`.
+- A `verifiable:` finding without attached evidence is a posting bug — hold the review until the evidence exists or retag.
+- Blockers (`request-changes`) are not tagged; tags are for the minor/comment tier only.
+
 ## Code-quality escalation
 
 | Severity | Action |

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -66,7 +66,7 @@ Rules:
 - Ambiguous "this might break X" / "could cause Y" language is forbidden. Either produce the failing assertion (`verifiable:`) or downgrade to `consider:`.
 - A `verifiable:` finding without attached evidence is a posting bug — hold the review until the evidence exists or retag.
 - Blockers (`request-changes`) are not tagged; tags are for the minor/comment tier only.
-- The tag set is shared with `/review-pr-prose` and `/verify-gate`. Keep all three in sync.
+- The tag set is shared with `/review-pr-prose` and `/verify-gate`. Keep all three in sync. Evidence forms differ by domain: code reviews use test_id/SHA:file:line; prose reviews use line citations and numeric rechecks.
 
 ## Code-quality escalation
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -66,6 +66,7 @@ Rules:
 - Ambiguous "this might break X" / "could cause Y" language is forbidden. Either produce the failing assertion (`verifiable:`) or downgrade to `consider:`.
 - A `verifiable:` finding without attached evidence is a posting bug — hold the review until the evidence exists or retag.
 - Blockers (`request-changes`) are not tagged; tags are for the minor/comment tier only.
+- The tag set is shared with `/review-pr-prose` and `/verify-gate`. Keep all three in sync.
 
 ## Code-quality escalation
 

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -32,6 +32,11 @@ standalone-callable for debugging.
    is a REROLL trigger.
 6. **Two rounds max.** Round 1 is initial gate. Round 2 is post-fix re-gate. Round 3 is
    forbidden — escalate.
+7. **Tagged minors are mandatory.** Review comments from `/review-pr` and
+   `/review-pr-prose` at the minor/suggestion tier must carry one of `verifiable:`,
+   `consider:`, or `nofollow:`. Untagged minors and ambiguous "X might break" /
+   "this could cause Y" phrasings are refused — the gate does not triage hedges. See
+   "Minor tag handling" below.
 
 ## Input
 
@@ -77,8 +82,15 @@ per_exit_criterion:
 unresolved_review_comments:
   - comment_ref: <url or id>
     author: <login>
+    tag: verifiable | consider | nofollow | untagged
     thread_excerpt: "<short>"
     why_unresolved: "<reason>"
+
+malformed_minors:
+  - comment_ref: <url or id>
+    author: <login>
+    excerpt: "<hedged phrasing>"
+    fix: "retag as verifiable: with assertion, or as consider:"
 
 unresolved_simplify_findings:
   - finding: "<verbatim>"
@@ -106,12 +118,41 @@ second_round_needed:
 - Any `UNRESOLVED` review comment from a human author → REROLL (round 1) / ESCALATE (round 2).
 - Any `UNRESOLVED` review comment from `/review-pr` labelled severity ≥ medium →
   REROLL (round 1) / ESCALATE (round 2).
+- Any unresolved `verifiable:` minor (failing assertion still reproduces) → treated as
+  blocker-adjacent: REROLL (round 1) / ESCALATE (round 2).
+- `consider:` minors are informational. They appear in the verdict comment but do not
+  bounce the PR. Author is free to ignore.
+- `nofollow:` minors are muted. The gate records them for the audit trail and does
+  nothing else.
 - Any `NOT_APPLIED` must-fix simplify finding without rationale → REROLL (round 1) /
   ESCALATE (round 2).
 - Any `blocking` adherence violation → REROLL (round 1) / ESCALATE (round 2).
 - All lists empty AND all criteria ADDRESSED → APPROVED.
 
 If `round == 2` and any trigger fires → upgrade to ESCALATE. Never a third round.
+
+## Minor tag handling
+
+Incoming `/review-pr` and `/review-pr-prose` comments at the minor/suggestion tier are
+expected to be prefixed `verifiable:`, `consider:`, or `nofollow:`.
+
+| Tag | Gate treatment |
+|---|---|
+| `verifiable:` | Blocker-adjacent. Must be ADDRESSED (commit closes the assertion, or a follow-up ticket is opened with rationale). Unresolved → REROLL. |
+| `consider:` | Informational. Surfaced in the verdict comment under a `consider:` section. Never bounces. |
+| `nofollow:` | Muted. Not surfaced, not counted. |
+
+Untagged or ambiguously-phrased minors ("might break", "could regress", "may confuse
+readers" without a line pointer) are a process failure, not a finding. The gate:
+
+1. Lists them under `malformed_minors` in the verdict bundle.
+2. Does not let them bounce the PR on their own.
+3. Flags the review author for retag — either promote to `verifiable:` with a failing
+   test, or downgrade to `consider:`.
+
+The gate itself also refuses to author hedged language in its own rationale. If the
+gate wants to raise a concern, it either attaches a reproducible check (making it a
+blocker or a `verifiable:` minor) or files it as `consider:`.
 
 ## Anti-patterns the gate refuses to indulge
 
@@ -122,6 +163,7 @@ If `round == 2` and any trigger fires → upgrade to ESCALATE. Never a third rou
 | "Reviewer concern filed as follow-up" with no ticket ID | Unverifiable; ticket must exist |
 | "Addressed in PR body" without commit | PR body is narrative; need the actual change |
 | "Edge case out of scope" without Scope audit confirmation | The Scope phase is Phase 7; gate cannot waive unilaterally |
+| "X might break" / "could cause Y" as a minor | Ambiguous middle ground. Require `verifiable:` with a failing assertion, or `consider:` as explicit hypothesis. |
 
 ## Standalone invocation
 
@@ -146,11 +188,20 @@ apply only when called from `/verify`.
    Simplify: <n_unresolved> must-fix not applied
    Adherence: <n_blocking> blocking violations
 
+   Minors:
+   - verifiable: <count> (<n_unresolved> unresolved, blocker-adjacent)
+   - consider:   <count> (informational, does not bounce)
+   - nofollow:   <count> (muted)
+   - malformed:  <count> (retag required)
+
    Top reasons (if not APPROVED):
    - <ranked list>
 
    Rationale: <paragraph>
    ```
+
+   The three prefixes (`verifiable:`, `consider:`, `nofollow:`) appear verbatim in the
+   posted comment so authors can see which class each minor falls into.
 
 ## Circuit breakers
 

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -118,6 +118,7 @@ second_round_needed:
 - Any `UNRESOLVED` review comment from a human author → REROLL (round 1) / ESCALATE (round 2).
 - Any `UNRESOLVED` review comment from `/review-pr` labelled severity ≥ medium →
   REROLL (round 1) / ESCALATE (round 2).
+  Severity triggers apply to blockers (request-changes). Tagged minors are triaged by tag, not severity.
 - Any unresolved `verifiable:` minor (failing assertion still reproduces) → treated as
   blocker-adjacent: REROLL (round 1) / ESCALATE (round 2).
 - `consider:` minors are informational. They appear in the verdict comment but do not
@@ -150,6 +151,7 @@ readers" without a line pointer) are a process failure, not a finding. The gate:
 2. Does not let them bounce the PR on their own.
 3. Flags the review author for retag — either promote to `verifiable:` with a failing
    test, or downgrade to `consider:`.
+4. On round 2, any untagged minor still present → ESCALATE. Ignoring retag requests is not free.
 
 The gate itself also refuses to author hedged language in its own rationale. If the
 gate wants to raise a concern, it either attaches a reproducible check (making it a
@@ -164,7 +166,7 @@ blocker or a `verifiable:` minor) or files it as `consider:`.
 | "Reviewer concern filed as follow-up" with no ticket ID | Unverifiable; ticket must exist |
 | "Addressed in PR body" without commit | PR body is narrative; need the actual change |
 | "Edge case out of scope" without Scope audit confirmation | The Scope phase is Phase 7; gate cannot waive unilaterally |
-| "X might break" / "could cause Y" as a minor | Ambiguous middle ground. Require `verifiable:` with a failing assertion, or `consider:` as explicit hypothesis. |
+| "X might break" / "could cause Y" as a minor | Ambiguous hypothesis with no reproducible evidence. |
 
 ## Standalone invocation
 

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -134,7 +134,8 @@ If `round == 2` and any trigger fires → upgrade to ESCALATE. Never a third rou
 ## Minor tag handling
 
 Incoming `/review-pr` and `/review-pr-prose` comments at the minor/suggestion tier are
-expected to be prefixed `verifiable:`, `consider:`, or `nofollow:`.
+expected to be prefixed `verifiable:`, `consider:`, or `nofollow:`. The tag set is
+defined in `/review-pr` and `/review-pr-prose`. Keep all three in sync.
 
 | Tag | Gate treatment |
 |---|---|

--- a/tickets/0007-verify-minors-language-discipline.erg
+++ b/tickets/0007-verify-minors-language-discipline.erg
@@ -1,11 +1,14 @@
 %erg v1
 Title: /verify minors — verifiable / consider / nofollow language discipline
-Status: open
+Status: closed
 Created: 2026-04-17
 Author: user
 
 --- log ---
 2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+2026-04-17T12:26Z claude claimed
+2026-04-17T12:26Z claude note added verifiable/consider/nofollow minor-tagging discipline to review-pr and review-pr-prose; verify-gate enforces tags, treats verifiable as blocker-adjacent, consider as informational, nofollow as muted, and refuses hedged X-might-break language
+2026-04-17T12:26Z claude status closed exit criteria met
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- `/review-pr` and `/review-pr-prose` now require every minor/suggestion finding to carry one of `verifiable:`, `consider:`, or `nofollow:`. Ambiguous "might break / could cause" phrasing is explicitly forbidden.
- `/verify-gate` treats `verifiable:` as blocker-adjacent, `consider:` as informational (does not bounce), `nofollow:` as muted, and refuses hedged language in its own rationale. Untagged or malformed minors are surfaced under `malformed_minors` and flagged for retag.
- The posted gate comment template exposes the three prefixes verbatim so authors can see which class each minor falls into.

Closes ticket 0007.

## Exit criteria

- [x] `/review-pr` and `/review-pr-prose` emit tagged minors.
- [x] `/verify-gate` enforces tagging (rejects ungrounded "X will break").
- [x] Verify comment visibly uses the three prefixes.
- [x] Memo-1 "ticket F" addressed.

## Test plan

- [ ] Human invokes `/verify` on this PR; gate comment shows the `verifiable / consider / nofollow / malformed` block.
- [ ] Inject a hedged minor ("this might break X") into a test review; confirm `/verify-gate` lists it under `malformed_minors` and does not bounce on it alone.
- [ ] Confirm a `consider:` minor is informational (no REROLL) and a `verifiable:` minor with unresolved assertion triggers REROLL.

https://claude.ai/code/session_01QrXqd2qfxTicDrnhD2LXjS

## Merge order
2 of 6. Merge after #37 (phase 1.0 must exist before gate references it).
Subsequent: #36 → #40 → #39 → #41.