### PR TITLE
harness-rules: split build by workpackage + don't gitignore handoffs

### DIFF
--- a/skills/harness-rules/coding.md
+++ b/skills/harness-rules/coding.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-04-04 -->
+<!-- last-reviewed: 2026-04-23 -->
 # Coding Rules
 
 ## Python (3.10+)
@@ -42,3 +42,4 @@ When writing new tests:
 - **Sentinel stamps for dynamic outputs.** Use a stamp file when a script produces data-dependent filenames.
 - **No `.PHONY` for real work.** Use `.PHONY` only for aliases.
 - **No hand-curated data in the pipeline.** Every CSV/tex file referenced by slides or report must have a Makefile target that generates it from `measurements.jsonl` or another tracked source.
+- **Split the build by workpackage.** Analysis (Python/R, data access) and writing (LaTeX, Quarto) workpackages live in separate Makefiles. A writing-side build must produce the manuscript from handoff artifacts alone — no `uv run`, no data fetch. Enables clean-room builds and enforces the artifact discipline in [git.md](./git.md).

--- a/skills/harness-rules/git.md
+++ b/skills/harness-rules/git.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-04-15 -->
+<!-- last-reviewed: 2026-04-23 -->
 # Git Discipline
 
 - **Always work on a branch.** Main is read-only except for STATE housekeeping.
@@ -7,3 +7,4 @@
 - **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`.
 - **Worktree isolation is automatic** — the SessionStart hook enforces it. All worktrees are throwaway; branches hold durable state.
 - **Create a merge request** for each ticket to review changes before merging.
+- **Don't gitignore handoff artifacts.** Generated files that a downstream workpackage consumes (figures, tables, macros `\input`ed by the manuscript) are durable state — commit them. Caches, LaTeX aux files, and the final rendered PDF are regenerable — gitignore.


### PR DESCRIPTION
## Summary

- **coding.md § Build (Make):** new bullet — split Makefiles by workpackage (analysis vs writing), so a writing-side build produces the manuscript from handoff artifacts alone (no `uv run`, no data fetch). Enables clean-room builds and formalises the analysis/writing boundary.
- **git.md:** new bullet — don't gitignore handoff artifacts. Generated files that a downstream workpackage consumes (figures, tables, macros `\input`ed by the manuscript) are durable state; caches and LaTeX aux files stay ignored.

Rules placed at their root cause (build structure → coding.md) with the git-facing consequence stated separately (git.md), matching the existing topic-bounded structure of the harness-rules skill files.

Context: came up while reviewing the build structure of four scientific-writing projects (Climate Finance, Fuzzy Corpus, Cadens, AEDIST tech report). All four already have handoff artifacts crossing an analysis→writing boundary; the rule names the pattern so it can be enforced mechanically via a workpackage-per-Makefile split. Companion tickets opened in each project repo.

## Test plan

- [ ] Visual review: both bullets read as natural additions to their respective files; no contradictions with existing bullets (especially the worktree-isolation line in git.md).
- [ ] `last-reviewed` header bumped to 2026-04-23 on both files (each was substantively edited).
- [ ] `/verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)