### PR TITLE
add shell-init.sh: harness-tracked claude wrapper with session naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ ImperialDragonHarness/
 │   ├── end-session/        # Day wrap-up
 │   ├── memory/             # Persistent memory management
 │   └── orchestrator/       # Autonomous batch across multiple tickets
-├── scripts/                # Hook implementations
+├── scripts/                # Hook implementations + shell init
+│   ├── shell-init.sh           # Source from ~/.bashrc — claude wrapper
 │   ├── on-start.sh             # Session start: env loading, worktree gate
 │   ├── guard-destructive-bash.sh
 │   ├── guard-commit-on-main.sh
@@ -64,11 +65,11 @@ ImperialDragonHarness/
    OPENAI_API_KEY=sk-...
    ```
 
-3. Add the shell alias to your `~/.bashrc` (or `~/.zshrc`):
+3. Add one line to your `~/.bashrc` (or `~/.zshrc`) to source the harness shell init:
    ```bash
-   alias claude='claude --dangerously-skip-permissions'
+   [ -f "$HOME/.claude/scripts/shell-init.sh" ] && source "$HOME/.claude/scripts/shell-init.sh"
    ```
-   The harness enforces worktree isolation via a SessionStart hook, so every new chat automatically enters its own worktree.
+   This installs a `claude` wrapper that skips permission prompts and auto-names each session after the current git repo. The script lives in the harness, so it updates on every pull.
 
 Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automatically via `settings.json`.
 

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -24,6 +24,13 @@ if [ -f "$_script_dir/warn-stale-rules.sh" ]; then
     [ -n "$_stale" ] && echo "$_stale"
 fi
 
+# Check shell-init.sh is sourced in the user's shell config
+_shell_init="$HOME/.claude/scripts/shell-init.sh"
+if ! grep -qlF "shell-init.sh" "$HOME/.bashrc" "$HOME/.zshrc" 2>/dev/null; then
+    echo "SETUP REMINDER: shell-init.sh is not sourced in your shell config. Add this line to ~/.bashrc or ~/.zshrc:"
+    echo "  [ -f \"$_shell_init\" ] && source \"$_shell_init\""
+fi
+
 # --- Nothing below this line may produce stdout (hook output = conversation context) ---
 exec >/dev/null 2>&1
 

--- a/scripts/shell-init.sh
+++ b/scripts/shell-init.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Harness shell init — source this from ~/.bashrc or ~/.zshrc.
+# Wraps the claude CLI to: skip permission prompts, name the session after the project.
+
+claude() {
+  local name
+  name=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null | xargs -r basename)
+  name=${name:-$(basename "$PWD")}
+  command claude --dangerously-skip-permissions --name "$name" "$@"
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/shell-init.sh` with a `claude()` wrapper that passes `--dangerously-skip-permissions` and `--name <git-repo>` so every session is named after the current project
- Updates `README.md` step 3: replaces the machine-local alias with a single `source` line pointing at the harness script (updates on pull)
- Adds a check in `on-start.sh` that warns at session start if the source line is missing from `.bashrc`/`.zshrc`

## Test plan
- [ ] `source ~/.claude/scripts/shell-init.sh` then `type claude` shows the function
- [ ] Starting claude from a git repo sets session name to the repo name
- [ ] On a machine without the source line, session start shows the SETUP REMINDER

🤖 Generated with [Claude Code](https://claude.com/claude-code)