### PR TITLE
orchestrator: nudge YAGNI scan to search the registry

### DIFF
--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -47,7 +47,8 @@ Read each ticket + STATE.md. Group by milestone. Identify dependency order and w
 For each ticket, launch an agent (background, no isolation needed — read-only):
 - Read ticket + STATE.md + surrounding code
 - Reimagine: why now, why this scope, what's the simplest path
-- **Antipattern scan (scope).** YAGNI, premature abstraction.
+- **Antipattern scan (scope).** YAGNI (search the package registry —
+  don't hand-roll what a library already does), premature abstraction.
   Annotate any hits with the proposed fix.
 
 Wait for all. Commit reimagined tickets. Report scorecard.


### PR DESCRIPTION
Follow-up to #62. Single-run experiment (sonnet 4.6, MAIBA ticket 0001) showed the previous terse "YAGNI" reference did not trigger a package-registry search — the agent flagged a minor scope nit and missed that rispy already exists. Adds 5-word parenthetical naming the desired behavior.