### PR TITLE
simplify: slim over-specified skills — trust the LLM

### DIFF
--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -14,35 +14,22 @@ This skill is user-level and must **gracefully degrade**: each check runs only i
 
 ## Checks
 
-1. **Recent activity** — `git log --since="12 hours ago" --oneline --all` — summarize commit count and key themes
-2. **Open PRs** — `gh pr list --state open` — list or confirm zero. Skip with reason if `gh` unavailable or no remote.
-3. **Origin sync** — `git fetch origin` then compare `HEAD` vs `origin/<default-branch>` — report ahead/behind/synced. Skip if no `origin` remote.
-4. **Branch hygiene** — `git branch -a` — list all, flag stale feature branches
-5. **Worktrees** — `git worktree list` — list all, flag any orphaned worktrees beyond the current session
-6. **Orphan commits** — `git fsck --unreachable --no-reflogs 2>&1 | grep "^unreachable commit"` — report count or "none"
-7. **Working tree** — `git status --short` — report clean or list uncommitted changes
-8. **Tests green** — run the project's test suite and report pass/fail. Entry-point autodetect:
-   - If `Makefile` defines a `test` target → `make test`
-   - Else if `pyproject.toml` exists → `uv run pytest` (or `pytest` if `uv` unavailable)
-   - Else if `package.json` defines a `test` script → `npm test`
-   - Else → skip with reason `no test entry point detected`
-
-   Report: `N passed`, or `K failed / N total` plus the first failing test name. Slowest check; expect 10s–minutes.
-
-9. **Docs freshness (deep verification)** — run `scripts/docs_freshness.sh` (bundled with this skill) to get the mechanical report, then perform the manual cross-checks below. This check **must not be shallow** — existence alone is not enough. Scan every canonical status/directive doc that exists at the repo root: `STATE.md`, `MASTERPLAN.md`, `README.md`, `ROADMAP.md`, `ARCHITECTURE.md`, and any other top-level `*.md` whose filename is all-caps or clearly a status/directive doc. Skip docs that don't exist; don't invent them.
-
-   a. **Staleness timestamp.** `git log -1 --format=%ci -- <file>` — days since last commit touching the file. Warn if > 7 days have passed *and* the "Status"/"Last updated" line inside the doc predates the most recent repo activity. Fail if > 30 days with no update.
-
-   b. **Ticket cross-check** (conditional on `tickets/*.erg` presence — git-erg in use). Extract every `0\d{3}` or `ticket 0\d{3}` reference in the doc. Partition by context: "done" (inside `[x]` checkbox, "Closed" section, "merged" phrase) vs "todo" (inside `[ ]` checkbox, "Next actions", "Open tickets", "pending"). For each ticket ID, read `tickets/0NNN-*.erg` `Status:` header. Flag mismatches:
-      - Ticket listed as todo but `Status: closed` → stale TODO (most common drift)
-      - Ticket listed as done but `Status: open` → premature claim
-      - Referenced ticket ID not found in `tickets/` → broken ref
-
-      If `tickets/*.erg` is absent, skip this sub-check with reason `no git-erg tickets detected`. The helper script automates the most common drift; always run it when tickets exist.
-
-   c. **PR cross-check.** Extract every `#\d{3,}` reference. For each PR mentioned as pending / in-flight / open, verify via `gh pr view N --json state,title`. Flag merged PRs still described as pending work, and closed-without-merge PRs still described as landed. Skip if `gh` unavailable.
-
-   d. **Count consistency.** If the doc contains a count like "Open tickets (N)" or "N open", cross-check N against `grep -l "^Status: open" tickets/*.erg | wc -l` (add `pending` count if included). Flag drift. Skip if tickets absent or no count pattern found.
+1. **Recent activity** — commits in the last 12 hours, key themes
+2. **Open PRs** — list or confirm zero. Skip if `gh` unavailable.
+3. **Origin sync** — ahead/behind/synced. Skip if no remote.
+4. **Branch hygiene** — list all, flag stale feature branches
+5. **Worktrees** — list all, flag orphaned ones
+6. **Orphan commits** — count unreachable commits
+7. **Working tree** — clean or list uncommitted changes
+8. **Tests green** — autodetect test runner (make/pytest/npm), report pass/fail
+9. **Docs freshness (deep verification)** — run `scripts/docs_freshness.sh`,
+   then cross-check status/directive docs (`STATE.md`, `README.md`, etc.):
+   - **Staleness** — flag docs whose content predates recent repo activity
+   - **Ticket cross-check** — references to tickets whose status contradicts
+     the doc (todo but closed, done but open, broken ref). Skip if no `.erg` tickets.
+   - **PR cross-check** — PRs described as pending but already merged/closed.
+     Skip if `gh` unavailable.
+   - **Count consistency** — "N open tickets" claims vs actual count
 
 ## Output format
 

--- a/skills/related-work-note/SKILL.md
+++ b/skills/related-work-note/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: related-work-note
-description: When writing a Related Work section (or any paragraph with non-trivial citations) — produce an author's due-diligence note for one cited paragraph of a manuscript. Seven required sections: relevance, history-of-science context, cited works (detailed), related-but-not-cited (justified), methods, author-verification checklist, formal bibliography with DOI/URL. Deep-researched with snowballing and grey-literature policy; fresh each invocation.
+description: Author's due-diligence note for one cited paragraph of a manuscript. Covers relevance, history, cited works (detailed), related-but-not-cited (justified), methods, verification checklist, bibliography with DOI/URL.
 disable-model-invocation: false
 user-invocable: true
 argument-hint: free-form inline — see "Inputs" section
@@ -8,319 +8,42 @@ argument-hint: free-form inline — see "Inputs" section
 
 # Related-work due-diligence note
 
-**Purpose.** Academic authorship obliges the author to *know* each
-cited work, not merely list it. This skill produces a companion
-document that sits alongside a single manuscript paragraph and gives
-the author everything needed to defend the paragraph under peer
-review — what each cited work did, why it was chosen, what the
-alternatives were and why they were dropped, what the field's lineage
-is, and how the note itself was assembled.
+Produce a companion document for a single manuscript paragraph that
+gives the author everything needed to defend the paragraph under
+peer review.
 
-**Positioning.** This is an author's due-diligence artefact, **not a
-systematic review** (PRISMA 2020) and **not a scoping review**
-(Arksey & O'Malley / JBI). The standard is *"defensible under peer
-review of one paragraph"*, not *"exhaustive coverage of the
-sub-field"*. Do not promise completeness you cannot deliver; do
-build a search deep enough that a referee's "why didn't you cite X?"
-has a prepared answer.
+**Not a systematic review.** The standard is "defensible under peer
+review of one paragraph," not exhaustive coverage. Build a search
+deep enough that a referee's "why didn't you cite X?" has a
+prepared answer.
 
-**Scope.** One invocation = one paragraph = one note file. A section
-with N paragraphs needs N invocations. Re-run the skill freshly on
-every invocation; do not recycle an older note as a cache. The
-Methods section records the invocation date as the freshness cutoff,
-so a stale reuse would make the note lie.
+## Constraints (non-obvious)
 
-**Tools to use.** `WebSearch` and `WebFetch` for scholar searches
-and to resolve DOIs/URLs. `Read` for the target manuscript and any
-existing `report/refs.bib`. `Write` only for the final output note
-file. Do not modify any other project file.
+- **One paragraph = one note = one invocation.** Re-run freshly
+  each time; never recycle an older note. Methods records the
+  invocation date as the freshness cutoff.
+- **Resolve every identifier before emitting.** WebFetch each DOI
+  or URL. Drop or replace entries that don't resolve — never ship
+  an unresolved identifier.
+- **Check existing refs.bib first.** Reuse existing keys rather
+  than minting duplicates. Match the library's key style if clear.
+- **Write one file, touch nothing else.** Output is a single
+  markdown note. Do not modify refs.bib or any other project file.
+- **"Related but not cited" is mandatory.** At least two entries
+  when alternatives exist. A thin list for a narrow sub-literature
+  is fine — say so in Methods rather than padding.
+- **No padding.** Every bibliography entry must be directly
+  justified. Do not add references for coverage.
+- **Non-English titles** must include a bracketed English
+  translation: `{Titre original [English translation]}`.
 
-## Inputs
+## Toolchain
 
-**Invocation style.** Pass all inputs as free-form labelled prose
-inside the skill's args — positional parsing is impractical because
-paragraph topics contain spaces. The skill extracts the labels.
+**biblatex** (not BibTeX) compiled with **biber**. Local `.bib` is
+staging; the canonical library is **Zotero**. Import into Zotero at
+manuscript submission (see ticket 0013).
 
-The caller must provide:
-
-1. **Paragraph topic or claim** — a phrase or sentence describing the
-   paragraph's thesis. Example: *"LLM evaluation targets QA and
-   reasoning, not structured statistical-table production."*
-2. **Target manuscript path** — repository-relative path to the
-   manuscript being written. Example:
-   `publications/journal-article/paper_benchmark_merged.md`.
-3. **Section identifier** — the section and paragraph number within
-   the manuscript. Example: *"§2 Related Work, paragraph 1"*. For a
-   pilot run, use *"PILOT — not for inclusion in paper"*.
-4. **Output path** — where the note file should be written. Example:
-   `publications/journal-article/notes/02_related_work/01_llm_benchmarks.md`.
-5. *(Optional)* **Citation budget** — the maximum number of citations
-   the paragraph will use. If supplied, the skill still proposes more
-   in "Related but not cited"; the operator cuts down later. Recorded
-   in the output note's frontmatter as `citation-budget: N`.
-
-Example invocation:
-
-```
-Paragraph topic: "…"
-Manuscript path: …
-Section identifier: "§2 Related Work, paragraph 1"
-Output path: …
-Citation budget: 5
-```
-
-If the caller provides these inline, use them. If any is missing, ask
-the caller once before proceeding.
-
-## Procedure
-
-### 1. Read the manuscript context
-
-Read the target manuscript (at minimum the section the paragraph sits
-in, ideally also the abstract and introduction) so the note is
-tailored to *this* paper's argument, not the general field.
-
-**Pilot or not-yet-written section.** If the section identifier is
-a pilot label ("PILOT — …") or points at a section that does not
-yet exist, read the abstract and introduction instead. Record the
-fallback in Methods.
-
-### 2. Deep-research the paragraph topic
-
-Run web and scholar searches to surface:
-
-- **Seminal works** — field-defining references, often older
-  (pre-2015). Example: Lewis et al. 2020 for RAG; BERT 2019 for
-  transformer-era IE.
-- **Review / survey papers** — to let the author drill down later.
-  Prefer recent surveys with strong citation counts; note the field's
-  pace when assessing currency.
-- **Recent frontier works** — 2024–2026 results. Preprints allowed
-  when no peer-reviewed equivalent exists; flag them as such.
-- **Superseded or widely-critiqued works** — so "related but not
-  cited" is informed, not arbitrary.
-
-**Keyword search alone misses landmark work.** Complement with:
-
-- **Backward snowballing** — chase the reference list of the most
-  on-topic seed paper; pick up anchors the seed cites.
-- **Forward snowballing** — "cited by" lookup on Semantic Scholar or
-  Google Scholar for the same seed; pick up the downstream wave.
-- **Venue-guided browsing** — open one or two top venues for the
-  sub-field (e.g., *Applied Energy*, *Energy Strategy Reviews*,
-  JMLR, ACL, EMNLP, NeurIPS datasets-and-benchmarks) and scan
-  recent issues for anchors the keyword queries missed.
-
-**Grey literature is often primary** — for domains like
-energy-data pipelines, public-sector modelling, and infrastructure
-inventories, the authoritative source is frequently a tech report,
-a government document, or a project website (e.g., GEM trackers,
-WRI GPPDB, PyPSA-Earth docs). Grey literature may be cited when it
-is the primary source for a closely-related artefact. **Prefer a
-versioned URL** (release tag, Zenodo DOI, Wayback snapshot) over a
-bare homepage, so the citation remains stable.
-
-Log every search in the Methods section: the query, the tool, the
-date, and the approximate result count that was usable. Stop when
-the searches saturate (new queries mostly re-surface already-seen
-anchors) and record the stop condition.
-
-### 3. Check the operator's existing bibliography
-
-Before minting new BibTeX keys, check whether the reference already
-exists in the project. Scan `report/refs.bib` (if present) and
-inspect its key style (e.g., 8-character uppercase Zotero-style
-keys, or author-year style). If a match exists, reuse the key.
-
-If no match, mint a new key. **Matching the existing library's key
-style is a best-effort**: if the scan was conclusive, match it; if
-the library is inaccessible or ambiguous, mint a readable
-`AuthorYEAR` key and record in Methods that final key reconciliation
-is deferred to the `bib-merge` skill (IDH issue #33) at import time.
-Do not block the note on key-style uncertainty.
-
-### 4. Draft the note
-
-Use the Output Template (next section) verbatim. Every section is
-mandatory — including the Author Verification Checklist. The skill
-rejects its own output if:
-
-- any of the seven sections is missing,
-- any cited-work entry lacks one of the four required fields,
-- any non-cited entry lacks a justification,
-- any bibliography entry lacks a stable URL (DOI is encouraged when
-  the published version has one, but not required — not every paper
-  is indexed by DOI), or
-- the Methods section omits the preprint-acceptability note, the
-  inclusion/exclusion rule, the identifier-resolution log, or the
-  freshness cutoff. (The grey-literature bullet is included only
-  when grey literature is cited.)
-
-### 5. Resolve every identifier before emitting
-
-Before writing the file, for each entry in the Bibliography:
-
-- If the entry has a DOI, fetch `https://doi.org/{DOI}` with
-  `WebFetch`. A 200 or 30x redirect confirms the DOI resolves.
-- If the entry has no DOI, `WebFetch` the stable URL and confirm
-  it returns a 200.
-- If neither resolves, **drop the entry or replace it**. Never ship
-  an unresolved identifier — that is how hallucinated citations
-  reach published papers.
-
-Record the resolution check in Methods as one line: "All N
-bibliography entries resolved on {YYYY-MM-DD}." If any were
-dropped, list them with the failure reason.
-
-### 6. Write the output file
-
-Write the note to the caller-specified path. Do not modify
-`report/refs.bib` or any other project file — the skill's output is
-a single markdown note.
-
-### 7. Report back
-
-Summarise to the caller in ≤100 words: the path of the produced
-note, the number of cited works, the number of "related but not
-cited" entries, any identifiers dropped at the resolution step,
-and any decision points the author should revisit (e.g., "Gao et
-al. 2024 RAG survey was dropped in favor of Wang et al. 2025 — the
-author may want to reconsider if coverage matters more than
-freshness").
-
-## Output template
-
-Emit this markdown structure, filling each section with the results
-of steps 1–5.
-
-```markdown
----
-title: {paragraph topic — imperative noun phrase}
-author: Claude prompted by Ha-Duong Minh
-date: {YYYY-MM-DD — the invocation date}
-paper: {manuscript path as provided}
-section: {section identifier as provided, e.g., "§2 Related Work, paragraph 1"}
-citation-budget: {N, or "unset"}
----
-
-## Relevance
-
-One paragraph. Why this note exists for this paragraph of this paper:
-what claim the paragraph makes, what a referee could legitimately
-probe, why each cited work is load-bearing. Do not repeat the
-paragraph's text — state the intellectual stakes.
-
-## History of science context
-
-200–400 words. The lineage of the sub-field the paragraph sits in:
-the problem's origin, the main paradigm shifts (named with
-approximate dates), the current state. The goal is for the author
-to position the cited works against the field, not the other way
-around. Avoid speculation. If a claim is contested, **name the
-opposing view and cite its strongest reference** — do not silently
-pick a side.
-
-## Cited works — detailed
-
-For each work the paragraph cites, produce a block with exactly
-these four fields:
-
-### {Author Year — short title}
-
-- **Reference.** Author, year, venue, DOI/URL.
-- **What the work did.** Method, data, main result — 2 to 4
-  sentences.
-- **Why this paragraph cites it.** The specific claim the paragraph
-  uses this work to support. One sentence.
-- **Limitations or critiques the author should know.** Known
-  weaknesses, superseding work, replication failures, or
-  community-level debates. One or two sentences.
-
-Repeat for every cited work.
-
-## Related but not cited — justified
-
-For each plausible alternative that an informed reader would expect
-to see but that is not cited, provide:
-
-### {Author Year — short title}
-
-One or two sentences: what the work is, and why it was not cited
-(superseded by X, off-topic, redundant with Y, weaker evidence,
-proprietary/closed, not yet peer-reviewed, too narrow, too broad,
-etc.).
-
-Aim for at least two entries when the field has plausible
-alternatives; more when the field is crowded. A thin list for a
-tight sub-literature is fine if the search was thorough — say so
-in Methods rather than padding.
-
-## Methods
-
-How this note was written (the LLM-side record):
-
-- **Searches run.** For each: query, tool (Tavily / Semantic Scholar
-  / arXiv / Google Scholar / operator's Zotero library), date,
-  approximate useful result count, and a one-phrase rationale (what
-  the agent was looking for with that query).
-- **Snowballing.** Seed papers used for forward and backward
-  citation chases; venue-guided scans (named).
-- **Databases consulted.** Named explicitly.
-- **Stop condition.** When queries saturated (most new hits already
-  seen) or a budget was hit. Named explicitly.
-- **Inclusion / exclusion rule.** *Kept when:* directly supports
-  the paragraph's claim, or is the field-defining anchor, or is a
-  recent frontier exemplar. *Dropped when:* superseded, off-topic,
-  redundant, weaker evidence, or otherwise unsuitable. The
-  "Related but not cited" list records every drop.
-- **Freshness cutoff.** "Deep research includes results published
-  through {invocation date}." No earlier cutoff — the skill is
-  re-run on every consumer invocation to keep this honest.
-- **Preprint policy.** arXiv preprints are cited when no
-  peer-reviewed equivalent exists; each such entry is flagged in
-  the bibliography. Preferred when covering 2024–2026 frontier.
-- **Grey-literature policy.** Include this bullet only if grey
-  literature is actually cited in this note. Tech reports, working
-  papers, government documents, and project websites may be cited
-  when they are the primary source for a closely-related artefact.
-  Prefer a versioned URL (release tag, Zenodo DOI, Wayback
-  snapshot) over a bare homepage. If no grey literature is cited,
-  omit this bullet — do not write "N/A" placeholder text.
-- **Identifier resolution.** "All N bibliography entries were
-  fetched on {YYYY-MM-DD} and returned a 200 (or 30x to a 200).
-  Entries that failed to resolve: {list, or 'none'}."
-- **LLM-assist disclosure.** This note was drafted by Claude from
-  retrieved sources. Cited facts must be verified against the
-  primary source by the author before publication.
-
-## Author verification checklist
-
-What the author must still do before the paragraph is defensible.
-This is distinct from the LLM-side Methods disclosure above.
-
-- [ ] Opened and read each cited primary source (not just its
-      abstract).
-- [ ] Confirmed the claim-to-citation mapping for every sentence of
-      the paragraph.
-- [ ] Checked that any preprint flagged in Methods is still the best
-      available citation (peer-reviewed version may now exist).
-- [ ] Agreed with the "Related but not cited" justifications — or
-      overridden them deliberately.
-- [ ] Confirmed no in-repo working document is cited in place of a
-      primary source.
-
-## Bibliography
-
-Alphabetical by first author, BibTeX-compatible. Every entry carries
-a stable URL. Include a DOI when the published version has one;
-arXiv-only entries, older conference papers, and grey literature may
-have only a URL. Entries flagged `[preprint]` in the key comment
-when they are not yet peer-reviewed.
-
-Non-English titles must include a bracketed English translation in
-the `title` field: `{Original title [Translated title]}`. This
-ensures the note remains readable without requiring the reader to
-know the source language.
+BibTeX template (aligned with `~/CNRS/html/src/Ha-Duong.bib`):
 
 ```bibtex
 @article{Author-NameYEAR:slug,
@@ -328,71 +51,72 @@ know the source language.
   title        = {{Full title}},
   journaltitle = {Venue},
   date         = {YYYY-MM},
-  number       = {42},
-  pages        = {100--115},
   doi          = {10.xxxx/yyyy},
   eprint       = {hal-XXXXXXXX},
   eprinttype   = {hal},
 }
-
-% Non-English example:
-@inproceedings{Muller2023:klimaschutz,
-  author       = {Müller, K.},
-  title        = {Ursprünglicher Titel [{Original} title in {English}]},
-  booktitle    = {Conference Name},
-  date         = {2023-07-07},
-  location     = {City},
-  doi          = {10.xxxx/yyyy},
-  eprint       = {hal-XXXXXXXX},
-  eprinttype   = {hal},
-}
-
-% ... more entries ...
 ```
 
-Style notes (aligned with `~/CNRS/html/src/Ha-Duong.bib`):
-- Keys: `Author-NameYEAR:slug` (hyphenated surname, colon-separated slug).
-- Use biblatex fields: `date` (not `year`), `journaltitle` (not `journal`),
-  `location` (not `address`).
-- Use `eprint` for HAL/arXiv links alongside `doi`.
-- Field values aligned with padding (max-width column for field names).
-- Omit `url` when `doi` resolves to open-access full text. Keep both when the DOI gates a paywall and `url` points to an open copy.
+Keys: `Author-NameYEAR:slug`. Biblatex fields: `date` (not `year`),
+`journaltitle` (not `journal`), `eprint` + `eprinttype` for HAL/arXiv.
+Omit `url` when `doi` resolves to open-access full text. Keep both
+when the DOI gates a paywall and `url` points to an open copy.
 
-## Notes on style
+## Inputs
 
-- Write the note in English.
-- Cite author-year in the prose; use the BibTeX key in the
-  Bibliography section.
-- Use present tense for claims ("Lewis et al. show that…"), past
-  tense for methods ("they trained…"), third person throughout.
-- Do not cite in-repo working documents (drafts, planning notes,
-  other tickets). The paper's related work must stand on external
-  published sources and forward references to the paper's own later
-  sections.
-- Keep the note self-contained: a reader should not need access to
-  anything else in the repo to judge the cited works.
+1. **Paragraph topic or claim**
+2. **Target manuscript path**
+3. **Section identifier** (e.g., "§2 Related Work, paragraph 1")
+4. **Output path**
+5. *(Optional)* **Citation budget**
 
-## Toolchain
+If any required input is missing, ask once.
 
-The project uses **biblatex** (not BibTeX) compiled with **biber**.
-Local `.bib` files in the repo are staging areas, not the canonical
-library. The canonical library is **Zotero** (currently v9+).
+## Output template
 
-At manuscript submission, approved entries must be imported into
-Zotero (File → Import the `.bib`, then attach fulltext PDFs). This
-is the author's responsibility — the skill does not automate it.
-The `/bib-merge` skill handles the intermediate step (note →
-local `.bib`); Zotero import is the final step.
+Seven mandatory sections:
 
-## Failure modes to avoid
+```markdown
+---
+title: {paragraph topic}
+author: Claude prompted by Ha-Duong Minh
+date: {YYYY-MM-DD}
+paper: {manuscript path}
+section: {section identifier}
+citation-budget: {N, or "unset"}
+---
 
-- Drafting a note with fewer than two "Related but not cited"
-  entries. If the search was shallow, say so and stop; do not pad.
-- Citing a survey when a specific primary result is what the
-  paragraph actually needs, or vice versa.
-- Minting a new BibTeX key when the operator's library already has
-  the reference under a different key. Always check first.
-- Omitting the preprint-acceptability note or the freshness cutoff
-  from Methods.
-- Padding the bibliography. Every entry must be directly justified;
-  do not add references for coverage.
+## Relevance
+Why this note exists for this paragraph. Intellectual stakes.
+
+## History of science context
+Lineage of the sub-field. Problem origin, paradigm shifts, current
+state. Name opposing views with references.
+
+## Cited works — detailed
+### {Author Year — short title}
+- **Reference.** Author, year, venue, DOI/URL.
+- **What the work did.** Method, data, main result.
+- **Why this paragraph cites it.** The specific claim it supports.
+- **Limitations or critiques.**
+
+## Related but not cited — justified
+### {Author Year — short title}
+Why not cited (superseded, off-topic, redundant, etc.).
+
+## Methods
+Searches run, snowballing seeds, databases, stop condition,
+inclusion/exclusion rule, freshness cutoff, preprint policy,
+grey-literature policy (if applicable), identifier resolution log,
+LLM-assist disclosure.
+
+## Author verification checklist
+- [ ] Read each cited primary source (not just abstract)
+- [ ] Confirmed claim-to-citation mapping
+- [ ] Checked preprints for peer-reviewed updates
+- [ ] Agreed with "related but not cited" justifications
+- [ ] No in-repo docs cited in place of primary sources
+
+## Bibliography
+Alphabetical, biblatex format per Toolchain section above.
+```

--- a/skills/ticket-new/SKILL.md
+++ b/skills/ticket-new/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: ticket-new
+description: Create a local %erg v1 file for agent coordination.
+disable-model-invocation: false
+user-invocable: true
+argument-hint: [title]
+---
+
+# Create local ticket
+
+**Input:** anything — a title, a sentence, a JSON blob from `gh`, a paste
+from a conversation. Extract the intent and normalize to `%erg v1`.
+
+## Steps
+
+1. Determine the next ID:
+   ```bash
+   ls tickets/*.erg tickets/archive/*.erg 2>/dev/null \
+     | sed 's|.*/||; s|-.*||' | sort -n | tail -1
+   ```
+   Increment by 1, zero-pad to 4 digits. If empty, start at `0001`.
+
+2. Choose a slug: lowercase kebab-case, ASCII only (`[a-z0-9-]`), derived from the title.
+
+3. Create `tickets/{ID}-{slug}.erg` with this exact structure:
+   ```
+   %erg v1
+   Title: {imperative title}
+   Status: open
+   Created: {YYYY-MM-DD}
+   Author: {agent or user}
+
+   --- log ---
+   {YYYY-MM-DD}T{HH:MM}Z {author} created
+
+   --- body ---
+   ## Context
+   {why this work exists}
+
+   ## Actions
+   1. {concrete step}
+
+   ## Test
+   {first test to write — TDD red step}
+
+   ## Exit criteria
+   {definition of done}
+   ```
+
+4. Commit the ticket file.
+
+Format spec: `tickets/FORMAT.md` (or global rule `tickets.md`).


### PR DESCRIPTION
## Summary

- **related-work-note**: 358 → 122 lines (-66%). Cut research methodology, snowballing instructions, style notes the LLM already knows. Kept: output template, identifier resolution, toolchain (biblatex/Zotero), non-obvious constraints.
- **healthcheck**: 69 → 56 lines (-19%). Removed git command flags and fake 7-day/30-day staleness thresholds. Kept: check list, output format, graceful degradation.
- **ticket-new**: 57 → 52 lines (-9%). Replaced duplicated format rules with reference to `tickets/FORMAT.md`.

Principle: silence is better than contradicting or confusing instructions. A skill should only contain constraints the LLM cannot infer from the task description alone.

## Merge order

Independent of PRs #36–#42. Can merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)