### PR TITLE
ticket 0001: L1 file-lock concurrency guard for /verify

### DIFF
--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -26,18 +26,53 @@ Merge is always the human's or the orchestrator's call.
 - The fix loop between rounds makes commits on the PR branch; no changes to other branches.
 - `--force-approve` is supported for explicit human override; it is logged loudly in the
   PR comments and the skill transcript.
+- Only one `/verify` may run per PR per machine at a time. Enforced by an L1 file lock
+  (see `## Claim file (L1)`). Cross-machine coordination is out of scope.
+
+## Claim file (L1)
+
+A same-machine concurrency guard that mirrors the `.git/ticket-wip/` pattern used for
+ticket claims. Prevents the common collision: two chats / two terminals running
+`/verify <same-pr>` simultaneously on the same workstation.
+
+- **Path:** `.git/verify-wip/<pr>.wip` (inside `.git/`, never committed, shared across
+  worktrees via `git-common-dir`).
+- **Content:** one line — `{ISO-8601-timestamp} {session_id} {worktree-path} round={n}`.
+- **Acquire (Phase 1, step 1a):**
+  1. If the file does not exist → create it with the current timestamp, session id,
+     worktree path, and `round=1`. Proceed.
+  2. If the file exists and its timestamp is < 30 minutes old → abort. Print the
+     lock file path and its single-line content so the user can find the owning
+     session. Do not post a PR comment (the other session is still running and
+     will post its own).
+  3. If the file exists and its timestamp is ≥ 30 minutes old → treat as stale.
+     Delete, recreate with current metadata, and record `L1: stale lock reclaimed
+     (previous: <content>)` as an informational line in the final verdict comment.
+- **Round 2 re-entry:** the lock is held across rounds. Rewrite the file with
+  `round=2` when entering round 2 (same session, updated round marker). Do not
+  re-acquire.
+- **Release:** delete the file on every terminal path — APPROVED, ESCALATE (including
+  round-2 REROLL upgraded to ESCALATE), telemetry-threshold escalation, and
+  `--force-approve`. Release must happen **after** the verdict comment is posted,
+  so an observer sees the lock tied to the posted outcome.
+- **Cross-machine:** not covered. If multi-machine `/verify` collisions become real,
+  add a GitHub-label layer (L2) and a monotonic round counter (L3) as a follow-up.
+  See ticket 0001 body for the deferred design.
 
 ## Phases
 
 ### 1. Setup
 
+- **1a. Acquire L1 lock** (see `## Claim file (L1)`). If held by another live session,
+  abort before doing any work. If stale, reclaim and record for the verdict comment.
 - `gh pr checkout $ARGUMENTS` into an isolated worktree. Abort if the PR is not mergeable
-  or if there are open merge conflicts.
+  or if there are open merge conflicts. On abort, release L1.
 - Collect:
   - The ticket file referenced in the PR title or body (`tickets/*.erg`).
   - PR body, full diff, all existing review comments, all inline comments, all commit
     messages on the branch.
-- If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
+- If any of these cannot be located, ESCALATE with a clear message and release L1.
+  Do not proceed.
 
 ### 2–4. Read-only review fan-out (parallel)
 
@@ -73,15 +108,15 @@ round: 1 | 2
 
 ## Branch on verdict
 
-- **APPROVED** → post a "verify: approved" comment on the PR summarising the evidence. End
-  the skill. The caller merges.
+- **APPROVED** → post a "verify: approved" comment on the PR summarising the evidence.
+  Release L1. End the skill. The caller merges.
 - **REROLL, round 1** → spawn a fix subagent with `isolation: "worktree"`, feeding it the
-  unresolved lists as input. Fix agent gets ≤10 min. On push, re-enter phase 6 with
-  `round=2`.
+  unresolved lists as input. Fix agent gets ≤10 min. On push, rewrite the L1 file with
+  `round=2` and re-enter phase 6. L1 stays held across the round transition.
 - **REROLL, round 2** → upgrade to ESCALATE (no third round). Post a PR comment with the
-  still-unresolved items and the gate's rationale. End the skill.
+  still-unresolved items and the gate's rationale. Release L1. End the skill.
 - **ESCALATE** → post a PR comment tagged `/verify stopped:` listing what needs human
-  judgment. End the skill.
+  judgment. Release L1. End the skill.
 
 ## Fix-agent contract
 
@@ -159,7 +194,7 @@ Behaviour on breach:
 - **Escalate** → stop the run, post a `/verify stopped:` comment explaining
   which threshold tripped and the measured value, skip remaining phases. Add
   the telemetry footer before exit so the human sees the numbers that caused
-  the escalation.
+  the escalation. Release L1 after posting.
 
 Escalate takes precedence over warn: if both thresholds are breached at the
 same boundary, only escalate. Check thresholds at phase boundaries, not
@@ -169,10 +204,11 @@ inside phases — a mid-phase abort leaves the PR in an unclear state.
 
 Explicit human override. Usage: `/verify <pr-number> --force-approve <reason>`.
 
-- Skips phase 6 gate.
+- Still acquires L1 at setup, then skips phase 6 gate.
 - Posts a loud PR comment: `/verify: force-approved — reason: <reason>`. Includes the
   outputs of phases 2–5 so reviewers see what was waived.
 - Logs the override in the skill transcript.
+- Releases L1 after posting the comment.
 - Still does not merge.
 
 ## Not in scope

--- a/tickets/0001-verify-concurrency-guard.erg
+++ b/tickets/0001-verify-concurrency-guard.erg
@@ -1,5 +1,5 @@
 %erg v1
-Title: /verify three-layer concurrency guard (file + label + counter)
+Title: /verify L1 file-lock concurrency guard (same-machine)
 Status: open
 Created: 2026-04-17
 Author: user
@@ -7,8 +7,27 @@ Author: user
 --- log ---
 2026-04-17T10:00Z claude created
 2026-04-17T10:00Z claude note migrated from Climate_finance ticket 0079 (misfiled) and IDH issue #34
+2026-04-17T17:00Z claude note rescoped to L1 only (orchestrator-001 reimagine); L2 label/claim-comment and L3 monotonic counter deferred — speculative for single-user harness, multi-machine sync is STATE.md backlog, and /verify-gate already caps rounds by comment scan. Body updated with Rescope section.
 
 --- body ---
+## Rescope (2026-04-17, orchestrator-001)
+
+Scope reduced from three layers to L1 only.
+
+- **L1 (this ticket):** `.git/verify-wip/<pr>.wip` file lock, matching the
+  existing `.git/ticket-wip/<ID>.wip` pattern. Catches the real collision:
+  two chats / two terminals on the same machine.
+- **L2 (deferred):** GitHub label + claim comment. Cross-machine authority.
+  Defer until multi-machine sync leaves STATE.md backlog.
+- **L3 (deferred / partial):** Monotonic round counter inside `/verify-gate`.
+  The gate already caps at round 2 by scanning PR comments; making it
+  strictly monotonic is incremental tightening, not new protection.
+  Revisit if L1+L2 ever deployed together.
+
+The rest of this body (threat model, original three-layer design, test plan,
+rejected alternatives) is kept for historical context. Only the L1 portion is
+in scope for implementation.
+
 ## Context
 
 `/verify` has no concurrency control. Two parallel `/verify <same-pr>`

--- a/tickets/0001-verify-concurrency-guard.erg
+++ b/tickets/0001-verify-concurrency-guard.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: /verify L1 file-lock concurrency guard (same-machine)
-Status: open
+Status: closed
 Created: 2026-04-17
 Author: user
 
@@ -8,6 +8,9 @@ Author: user
 2026-04-17T10:00Z claude created
 2026-04-17T10:00Z claude note migrated from Climate_finance ticket 0079 (misfiled) and IDH issue #34
 2026-04-17T17:00Z claude note rescoped to L1 only (orchestrator-001 reimagine); L2 label/claim-comment and L3 monotonic counter deferred — speculative for single-user harness, multi-machine sync is STATE.md backlog, and /verify-gate already caps rounds by comment scan. Body updated with Rescope section.
+2026-04-17T17:10Z claude claimed
+2026-04-17T17:15Z claude note added L1 file-lock contract to skills/verify/SKILL.md — Claim file section, Phase 1 step 1a acquire, release on APPROVED/ESCALATE/force-approve/telemetry-escalate, round 2 re-entry holds lock
+2026-04-17T17:15Z claude status closed exit criteria met for L1 scope
 
 --- body ---
 ## Rescope (2026-04-17, orchestrator-001)


### PR DESCRIPTION
## Summary

- Rescopes ticket 0001 from three coordination layers to L1 only (same-machine file lock). L2 (GitHub label) and L3 (monotonic counter) deferred — speculative for a single-user harness; multi-machine sync is STATE.md backlog; /verify-gate already caps rounds by comment scan.
- Adds L1 file lock to `skills/verify/SKILL.md` mirroring the existing `.git/ticket-wip/` pattern. Path: `.git/verify-wip/<pr>.wip`. Single-line content with ISO timestamp, session id, worktree path, round. 30-min staleness.
- Lock acquired at Phase 1 step 1a (before `gh pr checkout`). Released on every terminal path: APPROVED, ESCALATE, round-2 REROLL upgraded to ESCALATE, telemetry-threshold escalation, `--force-approve`. Round 2 re-entry holds the lock and rewrites the round marker.

## Test plan

- [ ] Terminal A: `/verify <pr>` — creates `.git/verify-wip/<pr>.wip`, proceeds.
- [ ] Terminal B (same machine, while A runs): `/verify <pr>` — aborts, prints lock path + content, no PR comment.
- [ ] After A completes (APPROVED or ESCALATE): lock file deleted.
- [ ] Manually age a lock file by 31 min: next `/verify` reclaims it and records an informational line on the verdict comment.
- [ ] `--force-approve` path: acquires, posts force-approved comment, releases.

Closes ticket 0001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)