### PR TITLE
fix(0020): make verify/verify-adherence forge-agnostic

### DIFF
--- a/skills/verify-adherence/SKILL.md
+++ b/skills/verify-adherence/SKILL.md
@@ -3,7 +3,7 @@ name: verify-adherence
 description: Check a branch's diff against project rules. Mechanical-first — runs hygiene tests + grep ratchet before falling back to LLM. Emits suggested tests for any semantic finding so the LLM surface shrinks over time.
 disable-model-invocation: false
 user-invocable: true
-argument-hint: <branch-or-pr-number>
+argument-hint: <branch>
 context: fork
 ---
 
@@ -27,8 +27,7 @@ rule is permanently enforced → never needs LLM again.
 
 ## Input
 
-<!-- harness-extension-point: gh pr view — forge-agnostic rework tracked in IDH ticket 0020 -->
-One argument: a branch name or merge-request number. Resolve MR → branch via forge CLI (currently: `gh pr view --json headRefName`).
+One argument: a branch name.
 
 ## Phases
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -31,19 +31,13 @@ Merge is always the human's or the orchestrator's call.
 
 ### 1. Setup
 
-<!-- harness-extension-point: forge CLI checkout — currently gh pr checkout; rework tracked in IDH ticket 0020 -->
 - Check out the merge-request branch into an isolated worktree. Abort if not mergeable
   or if there are open merge conflicts.
 - Collect:
   - The ticket file referenced in the PR title or body (`tickets/*.erg`).
   - PR body, full diff, all existing review comments, all inline comments, all commit
     messages on the branch.
-<!-- harness-extension-point: gh pr checks — forge-agnostic rework tracked in IDH ticket 0020 -->
-- Run CI status checks for the merge request. If no checks are reported (repo has
-  none configured), post a one-off informational comment `verify: CI gap — no CI
-  checks reported for this PR` and continue. Not a bounce — visible to the reviewer,
-  not a blocker. Skip if any prior `verify: CI gap` comment already exists on the PR
-  (idempotency across round 2). Pending or completed checks are not a gap; say nothing.
+- Check CI status for the merge request if the forge exposes it. If the forge CLI or API is unavailable, skip gracefully — CI status is informational only. If checks are configured and any are failing, note this in the setup summary; do not block on it (reviewer decides).
 - If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
 
 ### 2–4. Read-only review fan-out (parallel)

--- a/tickets/0020-forge-agnostic-verify-skills.erg
+++ b/tickets/0020-forge-agnostic-verify-skills.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Make verify/verify-adherence/verify-gate forge-agnostic
-Status: open
+Status: in-progress
 Created: 2026-04-24
 Author: claude
 
@@ -8,6 +8,7 @@ Author: claude
 2026-04-24T00:00Z claude created — leak-guard now catches \bgh \b in skills; three escape hatches mark the remaining violations
 2026-04-24T00:00Z claude note reimagine — simplest path: require branch-name input in both skills (drop PR-number resolution); CI-status check becomes best-effort with graceful skip; block-pr-merge-in-worktree.sh is out of scope (script, not skill). Three focused skill edits, zero new abstractions.
 2026-04-24T00:00Z claude note plan — verify/SKILL.md: drop escape-hatch comment on checkout (keep instruction), replace CI-status paragraph (best-effort/graceful skip, no "CI gap" comment). verify-adherence/SKILL.md: drop escape-hatch + MR-resolution sentence; argument-hint changes to <branch>. No caller changes needed (start-ticket already passes branch; orchestrator passes MR number to /verify which resolves internally).
+2026-04-24T00:00Z claude status claimed
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

Removes the three `<!-- harness-extension-point -->` escape hatches that allowed `\bgh ` leaks in verify skills, now that `check-project-leak.sh` catches them.

**Three changes made:**

1. **`skills/verify/SKILL.md` line 34** — Removed the escape-hatch comment before the checkout bullet. The bullet itself (check out MR branch into an isolated worktree) is kept unchanged.

2. **`skills/verify/SKILL.md` lines 41-46** — Removed escape-hatch comment and replaced the `gh pr checks`-based CI-status paragraph with a forge-agnostic best-effort/graceful-skip instruction: check CI if the forge exposes it, skip gracefully if the CLI/API is unavailable, and note (not block on) any failing checks.

3. **`skills/verify-adherence/SKILL.md`** — Changed `argument-hint` from `<branch-or-pr-number>` to `<branch>`, and replaced the `## Input` section (which contained the `gh pr view --json headRefName` MR-resolution instruction) with the simpler `One argument: a branch name.`

## Test plan

- [x] `bash scripts/check-project-leak.sh skills/verify skills/verify-adherence` exits 0 with no LEAK output
- [x] No `harness-extension-point` comments remain in either skill file

Closes #0020

🤖 Generated with [Claude Code](https://claude.com/claude-code)