### PR TITLE
housekeeping: doc sync, 2 new tickets, branch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every task passes through five phases:
 
 ```
 ImperialDragonHarness/
-├── skills/                 # Slash commands — 21 total: /celebrate, /verify, /orchestrator, etc.
+├── skills/                 # Slash commands — 26 total: /beat, /celebrate, /verify, /orchestrator, etc.
 │   ├── harness-rules/      # Auto-invoked rules (companion .md files)
 │   │   ├── SKILL.md
 │   │   ├── workflow.md         # Session start, escalation, worktree
@@ -45,7 +45,12 @@ ImperialDragonHarness/
 │   ├── memory/             # Persistent memory management
 │   ├── bib-merge/          # Merge approved bib entries into refs.bib
 │   ├── related-work-note/  # Due-diligence note for a cited paragraph
-│   └── related-work-note-validate/ # Re-resolve all DOIs/URLs in a note
+│   ├── related-work-note-validate/ # Re-resolve all DOIs/URLs in a note
+│   ├── beat/               # Trigger one beat cycle (housekeeping → pick-ticket → work)
+│   ├── housekeeping/       # Repo hygiene: git sync, healthcheck, stale-branch cleanup
+│   ├── nightbeat-report/   # Morning review of autonomous nightbeat runs
+│   ├── pick-ticket/        # Pick lowest-risk ready ticket for autonomous sweep
+│   └── smoke/              # Agent environment smoke test
 ├── scripts/                # Hook implementations + shell init
 │   ├── shell-init.sh           # Source from ~/.bashrc — claude wrapper
 │   ├── on-start.sh             # Session start: env loading, worktree gate

--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # Imperial Dragon Harness — State
 
-Last updated: 2026-04-27 (token-saving session)
+Last updated: 2026-04-29
 
 ## North star
 
@@ -33,6 +33,12 @@ Level 4 (Hooks) + orchestrator + `/verify` loop + git-erg tickets + bibliography
 - 0039 — remove/replace git fsck --unreachable in housekeeping
 - 0040 — skip housekeeping when repo is frozen (overlaps with 0036 — verify scope)
 - 0041 — investigate mid-session context reset between sub-skills
+- 0042 — replace harness-rules with hooks (metaskill panorama finding)
+- 0043 — weekly /fewer-permission-prompts run
+- 0044 — interactive session observer
+- 0045 — rename /orchestrator to /raid
+- 0046 — extract flying-projects list into projects.json
+- 0047 — auto early context compaction in beat and raid
 
 ## Blockers
 

--- a/tickets/0046-flying-projects-config-file.erg
+++ b/tickets/0046-flying-projects-config-file.erg
@@ -1,0 +1,58 @@
+%erg v1
+Title: Extract flying-projects list from beat.py into a standalone config file
+Status: open
+Created: 2026-04-29
+Author: claude
+
+--- log ---
+2026-04-29T08:00Z claude created
+
+--- body ---
+## Context
+
+`beat.py` hardcodes the list of monitored projects as a `PROJECTS: list[ProjectConfig]`
+constant (around line 85). Adding, removing, or tuning a project requires editing Python
+source. This creates friction for the common case of "I started a new project, add it to
+nightbeat" and couples project inventory to implementation.
+
+`beat-settings.json` already exists for Claude CLI settings; the pattern of a companion
+config file is established.
+
+## Goal
+
+A simple, human-editable config file (e.g., `projects.json` or `projects.toml`) that
+`beat.py` reads at startup to populate its `PROJECTS` list. The file should require no
+Python knowledge to edit.
+
+## Proposed config format (projects.json sketch)
+
+```json
+[
+  { "path": "~/CNRS/projets/actifs/aedist-technical-report", "day_budget": 0.40, "night_budget": 0.50 },
+  { "path": "~/CNRS/code/maiba",                             "day_budget": 0.40, "night_budget": 0.50 },
+  { "path": "~/.claude",                                     "day_budget": 0.40, "night_budget": 0.50 },
+  { "path": "~/Climate_finance" },
+  { "path": "~/fuzzy-corpus" }
+]
+```
+
+Omitted budget keys default to the existing `ProjectConfig` defaults.
+
+## Actions
+
+1. Define the schema (JSON preferred for zero-dependency parsing; TOML acceptable if
+   already available in the venv).
+2. Add a `load_projects(config_path)` function in `beat.py` that reads the file and
+   returns `list[ProjectConfig]`. Fall back gracefully if file absent (warn + use
+   current hardcoded defaults).
+3. Replace the `PROJECTS` constant initializer with a call to `load_projects`.
+4. Write a new `projects.json` in `scripts/` with the current project list.
+5. Update `tests/test_beat.py` to cover the load function.
+
+## Exit criteria
+
+- `projects.json` is the authoritative source; `beat.py` no longer contains a hardcoded
+  project list.
+- Adding a project requires only editing `projects.json`.
+- 62 + N pytest tests pass.
+- `beat.py` falls back to logged defaults when config file is missing.

--- a/tickets/0047-early-context-compaction-beat-raid.erg
+++ b/tickets/0047-early-context-compaction-beat-raid.erg
@@ -1,0 +1,70 @@
+%erg v1
+Title: Auto early context compaction in beat and raid based on context signals
+Status: open
+Created: 2026-04-29
+Author: claude
+
+--- log ---
+2026-04-29T08:00Z claude created
+
+--- body ---
+## Context
+
+Long-running workflows — `beat` (nightbeat) and `raid` (/orchestrator, soon /raid) —
+spawn multiple Claude sub-sessions. Each sub-session can accumulate substantial context
+before automatic compaction kicks in, wasting token budget re-reading stale tool output.
+
+Ticket 0041 investigated whether the problem exists in `beat.py`. The answer is yes:
+each skill invocation (`housekeeping`, `pick-ticket`) is a fresh `claude` CLI call, but
+the **skill itself** can run for many turns and accumulate context. The outer beat loop
+is also a fresh invocation per run, so outer accumulation is not the issue — inner
+sub-session growth is.
+
+The same pattern applies to `raid` (orchestrator): it drives N tickets sequentially, and
+each ticket's work session can grow long before compaction.
+
+## Goal
+
+Detect when a running sub-session is approaching a context-size threshold and trigger
+early compaction — or limit the session before it gets there — based on observable
+signals (logs, token counters, turn counts) rather than waiting for automatic compaction
+to fire at an inopportune moment.
+
+## Signals available
+
+1. **Turn count** — `--max-turns N` hard cap already available in the CLI. Set it per
+   skill to prevent runaway accumulation.
+2. **Context log lines** — The Claude CLI emits compaction events to stderr/stdout.
+   `beat.py` / `raid` can parse these to know if compaction already happened.
+3. **Token usage in API response** — If using API mode, `usage.input_tokens` after each
+   turn. Not available in CLI mode without instrumentation.
+4. **`/compact` slash command** — Injects a compaction step at a known point. Can be
+   passed as an initial prompt or injected between turns.
+
+## Proposed approach
+
+**Phase 1 — conservative caps (low-risk, implement first):**
+- Add `--max-turns 40` to each skill invocation in `beat.py` and `raid`.
+- Log a warning when max-turns is hit so it's visible in nightbeat logs.
+
+**Phase 2 — context-signal-aware early compact (investigate first):**
+- Parse Claude CLI output for context-window-used percentage (if available).
+- When usage exceeds a threshold (e.g., 70%), inject `/compact` before the next
+  sub-task rather than letting automatic compaction fire mid-task.
+- Requires confirming what the CLI actually exposes — read CLI docs / test empirically.
+
+## Relationship to existing tickets
+
+- 0041 (`beat-mid-session-context-reset`): this ticket supersedes 0041 in scope.
+  Close 0041 once Phase 1 is implemented.
+- 0045 (`rename-orchestrator-to-raid`): coordinate naming — use `raid` throughout once
+  that ticket is closed.
+
+## Exit criteria
+
+- Phase 1: `beat.py` and `raid` both pass `--max-turns N` to every sub-session;
+  cap is logged when hit; no existing test broken.
+- Phase 2 (if feasible): context-window usage parsed from CLI output; early compact
+  triggered at configurable threshold; integration test or log inspection confirms it.
+- Acceptance can be Phase 1 only if Phase 2 turns out to require CLI features not yet
+  exposed.

--- a/tickets/0048-ticket-slug-status-markers.erg
+++ b/tickets/0048-ticket-slug-status-markers.erg
@@ -1,0 +1,58 @@
+%erg v1
+Title: Audit whether ticket slugs should carry status or triage markers
+Status: open
+Created: 2026-04-29
+Author: claude
+
+--- log ---
+2026-04-29T08:30Z claude created
+
+--- body ---
+## Context
+
+Ticket slugs today are pure kebab-case titles: `0037-fix-beat-double-pick.erg`.
+Status lives only in the `Status:` header. When scanning `ls tickets/` or a git log,
+there is no at-a-glance signal about what is closed, ready, or blocked.
+
+The question is whether to decorate slugs with a prefix or suffix marker — and if so,
+what encoding (UTF-8 or ASCII) and what vocabulary.
+
+## Design space
+
+### Where to put the marker
+
+- **Filename prefix**: `CLOSED-0037-fix-beat-double-pick.erg` — sorts by status, breaks ID-first ordering
+- **Filename suffix**: `0037-fix-beat-double-pick.CLOSED.erg` — preserves ID sort, but `.CLOSED.erg` is a double extension
+- **Directory**: `tickets/closed/0037-fix-beat-double-pick.erg` — already partially done (`tickets/archive/`)
+- **No filename change**: status stays in header only; tooling (erg, grep) is the display layer
+
+### Marker vocabulary candidates
+
+| Marker | Style | Notes |
+|--------|-------|-------|
+| `CLOSED`, `OPEN`, `READY` | ASCII uppercase | Shell-safe, no encoding issues |
+| `[x]`, `[ ]` | ASCII checkbox | Familiar from markdown, but `[` is shell-special |
+| `✓`, `○`, `✗` | UTF-8 symbols | Pretty in GUI, risky in scripts / older terminals |
+| `HITL` | ASCII acronym | Human-in-the-loop triage flag — orthogonal to status |
+
+### HITL as a separate concept
+
+`HITL` (human-in-the-loop) is a triage marker, not a status. A ticket can be
+`open` + `HITL` (needs human decision before an agent can work it). This is
+distinct from `pending` (awaiting external input). Worth deciding if HITL belongs
+in the slug, a header, or a tag.
+
+## Questions to resolve
+
+1. Is the pain point real? Do `ls tickets/` outputs actually mislead or slow work?
+   Or is `erg ready` the right query layer and filenames should stay opaque?
+2. If markers are added: filename vs directory vs header-only?
+3. Encoding: ASCII-only (portability, sort correctness) or UTF-8 (readability in GUI)?
+4. Does HITL need a formal representation, or is a log note enough?
+5. Validator impact: new filename patterns require updating the `NNNN-{slug}.erg` regex.
+
+## Exit criteria
+
+- Decision recorded (even "no change") with rationale in this ticket's log.
+- If change adopted: validator updated, existing tickets migrated, FORMAT.md updated.
+- If no change: ticket closed with explanation of why the current design is sufficient.


### PR DESCRIPTION
## Summary
- STATE.md: add tickets 0042–0047 to open list; date bump to 2026-04-29
- README.md: skill count 21→26; list the 5 missing skills (beat, housekeeping, nightbeat-report, pick-ticket, smoke)
- New tickets: 0046 (extract projects list into projects.json), 0047 (early context compaction in beat/raid)
- Deleted 4 merged local+remote chore/* branches; pruned 2 stale remote-tracking refs

## Test plan
- [ ] Validate tickets: `erg validate tickets/0046*.erg tickets/0047*.erg`
- [ ] README skill count matches `ls skills/ | wc -l`

🤖 Generated with [Claude Code](https://claude.com/claude-code)