### PR TITLE
orchestrator: Phase 3 antipattern nudges (half-finished, tautological)

### DIFF
--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -58,8 +58,10 @@ Wait for all. Commit reimagined tickets. Report scorecard.
 For each reimagined ticket, launch an agent (background):
 - Read ticket + actual source code
 - Write Actions, first test, dependencies
-- **Antipattern scan (execution).** Half-finished work, tautological
-  tests. Annotate any hits with the proposed fix.
+- **Antipattern scan (execution).** Half-finished work (no
+  NotImplementedError, pytest.skip, or TODO), tautological tests
+  (would this test catch a wrong implementation, or only a different
+  one?). Annotate any hits with the proposed fix.
 
 Wait for all. Commit planned tickets. Report scorecard.
 


### PR DESCRIPTION
Follow-up to #62 and #63. Adds the same shape of behavioral nudge to the two Phase 3 antipatterns:

- **Half-finished work** — names the three sentinel literals (`NotImplementedError`, `pytest.skip`, `TODO`) so the agent has a mechanical grep target.
- **Tautological tests** — the imagined-wrong-impl heuristic. "Would this test catch a wrong implementation, or only a different one?" forces evaluation of behavior vs. structure.

Premature abstraction in Phase 2 stays bare-named — its verification is a judgment the model performs natively, and a blunt "one impl earns no protocol" rule would generate false positives on legitimate Level-1 designs (e.g. MAIBA's LibraryBackend with planned Zotero SQLite/Web-API consumers per ARCHITECTURE.md §2.4).

Same shape principle as the YAGNI nudge in #63: name the antipattern, name the verification verb in 5–10 words, no noun lists, no prescribed annotation formats.