### PR TITLE
orchestrator: drop half-finished-work from Phase 3

### DIFF
--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -58,10 +58,9 @@ Wait for all. Commit reimagined tickets. Report scorecard.
 For each reimagined ticket, launch an agent (background):
 - Read ticket + actual source code
 - Write Actions, first test, dependencies
-- **Antipattern scan (execution).** Half-finished work (no
-  NotImplementedError, pytest.skip, or TODO), tautological tests
-  (would this test catch a wrong implementation, or only a different
-  one?). Annotate any hits with the proposed fix.
+- **Antipattern scan.** Tautological tests — would this test catch a
+  wrong implementation, or only a different one? Annotate any hits
+  with the proposed fix.
 
 Wait for all. Commit planned tickets. Report scorecard.
 


### PR DESCRIPTION
Half-finished work means literal stubs in committed code; those don't exist at Plan time. Symmetry-of-list reflex, not fit-to-phase. Right home is `/verify-adherence` in Phase 6 (per-project `@pytest.mark.adherence` ratchet).