### PR TITLE
fix(beat): projects.json config, double-pick guard, slug-marker decision

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -55,6 +55,8 @@ BUDGET_ORCHESTRATOR: float = 5.00
 MODEL_SONNET: str = "sonnet"
 MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
 
+PROJECTS_CONFIG: Path = HARNESS_DIR / "scripts" / "projects.json"
+
 DRY_RUN: bool = os.environ.get("BEAT_DRY_RUN") == "1"
 
 
@@ -86,7 +88,7 @@ class ProjectConfig:
     pick_ticket_model: str = MODEL_HAIKU  # model used when repo has no recent commits
 
 
-PROJECTS: list[ProjectConfig] = [
+_BUILTIN_PROJECTS: list[ProjectConfig] = [
     ProjectConfig(
         path=Path.home() / "aedist-technical-report",
         budget_housekeeping=0.40,
@@ -105,6 +107,35 @@ PROJECTS: list[ProjectConfig] = [
         budget_pick_ticket=0.50,
     ),
 ]
+
+_PROJ_KEYS = {"budget_housekeeping", "budget_pick_ticket", "pick_ticket_model"}
+
+
+def load_projects(config_path: Path) -> list[ProjectConfig]:
+    """Load project list from JSON; fall back to built-in defaults on any error."""
+    if not config_path.exists():
+        print(
+            f"[beat] {config_path} not found, using built-in defaults", file=sys.stderr
+        )
+        return list(_BUILTIN_PROJECTS)
+    try:
+        entries = json.loads(config_path.read_text())
+        return [
+            ProjectConfig(
+                path=Path(e["path"]).expanduser(),
+                **{k: e[k] for k in _PROJ_KEYS if k in e},
+            )
+            for e in entries
+        ]
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[beat] error loading {config_path}: {exc}, using built-in defaults",
+            file=sys.stderr,
+        )
+        return list(_BUILTIN_PROJECTS)
+
+
+PROJECTS: list[ProjectConfig] = load_projects(PROJECTS_CONFIG)
 
 
 # ── Logging ────────────────────────────────────────────────────────────────────
@@ -555,6 +586,22 @@ def _orchestrate(project: ProjectConfig) -> tuple[str, str | None]:
         # v1 simplification: rc=0 → "done"; orchestrator may write finer-grained
         # outcomes into beat-log itself, but we don't parse those here.
         outcome = "done"
+        # Warn if orchestrator exited cleanly but left the ticket open (double-pick risk).
+        ticket_files = list(path.glob(f"tickets/{ticket_id}-*.erg"))
+        if ticket_files:
+            status = next(
+                (
+                    ln.split()[1]
+                    for ln in ticket_files[0].read_text().splitlines()
+                    if ln.startswith("Status:")
+                ),
+                "",
+            )
+            if status and status != "closed":
+                _log(
+                    f"=== warning: orchestrator done but ticket {ticket_id}"
+                    f" Status: {status} (not closed) — double-pick risk ==="
+                )
 
     _log(f"=== orchestrator: outcome={outcome} {_now_iso()} ===")
     return outcome, ticket_id

--- a/scripts/projects.json
+++ b/scripts/projects.json
@@ -1,0 +1,7 @@
+[
+  { "path": "~/aedist-technical-report", "budget_housekeeping": 0.40, "budget_pick_ticket": 0.50 },
+  { "path": "~/cadens",                  "budget_housekeeping": 0.40, "budget_pick_ticket": 0.50 },
+  { "path": "~/Climate_finance" },
+  { "path": "~/fuzzy-corpus" },
+  { "path": "~/.claude",                 "budget_housekeeping": 0.40, "budget_pick_ticket": 0.50 }
+]

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -33,6 +33,10 @@ Attempt history is read directly from each ticket's `## Attempt log` section.
      `erg sweep-skip tickets/{file} cooldown-24h expires:{failed-ts+24h}`
    - Tickets whose scope won't fit the 50-minute beat window (read body):
      `erg sweep-skip tickets/{file} scope-too-large expires:{now+24h}`
+   - Tickets whose log contains a `sweep-pick: picked` entry less than 8 h old
+     **and** whose `Status` is still `open` (orchestrator ran but did not close
+     the ticket — re-picking immediately wastes a beat):
+     `erg sweep-skip tickets/{file} cooldown-recent-pick expires:{pick-ts+8h}`
 
    Run `erg sweep-skip` before any further exclusion action so the cache entry
    is durable even if later steps fail. The binary computes the hash.

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -865,3 +865,159 @@ class TestHousekeepingFrozenSkip:
                 MagicMock(stdout="abc1234 recent work\n", returncode=0),  # not frozen
             ]
             assert beat.housekeeping_needed(tmp_project) is True
+
+
+# ── load_projects (ticket 0046) ────────────────────────────────────────────────
+
+
+class TestLoadProjects:
+    def test_loads_from_json(self, tmp_path):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "path": "~/foo",
+                        "budget_housekeeping": 0.30,
+                        "budget_pick_ticket": 0.20,
+                    },
+                    {"path": "~/bar"},
+                ]
+            )
+        )
+        projects = beat.load_projects(cfg)
+        assert len(projects) == 2
+        assert projects[0].path == Path.home() / "foo"
+        assert projects[0].budget_housekeeping == 0.30
+        assert projects[0].budget_pick_ticket == 0.20
+        assert projects[1].budget_housekeeping == beat.BUDGET_HOUSEKEEPING
+
+    def test_tilde_expansion(self, tmp_path):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(json.dumps([{"path": "~/.claude"}]))
+        projects = beat.load_projects(cfg)
+        assert projects[0].path == Path.home() / ".claude"
+
+    def test_pick_ticket_model_optional(self, tmp_path):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(
+            json.dumps([{"path": "~/x", "pick_ticket_model": "claude-opus-4-7"}])
+        )
+        projects = beat.load_projects(cfg)
+        assert projects[0].pick_ticket_model == "claude-opus-4-7"
+
+    def test_falls_back_when_missing(self, tmp_path, capsys):
+        projects = beat.load_projects(tmp_path / "nonexistent.json")
+        assert projects == beat._BUILTIN_PROJECTS
+        assert "not found" in capsys.readouterr().err
+
+    def test_falls_back_on_bad_json(self, tmp_path, capsys):
+        bad = tmp_path / "projects.json"
+        bad.write_text("not { valid json")
+        projects = beat.load_projects(bad)
+        assert projects == beat._BUILTIN_PROJECTS
+        assert "error" in capsys.readouterr().err.lower()
+
+    def test_falls_back_on_missing_path_key(self, tmp_path, capsys):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(json.dumps([{"budget_housekeeping": 0.4}]))
+        projects = beat.load_projects(cfg)
+        assert projects == beat._BUILTIN_PROJECTS
+        assert "error" in capsys.readouterr().err.lower()
+
+
+# ── orchestrator done-but-open warning (ticket 0037) ──────────────────────────
+
+
+class TestOrchestratorDoneButOpenWarning:
+    def setup_method(self):
+        beat.DRY_RUN = False
+
+    def _make_ticket(self, tmp_project, ticket_id: str, status: str) -> None:
+        (tmp_project / "tickets").mkdir(exist_ok=True)
+        (tmp_project / f"tickets/{ticket_id}-test-ticket.erg").write_text(
+            f"%erg v1\nTitle: test\nStatus: {status}\nCreated: 2026-01-01\nAuthor: claude\n"
+            f"\n--- log ---\n\n--- body ---\n"
+        )
+
+    def test_warns_when_ticket_not_closed(self, tmp_project):
+        self._make_ticket(tmp_project, "0001", "open")
+        log_lines: list[str] = []
+
+        def fake_run_skill(
+            skill,
+            *,
+            budget,
+            timeout_s,
+            cwd,
+            project_scoped=False,
+            model=beat.MODEL_SONNET,
+        ):
+            if "pick-ticket" in skill:
+                return (0, "PICK: 0001")
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+            patch("beat._log", side_effect=log_lines.append),
+        ):
+            beat._orchestrate(beat.ProjectConfig(path=tmp_project))
+
+        assert any(
+            "warning" in l and "0001" in l and "not closed" in l for l in log_lines
+        )
+
+    def test_no_warning_when_ticket_closed(self, tmp_project):
+        self._make_ticket(tmp_project, "0002", "closed")
+        log_lines: list[str] = []
+
+        def fake_run_skill(
+            skill,
+            *,
+            budget,
+            timeout_s,
+            cwd,
+            project_scoped=False,
+            model=beat.MODEL_SONNET,
+        ):
+            if "pick-ticket" in skill:
+                return (0, "PICK: 0002")
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+            patch("beat._log", side_effect=log_lines.append),
+        ):
+            beat._orchestrate(beat.ProjectConfig(path=tmp_project))
+
+        assert not any("warning" in l and "not closed" in l for l in log_lines)
+
+    def test_no_warning_when_ticket_file_missing(self, tmp_project):
+        log_lines: list[str] = []
+
+        def fake_run_skill(
+            skill,
+            *,
+            budget,
+            timeout_s,
+            cwd,
+            project_scoped=False,
+            model=beat.MODEL_SONNET,
+        ):
+            if "pick-ticket" in skill:
+                return (0, "PICK: 9999")
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+            patch("beat._log", side_effect=log_lines.append),
+        ):
+            beat._orchestrate(beat.ProjectConfig(path=tmp_project))
+
+        assert not any("warning" in l and "not closed" in l for l in log_lines)

--- a/tickets/0037-fix-beat-double-pick.erg
+++ b/tickets/0037-fix-beat-double-pick.erg
@@ -8,6 +8,8 @@ Author: claude
 2026-04-27T09:00Z claude created
 
 2026-04-27T21:04Z claude note sweep-assess: not-picked hash:a0c7372a77a9 scope:add cooldown guard in pick-ticket skill and warning in beat.py risk:medium
+2026-04-29T08:11Z claude status closed — cooldown-recent-pick guard in pick-ticket skill (A) + done-but-open warning in beat.py (B)
+2026-04-29T08:11Z claude note guard-A-validation — rule implemented in skills/pick-ticket/SKILL.md step 2; manual verification is the validation path (observe nightbeat logs post-merge for absence of cooldown-recent-pick warnings)
 --- body ---
 ## Context
 
@@ -68,4 +70,3 @@ guard d'exclusion — pick-ticket ne le consulte pas pour éviter les re-picks.
 **Risk:** medium
 **Reason:** touches both pick-ticket skill and beat.py with more complex logic
 
-2026-04-29T08:11Z claude status closed — cooldown-recent-pick guard in pick-ticket skill (A) + done-but-open warning in beat.py (B)

--- a/tickets/0037-fix-beat-double-pick.erg
+++ b/tickets/0037-fix-beat-double-pick.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Fix beat double-pick: orchestrateur termine sans fermer le ticket
-Status: open
+Status: closed
 Created: 2026-04-27
 Author: claude
 
@@ -67,3 +67,5 @@ guard d'exclusion — pick-ticket ne le consulte pas pour éviter les re-picks.
 **Scope:** add cooldown guard in pick-ticket skill and warning in beat.py
 **Risk:** medium
 **Reason:** touches both pick-ticket skill and beat.py with more complex logic
+
+2026-04-29T08:11Z claude status closed — cooldown-recent-pick guard in pick-ticket skill (A) + done-but-open warning in beat.py (B)

--- a/tickets/0046-flying-projects-config-file.erg
+++ b/tickets/0046-flying-projects-config-file.erg
@@ -6,7 +6,7 @@ Author: claude
 
 --- log ---
 2026-04-29T08:00Z claude created
-
+2026-04-29T08:11Z claude status closed — load_projects() + projects.json; beat.py no longer hardcodes project list
 --- body ---
 ## Context
 
@@ -57,4 +57,3 @@ Omitted budget keys default to the existing `ProjectConfig` defaults.
 - 62 + N pytest tests pass.
 - `beat.py` falls back to logged defaults when config file is missing.
 
-2026-04-29T08:11Z claude status closed — load_projects() + projects.json; beat.py no longer hardcodes project list

--- a/tickets/0046-flying-projects-config-file.erg
+++ b/tickets/0046-flying-projects-config-file.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Extract flying-projects list from beat.py into a standalone config file
-Status: open
+Status: closed
 Created: 2026-04-29
 Author: claude
 
@@ -56,3 +56,5 @@ Omitted budget keys default to the existing `ProjectConfig` defaults.
 - Adding a project requires only editing `projects.json`.
 - 62 + N pytest tests pass.
 - `beat.py` falls back to logged defaults when config file is missing.
+
+2026-04-29T08:11Z claude status closed — load_projects() + projects.json; beat.py no longer hardcodes project list

--- a/tickets/0048-ticket-slug-status-markers.erg
+++ b/tickets/0048-ticket-slug-status-markers.erg
@@ -1,11 +1,13 @@
 %erg v1
 Title: Audit whether ticket slugs should carry status or triage markers
-Status: open
+Status: closed
 Created: 2026-04-29
 Author: claude
 
 --- log ---
 2026-04-29T08:30Z claude created
+2026-04-29T12:00Z claude note decision — no change. Filenames stay opaque (NNNN-slug.erg). Status remains a header. Rationale appended to body under "## Decision".
+2026-04-29T12:00Z claude status closed — design question resolved; no code/format changes required.
 
 --- body ---
 ## Context
@@ -56,3 +58,77 @@ in the slug, a header, or a tag.
 - Decision recorded (even "no change") with rationale in this ticket's log.
 - If change adopted: validator updated, existing tickets migrated, FORMAT.md updated.
 - If no change: ticket closed with explanation of why the current design is sufficient.
+
+## Decision — no change
+
+Filenames stay opaque: `NNNN-slug.erg`. Status remains a header. No validator
+change, no bulk rename of the existing 47 tickets, no new vocabulary.
+
+### Load-bearing rationale: identity vs state
+
+A filename is an **identity** — immutable, referenced from commit messages,
+PR descriptions, `Blocked-by:` headers, and human conversation. A `Status:`
+value is **state** — mutable, changing roughly three times per ticket
+lifecycle (`open` → `doing` → `closed`, sometimes via `pending`).
+
+Encoding state in identity means every transition triggers a `git mv`. With
+34 of 47 current tickets already closed, adopting a status marker now would
+require 34+ renames in a single migration commit and would force every
+future close to perform a rename + header-edit pair with no transaction
+guarantee. Past commits referencing "see 0037-fix-beat-double-pick" become
+stale text. The `git log --follow` story degrades for everyone.
+
+The right separation is what we already have:
+- **Identity** (filename, ID, blocker refs) — stable.
+- **State** (Status header, log lines) — mutates freely without renames.
+- **Display** — `erg ready`, `erg ready --json`, `erg graph`. The query
+  layer is the at-a-glance view; `ls tickets/` was never designed to be it.
+
+### Supporting arguments
+
+1. **`erg ready` already solves the stated friction.** Running it on this
+   repo right now returns 11 unblocked tickets sorted by ID with titles —
+   strictly more useful than any filename-prefix scheme would be, because it
+   resolves `Blocked-by` transitively and consults `.git/ticket-wip/` for
+   live claims. Filenames cannot encode either.
+2. **Shell portability.** `[`, `]`, and UTF-8 glyphs (`✓`, `○`) in
+   filenames break globs, complete-on-tab in some shells, and `find -name`
+   patterns. ASCII-only markers (`CLOSED-`, `OPEN-`) are safe but ugly and
+   still trip sort order (closed tickets cluster away from their ID
+   neighbours).
+3. **Validator churn.** The current regex is
+   `^\d{4}-[a-z0-9]+(-[a-z0-9]+)*\.erg$` (one line in `tickets/tools/go/main.go`).
+   Loosening it to accept optional status prefixes/suffixes adds parsing
+   ambiguity (is `CLOSED` a slug word or a marker?) and pulls Postel's-Law
+   tolerance into the validator, which is meant to be strict on write.
+4. **Migration cost vs benefit.** A bulk rename touches 34 files, every
+   `Blocked-by` resolver in tooling, and the archive directory if it
+   existed (it doesn't yet). The benefit — replacing one `erg ready`
+   invocation with one `ls` invocation — is not worth that.
+
+### HITL question — also no slug change
+
+Human-in-the-loop is already covered by the `pending` status (defined in
+FORMAT.md as "awaiting external input"). The `bump` log verb with its
+mandatory category (`permission`, `author-decision`, `test-failure`,
+`verify-reroll`, `circuit-breaker`) gives finer-grained signal than a slug
+marker ever could, and it lives in append-only history rather than a
+mutable filename. If a future need emerges for a triage axis truly
+orthogonal to status, the right move is a new optional header in
+`%erg v2` (e.g., `Triage: hitl`) — not a filename token.
+
+### Adjacent finding (not fixed here)
+
+The "ls tickets/ is noisy" intuition behind this ticket is real: 34 of 47
+files are closed. The remedy is **archive cadence**, not slug encoding.
+Current archive criterion is `closed + 90 days`; running `erg archive
+tickets/` today reports nothing eligible because the closes are recent.
+When the cohort ages, `tickets/archive/` will absorb the noise and active
+`ls` output will shrink naturally. A separate ticket can revisit the
+90-day threshold if friction persists past that horizon.
+
+### Net effect
+
+No files renamed. No validator edits. No FORMAT.md edits. The design
+question is resolved with rationale in this log; future ambiguity should be
+answered by pointing back to this ticket.

--- a/tickets/0050-beat-idle-project-fallback.erg
+++ b/tickets/0050-beat-idle-project-fallback.erg
@@ -1,0 +1,84 @@
+%erg v1
+Title: Beat should try another project when current one is idle or frozen
+Status: open
+Created: 2026-04-29
+Author: claude
+
+--- log ---
+2026-04-29T10:15Z claude created
+
+--- body ---
+## Context
+
+When `pick-ticket` returns IDLE for the selected project, beat logs
+`outcome=idle` and stops. The timeslot is wasted. Meanwhile other
+projects in the rotation may have eligible tickets.
+
+Similarly, `housekeeping_needed()` already short-circuits on frozen
+repos — but `_repo_active()` is called per-project and the script
+still spins up a full Claude session for pick-ticket even when a
+quick pre-check could skip it.
+
+The user request is two-layered:
+
+1. **Fallback to next project** (runtime layer): if pick-ticket
+   returns IDLE, try the next project in the rotation before
+   reporting idle.
+2. **Script-level skip** (Python layer): before even launching
+   a Claude session for pick-ticket, check from Python whether
+   the repo has any commits or ticket changes since the last
+   pick-ticket run. If nothing changed, skip the Claude invocation
+   entirely and record `outcome=idle` directly.
+
+## Actions
+
+### Layer 1 — Fallback rotation in `_orchestrate` / `main`
+
+In `beat.py`, after `outcome == "idle"`, iterate to the next
+project in `PROJECTS` (skipping the current one and any that are
+locked). Limit fallback depth to `len(PROJECTS) - 1` to avoid
+infinite loops. Log each fallback attempt.
+
+Simplest approach: extract the pick→orchestrate sequence into a
+helper and loop over a shuffled/rotated project list in `main`.
+
+### Layer 2 — Pre-flight pick-ticket skip in Python
+
+Before calling `run_skill("/pick-ticket", ...)`, check:
+
+```python
+def _pick_needed(project: Path, last_beat_at: datetime | None) -> bool:
+    """False when nothing has changed since the last pick run."""
+    if last_beat_at is None:
+        return True
+    # Any commit since last beat?
+    if _repo_active_since(project, last_beat_at):
+        return True
+    # Any ticket file modified since last beat?
+    changed = subprocess.run(
+        ["git", "-C", str(project), "diff", "--name-only",
+         f"HEAD@{{{last_beat_at.isoformat()}}}"],
+        capture_output=True, text=True, check=False,
+    ).stdout
+    return any("tickets/" in l for l in changed.splitlines())
+```
+
+`last_beat_at` is read from the last `beat-log.jsonl` record's
+`last_run_at` field.
+
+If `_pick_needed()` returns False, log `pick-ticket: skipped
+(nothing changed since {last_beat_at})` and record `outcome=idle`
+without spending tokens.
+
+## Exit criteria
+
+- When pick-ticket returns IDLE, beat tries the next unlocked project
+  before reporting idle to the beat log.
+- When nothing changed in the repo since last beat (no commits, no
+  ticket changes), pick-ticket invocation is skipped entirely at
+  the Python level; outcome logged as idle with skip reason.
+- `test_beat.py` covers: fallback-to-next-project path, skip-when-
+  nothing-changed path, and safety (no infinite loop when all
+  projects are idle).
+- Nightbeat logs show `pick-ticket: skipped` or `fallback: trying
+  <project>` lines where applicable.


### PR DESCRIPTION
## Summary

- **0046** — `scripts/projects.json` is now the authoritative project list. `load_projects()` reads it at startup; falls back to built-in defaults (with stderr warning) if file absent or malformed. No Python editing required to add a project.
- **0037** — Two-pronged double-pick fix: (A) `pick-ticket` skill now excludes tickets with a `sweep-pick: picked` log entry < 8h old whose Status is still `open` (`cooldown-recent-pick`); (B) `beat.py` logs a warning after outcome=done when the ticket file is not `Status: closed`.
- **0048** — Design decision recorded and ticket closed: slugs stay opaque (`NNNN-slug.erg`), status stays in header. Rationale: coupling mutable state to filenames forces `git mv` on every transition and breaks references. `erg ready` already solves the at-a-glance need.

## Test plan

- [ ] `uv run pytest tests/test_beat.py` — 82 tests pass
- [ ] `TestLoadProjects`: 6 tests cover load, tilde expansion, optional fields, fallback paths
- [ ] `TestOrchestratorDoneButOpenWarning`: 3 tests cover warn/no-warn/missing-file
- [ ] Existing tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)