### PR TITLE
feat(0016): harness neutrality guard — reject consumer-project leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 # Exclude compiled Go binaries from ticket tools
 tickets/tools/go/git-erg
 tickets/tools/go/*.test
+!hooks/
+!hooks/**
+!tests/
+!tests/**
 
 # settings.json: universal config (hooks, effortLevel, universal permissions) — tracked
 # settings.local.json: machine-specific permissions — gitignored

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Imperial Dragon Harness pre-commit hook
+# Installed via: git config core.hooksPath hooks (see scripts/on-start.sh)
+
+set -euo pipefail
+
+# Check for consumer-project leakage in skills/ and tickets/
+if [ -f "$(git rev-parse --show-toplevel)/scripts/check-harness-neutrality.sh" ]; then
+    bash "$(git rev-parse --show-toplevel)/scripts/check-harness-neutrality.sh" HEAD
+fi

--- a/scripts/check-harness-neutrality.sh
+++ b/scripts/check-harness-neutrality.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Check that new commits to skills/ and tickets/ don't encode consumer-project assumptions.
+# Runs diff-only against BASE (default: origin/main).
+# Exit 0 = clean. Exit 1 = leakage found.
+# Suppress a match by placing <!-- harness-extension-point --> on the preceding line.
+#
+# Special case: BASE=HEAD uses git diff --cached (staged changes, for pre-commit hook).
+
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+# Consumer-project patterns to reject
+PATTERNS=(
+    'Climate[-_]finance'
+    'AEDIST'
+    'CIRED\.digital'
+)
+
+# Build combined regex
+combined=$(printf '%s\n' "${PATTERNS[@]}" | paste -sd '|' -)
+
+fail=0
+
+# Get the diff: added lines only, in skills/**/*.md and tickets/*.erg
+if [ "$BASE" = "HEAD" ]; then
+    # Pre-commit: check staged changes
+    diff_output=$(git diff --cached -- 'skills/**/*.md' 'tickets/*.erg' 2>/dev/null)
+else
+    # CI / manual: check commits since diverging from BASE
+    diff_output=$(git diff "$BASE"...HEAD -- 'skills/**/*.md' 'tickets/*.erg' 2>/dev/null || \
+                  git diff "$BASE" -- 'skills/**/*.md' 'tickets/*.erg' 2>/dev/null)
+fi
+
+if [ -z "$diff_output" ]; then
+    exit 0
+fi
+
+# Parse diff: track current file, check for escape hatch on preceding line
+current_file=""
+prev_line=""
+
+while IFS= read -r line; do
+    # Track which file we're in
+    if [[ "$line" =~ ^\+\+\+\ b/(.+)$ ]]; then
+        current_file="${BASH_REMATCH[1]}"
+        prev_line=""
+        continue
+    fi
+    # Only check added lines (exclude diff header +++)
+    if [[ "$line" =~ ^\+[^+] ]]; then
+        content="${line:1}"
+        if echo "$content" | grep -qEi "$combined"; then
+            # Check escape hatch in the preceding line (context or another added line)
+            if echo "$prev_line" | grep -qF '<!-- harness-extension-point -->'; then
+                : # suppressed
+            else
+                echo "LEAK: $current_file: $content"
+                fail=1
+            fi
+        fi
+    fi
+    # Track previous non-diff-header line for escape hatch check
+    if [[ ! "$line" =~ ^(diff\ |index\ |---\ |\+\+\+\ |@@) ]]; then
+        prev_line="$line"
+    fi
+done <<< "$diff_output"
+
+exit $fail

--- a/tests/fixtures/leaky-ticket.erg
+++ b/tests/fixtures/leaky-ticket.erg
@@ -1,0 +1,31 @@
+%erg v1
+Title: test fixture — harness neutrality guard
+Status: closed
+Created: 2026-04-23
+Author: claude
+
+--- log ---
+2026-04-23T00:00Z claude created — test fixture only, not a real ticket
+
+--- body ---
+This file tests the harness neutrality guard script. It must never be
+archived or validated as a real ticket. The patterns below are intentionally
+present for test purposes.
+
+## Should be caught (no escape hatch)
+
+The Climate_finance pipeline uses uv run pytest tests/.
+
+## Should pass (escape hatch present)
+
+<!-- harness-extension-point -->
+The Climate_finance repo is a downstream consumer of this harness.
+
+## Should be caught
+
+AEDIST PR #42 uses a different approach.
+
+## Should pass
+
+<!-- harness-extension-point -->
+AEDIST is a consumer project example.

--- a/tests/test-harness-neutrality.sh
+++ b/tests/test-harness-neutrality.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-harness-neutrality.sh
+#
+# Creates a temporary git repo, stages leaky and clean files, and verifies
+# that the checker exits 1 on leakage and 0 when escape hatches suppress matches.
+#
+# Run from any directory: bash tests/test-harness-neutrality.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check-harness-neutrality.sh"
+
+pass=0
+fail=0
+
+ok() {
+    echo "PASS: $1"
+    pass=$((pass + 1))
+}
+
+fail_test() {
+    echo "FAIL: $1"
+    fail=$((fail + 1))
+}
+
+# Create a temp git repo for isolated testing
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git -C "$TMPDIR" init -q
+git -C "$TMPDIR" config user.email "test@example.com"
+git -C "$TMPDIR" config user.name "Test"
+
+# Make an empty initial commit so HEAD exists
+git -C "$TMPDIR" commit -q --allow-empty -m "init"
+
+mkdir -p "$TMPDIR/skills/testskill" "$TMPDIR/tickets"
+
+# --- Test 1: leaked pattern in skills/ → checker must exit 1 ---
+cat > "$TMPDIR/skills/testskill/SKILL.md" <<'EOF'
+# Test skill
+Climate_finance pipeline integration.
+EOF
+git -C "$TMPDIR" add "skills/testskill/SKILL.md"
+
+# Run the checker in the temp repo (BASE=HEAD → git diff --cached)
+actual_exit=0
+(
+    cd "$TMPDIR"
+    bash "$CHECKER" HEAD 2>&1
+) && actual_exit=0 || actual_exit=$?
+
+if [ "$actual_exit" -eq 1 ]; then
+    ok "leak in skills/SKILL.md caught (exit 1)"
+else
+    fail_test "leak in skills/SKILL.md not caught (expected exit 1, got $actual_exit)"
+fi
+
+# --- Test 2: escape hatch suppresses match → checker must exit 0 ---
+cat > "$TMPDIR/skills/testskill/SKILL.md" <<'EOF'
+# Test skill
+
+<!-- harness-extension-point -->
+Climate_finance pipeline integration.
+EOF
+git -C "$TMPDIR" add "skills/testskill/SKILL.md"
+
+(
+    cd "$TMPDIR"
+    bash "$CHECKER" HEAD 2>&1
+) && actual_exit=0 || actual_exit=$?
+
+if [ "$actual_exit" -eq 0 ]; then
+    ok "escape hatch suppresses match (exit 0)"
+else
+    fail_test "escape hatch not working (expected exit 0, got $actual_exit)"
+fi
+
+# --- Test 3: AEDIST pattern caught in tickets/ ---
+cat > "$TMPDIR/tickets/9999-test.erg" <<'EOF'
+%erg v1
+Title: test
+Status: open
+Created: 2026-04-23
+Author: test
+
+--- log ---
+2026-04-23T00:00Z test created
+
+--- body ---
+AEDIST uses this approach.
+EOF
+# Clear skills leak first
+cat > "$TMPDIR/skills/testskill/SKILL.md" <<'EOF'
+# Test skill
+No project references here.
+EOF
+git -C "$TMPDIR" add "tickets/9999-test.erg" "skills/testskill/SKILL.md"
+
+(
+    cd "$TMPDIR"
+    bash "$CHECKER" HEAD 2>&1
+) && actual_exit=0 || actual_exit=$?
+
+if [ "$actual_exit" -eq 1 ]; then
+    ok "AEDIST leak in tickets/ caught (exit 1)"
+else
+    fail_test "AEDIST leak in tickets/ not caught (expected exit 1, got $actual_exit)"
+fi
+
+# --- Test 4: clean staged changes → checker must exit 0 ---
+cat > "$TMPDIR/tickets/9999-test.erg" <<'EOF'
+%erg v1
+Title: test
+Status: open
+Created: 2026-04-23
+Author: test
+
+--- log ---
+2026-04-23T00:00Z test created
+
+--- body ---
+Generic workflow documentation only.
+EOF
+git -C "$TMPDIR" add "tickets/9999-test.erg"
+
+(
+    cd "$TMPDIR"
+    bash "$CHECKER" HEAD 2>&1
+) && actual_exit=0 || actual_exit=$?
+
+if [ "$actual_exit" -eq 0 ]; then
+    ok "clean staged changes pass (exit 0)"
+else
+    fail_test "clean staged changes wrongly flagged (expected exit 0, got $actual_exit)"
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tickets/0016-harness-project-leak-guard.erg
+++ b/tickets/0016-harness-project-leak-guard.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: standing guard — IDH tickets/skills must not encode project-specific assumptions
-Status: open
+Status: pending
 Created: 2026-04-17
 Author: claude
 
 --- log ---
 2026-04-17T16:30Z claude created — /celebrate sweep found a recurring class: tickets 0001, 0002, 0003, 0006 were all carved out after leaking consumer-project pain into harness-generic skills.
+2026-04-24T08:30Z claude status pending — in-review PR #54
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Adds `scripts/check-harness-neutrality.sh`: diff-only grep guard that rejects consumer-project strings (`Climate_finance`, `AEDIST`, `CIRED.digital`) in added lines of `skills/**/*.md` and `tickets/*.erg`
- Escape hatch: `<!-- harness-extension-point -->` on the preceding line suppresses the match
- Wires guard into `hooks/pre-commit` (activated on next session start via `on-start.sh`)
- Adds `tests/fixtures/leaky-ticket.erg` with both caught and escaped patterns as the durable test artifact
- Adds `tests/test-harness-neutrality.sh`: automated self-test using a temp git repo (4 tests pass)
- Updates `.gitignore` to track `hooks/` and `tests/`

Closes ticket 0016.

## Test plan

- [ ] `bash scripts/check-harness-neutrality.sh origin/main` exits 0 on current repo
- [ ] `bash tests/test-harness-neutrality.sh` passes (4/4)
- [ ] `tests/fixtures/leaky-ticket.erg` contains both caught patterns and escaped patterns
- [ ] `hooks/pre-commit` is executable and references the checker
- [ ] `ls -la hooks/pre-commit` shows `x` bit set

🤖 Generated with [Claude Code](https://claude.com/claude-code)