### PR TITLE
ticket: rename 0050-idle-fallback → 0051 (decollide)

### DIFF
--- a/tickets/0051-beat-idle-project-fallback.erg
+++ b/tickets/0051-beat-idle-project-fallback.erg
@@ -6,6 +6,7 @@ Author: claude
 
 --- log ---
 2026-04-29T10:15Z claude created
+2026-04-29T12:00Z claude note renamed from 0050 to 0051 (decollide; 0050 kept by beat-erg-edit-permission-denied)
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Two tickets both landed with ID 0050: `beat-erg-edit-permission-denied` (nightbeat, landed first) and `beat-idle-project-fallback` (manual, landed via PR squash).
- The nightbeat-created ticket keeps its ID 0050.
- `beat-idle-project-fallback` is renamed to 0051 (next free ID after the current max).
- A log entry is appended to the renamed ticket recording the rename for audit provenance.

## Test plan

- [ ] Verify `tickets/0050-beat-erg-edit-permission-denied.erg` is unchanged
- [ ] Verify `tickets/0051-beat-idle-project-fallback.erg` exists and contains the rename log note
- [ ] Verify no duplicate IDs remain in `tickets/` (pre-commit validator should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)