### PR TITLE
feat(0018): add set -euo pipefail to all hook scripts + CI guard

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,3 +65,28 @@ jobs:
             exit 1
           fi
           echo "OK: escape hatch suppressed leak"
+
+  pipefail-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: All hook scripts must have set -euo pipefail
+        run: |
+          missing=$(grep -L 'set -euo pipefail' scripts/*.sh | grep -v 'shell-init\.sh')
+          if [ -n "$missing" ]; then
+            echo "FAIL: missing set -euo pipefail in:"
+            echo "$missing"
+            exit 1
+          fi
+          echo "OK: all hook scripts have set -euo pipefail"
+      - name: Self-test — guard must catch a script without pipefail
+        run: |
+          tmp=$(mktemp --suffix=.sh)
+          echo '#!/bin/bash' > "$tmp"
+          echo 'echo hello' >> "$tmp"
+          missing=$(grep -L 'set -euo pipefail' "$tmp")
+          if [ -z "$missing" ]; then
+            echo "FAIL: guard did not catch missing pipefail"
+            exit 1
+          fi
+          echo "OK: guard catches missing pipefail"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: All hook scripts must have set -euo pipefail
         run: |
-          missing=$(grep -L 'set -euo pipefail' scripts/*.sh | grep -v 'shell-init\.sh')
+          missing=$(grep -L 'set -euo pipefail' scripts/*.sh | grep -v 'shell-init\.sh' || true)
           if [ -n "$missing" ]; then
             echo "FAIL: missing set -euo pipefail in:"
             echo "$missing"
@@ -84,9 +84,21 @@ jobs:
           tmp=$(mktemp --suffix=.sh)
           echo '#!/bin/bash' > "$tmp"
           echo 'echo hello' >> "$tmp"
-          missing=$(grep -L 'set -euo pipefail' "$tmp")
+          missing=$(grep -L 'set -euo pipefail' "$tmp" || true)
           if [ -z "$missing" ]; then
             echo "FAIL: guard did not catch missing pipefail"
             exit 1
           fi
           echo "OK: guard catches missing pipefail"
+      - name: Self-test — guard must pass when all scripts are compliant
+        run: |
+          tmp=$(mktemp --suffix=.sh)
+          echo '#!/bin/bash' > "$tmp"
+          echo 'set -euo pipefail' >> "$tmp"
+          echo 'echo hello' >> "$tmp"
+          missing=$(grep -L 'set -euo pipefail' "$tmp" || true)
+          if [ -n "$missing" ]; then
+            echo "FAIL: guard reported false positive on compliant script"
+            exit 1
+          fi
+          echo "OK: guard passes compliant script"

--- a/scripts/block-pr-merge-in-worktree.sh
+++ b/scripts/block-pr-merge-in-worktree.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Block "gh pr merge" inside a git worktree.
 # Matcher in settings.json ensures this only runs for "gh pr merge" commands.
 

--- a/scripts/guard-commit-on-main.sh
+++ b/scripts/guard-commit-on-main.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # PreToolUse hook: block git commit on main/master branch.
 # Enforces the "main is read-only" rule from git.md.
 
@@ -16,7 +17,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
 echo "$cmd" | grep -qE '\bgit\s+commit\b' || exit 0
 
 # Get current branch
-branch=$(git branch --show-current 2>/dev/null)
+branch=$(git branch --show-current 2>/dev/null || true)
 
 if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     echo "BLOCKED: committing directly to $branch. Create a branch first: git switch -c <branch-name>" >&2

--- a/scripts/guard-destructive-bash.sh
+++ b/scripts/guard-destructive-bash.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # PreToolUse hook: block destructive Bash commands.
 # Exit 0 = allow, Exit 2 = deny with message.
 

--- a/scripts/lint-on-edit.sh
+++ b/scripts/lint-on-edit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # PostToolUse hook: run ruff on edited Python files.
 # Feeds errors back to the agent so it can self-correct.
 
@@ -14,11 +15,11 @@ file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
 
 # Run ruff check (fix safe violations) then format
 if command -v uv &>/dev/null; then
-    output=$(uv run ruff check --fix --quiet "$file_path" 2>&1)
-    uv run ruff format --quiet "$file_path" 2>/dev/null
+    output=$(uv run ruff check --fix --quiet "$file_path" 2>&1 || true)
+    uv run ruff format --quiet "$file_path" 2>/dev/null || true
 elif command -v ruff &>/dev/null; then
-    output=$(ruff check --fix --quiet "$file_path" 2>&1)
-    ruff format --quiet "$file_path" 2>/dev/null
+    output=$(ruff check --fix --quiet "$file_path" 2>&1 || true)
+    ruff format --quiet "$file_path" 2>/dev/null || true
 else
     exit 0  # no linter available
 fi

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # SessionStart hook: load env vars, enforce worktree isolation.
 # Runs at the beginning of every Claude Code session.
 
@@ -7,8 +8,8 @@
 persist_env() {
     local envfile="$1"
     [ -f "$envfile" ] || return 0
-    [ -n "$CLAUDE_ENV_FILE" ] || return 0
-    grep -v '^\s*#' "$envfile" | grep -v '^\s*$' | sed 's/^export //' >> "$CLAUDE_ENV_FILE"
+    [ -n "${CLAUDE_ENV_FILE:-}" ] || return 0
+    grep -v '^\s*#' "$envfile" | grep -v '^\s*$' | sed 's/^export //' >> "$CLAUDE_ENV_FILE" || true
 }
 
 # User-level env
@@ -35,10 +36,10 @@ fi
 exec >/dev/null 2>&1
 
 # Everything below requires a project directory
-[ -n "$CLAUDE_PROJECT_DIR" ] && cd "$CLAUDE_PROJECT_DIR" || exit 0
+[ -n "${CLAUDE_PROJECT_DIR:-}" ] && cd "$CLAUDE_PROJECT_DIR" || exit 0
 
 # Project-level env (skip if same as user-level to avoid duplication)
-if [ "$(readlink -f "$CLAUDE_PROJECT_DIR/.env" 2>/dev/null)" != "$(readlink -f "$HOME/.claude/.env" 2>/dev/null)" ]; then
+if [ "$(readlink -f "${CLAUDE_PROJECT_DIR:-}/.env" 2>/dev/null)" != "$(readlink -f "$HOME/.claude/.env" 2>/dev/null)" ]; then
     persist_env "$CLAUDE_PROJECT_DIR/.env"
 fi
 

--- a/scripts/warn-stale-rules.sh
+++ b/scripts/warn-stale-rules.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Warn if any rules/*.md file hasn't been reviewed in 30+ days.
 # Advisory only — always exits 0.
 
@@ -9,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
 
 for f in "$PLUGIN_ROOT"/skills/harness-rules/*.md; do
-    date_str=$(grep -oP 'last-reviewed:\s*\K\d{4}-\d{2}-\d{2}' "$f" 2>/dev/null)
+    date_str=$(grep -oP 'last-reviewed:\s*\K\d{4}-\d{2}-\d{2}' "$f" 2>/dev/null || true)
     [ -z "$date_str" ] && continue
     reviewed=$(date -d "$date_str" +%s 2>/dev/null) || continue
     age_days=$(( (now - reviewed) / 86400 ))


### PR DESCRIPTION
## Summary

- Add `set -euo pipefail` as line 2 to all 6 hook scripts (`guard-destructive-bash.sh`, `guard-commit-on-main.sh`, `block-pr-merge-in-worktree.sh`, `on-start.sh`, `lint-on-edit.sh`, `warn-stale-rules.sh`); `shell-init.sh` is sourced and stays exempt
- Add `|| true` where commands legitimately return non-zero: `git branch --show-current`, `grep` pipeline in `persist_env`, all 4 ruff invocations (`check` + `format`, both `uv` and direct paths), and `grep -oP` in `warn-stale-rules.sh`
- Switch `$CLAUDE_PROJECT_DIR` and `$CLAUDE_ENV_FILE` expansions to `${VAR:-}` form to be safe under `set -u` when variables may be unset
- Add `pipefail-guard` CI job that checks all `scripts/*.sh` (except `shell-init.sh`) have the guard, with a self-test that verifies the guard catches a script without it

## Test plan

- [ ] CI `pipefail-guard` job passes on this branch
- [ ] `grep -L 'set -euo pipefail' scripts/*.sh | grep -v 'shell-init\.sh'` returns empty
- [ ] `bash scripts/check-project-leak.sh` exits 0 (no regressions)
- [ ] Existing CI jobs (`validate-tickets`, `skill-lint`, `leak-guard`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)