### PR TITLE
feat(0021): verify-adherence adherence protocol is stack-agnostic

### DIFF
--- a/skills/verify-adherence/SKILL.md
+++ b/skills/verify-adherence/SKILL.md
@@ -29,6 +29,12 @@ rule is permanently enforced → never needs LLM again.
 
 One argument: a branch name.
 
+## Protocol
+
+Any project using this skill must expose a command or test suite that emits verdicts in the schema defined in `## Phases → 4. Emit verdict`. The harness calls that entry point; the project owns what runs internally.
+
+Python projects fulfill the protocol via `@pytest.mark.adherence` tests invoked by `uv run python -m pytest`. A Go project would expose `go test -run Adherence ./...`; a LaTeX project might expose a `make check-adherence` target that runs a custom linter. The stack is the project's concern; the verdict schema is the harness's concern.
+
 ## Phases
 
 **Label skip.** When called from `/verify`, if the PR carries the

--- a/tickets/0021-verify-adherence-stack-agnostic.erg
+++ b/tickets/0021-verify-adherence-stack-agnostic.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Decouple verify-adherence ratchet from Python/pytest
-Status: open
+Status: in-progress
 Created: 2026-04-24
 Author: claude
 
@@ -8,6 +8,7 @@ Author: claude
 2026-04-24T00:00Z claude created — harness sweep found ~15 lines binding adherence ratchet to Python/pytest/uv
 2026-04-24T00:00Z claude note reimagine — Python binding is structural (45-50% of file, Phase 1.0 is 100% Python). No non-Python consumer exists yet. Full rewrite is YAGNI. Minimal fix: adapter paragraph stating "a project exposes any command emitting the verdict schema; Python projects fulfill this via pytest markers." ~5 lines, no new stack assumption, preserves all current behavior.
 2026-04-24T00:00Z claude note plan — leak-guard already passes (file uses "uv run python -m pytest" not "uv run pytest"). Insert ## Protocol section between ## Input and ## Phases. 5-sentence paragraph: names the contract, frames Python/pytest as the current binding, gives Go/LaTeX examples as illustration only. No removals, no escape hatches needed.
+2026-04-24T00:00Z claude status claimed
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Adds a `## Protocol` section to `skills/verify-adherence/SKILL.md` between `## Input` and `## Phases`
- Frames the adherence ratchet concept as stack-agnostic: any project exposes a command or test suite emitting verdicts; the harness calls that entry point
- Python/pytest (`@pytest.mark.adherence` + `uv run python -m pytest`) is named as the current binding, with Go and LaTeX as illustrative alternatives
- No existing content removed; no escape hatches added

## Dependencies

This branch is based on `t0020-forge-agnostic-verify-skills` and depends on PR #57. Merge #57 first.

## Test plan

- [ ] `bash scripts/check-project-leak.sh` exits 0 (verified locally)
- [ ] `## Protocol` section appears at line 32, between `## Input` and `## Phases`
- [ ] No stack-specific commands introduced beyond those already present in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)