### PR TITLE
start-ticket: pre-PR /verify-adherence self-gate (ticket 0004)

### DIFF
--- a/skills/start-ticket/SKILL.md
+++ b/skills/start-ticket/SKILL.md
@@ -23,7 +23,13 @@ argument-hint: <ticket-id>
 6. Write the first test from the **Test** section of the ticket.
 7. Run `make check-fast` — confirm the test fails.
 8. Announce `[Plan → Execute]`, then implement until `make check` passes.
-9. Push the branch and open a merge request.
-10. Review according to `/review-pr`.
-11. Fix all comments regardless of severity.
-12. Repeat 10–11 up to 3 times. If still not clean, escalate (see workflow rules).
+9. Pre-PR self-gate: run `/verify-adherence <branch>` (the branch created in step 4).
+   - Clean → proceed to step 10 and pass `--label verify:adherence-passed` to `gh pr create`. The label signals to the downstream `/verify` merge gate that the mechanical adherence phase already ran clean and can be skipped on its next pass.
+   - Blockers → decide per blocker:
+     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check` and `/verify-adherence`, then proceed only once clean.
+     - Otherwise → STOP. Do not open the PR. Escalate with the adherence report and the blocker list.
+   - Circuit breaker: if `/verify-adherence` itself errors, times out, or returns an unparseable result → ESCALATE. Do not open the PR and do not silently skip the gate.
+10. Push the branch and open a merge request with `gh pr create ... --label verify:adherence-passed`.
+11. Review according to `/review-pr`.
+12. Fix all comments regardless of severity.
+13. Repeat 11–12 up to 3 times. If still not clean, escalate (see workflow rules).

--- a/skills/start-ticket/SKILL.md
+++ b/skills/start-ticket/SKILL.md
@@ -26,7 +26,7 @@ argument-hint: <ticket-id>
 9. Pre-PR self-gate: run `/verify-adherence <branch>` (the branch created in step 4).
    - Clean → proceed to step 10 and pass `--label verify:adherence-passed` to `gh pr create`. The label signals to the downstream `/verify` merge gate that the mechanical adherence phase already ran clean and can be skipped on its next pass.
    - Blockers → decide per blocker:
-     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check` and `/verify-adherence`, then proceed only once clean.
+     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check` and `/verify-adherence`, then proceed only once clean. Up to 2 fix-and-recheck cycles; if still not clean after 2 rounds, escalate.
      - Otherwise → STOP. Do not open the PR. Escalate with the adherence report and the blocker list.
    - Circuit breaker: if `/verify-adherence` itself errors, times out, or returns an unparseable result → ESCALATE. Do not open the PR and do not silently skip the gate.
 10. Push the branch and open a merge request with `gh pr create ... --label verify:adherence-passed`.

--- a/skills/start-ticket/SKILL.md
+++ b/skills/start-ticket/SKILL.md
@@ -24,12 +24,12 @@ argument-hint: <ticket-id>
 7. Run `make check-fast` — confirm the test fails.
 8. Announce `[Plan → Execute]`, then implement until `make check` passes.
 9. Pre-PR self-gate: run `/verify-adherence <branch>` (the branch created in step 4).
-   - Clean → proceed to step 10 and pass `--label verify:adherence-passed` to `gh pr create`. The label signals to the downstream `/verify` merge gate that the mechanical adherence phase already ran clean and can be skipped on its next pass.
+   - Clean → proceed to step 10 and pass `--label verify:adherence-passed` to `gh pr create`. The label signals to the downstream `/verify` merge gate that the mechanical adherence phase already ran clean and can be skipped on its next pass. (Create the label first with `gh label create verify:adherence-passed --force` if it does not yet exist.)
    - Blockers → decide per blocker:
-     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check` and `/verify-adherence`, then proceed only once clean. Up to 2 fix-and-recheck cycles; if still not clean after 2 rounds, escalate.
+     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check` and `/verify-adherence`, then proceed only once clean. Up to 3 fix-and-recheck cycles; if still not clean after 3 rounds, escalate.
      - Otherwise → STOP. Do not open the PR. Escalate with the adherence report and the blocker list.
    - Circuit breaker: if `/verify-adherence` itself errors, times out, or returns an unparseable result → ESCALATE. Do not open the PR and do not silently skip the gate.
-10. Push the branch and open a merge request with `gh pr create ... --label verify:adherence-passed`.
+10. Push the branch and open a merge request.
 11. Review according to `/review-pr`.
 12. Fix all comments regardless of severity.
 13. Repeat 11–12 up to 3 times. If still not clean, escalate (see workflow rules).

--- a/tickets/0004-wire-verify-adherence-pre-pr.erg
+++ b/tickets/0004-wire-verify-adherence-pre-pr.erg
@@ -1,11 +1,14 @@
 %erg v1
 Title: Wire /verify-adherence into Execute (pre-PR self-gate)
-Status: open
+Status: closed
 Created: 2026-04-17
 Author: user
 
 --- log ---
 2026-04-17T10:00Z claude created from verify reflection memo (PR 691)
+2026-04-17T12:41Z claude claimed
+2026-04-17T12:41Z claude note added pre-PR /verify-adherence self-gate to start-ticket Execute phase; clean runs tag PR with verify:adherence-passed, blockers halt PR creation, circuit-breaker escalates on adherence tool failure
+2026-04-17T12:41Z claude status closed exit criteria met
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

Wires `/verify-adherence <branch>` into `skills/start-ticket/SKILL.md` between `make check` and `gh pr create` as a cheap pre-PR self-gate. Clean runs propagate a `verify:adherence-passed` label via `gh pr create --label`, letting the downstream `/verify` merge gate skip the mechanical adherence phase on its next pass. Blockers halt PR creation (cheap/mechanical fixes are applied in place; everything else escalates), and a circuit breaker escalates if `/verify-adherence` itself errors or times out rather than silently skipping.

Closes ticket 0004.

## Exit criteria

- [x] `/start-ticket` invokes `/verify-adherence` before `gh pr create`.
- [x] Blockers in pre-PR check halt PR creation.
- [x] `verify:adherence-passed` label propagates to the PR.
- [x] Memo-1 "ticket C" addressed.

## Test plan

- [ ] Drop a `np.random.RandomState()` (no seed) into a Phase 2 script and verify Execute refuses to open a PR.
- [ ] Confirm a clean adherence run results in `gh pr create --label verify:adherence-passed` and the label lands on the PR.
- [ ] Simulate a `/verify-adherence` tool failure (error/timeout) and confirm Execute escalates rather than opening the PR.

## Follow-ups (not done here)

- Cross-reference note in `skills/verify/SKILL.md` and/or `skills/verify-adherence/SKILL.md` documenting the `verify:adherence-passed` label-skip behaviour. Skipped because those files are in sibling PRs (#36, #37, #38, #39); should be added after they merge.

https://claude.ai/code/session_01QrXqd2qfxTicDrnhD2LXjS

## Merge order
4 of 6. Merge after #36. Wires `/verify-adherence` into start-ticket; needs #37's phase 1.0 and #36's telemetry to exist. Cross-reference notes for the `verify:adherence-passed` label should be added to #36/#37 files after this merges.
Subsequent: #39 → #41.