### PR TITLE
fix(0060): erg sweep-skip slice-aliasing — fix + repair 8 tickets + validator rule

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -41,7 +41,6 @@ Level 4 (Hooks) + raid + `/verify` loop + git-erg tickets + bibliography pipelin
 - 0051 — beat should try another project when current one is idle or frozen
 - 0057 — route .erg mutations through erg binary (blocked by erg binary exposing mutation commands)
 - 0058 — rewrite README with Imperial Dragon voice (remove GSD, new opener)
-- 0060 — fix erg sweep-skip slice-aliasing bug + repair 8 corrupted tickets
 - 0054 — [discussion] restore Five-Claws phase announcement at session start
 - 0055 — [discussion] milestone/epic layer above tickets
 - 0056 — [discussion] mid-session pause/resume checkpoints

--- a/tickets/0013-bib-to-zotero-skill.erg
+++ b/tickets/0013-bib-to-zotero-skill.erg
@@ -12,10 +12,12 @@ Author: user
 2026-04-29T02:05Z claude note sweep-skip: scope-too-large hash:eb7beb6f93fa expires:2026-04-30T02:05Z
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:f6250604695b expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:5e3f6732fbef expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:5e3f6732fbef expires:2026-04-30T09:21Z
---- body ---
-ib is staging. The canonical library is Zotero. Today the last step
+## Context
+
+The bibliography pipeline is: related-work-note → bib-merge → local refs.bib.
+Local .bib is staging. The canonical library is Zotero. Today the last step
 (refs.bib → Zotero) is manual (File → Import). This ticket automates it.
 
 The user has a Zotero PAT and Zotero v9+ (fast release cycle, API stable).

--- a/tickets/0028-multiproject-beat-dashboard.erg
+++ b/tickets/0028-multiproject-beat-dashboard.erg
@@ -13,10 +13,11 @@ Author: claude
 2026-04-29T02:05Z claude note sweep-skip: scope-too-large hash:eb412fd8aec8 expires:2026-04-30T02:05Z
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:b6e8921ac8c1 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:18e6d4e648d8 expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:18e6d4e648d8 expires:2026-04-30T09:21Z
---- body ---
-nel
+## Context
+
+PR 61 prototype (`bin/beat-dashboard`) showed a working hourly disc grid + ticket queue panel
 (stdlib-only, 496 lines). Two weaknesses to fix:
 
 1. Beat-log is not the primary activity signal — most work runs through the orchestrator skill

--- a/tickets/0034-housekeeping-split-git-and-ticket-phases.erg
+++ b/tickets/0034-housekeeping-split-git-and-ticket-phases.erg
@@ -12,10 +12,12 @@ Author: claude
 2026-04-29T02:05Z claude note sweep-skip: scope-too-large hash:8632df653b14 expires:2026-04-30T02:05Z
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:8895985d7704 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:fd5819165802 expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:fd5819165802 expires:2026-04-30T09:21Z
---- body ---
-ktrees, STATE.md, commit
+## Problem
+
+Housekeeping does two expensive things in one session:
+1. Git hygiene: stale branches, worktrees, STATE.md, commit
 2. Ticket scan: sweep-skip expiry, pick-assessments
 
 Combining them in a single long session (30–41 turns, $0.50+) means a budget

--- a/tickets/0042-replace-harness-rules-with-hooks.erg
+++ b/tickets/0042-replace-harness-rules-with-hooks.erg
@@ -9,10 +9,12 @@ Author: claude
 
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:7aedbe92df8c expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:edaeb529c775 expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:edaeb529c775 expires:2026-04-30T09:21Z
---- body ---
-on phrase "Auto-invoked at session start to establish
+## Context
+
+`skills/harness-rules/` (5 files, 204 lines) is loaded into every session
+via the persuasion phrase "Auto-invoked at session start to establish
 behavioral constraints" in its SKILL.md description. Claude Code has no
 auto-invoke mechanism for skills — that phrase is a probabilistic nudge,
 not a runtime guarantee. The pattern also fights Anthropic's progressive

--- a/tickets/0043-weekly-fewer-permission-prompts.erg
+++ b/tickets/0043-weekly-fewer-permission-prompts.erg
@@ -9,10 +9,12 @@ Author: claude
 
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:c3bfb0ede8f9 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:9f5957e07f6c expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:9f5957e07f6c expires:2026-04-30T09:21Z
---- body ---
-n `docs/20260404-review/00-synthesis.md`).
+## Context
+
+`settings.local.json` has accumulated 140 lines of one-off allowlist
+entries (finding C3 in `docs/20260404-review/00-synthesis.md`).
 Anthropic ships an official skill `/fewer-permission-prompts` that
 scans transcript history and emits a recommended allowlist diff
 against `.claude/settings.json`. Manual invocation gets procrastinated;

--- a/tickets/0047-early-context-compaction-beat-raid.erg
+++ b/tickets/0047-early-context-compaction-beat-raid.erg
@@ -9,10 +9,12 @@ Author: claude
 
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:567998f68005 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:296a99bcaf67 expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:296a99bcaf67 expires:2026-04-30T09:21Z
---- body ---
-pawn multiple Claude sub-sessions. Each sub-session can accumulate substantial context
+## Context
+
+Long-running workflows — `beat` (nightbeat) and `raid` (/orchestrator, soon /raid) —
+spawn multiple Claude sub-sessions. Each sub-session can accumulate substantial context
 before automatic compaction kicks in, wasting token budget re-reading stale tool output.
 
 Ticket 0041 investigated whether the problem exists in `beat.py`. The answer is yes:

--- a/tickets/0049-truth-in-ticket-open-status.erg
+++ b/tickets/0049-truth-in-ticket-open-status.erg
@@ -9,10 +9,12 @@ Author: claude
 
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:a817bfe3a1a2 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:1141174ff292 expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:1141174ff292 expires:2026-04-30T09:21Z
---- body ---
-eaks when a ticket's acceptance criteria are already met
+## Context
+
+The beat pipeline assumes `Status: open` means the work is not yet done.
+This invariant breaks when a ticket's acceptance criteria are already met
 in the codebase — either because the work was done as a side effect of
 another ticket, or because the ticket described a condition that never
 existed (e.g., 0039: `git fsck --unreachable` was already absent).

--- a/tickets/0051-beat-idle-project-fallback.erg
+++ b/tickets/0051-beat-idle-project-fallback.erg
@@ -10,10 +10,12 @@ Author: claude
 
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:aff71a026b83 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:3cb6ec4ca46b expires:2026-04-30T09:21Z
+2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 --- body ---
-:25Z claude note sweep-skip: scope-too-large hash:3cb6ec4ca46b expires:2026-04-30T09:21Z
---- body ---
-ps. The timeslot is wasted. Meanwhile other
+## Context
+
+When `pick-ticket` returns IDLE for the selected project, beat logs
+`outcome=idle` and stops. The timeslot is wasted. Meanwhile other
 projects in the rotation may have eligible tickets.
 
 Similarly, `housekeeping_needed()` already short-circuits on frozen

--- a/tickets/0060-erg-sweep-skip-corrupts-tickets.erg
+++ b/tickets/0060-erg-sweep-skip-corrupts-tickets.erg
@@ -1,11 +1,13 @@
 %erg v1
 Title: erg sweep-skip corrupts ticket bodies via slice aliasing
-Status: open
+Status: doing
 Created: 2026-04-29
 Author: claude
 
 --- log ---
 2026-04-29T15:55Z claude created
+2026-04-29T18:54Z claude claimed
+2026-04-29T18:54Z claude status doing starting-implementation
 
 --- body ---
 ## Context

--- a/tickets/0060-erg-sweep-skip-corrupts-tickets.erg
+++ b/tickets/0060-erg-sweep-skip-corrupts-tickets.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: erg sweep-skip corrupts ticket bodies via slice aliasing
-Status: doing
+Status: closed
 Created: 2026-04-29
 Author: claude
 
@@ -8,6 +8,7 @@ Author: claude
 2026-04-29T15:55Z claude created
 2026-04-29T18:54Z claude claimed
 2026-04-29T18:54Z claude status doing starting-implementation
+2026-04-29T19:05Z claude status closed all-exit-criteria-met
 
 --- body ---
 ## Context

--- a/tickets/FORMAT.md
+++ b/tickets/FORMAT.md
@@ -178,7 +178,7 @@ The Go validator enforces:
 8. `Blocked-by` local refs point to existing ticket IDs
 9. No dependency cycles
 10. Log lines match `{timestamp} {actor} {verb}` format
-11. Both `--- log ---` and `--- body ---` separators present
+11. Each separator (`--- log ---`, `--- body ---`) appears exactly once
 
 ## Relationship to GitHub Issues
 

--- a/tickets/tools/go/main.go
+++ b/tickets/tools/go/main.go
@@ -1300,13 +1300,20 @@ func cmdSweepSkip(args []string) int {
 		fmt.Fprintf(os.Stderr, "error: %s has no --- body --- separator\n", path)
 		return 1
 	}
-	beforeBody := raw[:idx]
-	if !bytes.HasSuffix(beforeBody, []byte("\n")) {
-		beforeBody = append(beforeBody, '\n')
+	// Build result in a fresh buffer. Do NOT take a sub-slice of raw and
+	// append into it: os.ReadFile returns a slice with cap > len, so
+	// `raw[:idx]` shares the backing array and a subsequent append
+	// silently overwrites the body — corrupting it on disk.
+	logAppend := []byte(logLine + "\n")
+	bodyContent := raw[idx+len(sep):]
+	result := make([]byte, 0, idx+1+len(logAppend)+len(sep)+len(bodyContent))
+	result = append(result, raw[:idx]...)
+	if !bytes.HasSuffix(result, []byte("\n")) {
+		result = append(result, '\n')
 	}
-	result := append(beforeBody, []byte(logLine+"\n")...)
+	result = append(result, logAppend...)
 	result = append(result, sep...)
-	result = append(result, raw[idx+len(sep):]...)
+	result = append(result, bodyContent...)
 	if err := os.WriteFile(path, result, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1

--- a/tickets/tools/go/main.go
+++ b/tickets/tools/go/main.go
@@ -39,6 +39,10 @@ type Erg struct {
 	HasMagic bool
 	HasLog   bool
 	HasBody  bool
+	// Separator occurrence counts. A well-formed ticket has exactly 1 of each;
+	// 2+ body separators is the fingerprint of the cmdSweepSkip aliasing bug.
+	LogSepCount  int
+	BodySepCount int
 }
 
 func (t *Erg) Title() string {
@@ -133,6 +137,8 @@ func parseErg(path string) Erg {
 	hasMagic := false
 	hasLog := false
 	hasBody := false
+	logSepCount := 0
+	bodySepCount := 0
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -152,15 +158,21 @@ func parseErg(path string) Erg {
 			// Fall through to header parsing
 		}
 
-		if !hasBody && trimmed == "--- log ---" {
-			section = "log"
-			hasLog = true
-			continue
+		if trimmed == "--- log ---" {
+			logSepCount++
+			if !hasBody {
+				section = "log"
+				hasLog = true
+				continue
+			}
 		}
-		if !hasBody && trimmed == "--- body ---" {
-			section = "body"
-			hasBody = true
-			continue
+		if trimmed == "--- body ---" {
+			bodySepCount++
+			if !hasBody {
+				section = "body"
+				hasBody = true
+				continue
+			}
 		}
 
 		switch section {
@@ -184,13 +196,15 @@ func parseErg(path string) Erg {
 	}
 
 	return Erg{
-		Path:     path,
-		Headers:  headers,
-		LogLines: logLines,
-		Body:     strings.Join(bodyLines, "\n"),
-		HasMagic: hasMagic,
-		HasLog:   hasLog,
-		HasBody:  hasBody,
+		Path:         path,
+		Headers:      headers,
+		LogLines:     logLines,
+		Body:         strings.Join(bodyLines, "\n"),
+		HasMagic:     hasMagic,
+		HasLog:       hasLog,
+		HasBody:      hasBody,
+		LogSepCount:  logSepCount,
+		BodySepCount: bodySepCount,
 	}
 }
 
@@ -329,12 +343,16 @@ func validateErg(t *Erg, allIDs map[string]bool) []string {
 		}
 	}
 
-	// Rule 11: both separators present
+	// Rule 11: each separator appears exactly once
 	if !t.HasLog {
 		errors = append(errors, fmt.Sprintf("%s: missing '--- log ---' separator", name))
+	} else if t.LogSepCount > 1 {
+		errors = append(errors, fmt.Sprintf("%s: '--- log ---' separator appears %d times (expected 1)", name, t.LogSepCount))
 	}
 	if !t.HasBody {
 		errors = append(errors, fmt.Sprintf("%s: missing '--- body ---' separator", name))
+	} else if t.BodySepCount > 1 {
+		errors = append(errors, fmt.Sprintf("%s: '--- body ---' separator appears %d times (expected 1)", name, t.BodySepCount))
 	}
 
 	return errors

--- a/tickets/tools/go/main_test.go
+++ b/tickets/tools/go/main_test.go
@@ -382,3 +382,102 @@ func TestCmdValidateFileArgValidRefNoFalsePositive(t *testing.T) {
 		t.Errorf("expected exit 0 (valid ref), got %d; output: %s", exit, out)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// sweep-skip / appendToTicket: body must not be mutated by slice aliasing
+// ---------------------------------------------------------------------------
+
+// captureSweepSkip runs cmdSweepSkip(args) and returns exit code + stdout.
+func captureSweepSkip(args []string) (int, string) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	exit := cmdSweepSkip(args)
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return exit, string(out)
+}
+
+// TestSweepSkipPreservesBody guards against the slice-aliasing bug in
+// cmdSweepSkip where `beforeBody := raw[:idx]` shared the backing array
+// with the bytes from os.ReadFile and a subsequent append corrupted the
+// body. A correct implementation leaves the body byte-identical and
+// keeps exactly one `--- body ---` separator.
+func TestSweepSkipPreservesBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "0001-roundtrip.erg")
+	body := "## Context\n\nThis body must survive sweep-skip without a single byte changed.\n" +
+		"It is long enough that any aliasing append from cmdSweepSkip would visibly\n" +
+		"overwrite the start of the body section.\n\n## Actions\n1. Round-trip.\n"
+	original := minimalErg("0001", "roundtrip", nil)
+	// Replace the placeholder body with our long body.
+	original = strings.Replace(original, "Test body.\n", body, 1)
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	exit, out := captureSweepSkip([]string{path, "scope-too-large", "expires:2026-12-31T00:00Z"})
+	if exit != 0 {
+		t.Fatalf("sweep-skip exit %d, stdout=%q", exit, out)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotStr := string(got)
+
+	sepCount := strings.Count(gotStr, "\n--- body ---\n")
+	if sepCount != 1 {
+		t.Errorf("expected exactly one '--- body ---' separator, got %d", sepCount)
+	}
+
+	idx := strings.Index(gotStr, "\n--- body ---\n")
+	if idx < 0 {
+		t.Fatal("no '--- body ---' separator found")
+	}
+	gotBody := gotStr[idx+len("\n--- body ---\n"):]
+	if gotBody != body {
+		t.Errorf("body corrupted by sweep-skip\nwant: %q\n got: %q", body, gotBody)
+	}
+}
+
+// TestAppendToTicketPreservesBody confirms appendToTicket (used by
+// cmdSweepWrite) does not corrupt body content via slice aliasing.
+func TestAppendToTicketPreservesBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "0002-append.erg")
+	body := "## Context\n\nAppendToTicket must leave existing body bytes intact and\n" +
+		"only add the new section at the tail.\n"
+	original := minimalErg("0002", "append", nil)
+	original = strings.Replace(original, "Test body.\n", body, 1)
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logLine := "2026-04-29T10:00Z test note sweep-pick: picked hash:abcdef012345 scope:S risk:R"
+	addition := "## Picker assessment 2026-04-29T10:00Z\n**Decision:** picked\n"
+	if err := appendToTicket(path, logLine, addition); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotStr := string(got)
+
+	if c := strings.Count(gotStr, "\n--- body ---\n"); c != 1 {
+		t.Errorf("expected exactly one '--- body ---' separator, got %d", c)
+	}
+	if !strings.Contains(gotStr, body) {
+		t.Errorf("original body content missing from result:\n%s", gotStr)
+	}
+	if !strings.Contains(gotStr, logLine) {
+		t.Errorf("new log line missing")
+	}
+	if !strings.Contains(gotStr, addition) {
+		t.Errorf("new body section missing")
+	}
+}

--- a/tickets/tools/go/main_test.go
+++ b/tickets/tools/go/main_test.go
@@ -481,3 +481,62 @@ func TestAppendToTicketPreservesBody(t *testing.T) {
 		t.Errorf("new body section missing")
 	}
 }
+
+// TestValidateRejectsDuplicateBodySeparator guards rule 11: a ticket with
+// more than one `--- body ---` separator (the fingerprint of the
+// cmdSweepSkip aliasing bug) must fail validation rather than ship.
+func TestValidateRejectsDuplicateBodySeparator(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "0001-dup.erg")
+	content := "%erg v1\n" +
+		"Title: dup body sep\n" +
+		"Status: open\n" +
+		"Created: 2026-04-29\n" +
+		"Author: test\n" +
+		"\n--- log ---\n" +
+		"2026-04-29T00:00Z test created\n" +
+		"--- body ---\n" +
+		"first body line\n" +
+		"--- body ---\n" +
+		"after the duplicate separator\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	exit, out := captureValidate([]string{path})
+	if exit == 0 {
+		t.Fatalf("expected validate to fail, got exit 0; output: %s", out)
+	}
+	if !strings.Contains(out, "--- body ---") || !strings.Contains(out, "expected 1") {
+		t.Errorf("error message missing duplicate-separator detail: %s", out)
+	}
+}
+
+// TestValidateRejectsDuplicateLogSeparator covers the symmetric case for
+// the `--- log ---` separator.
+func TestValidateRejectsDuplicateLogSeparator(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "0001-duplog.erg")
+	content := "%erg v1\n" +
+		"Title: dup log sep\n" +
+		"Status: open\n" +
+		"Created: 2026-04-29\n" +
+		"Author: test\n" +
+		"\n--- log ---\n" +
+		"2026-04-29T00:00Z test created\n" +
+		"--- log ---\n" +
+		"2026-04-29T00:01Z test note duplicate\n" +
+		"--- body ---\n" +
+		"body\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	exit, out := captureValidate([]string{path})
+	if exit == 0 {
+		t.Fatalf("expected validate to fail, got exit 0; output: %s", out)
+	}
+	if !strings.Contains(out, "--- log ---") || !strings.Contains(out, "expected 1") {
+		t.Errorf("error message missing duplicate-separator detail: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix**: `cmdSweepSkip` corrupted ticket bodies via slice aliasing (`os.ReadFile` returns `cap > len`; `beforeBody := raw[:idx]` then `append` mutated `raw[idx:]` in place). Build the result in a fresh buffer.
- **Repair**: 8 tickets carried the corruption (0013, 0028, 0034, 0042, 0043, 0047, 0049, 0051) — bodies restored from each ticket's last clean commit.
- **Validator**: rule 11 extended to reject duplicate `--- log ---` / `--- body ---` separators (the corruption fingerprint), so any future regression is caught at commit time.

`appendToTicket` was audited (per ticket 0060 action 1) and a round-trip test confirmed it is already safe; left alone.

## Test plan

- [x] Go: `TestSweepSkipPreservesBody` (red without the fix)
- [x] Go: `TestAppendToTicketPreservesBody` (locks in current safety)
- [x] Go: `TestValidateRejectsDuplicateBodySeparator` + `…LogSeparator`
- [x] All 18 Go tests pass; all 85 Python tests pass
- [x] All 9 previously corrupt tickets now show one separator and a byte-identical pre-corruption body (verified against each ticket's `LAST_CLEAN` commit)

## Note for the operator

The system `erg` binary at `~/.local/bin/erg` is stale (Apr 13). After merge, rebuild and reinstall:

```sh
cd tickets/tools/go && go build -o ~/.local/bin/erg .
```

Closes ticket 0060 (closed in `a17ed5b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)