### PR TITLE
Metaskill panorama: report + 4 follow-up tickets

### DIFF
--- a/docs/2026-04-28-metaskill-panorama.md
+++ b/docs/2026-04-28-metaskill-panorama.md
@@ -1,0 +1,175 @@
+# The Metaskill Panorama — implications for IDH
+
+**Date:** 2026-04-28
+**Scope:** Thematic supplement to the 2026-04-04 review. Looks at what people in the Claude Code ecosystem mean when they say "metaskill" and what that lens reveals about IDH.
+**Companion to:** [`20260404-review/00-synthesis.md`](20260404-review/00-synthesis.md). The earlier review covered hooks, settings hygiene, verification, and review personas. This report does not redo that work; it adds a single dimension the earlier sweep did not isolate.
+
+---
+
+## Résumé (FR)
+
+« Métaskill » est devenu un terme valise. Cinq usages distincts coexistent dans l'écosystème Claude Code, et la plupart des recommandations applicables à IDH dépendent de la catégorie ciblée. Ce rapport propose une taxonomie en cinq classes (auto-tuning de configuration, observer/améliorateur, générateur de skills/agents, enseignant de configuration, orchestrateur de cycle de vie), situe IDH explicitement dans cette taxonomie, et ne propose que les ajouts qui correspondent au périmètre d'une harness mono-utilisateur. Trois recommandations concrètes : adopter le skill officiel `/fewer-permission-prompts` (résout C3 du 2026-04-04), ajouter un observer pour les sessions interactives (le canal manquant à côté de `nightbeat-report`), et formaliser `/orchestrator` comme métaskill dans la documentation.
+
+---
+
+## 1. The word "metaskill" means at least five different things
+
+Surveying eight reference repositories and three commentaries (sources at end), the term covers five conceptually distinct patterns:
+
+| # | Pattern | What it does | Reference |
+|---|---------|--------------|-----------|
+| **A** | **Configuration auto-tuner** | Reads session/transcript history, emits a diff to the harness configuration. | `/fewer-permission-prompts` (Anthropic, official) |
+| **B** | **Observer / improver** | Silently logs friction during normal work; periodic review surfaces patterns; humans approve changes. | `rebelytics/one-skill-to-rule-them-all` (`task-observer`) |
+| **C** | **Skill / agent generator** | Produces new SKILL.md files, subagent definitions, or whole agent teams. | `xvirobotics/metaskill`, `obra/superpowers/writing-skills`, `FrancyJGLisboa/agent-skill-creator` |
+| **D** | **Configuration teacher** | Teaches Claude *about Claude Code itself* (skills, hooks, MCP, permissions) so users can be guided through configuration. | `werkamsus/claude-metaskill` |
+| **E** | **Lifecycle orchestrator** | Runs existing skills in sequence to drive a multi-phase workflow end-to-end. | IDH `/orchestrator`, `/beat`, `obra/superpowers/executing-plans` |
+
+These do not collapse into one another. A generator (C) creates artifacts; an observer (B) creates *recommendations* that humans turn into artifacts; an auto-tuner (A) creates a constrained, verifiable diff against a known config schema; an orchestrator (E) runs nothing new — it sequences what exists. Conflating them produces unfocused recommendations.
+
+A second observation about the panorama itself: the population of "metaskills" is heavily biased toward C (generators) and D (teachers). Both presume the user does not yet have a harness. IDH already has one. That immediately rules out half of the panorama as scope-mismatched.
+
+---
+
+## 2. Where IDH already sits
+
+IDH covers three of the five categories already, two implicitly:
+
+| Pattern | IDH surface | Status |
+|---------|-------------|--------|
+| **A** Auto-tuner | None — `settings.local.json` is curated by hand. The 2026-04-04 synthesis flagged this as finding C3 (140 lines of accumulated one-off permissions). | **Gap** |
+| **B** Observer | Three partial surfaces: `nightbeat-report` Step 4 (autonomous-channel only, post-hoc, structured), `celebrate` Step 11 ("Offer to improve workflow rules if lessons were learned" — per-task, suggestion), `memory` sweep (TTL-managed, semantic). No surface logs interactive-session friction structurally. | **Partial** |
+| **C** Generator | `new-ticket` generates ticket scaffolds. No skill creates other skills. | **Out of scope** |
+| **D** Teacher | `harness-rules` (companion `.md`s) auto-loads at session start. Functional, but inverts the progressive-disclosure pattern Anthropic recommends — it teaches by being always-loaded, not by being discoverable on demand. | **Architecturally different** |
+| **E** Orchestrator | `/orchestrator` (171 lines) runs the Five Claws across N tickets autonomously. `/beat` is its single-cycle wrapper. `/verify` runs a sub-orchestration of adherence + review + gate. | **Strong — defining feature of IDH** |
+
+The strongest IDH-specific observation: **`/orchestrator` is a lifecycle metaskill in the (E) sense, but it is not labelled as one anywhere in the README or harness-rules.** It is currently described as "Run Imperial Dragon batch across multiple tickets." That is operational, not categorical. The label matters because users searching for a metaskill pattern in IDH won't find it under that description.
+
+---
+
+## 3. Findings against the panorama
+
+### F1. The interactive observer is the only real metaskill gap
+
+`nightbeat-report` covers the autonomous channel comprehensively — six categories of friction patterns (permission denials, budget exhaustion, recurring tickets, ambiguous orchestrator outputs, idle projects, expensive stuck tickets), with concrete fix proposals per pattern. It is a strong example of pattern (B), but it only fires after `claude-nightbeat.timer` runs.
+
+Interactive sessions — the bulk of IDH usage — produce no equivalent structured log. `celebrate` Step 11 is a one-line nudge ("Offer to improve workflow rules if lessons were learned"). It depends on the model deciding to surface lessons; it does not append to a durable log; it does not trigger a periodic aggregate review. `task-observer`'s key contribution over IDH's existing surface is the **silent-log-plus-weekly-review** pattern: every session adds observations to a JSONL, and once a week (or after N entries) an aggregate sweep proposes harness changes.
+
+This is a closable gap. IDH already has the JSONL convention (`celebrations.jsonl`, 46 entries, ~25 days of data). Adding `observations.jsonl` and a weekly aggregator skill costs a few hundred lines and reuses the existing telemetry-directory pattern.
+
+### F2. `/fewer-permission-prompts` directly resolves an open finding
+
+Anthropic shipped this skill (Boris Cherny announced it 2026-Q1). It scans the user's session transcript for bash and MCP commands that are safe but caused repeated permission prompts and emits a recommended allowlist diff against `.claude/settings.json`. This is a textbook pattern (A) auto-tuner.
+
+It maps one-to-one onto the 2026-04-04 finding **C3** ("`settings.local.json` is bloated — 140 lines of accumulated one-off permissions including `sudo tee:*`, `sudo cp:*`. Not a curated policy"). The earlier review's recommendation **T3** was "Audit and prune `settings.local.json` — remove one-offs, narrow `sudo` grants, document policy." `/fewer-permission-prompts` automates the first half of T3 against fresh transcript evidence. The "document policy" half remains manual.
+
+Caveat: there is one known bug. The skill strips environment-variable prefixes during extraction, so commands of the shape `TEST_DATABASE_URL="..." uv run pytest` are missed (`anthropics/claude-code` issue #51057). For IDH's use case — which has many `make` and `uv run` invocations — this matters but does not invalidate adoption.
+
+### F3. SKILL.md description audit returns a clean bill of health
+
+The current best-practice rule from Anthropic and from Lee Hanchung's first-principles essay is that descriptions should be action-oriented ("Use when…", with specific task verbs). Vague capability lists prevent discovery; kitchen-sink descriptions defeat progressive disclosure.
+
+A pass over IDH's 26 skill descriptions (extracted by `awk` from frontmatter) finds them mostly compliant: they lead with imperative verbs (`Trigger`, `Merge`, `Pick`, `Create`, `Begin`, `Claim`, `Close`, `Run`, `Check`, `Validate`, `Re-resolve`, `End-of-day`, `Post-task`, etc.) and they specify the trigger condition by context (e.g., `verify-gate`: "Validates every ticket exit criterion and every review comment against the actual diff. Emits APPROVED / REROLL / ESCALATE…").
+
+Two minor exceptions worth noting (not fixing — these are genuine edge cases):
+
+- `harness-rules` uses `description: >` (folded YAML) — likely a multi-line description. By design this skill *should* always load (it's the rules file). If Anthropic's progressive-disclosure model rewards descriptions that match user intent, an always-loaded skill has no intent to match. This is the architectural mismatch flagged in §2 row D, not a bug.
+- `smoke` description ("Agent environment smoke test — reports runtime identity, auth method, and harness context") is descriptive rather than imperative ("Use when verifying…"). Low-stakes — `smoke` is rarely invoked.
+
+The clean bill is itself a finding: it suggests the implicit description-style discipline (likely inherited from harness-rules' brevity culture) is doing real work without being stated as a rule.
+
+### F4. The `harness-rules` pattern is not progressive disclosure
+
+`harness-rules` loads its companion `.md` files (workflow, git, tickets, state, coding-python — 204 lines total) at session start regardless of task. Anthropic's documented model is the inverse: SKILL.md frontmatter is the only thing always loaded; the body and references are loaded on demand when the description matches.
+
+Two ways to read this:
+
+1. **The Anthropic model is wrong for rules.** Rules are universally applicable; loading them on demand introduces uncertainty about whether the rule fires. This is the case the harness-rules pattern bets on.
+2. **The Anthropic model is right and harness-rules is paying a context tax.** 204 lines of rules occupy ~1500 tokens of every session, whether the session is one ticket close or a deep refactor. Lee Hanchung's anti-pattern list explicitly names "kitchen-sink skills" and "embedding verbose documentation in SKILL.md" as the pattern that defeats progressive disclosure.
+
+Empirically, IDH's session counts are healthy and the harness has measurably improved over the year (46 celebrations across 8 projects, 25 active skills shipped). That is weak evidence that interpretation #1 holds in practice. But it does not prove the rules are pulling their context-tax weight; an A/B with rules behind progressive disclosure (`workflow.md` loads on session-start mention; `coding-python.md` loads only on .py edits; `tickets.md` loads only when a ticket verb fires) would.
+
+This is a research question, not an action item. Flagging because the panorama specifically rejects always-loaded patterns and IDH should know it is making a counter-bet.
+
+### F5. Patterns the panorama offers that IDH should *not* adopt
+
+The panorama is a buffet, not a checklist. Three patterns are popular in the ecosystem but mismatched to IDH:
+
+- **Team-generation metaskills (xvirobotics/metaskill, generated `tech-lead` + `specialists` + `code-reviewer`).** IDH is a single-user research harness; a generated agent team adds coordination overhead that pays back only on multi-developer projects.
+- **Prompt-enrichment hooks (severity1/claude-code-prompt-improver, ckelsoe/prompt-architect).** These rewrite vague user prompts into structured CO-STAR / RISEN / etc. frames before Claude executes. IDH's terseness culture (the 87-line rules budget, the "Mind Your Tone" finding from 2026-04-03) is a deliberate counter-bet against verbose prompt scaffolding.
+- **Configuration-teacher metaskills (werkamsus/claude-metaskill).** Useful for users still learning Claude Code; redundant for the IDH author.
+
+Naming these is part of the contribution — it forecloses obvious future "should we add X?" branches.
+
+---
+
+## 4. Recommendations
+
+Three concrete actions, ranked by leverage. None duplicate the 2026-04-04 action plan.
+
+### R1 (Tier 1) — Adopt `/fewer-permission-prompts` and run it on doudou
+
+**What:** Run the official Anthropic skill against the current session-history corpus to generate an allowlist diff for `settings.local.json`. Review, prune one-offs (per 2026-04-04 T3), commit the pruned file.
+
+**Why:** Closes the bottom half of finding C3 from 2026-04-04 with vendor-supported tooling. Pattern-(A) auto-tuners are the only metaskill class IDH currently lacks entirely.
+
+**Caveat:** Watch for the env-var-prefix bug on `make`/`uv run` invocations; verify the diff manually before applying.
+
+**Out:** A pruned, justified `settings.local.json` and a one-line policy note in the harness CLAUDE.md ("permissions allowlist is regenerated quarterly via `/fewer-permission-prompts`").
+
+### R2 (Tier 2) — Add an interactive-session observer
+
+**What:** A new skill `/observe` (or a hook) that appends one line per session-end to `~/.claude/telemetry/observations.jsonl` capturing friction patterns: tool denials encountered, retries, instructions ignored, manual workarounds. Pair it with a weekly aggregator that runs from the existing `claude-nightbeat.timer` and emits a harness-improvement digest analogous to `nightbeat-report` Step 4 but for the interactive channel.
+
+**Why:** Closes the only real gap in IDH's observer coverage (F1). Reuses the existing telemetry directory and JSONL convention. Inspired by `rebelytics/one-skill-to-rule-them-all`'s silent-log-plus-weekly-review pattern, but feeds IDH's existing aggregation pipeline rather than introducing a parallel one.
+
+**Out of scope:** Auto-applying the proposed changes. Observations go to a log; humans approve; humans edit. This matches the conservative posture in `task-observer`'s design note ("never modifies skills directly").
+
+**Open question:** What goes in the observation log entry? Minimum viable: timestamp, session-id, project, three free-text fields (issue / suggested fix / generalisable principle). The `task-observer` schema is a good starting reference.
+
+### R3 (Tier 3) — Document `/orchestrator` as IDH's lifecycle metaskill
+
+**What:** One sentence in README.md and one section in `harness-rules/workflow.md` naming `/orchestrator` (and `/beat` as its single-cycle invocation) as IDH's metaskill — the skill that runs other skills. Cross-link `/verify`, which is a sub-orchestrator, in the same place.
+
+**Why:** Discoverability. Users (and future-Claude reading the harness for the first time) will look for the entry point. Right now the description ("Run Imperial Dragon batch across multiple tickets") buries the categorical role under the operational summary.
+
+**Cost:** Two paragraphs. No code change.
+
+**Non-goal:** Don't promote `/orchestrator` into a generator (pattern C) or observer (pattern B). Lifecycle orchestration is a different metaskill class and conflating them is exactly the trap §1 warns against.
+
+---
+
+## 5. Open questions for follow-up
+
+These don't fit into actions but are worth a future doc:
+
+- **Is `harness-rules`' always-loaded design paying for itself?** §F4 frames this. An A/B over a week of session telemetry (rules loaded vs. rules behind progressive disclosure) would settle it. Current evidence is suggestive but not conclusive.
+- **Should `/celebrate` Step 11 be replaced by R2 (the observer log)?** They overlap. Either Step 11 stays as the synchronous "do you want to update rules?" prompt and the observer captures the silent residue, or Step 11 is dropped in favor of the observer's aggregate review. Probably the former, but worth deciding.
+- **Should the harness publish a skills-search tool?** `obra/superpowers` ships `skills-search` as the discovery surface for its 20+ skills. IDH has 26 skills and a flat `/<skill-name>` namespace; a search tool would matter once the count exceeds ~40. Not now.
+
+---
+
+## 6. Sources
+
+Primary references consulted:
+
+- [Anthropic — Agent Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) — three-level loading model, progressive disclosure, description format requirements.
+- [Anthropic — Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) — anti-patterns (kitchen-sink, vague descriptions).
+- [Boris Cherny / Anthropic — `/fewer-permission-prompts` announcement](https://www.threads.com/@boris_cherny/post/DXM_ATCjwKj) — pattern (A) reference implementation.
+- [`anthropics/claude-code` issue #51057](https://github.com/anthropics/claude-code/issues/51057) — env-var-prefix bug in the auto-tuner.
+
+Community / third-party:
+
+- [`rebelytics/one-skill-to-rule-them-all`](https://github.com/rebelytics/one-skill-to-rule-them-all) — pattern (B) reference. CC BY 4.0.
+- [`werkamsus/claude-metaskill`](https://github.com/werkamsus/claude-metaskill) — pattern (D).
+- [`xvirobotics/metaskill`](https://github.com/xvirobotics/metaskill) — pattern (C), team generation variant.
+- [`FrancyJGLisboa/agent-skill-creator`](https://github.com/FrancyJGLisboa/agent-skill-creator) — pattern (C), cross-platform variant.
+- [`obra/superpowers`](https://github.com/obra/superpowers) — pattern (E) plus a `writing-skills` meta-skill in pattern (C).
+- [`severity1/claude-code-prompt-improver`](https://github.com/severity1/claude-code-prompt-improver) — pattern not adopted (rejected, §F5).
+- [Lee Hanchung — Claude Agent Skills: A First Principles Deep Dive](https://leehanchung.github.io/blogs/2025/10/26/claude-skills-deep-dive/) — discovery mechanism, anti-patterns.
+- [Massively Parallel Procrastination — Skills for Claude!](https://blog.fsck.com/2025/10/16/skills-for-claude/) — composition wishlist and TDD-for-skills.
+
+Internal (companion documents):
+
+- [`docs/20260404-review/00-synthesis.md`](20260404-review/00-synthesis.md) — comprehensive review, this report supplements not duplicates.
+- [`docs/2026-04-03-harness-best-practices-research.md`](2026-04-03-harness-best-practices-research.md) — evidence base for context-hygiene and verification claims.
+- `~/.claude/telemetry/celebrations.jsonl` — 46 entries, 2026-03 to 2026-04, basis for the JSONL-aggregator pattern reuse argument.

--- a/tickets/0042-replace-harness-rules-with-hooks.erg
+++ b/tickets/0042-replace-harness-rules-with-hooks.erg
@@ -1,0 +1,106 @@
+%erg v1
+Title: Replace harness-rules skill with context-aware hook injection
+Status: open
+Created: 2026-04-28
+Author: claude
+
+--- log ---
+2026-04-28T14:00Z claude created
+
+--- body ---
+## Context
+
+`skills/harness-rules/` (5 files, 204 lines) is loaded into every session
+via the persuasion phrase "Auto-invoked at session start to establish
+behavioral constraints" in its SKILL.md description. Claude Code has no
+auto-invoke mechanism for skills — that phrase is a probabilistic nudge,
+not a runtime guarantee. The pattern also fights Anthropic's progressive
+disclosure model: the body loads unconditionally, occupying ~1500 tokens
+of every session whether or not the rules apply to the task.
+
+Hooks are the deterministic mechanism for unconditional injection.
+Rules that must always fire belong in hooks, not in a skill description
+that hopes the model reads it.
+
+See `docs/2026-04-28-metaskill-panorama.md` §F4 and the harness-rules
+follow-up exchange for the architectural rationale.
+
+## Relevant files
+
+- `skills/harness-rules/SKILL.md` — the umbrella, to be removed
+- `skills/harness-rules/workflow.md` — unconditional, → hook
+- `skills/harness-rules/git.md` — unconditional, → hook
+- `skills/harness-rules/state.md` — only used by `/end-session`, → fold into that skill
+- `skills/harness-rules/tickets.md` — used by `/new-ticket` + `/ticket-*`, → reference file shared across those skills
+- `skills/harness-rules/coding-python.md` — conditional on Python project, → PreToolUse hook on Edit/Write when `pyproject.toml` exists
+- `scripts/on-start.sh` — SessionStart hook, target for workflow.md + git.md content
+- `settings.json` — register the new PreToolUse hook for coding-python
+
+## Actions
+
+1. Audit each companion file: classify as **unconditional** (every
+   session), **scoped** (only N skills), or **conditional** (project
+   shape). Decision table goes in the PR description.
+2. **Unconditional** rules (workflow.md, git.md) → emit from
+   `on-start.sh` as additional context on session start. Keep the lines
+   above the `exec >/dev/null` cutoff so they actually reach the
+   conversation.
+3. **Scoped** rules (state.md, tickets.md) → move into the bodies (or
+   shared `references/` directory) of the skills that use them.
+   `/end-session` references state.md; `/new-ticket`, `/ticket-new`,
+   `/ticket-claim`, `/ticket-close`, `/ticket-release`, `/ticket-ready`
+   reference tickets.md.
+4. **Conditional** rules (coding-python.md) → register a PreToolUse
+   hook in `settings.json` that injects the file when:
+   - tool is Edit/Write/NotebookEdit, AND
+   - target path matches `*.py`, OR project root has `pyproject.toml`
+5. Delete `skills/harness-rules/` once all consumers are converted.
+6. Update `README.md` (lists harness-rules in the structure tree) and
+   `STATE.md` (mentions auto-invoked rules implicitly).
+
+## Test
+
+Red step: a test that the rules content is reachable when expected and
+absent when not.
+
+- `tests/test_harness_rules_injection.sh`:
+  - Spawn a Claude Code session in a non-Python project. Assert
+    coding-python.md content does **not** appear in the session
+    transcript.
+  - Spawn a session in a Python project (`pyproject.toml` present)
+    and trigger an Edit on a `.py` file. Assert coding-python.md
+    content **does** appear before the edit completes.
+  - Spawn any session. Assert workflow.md and git.md content appears
+    in the SessionStart hook output (verifiable via a fixture session).
+
+## Verification
+
+- [ ] `find skills/harness-rules` returns nothing
+- [ ] `grep -r "harness-rules" skills/ scripts/ settings.json README.md` returns no matches
+- [ ] Non-Python project session does not load coding-python.md
+- [ ] Python project Edit on `.py` triggers coding-python.md injection
+- [ ] `nightbeat-report` for the week after the change shows no spike
+      in rule-violation patterns (baseline comparison)
+- [ ] CI green: `validate-tickets`, `skill-lint`, `leak-guard`,
+      `pipefail-guard`
+
+## Invariants
+
+- The Five Claws workflow phases remain documented somewhere reachable
+  (probably README.md or a single `docs/workflow.md` reference).
+- `/orchestrator`, `/verify`, `/celebrate` continue to read consistent
+  rules (they currently inherit from harness-rules being always loaded;
+  they may need explicit references after the change).
+- No behavioral regression on the autonomous nightbeat channel — the
+  weekly comparison above gates this.
+
+## Exit criteria
+
+- `skills/harness-rules/` removed.
+- Rules previously in companion files are injected by hooks (always)
+  or referenced explicitly by the skills that need them (scoped).
+- One week of nightbeat runs after merge shows no rule-adherence
+  regression vs. the prior week.
+- Token budget per session reduced by the size of harness-rules
+  bodies on tasks that don't need them (measurable via session-end
+  token counts in telemetry).

--- a/tickets/0043-weekly-fewer-permission-prompts.erg
+++ b/tickets/0043-weekly-fewer-permission-prompts.erg
@@ -1,0 +1,93 @@
+%erg v1
+Title: Run /fewer-permission-prompts weekly via systemd timer
+Status: open
+Created: 2026-04-28
+Author: claude
+
+--- log ---
+2026-04-28T14:10Z claude created
+
+--- body ---
+## Context
+
+`settings.local.json` has accumulated 140 lines of one-off allowlist
+entries (finding C3 in `docs/20260404-review/00-synthesis.md`).
+Anthropic ships an official skill `/fewer-permission-prompts` that
+scans transcript history and emits a recommended allowlist diff
+against `.claude/settings.json`. Manual invocation gets procrastinated;
+a weekly cadence keeps the allowlist tracking actual usage.
+
+Pattern (A) auto-tuner from `docs/2026-04-28-metaskill-panorama.md` §1.
+Concrete carryover from §R1.
+
+Caveat: known bug `anthropics/claude-code#51057` strips env-var
+prefixes during extraction, so commands like
+`TEST_DATABASE_URL=... uv run pytest` are missed. Verify diffs by hand
+before applying.
+
+## Relevant files
+
+- `settings.local.json` — target of the allowlist diff
+- `bin/install-cron` — existing cron/systemd installer pattern
+- `~/.config/systemd/user/claude-nightbeat.timer` — reference timer
+- `scripts/` — likely home of the new runner script
+- `docs/2026-04-28-metaskill-panorama.md` — rationale, §R1
+
+## Actions
+
+1. Write `scripts/fewer-permission-prompts-weekly.sh`:
+   - Spawn a non-interactive Claude Code session
+   - Prompt: invoke `/fewer-permission-prompts` and write the
+     proposed diff to `~/.claude/telemetry/permission-diffs/<date>.diff`
+   - Do NOT auto-apply. Human review only.
+2. Create systemd user unit + timer
+   `~/.config/systemd/user/claude-permissions-prune.{service,timer}`,
+   modelled on `claude-nightbeat.timer`. Cadence: weekly, e.g.
+   Sunday 10:00.
+3. Surface the proposed diff in the morning review:
+   - Extend `nightbeat-report` (or add a small companion line) to
+     check `permission-diffs/` for unreviewed proposals and list
+     them in the daily summary.
+4. One-shot bootstrap: run the script manually once on doudou and
+   on padme to seed the directory.
+5. Document the cadence in README.md (under "permissions") and
+   in the harness CLAUDE.md as a one-line policy.
+
+## Test
+
+Red step: assert the script produces a diff file when run, and that
+the diff is non-destructive.
+
+- `tests/test_permissions_prune.sh`:
+  - Run the script in a sandbox with a synthetic transcript
+    containing repeated permission prompts for `Bash(git status)`.
+  - Assert a diff file is created under `permission-diffs/`.
+  - Assert `settings.local.json` is **unchanged** on disk.
+  - Assert the diff, if applied, is valid JSON.
+
+## Verification
+
+- [ ] `systemctl --user list-timers | grep claude-permissions-prune`
+      shows next-fire ≤ 7 days
+- [ ] `permission-diffs/` directory contains at least one diff file
+      after first run
+- [ ] `settings.local.json` is not modified by the timer
+- [ ] Daily nightbeat summary mentions any unreviewed diff
+- [ ] Known bug #51057 documented in script comment
+
+## Invariants
+
+- No automatic application of diffs. Allowlist changes remain a
+  human decision.
+- Per-host `settings.local.json` files (not the shared
+  `settings.json`) are the only target.
+- `/fewer-permission-prompts` is invoked the same way an interactive
+  user would invoke it — no privileged path.
+
+## Exit criteria
+
+- Weekly timer running on padme and doudou.
+- First diff produced, reviewed, and either applied or rejected
+  (closing the loop on C3).
+- Documentation updated.
+- Bug #51057 caveat noted in the runner script.

--- a/tickets/0044-interactive-session-observer.erg
+++ b/tickets/0044-interactive-session-observer.erg
@@ -1,0 +1,145 @@
+%erg v1
+Title: Interactive-session observer + weekly aggregator
+Status: open
+Created: 2026-04-28
+Author: claude
+Blocked-by: 0042
+
+--- log ---
+2026-04-28T14:20Z claude created
+
+--- body ---
+## Context
+
+IDH's observer surface (pattern B in
+`docs/2026-04-28-metaskill-panorama.md` §1) covers the autonomous
+nightbeat channel via `nightbeat-report` Step 4, but interactive
+sessions produce no structured log of skill friction. `celebrate`
+Step 11 ("Offer to improve workflow rules if lessons were learned")
+is a one-off nudge — it depends on the model deciding to surface
+lessons, doesn't append durably, and has no aggregate review.
+
+Reference: `rebelytics/one-skill-to-rule-them-all` (task-observer)
+implements silent-log-plus-weekly-review. This ticket adapts that
+pattern to IDH's existing telemetry directory and aggregator
+conventions, rather than introducing a parallel pipeline.
+
+Concrete carryover from `docs/2026-04-28-metaskill-panorama.md` §R2.
+
+Blocked by 0042 (replace harness-rules) because part of the observer's
+job is to surface rule-load friction, and the rule-load mechanism
+must be settled first — otherwise observations will be churned by
+the migration itself.
+
+## Relevant files
+
+- `~/.claude/telemetry/celebrations.jsonl` — existing JSONL log,
+  schema model
+- `skills/celebrate/log-celebration` — existing pattern: shell
+  script that appends a JSON line with timestamp prepended
+- `skills/nightbeat-report/SKILL.md` — aggregator-style sibling,
+  reference for the digest section
+- `skills/celebrate/SKILL.md` Step 11 — overlaps; must be
+  reconciled
+- New: `skills/observe/SKILL.md` (or hook entry in
+  `settings.json`)
+- New: `skills/observe-digest/SKILL.md` (or extension of
+  nightbeat-report)
+- New: `~/.claude/telemetry/observations.jsonl`
+
+## Actions
+
+### Part 1 — the observer (logger)
+
+1. Decide: skill (`/observe`) or hook (Stop hook on session end)?
+   - Skill: explicit, user-invocable, no token cost when not invoked.
+   - Hook: deterministic, captures every session, but requires the
+     session metadata to be available in the hook env.
+   - Default choice: hook. Aligns with the deterministic-injection
+     direction set by 0042.
+2. Implement the appender as `scripts/log-observation` (sister of
+   `skills/celebrate/log-celebration`):
+   - Reads JSON from stdin or argv
+   - Prepends `ts` and `date`
+   - Appends to `~/.claude/telemetry/observations.jsonl`
+3. Define the observation schema. Minimum viable:
+   ```json
+   {
+     "session_id": "...",
+     "project": "...",
+     "issue": "free text — what produced friction",
+     "suggested_fix": "free text — concrete proposal",
+     "principle": "free text — generalisable insight"
+   }
+   ```
+   (Schema borrowed from task-observer; "principle" is the field
+   the weekly aggregator clusters on.)
+4. Wire the trigger: at session end, either the Stop hook calls a
+   small Claude invocation that decides whether the session
+   produced an observation worth logging (parallel to celebrate's
+   reflection step but mandatory and structured), or the user
+   invokes `/observe` explicitly when something stings.
+
+### Part 2 — the weekly aggregator
+
+5. New skill `/observations-digest` (or extension of
+   `nightbeat-report` with a `--observations` flag):
+   - Reads the last 7 days of `observations.jsonl`
+   - Clusters by `principle` field
+   - Emits a digest with: cluster count, exemplar issue, proposed
+     harness change
+   - Output format mirrors `nightbeat-report` Step 4
+6. Schedule: systemd timer, weekly. Reuse the cadence from 0043
+   (Sunday morning) so review work batches.
+7. Reconcile with `celebrate` Step 11: drop Step 11, OR keep it as
+   the synchronous opt-in path while the observer captures the
+   silent residue. Decide in the PR.
+
+## Test
+
+Red step: assert observations append correctly and the digest
+clusters them.
+
+- `tests/test_observe.sh`:
+  - Pipe a synthetic JSON observation to `scripts/log-observation`
+  - Assert the line appears in `observations.jsonl` with `ts` and
+    `date` fields populated
+  - Assert no fields from the input are dropped
+- `tests/test_observations_digest.sh`:
+  - Seed `observations.jsonl` with N synthetic entries across 3
+    distinct principles
+  - Run the digest skill
+  - Assert output contains 3 clusters, ordered by frequency
+
+## Verification
+
+- [ ] `observations.jsonl` exists and grows over a week of normal
+      use
+- [ ] Weekly digest fires from systemd timer
+- [ ] Digest output names actionable harness changes (not just
+      "we logged 7 frictions")
+- [ ] `celebrate` Step 11 reconciliation decision documented in
+      the PR (kept / dropped / replaced)
+- [ ] Schema is backward-compatible with task-observer's format
+      so future cross-import is possible
+
+## Invariants
+
+- Observer never modifies skills directly. Output is read-only
+  recommendations. (Inherits the task-observer design constraint.)
+- No PII or client-identifying information in observation entries.
+- The observer itself is observable — the weekly digest must
+  flag its own blind spots, per the
+  "the observer watches itself too" principle.
+- No regression in existing `celebrations.jsonl` flow.
+
+## Exit criteria
+
+- One full week of observations logged from interactive sessions
+  on doudou.
+- One weekly digest reviewed by the user, with at least one
+  proposed change either accepted (a follow-up ticket created) or
+  explicitly rejected.
+- `celebrate` Step 11 status decided.
+- Open question from `docs/2026-04-28-metaskill-panorama.md` §5
+  ("Should `/celebrate` Step 11 be replaced by R2?") closed.

--- a/tickets/0045-rename-orchestrator-to-raid.erg
+++ b/tickets/0045-rename-orchestrator-to-raid.erg
@@ -1,0 +1,151 @@
+%erg v1
+Title: Rename /orchestrator skill to /raid
+Status: open
+Created: 2026-04-28
+Author: claude
+
+--- log ---
+2026-04-28T14:45Z claude created
+
+--- body ---
+## Context
+
+`/orchestrator` is the lifecycle metaskill of IDH (pattern E in
+`docs/2026-04-28-metaskill-panorama.md` §1) but the name is generic
+software jargon. The Imperial Dragon Harness already themes its
+phases as the Five Claws and its single-cycle wrapper as `/beat`.
+A dragon raids — multi-target, autonomous, time-bounded, returns to
+its hoard without merging. The mapping to the skill's actual
+behaviour is exact: pick a wave of tickets, work them in isolated
+worktrees, never merge, return.
+
+Decision: rename `/orchestrator` → `/raid`. `/beat` stays
+(heart/wing-beat — single-cycle pulse, distinct metaphor).
+
+Pair semantics: **beat = one cycle of a heart, raid = one hunt of a
+flight**.
+
+## Relevant files
+
+29 files touch `orchestrator`. Three classes:
+
+**Skill identity (must rename):**
+- `skills/orchestrator/SKILL.md` → `skills/raid/SKILL.md`
+- frontmatter `name: orchestrator` → `name: raid`
+
+**Active consumers — slash invocation or log-label producer:**
+- `scripts/beat.py` line ~508: `/orchestrator <id>` literal invocation
+- `scripts/beat.py` lines ~506, 524: log lines `=== orchestrator: ===`
+- `scripts/nightbeat-report.py` lines ~184, 385: log-label parser
+  matching `orchestrator:` prefix
+- `tests/test_beat.py`: assertions on the above
+
+**Cross-references in skills (rename to /raid):**
+- `skills/beat/SKILL.md`
+- `skills/nightbeat-report/SKILL.md`
+- `skills/verify/SKILL.md`, `verify-adherence/SKILL.md`,
+  `verify-gate/SKILL.md`
+
+**Documentation:**
+- `README.md` (skill tree)
+- `STATE.md` (status section)
+- `docs/20260404-review/03-five-levels.md`
+- `commands/gsd/{audit-milestone,execute-phase,map-codebase,research-phase}.md`
+
+**Historical record — leave as-is:**
+- 14 ticket bodies (`tickets/00*.erg`). Tickets are immutable history.
+  New tickets use `/raid`; closed tickets keep their original prose.
+- Existing `nightbeat.log` lines with `orchestrator:` labels —
+  see "log-label compatibility" below.
+
+## Actions
+
+1. **Plan the parser compatibility window.** The nightbeat log
+   parser in `nightbeat-report.py` reads historical lines with
+   `orchestrator:` prefix. Decision:
+   - **Option A (clean cut):** rotate `nightbeat.log` at rename
+     time, accept that pre-rename history is no longer parseable.
+     Cheap, loses ~25 days of history.
+   - **Option B (dual-accept):** parser accepts both
+     `orchestrator:` and `raid:` for one quarter, then drops
+     `orchestrator:`. Preserves history.
+   - Default: **B**. Cost is ~3 lines of code.
+2. `git mv skills/orchestrator skills/raid`.
+3. Edit `skills/raid/SKILL.md`:
+   - frontmatter `name: orchestrator` → `name: raid`
+   - body self-references
+   - Optional: refresh description from "Run Imperial Dragon batch
+     across multiple tickets" to something that uses "raid".
+     Defer to PR review.
+4. Update `scripts/beat.py`:
+   - Change `/orchestrator <id>` → `/raid <id>` in the prompt
+     literal.
+   - Change log-label producer `=== orchestrator: ===` → `=== raid:
+     ===`.
+5. Update `scripts/nightbeat-report.py`:
+   - Accept both `orchestrator:` and `raid:` prefixes per Option B.
+   - Update `--help` text from "show full orchestrator result text"
+     to "show full raid result text" (or just "result text").
+6. Update `tests/test_beat.py` to match new label format. Add a
+   regression test that asserts the parser still accepts
+   `orchestrator:` labels (compatibility).
+7. Grep-replace `/orchestrator` → `/raid` across the **active**
+   skill bodies (verify*, beat, nightbeat-report). Do NOT touch
+   ticket files.
+8. Update `README.md` skill tree and `STATE.md` status section.
+9. Update `docs/20260404-review/03-five-levels.md` (factual record
+   about the harness — this one may move to "see also: 0045" rather
+   than rename, since it's a snapshot review).
+10. Update `commands/gsd/*` references.
+11. Mention the rename in `docs/2026-04-28-metaskill-panorama.md`
+    §R3 — that section recommends documenting `/orchestrator` as
+    the lifecycle metaskill. With the rename, the recommendation
+    becomes "document `/raid`" — fold the rename in or leave a
+    cross-reference.
+
+## Test
+
+Red step: a structural test that no live skill or active script
+references `/orchestrator` as a slash command after the migration,
+while ticket bodies remain untouched.
+
+- `tests/test_rename_orchestrator_to_raid.sh`:
+  - `! grep -rn "/orchestrator" skills/ scripts/ README.md STATE.md commands/`
+    (zero matches)
+  - `grep -rn "/orchestrator" tickets/ | wc -l` returns ≥ 14
+    (history preserved)
+  - `python3 scripts/nightbeat-report.py` parses a fixture log
+    with mixed `orchestrator:` and `raid:` labels without error
+    (dual-accept compatibility)
+
+## Verification
+
+- [ ] `find skills/orchestrator` returns nothing
+- [ ] `find skills/raid/SKILL.md` exists and validates against
+      skill-lint
+- [ ] `beat.py` produces `=== raid: ===` labels on next run
+- [ ] `nightbeat-report` parses both old and new labels
+- [ ] One full beat cycle on padme runs end-to-end with the new
+      slash command
+- [ ] CI green: `validate-tickets`, `skill-lint`, `leak-guard`,
+      `pipefail-guard`
+
+## Invariants
+
+- Closed tickets are immutable. Their `orchestrator` references
+  stay.
+- Nightbeat log history remains parseable for at least one
+  quarter (Option B).
+- No behaviour change. Pure rename.
+- The `/beat` skill name is preserved.
+
+## Exit criteria
+
+- `/raid` is the canonical name. `/orchestrator` returns "skill not
+  found" or a deprecation pointer.
+- Active scripts, skills, and docs reference `/raid`.
+- Old ticket bodies untouched.
+- Parser dual-accepts both labels with a TODO to drop
+  `orchestrator:` after one quarter (target: 2026-07-28).
+- README structure tree updated.
+- STATE.md updated.


### PR DESCRIPTION
## Summary

- Adds `docs/2026-04-28-metaskill-panorama.md` — survey of "metaskill" patterns in the Claude Code ecosystem (fewer-prompt, one-skill-to-rule-them-all, claude-metaskill, xvirobotics/metaskill, agent-skill-creator, superpowers). Taxonomizes five distinct uses of the term, places IDH explicitly within the taxonomy, and identifies three concrete gaps.
- Files four follow-up tickets that emerged from the survey:
  - **0042** Replace `harness-rules` skill with context-aware hook injection — closes the architectural mismatch in §F4 (skill that pretends to auto-invoke via persuasive description; Claude Code has no auto-invoke for skills).
  - **0043** Run `/fewer-permission-prompts` weekly via systemd timer — concrete carryover to 2026-04-04 finding C3 (`settings.local.json` bloat).
  - **0044** Interactive-session observer + weekly aggregator (blocked-by 0042) — adapts the `task-observer` pattern to IDH's existing telemetry pipeline; closes the only real observer-coverage gap.
  - **0045** Rename `/orchestrator` skill to `/raid` — dragon-themed naming for IDH's lifecycle metaskill; pairs with `/beat`.

The report is a thematic supplement to `docs/20260404-review/00-synthesis.md`, not a duplicate. It explicitly rejects three popular ecosystem patterns as scope-mismatched (team-generation, prompt-enrichment hooks, configuration-teacher).

## Test plan

- [x] `tickets/tools/go/erg validate tickets/` — PASS (44 tickets)
- [x] `bash scripts/check-project-leak.sh` — rc=0
- [ ] CI green on `validate-tickets` + `skill-lint` + `leak-guard` + `pipefail-guard`
- [ ] Visual review of `docs/2026-04-28-metaskill-panorama.md` taxonomy table
- [ ] Verify ticket `Blocked-by: 0042` reference in 0044 resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)