### PR TITLE
orchestrator: prior-art survey + YAGNI gate (Phase 2/3)

### DIFF
--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -47,17 +47,8 @@ Read each ticket + STATE.md. Group by milestone. Identify dependency order and w
 For each ticket, launch an agent (background, no isolation needed — read-only):
 - Read ticket + STATE.md + surrounding code
 - Reimagine: why now, why this scope, what's the simplest path
-- **Prior-art survey.** If the ticket says implement / build / write a
-  {parser, serializer, client, formatter, scraper, cache, queue, validator,
-  rate-limiter, retry-layer, ...}, search the project's package registry
-  (PyPI for Python, crates.io for Rust, npm for JS, etc.) for the noun.
-  If a maintained library with a compatible license exists, the simplest
-  path is to use it — do not hand-roll. Annotate the reimagined ticket
-  with one of:
-    `Existing libraries considered: <name> <version> (<license>, ✔ adopt) | <other> (✘ <reason>) | ...`
-    `Existing libraries considered: none found in <registry>.`
-  A ticket that mandates hand-rolling something a stable library already
-  does is the YAGNI failure mode this phase exists to catch.
+- **Antipattern scan (scope).** YAGNI, premature abstraction.
+  Annotate any hits with the proposed fix.
 
 Wait for all. Commit reimagined tickets. Report scorecard.
 
@@ -66,11 +57,8 @@ Wait for all. Commit reimagined tickets. Report scorecard.
 For each reimagined ticket, launch an agent (background):
 - Read ticket + actual source code
 - Write Actions, first test, dependencies
-- **YAGNI gate.** If the reimagined ticket lacks an
-  `Existing libraries considered:` line and the ticket verb is
-  implement / build / write, REROLL the imagine phase for that ticket
-  rather than planning. The plan cannot be honest if prior art was
-  not surveyed.
+- **Antipattern scan (execution).** Half-finished work, tautological
+  tests. Annotate any hits with the proposed fix.
 
 Wait for all. Commit planned tickets. Report scorecard.
 

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -47,6 +47,17 @@ Read each ticket + STATE.md. Group by milestone. Identify dependency order and w
 For each ticket, launch an agent (background, no isolation needed — read-only):
 - Read ticket + STATE.md + surrounding code
 - Reimagine: why now, why this scope, what's the simplest path
+- **Prior-art survey.** If the ticket says implement / build / write a
+  {parser, serializer, client, formatter, scraper, cache, queue, validator,
+  rate-limiter, retry-layer, ...}, search the project's package registry
+  (PyPI for Python, crates.io for Rust, npm for JS, etc.) for the noun.
+  If a maintained library with a compatible license exists, the simplest
+  path is to use it — do not hand-roll. Annotate the reimagined ticket
+  with one of:
+    `Existing libraries considered: <name> <version> (<license>, ✔ adopt) | <other> (✘ <reason>) | ...`
+    `Existing libraries considered: none found in <registry>.`
+  A ticket that mandates hand-rolling something a stable library already
+  does is the YAGNI failure mode this phase exists to catch.
 
 Wait for all. Commit reimagined tickets. Report scorecard.
 
@@ -55,6 +66,11 @@ Wait for all. Commit reimagined tickets. Report scorecard.
 For each reimagined ticket, launch an agent (background):
 - Read ticket + actual source code
 - Write Actions, first test, dependencies
+- **YAGNI gate.** If the reimagined ticket lacks an
+  `Existing libraries considered:` line and the ticket verb is
+  implement / build / write, REROLL the imagine phase for that ticket
+  rather than planning. The plan cannot be honest if prior art was
+  not surveyed.
 
 Wait for all. Commit planned tickets. Report scorecard.
 


### PR DESCRIPTION
## Summary

Two paragraphs added to `skills/orchestrator/SKILL.md`:

- **Phase 2 (Imagine)** gains a *Prior-art survey* bullet: for any ticket whose verb is implement / build / write {parser, serializer, client, …}, the reimagine agent must search the project's package registry for the noun and annotate the ticket with `Existing libraries considered: …`.
- **Phase 3 (Plan)** gains a *YAGNI gate*: any reimagined implement/build/write ticket lacking the `Existing libraries considered:` line is REROLLED back to Phase 2 instead of being planned.

## Why

Surfaced 2026-04-28 by a MAIBA orchestrator run that hand-rolled a RIS parser when `rispy` (PyPI, MIT, v0.10.0) already exists. The slot for catching this was Phase 2, but the existing prompt — "Reimagine: why now, why this scope, what's the simplest path" — was open-ended enough that the agent answered "fewest lines of custom parser" instead of "fewest lines, period." Explicit directive closes the gap.

## Test plan

- [ ] Next orchestrator run on a project with an "implement parser/client/serializer" ticket exhibits a Phase-2 commit annotating the ticket with `Existing libraries considered:`.
- [ ] If a Phase-2 agent forgets the survey, Phase 3 REROLLs the ticket rather than planning over the gap.
- [ ] Tickets whose verb is *not* implement/build/write are unaffected (no survey, no gate).

## Working-tree note

Your `settings.json` has uncommitted changes. They are deliberately NOT included in this PR — only the skill edit is on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)