### PR TITLE
feat(0015): add CI workflow (validate-tickets + skill-lint)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate-tickets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Build erg validator
+        working-directory: tickets/tools/go
+        run: go build -o erg .
+      - name: Validate tickets
+        run: ./tickets/tools/go/erg validate tickets/
+
+  skill-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check SKILL.md frontmatter
+        run: |
+          fail=0
+          for f in skills/*/SKILL.md; do
+            front=$(sed -n '/^---$/,/^---$/p' "$f" | sed '1d;$d')
+            if ! echo "$front" | grep -q '^name:'; then
+              echo "FAIL: $f missing 'name:' in frontmatter"
+              fail=1
+            fi
+            if ! echo "$front" | grep -q '^description:'; then
+              echo "FAIL: $f missing 'description:' in frontmatter"
+              fail=1
+            fi
+          done
+          exit $fail

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 !README.md
 !STATE.md
 !CLAUDE.md
+!.github/
+!.github/**
 !skills/
 !skills/**
 !scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 !tickets/**
 # Exclude compiled Go binaries from ticket tools
 tickets/tools/go/git-erg
+tickets/tools/go/erg
 tickets/tools/go/*.test
 
 # settings.json: universal config (hooks, effortLevel, universal permissions) — tracked

--- a/tickets/0015-add-ci.erg
+++ b/tickets/0015-add-ci.erg
@@ -1,13 +1,13 @@
 %erg v1
 Title: add CI — validator + skill sanity on PR/push
-Status: open
+Status: pending
 Created: 2026-04-17
 Author: claude
 
 --- log ---
 2026-04-17T15:36Z claude created — part of the "CI across active repos" batch
 2026-04-23T00:00Z claude claimed
-2026-04-23T00:01Z claude status in-review — PR #51
+2026-04-23T00:01Z claude status pending — PR #51 opened
 
 --- body ---
 ## Context

--- a/tickets/0015-add-ci.erg
+++ b/tickets/0015-add-ci.erg
@@ -7,6 +7,7 @@ Author: claude
 --- log ---
 2026-04-17T15:36Z claude created — part of the "CI across active repos" batch
 2026-04-23T00:00Z claude claimed
+2026-04-23T00:01Z claude status in-review — PR #51
 
 --- body ---
 ## Context

--- a/tickets/0015-add-ci.erg
+++ b/tickets/0015-add-ci.erg
@@ -6,6 +6,7 @@ Author: claude
 
 --- log ---
 2026-04-17T15:36Z claude created — part of the "CI across active repos" batch
+2026-04-23T00:00Z claude claimed
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Fix `.gitignore` allowlist to track `.github/` and workflow files
- Add `.github/workflows/CI.yml` with two jobs:
  - `validate-tickets`: builds the Go `erg` validator and runs it against `tickets/`
  - `skill-lint`: checks all `skills/*/SKILL.md` frontmatter for required `name:` and `description:` fields
- Both jobs trigger on `push: main` and `pull_request`

## Deviations from ticket spec

- `erg validate` argument is `tickets/` only (not `tickets/ tickets/archive/`): the validator already auto-discovers `tickets/archive/` when given the parent dir (lines 491–499 of `main.go`). Passing a non-existent `tickets/archive/` would emit a WARNING. Simplified to avoid the warning and since `tickets/archive/` does not yet exist.

## Exit criteria verified locally

- `git check-ignore -v .github/workflows/CI.yml` — negation rule applies, file is not ignored
- `go build` succeeds in `tickets/tools/go/`
- `./erg validate tickets/` exits 0 (17 tickets pass)
- Skill-lint simulation exits 0 (21 skills pass)
- YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/CI.yml'))"`

## Test plan

- [ ] Verify CI jobs appear green on this PR
- [ ] Break a ticket's `%erg v1` magic line on a test branch — expect `validate-tickets` red
- [ ] Strip `description:` from a SKILL.md — expect `skill-lint` red
- [ ] Enable branch protection requiring `validate-tickets` on main (follow-on ticket 0015)

Closes ticket 0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)