### PR TITLE
feat(beat,0072): housekeeping → dedicated branch + distinct PR before pick-ticket runs

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -519,24 +519,170 @@ def _pick_project() -> tuple[int, ProjectConfig]:
     return count, PROJECTS[idx]
 
 
-def _raid(project: ProjectConfig) -> tuple[str, str | None]:
-    """Run the pick→raid sequence; return (outcome, ticket_id)."""
-    ticket_id: str | None = None
-    path = project.path
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603
+        ["git", *args], capture_output=True, text=True, check=False, cwd=cwd
+    )
 
-    # Housekeeping (conditional)
-    if housekeeping_needed(path):
-        _log(f"=== housekeeping: running {_now_iso()} ===")
+
+def _gh_available() -> bool:
+    return (
+        subprocess.run(  # noqa: S603, S607
+            ["sh", "-c", "command -v gh"], capture_output=True, check=False
+        ).returncode
+        == 0
+    )
+
+
+PR_CHECK_POLL_INTERVAL_S: int = 15
+PR_CHECK_TIMEOUT_S: int = 10 * 60
+
+
+def _wait_for_pr_checks(branch: str, *, cwd: Path) -> bool:
+    """Block until all PR checks settle. Return True iff all pass."""
+    deadline = time.monotonic() + PR_CHECK_TIMEOUT_S
+    while time.monotonic() < deadline:
+        result = subprocess.run(  # noqa: S603, S607
+            ["gh", "pr", "checks", branch, "--json", "name,bucket"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd,
+        )
+        if result.returncode != 0:
+            return False
+        try:
+            checks = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return False
+        if not checks:
+            time.sleep(PR_CHECK_POLL_INTERVAL_S)
+            continue
+        buckets = {c.get("bucket") for c in checks}
+        if "pending" in buckets:
+            time.sleep(PR_CHECK_POLL_INTERVAL_S)
+            continue
+        return buckets <= {"pass"}
+    return False
+
+
+def _housekeeping_phase(project: ProjectConfig) -> str:
+    """Run housekeeping on a dedicated branch; PR+merge if commits land.
+
+    Returns one of:
+      "skipped"    — housekeeping_needed was False
+      "no-changes" — skill ran clean, produced no commits
+      "merged"     — PR opened, CI green, squash-merged into main
+      "deferred"   — commits exist locally; PR/merge automation off (no gh
+                     or BEAT_HOUSEKEEPING_PR != 1) — branch left for human
+      "ci-failed"  — PR opened but at least one check failed
+      "timeout"    — skill timed out
+      "failed"     — git/gh/skill error
+    """
+    path = project.path
+    if not housekeeping_needed(path):
+        _log(f"=== housekeeping: skipped {_now_iso()} ===")
+        return "skipped"
+
+    base = _git("rev-parse", "origin/main", cwd=path).stdout.strip()
+    if not base:
+        _log("=== housekeeping: cannot resolve origin/main ===")
+        return "failed"
+
+    nonce = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    branch = f"claude/housekeeping-{nonce}"
+    if _git("checkout", "-B", branch, base, cwd=path).returncode != 0:
+        _log(f"=== housekeeping: failed to create {branch} ===")
+        return "failed"
+
+    _log(f"=== housekeeping: running on {branch} {_now_iso()} ===")
+    os.environ["BEAT_HOUSEKEEPING_BRANCH"] = branch
+    try:
         hk_rc, _ = run_skill(
             "/housekeeping",
             budget=project.budget_housekeeping,
             timeout_s=HOUSEKEEPING_TIMEOUT_S,
             cwd=path,
         )
-        suffix = "timeout" if hk_rc == TIMEOUT_EXIT_CODE else f"rc={hk_rc}"
-        _log(f"=== housekeeping: {suffix if hk_rc != 0 else 'done'} {_now_iso()} ===")
-    else:
-        _log(f"=== housekeeping: skipped {_now_iso()} ===")
+    finally:
+        os.environ.pop("BEAT_HOUSEKEEPING_BRANCH", None)
+
+    if hk_rc == TIMEOUT_EXIT_CODE:
+        _log(f"=== housekeeping: timeout — {branch} left in place {_now_iso()} ===")
+        return "timeout"
+    if hk_rc != 0:
+        _log(f"=== housekeeping: rc={hk_rc} on {branch} {_now_iso()} ===")
+        return "failed"
+
+    n = _git("rev-list", "--count", f"{base}..HEAD", cwd=path).stdout.strip() or "0"
+    if int(n) == 0:
+        _log("=== housekeeping: no commits, deleting branch ===")
+        _git("checkout", "main", cwd=path)
+        _git("branch", "-D", branch, cwd=path)
+        return "no-changes"
+
+    _log(f"=== housekeeping: {n} commit(s) on {branch} ===")
+
+    if not (os.environ.get("BEAT_HOUSEKEEPING_PR") == "1" and _gh_available()):
+        _log(f"=== housekeeping: deferred — branch {branch} ready for review ===")
+        return "deferred"
+
+    if _git("push", "-u", "origin", branch, cwd=path).returncode != 0:
+        return "failed"
+    pr = subprocess.run(  # noqa: S603, S607
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            "main",
+            "--head",
+            branch,
+            "--title",
+            "chore: housekeeping fixes (sweep)",
+            "--body",
+            "Automated nightbeat housekeeping sweep.",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=path,
+    )
+    if pr.returncode != 0:
+        _log(f"=== housekeeping: gh pr create failed: {pr.stderr.strip()} ===")
+        return "failed"
+
+    if not _wait_for_pr_checks(branch, cwd=path):
+        _log(f"=== housekeeping: CI red on {branch} — aborting beat ===")
+        return "ci-failed"
+
+    merge = subprocess.run(  # noqa: S603, S607
+        ["gh", "pr", "merge", branch, "--squash", "--delete-branch"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=path,
+    )
+    if merge.returncode != 0:
+        _log(f"=== housekeeping: gh pr merge failed: {merge.stderr.strip()} ===")
+        return "failed"
+
+    _git("checkout", "main", cwd=path)
+    _git("pull", "--ff-only", "origin", "main", cwd=path)
+    _log(f"=== housekeeping: merged {branch} {_now_iso()} ===")
+    return "merged"
+
+
+def _raid(project: ProjectConfig) -> tuple[str, str | None]:
+    """Run the pick→raid sequence; return (outcome, ticket_id)."""
+    ticket_id: str | None = None
+    path = project.path
+
+    # Housekeeping (conditional). Aborts beat on failure/timeout/CI-red so
+    # pick-ticket → raid never runs against a known-bad main.
+    hk_outcome = _housekeeping_phase(project)
+    if hk_outcome in ("failed", "timeout", "ci-failed"):
+        return "aborted", None
 
     # Pick ticket
     hostname = socket.gethostname()

--- a/scripts/guard-no-push.sh
+++ b/scripts/guard-no-push.sh
@@ -10,6 +10,12 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
 [ -z "$cmd" ] && exit 0
 
 if echo "$cmd" | grep -qE '\bgit\s+push\b'; then
+    # Housekeeping-PR exception: when beat is driving a dedicated
+    # claude/housekeeping-* branch with PR/merge opted in, push is allowed.
+    if [ "${BEAT_HOUSEKEEPING_PR:-}" = "1" ] && [ -n "${BEAT_HOUSEKEEPING_BRANCH:-}" ] \
+        && echo "$cmd" | grep -qE "\b${BEAT_HOUSEKEEPING_BRANCH}\b"; then
+        exit 0
+    fi
     echo "BLOCKED (night-sweep): git push is not allowed in automated mode. Commits are local — a human will push." >&2
     exit 2
 fi

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -30,3 +30,15 @@ Run full repo housekeeping and act on every finding.
 6. **Timestamp.** Update STATE.md to note the housekeeping run UTC date and time, commit it.
 
 7. **Report.** Summarize what you did.
+
+## Beat mode
+
+When `BEAT_HOUSEKEEPING_BRANCH` is set in the environment, you are running
+under `beat.py` on a dedicated `claude/housekeeping-*` branch already cut
+from `origin/main`. Behaviour stays the same — commit fix-now items and the
+timestamp as usual. `beat.py` handles push, PR creation, CI verification,
+and squash-merge once you exit; do NOT push or open a PR yourself. The
+no-push guard is relaxed for that branch only.
+
+If `BEAT_HOUSEKEEPING_BRANCH` is unset (interactive `/housekeeping`), commit
+in place as before — no PR detour for hand-typed runs.

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -486,6 +486,7 @@ class TestRaid:
 
         with (
             patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=0)),
             patch("beat.run_skill", side_effect=fake_run_skill),
         ):
             beat._raid(beat.ProjectConfig(path=tmp_project))
@@ -506,6 +507,140 @@ class TestRaid:
             beat._raid(beat.ProjectConfig(path=tmp_project))
 
         assert not any("housekeeping" in c for c in calls)
+
+
+# ── housekeeping phase: dedicated branch + PR flow (ticket 0072) ──────────────
+
+
+def _git_runner(commit_count: int):
+    """Return a side_effect for _git that yields N new commits ahead of base."""
+
+    def runner(*args, cwd):
+        # First arg is the git subcommand
+        sub = args[0] if args else ""
+        if sub == "rev-parse":
+            return MagicMock(returncode=0, stdout="basesha\n", stderr="")
+        if sub == "rev-list":
+            return MagicMock(returncode=0, stdout=f"{commit_count}\n", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    return runner
+
+
+class TestHousekeepingPhase:
+    """Ticket 0072: beat-mode housekeeping runs on a dedicated branch and
+    only reaches main via a green-CI PR."""
+
+    def test_skipped_when_not_needed(self, tmp_project):
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._git") as mock_git,
+            patch("beat.run_skill") as mock_skill,
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "skipped"
+        mock_git.assert_not_called()
+        mock_skill.assert_not_called()
+
+    def test_no_changes_deletes_branch(self, tmp_project):
+        with (
+            patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=0)) as mock_git,
+            patch("beat.run_skill", return_value=(0, "")),
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "no-changes"
+        # Branch must be created then deleted; main must be checked out
+        subcommands = [call.args[0] for call in mock_git.call_args_list]
+        assert "checkout" in subcommands
+        assert "branch" in subcommands
+
+    def test_deferred_when_pr_opt_in_off(self, tmp_project, monkeypatch):
+        monkeypatch.delenv("BEAT_HOUSEKEEPING_PR", raising=False)
+        with (
+            patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=2)),
+            patch("beat.run_skill", return_value=(0, "")),
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "deferred"
+
+    def test_merged_when_pr_opt_in_and_ci_green(self, tmp_project, monkeypatch):
+        monkeypatch.setenv("BEAT_HOUSEKEEPING_PR", "1")
+        gh_calls: list[list[str]] = []
+
+        def fake_subprocess_run(argv, **kwargs):
+            if argv and argv[0] == "gh":
+                gh_calls.append(argv)
+                return MagicMock(returncode=0, stdout='[{"bucket":"pass"}]', stderr="")
+            if argv == ["sh", "-c", "command -v gh"]:
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=2)),
+            patch("beat.run_skill", return_value=(0, "")),
+            patch("beat.subprocess.run", side_effect=fake_subprocess_run),
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "merged"
+        assert any("create" in c for c in gh_calls)
+        assert any("merge" in c for c in gh_calls)
+
+    def test_ci_failed_blocks_merge(self, tmp_project, monkeypatch):
+        monkeypatch.setenv("BEAT_HOUSEKEEPING_PR", "1")
+
+        def fake_subprocess_run(argv, **kwargs):
+            if argv == ["sh", "-c", "command -v gh"]:
+                return MagicMock(returncode=0)
+            if argv and argv[:3] == ["gh", "pr", "checks"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout='[{"name":"validate","bucket":"fail"}]',
+                    stderr="",
+                )
+            if argv and argv[:3] == ["gh", "pr", "create"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=1)),
+            patch("beat.run_skill", return_value=(0, "")),
+            patch("beat.subprocess.run", side_effect=fake_subprocess_run),
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "ci-failed"
+
+    def test_skill_timeout_returns_timeout(self, tmp_project):
+        with (
+            patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=0)),
+            patch("beat.run_skill", return_value=(beat.TIMEOUT_EXIT_CODE, "")),
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "timeout"
+
+    def test_raid_aborts_on_ci_failed(self, tmp_project):
+        with patch("beat._housekeeping_phase", return_value="ci-failed"):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "aborted"
+        assert ticket is None
+
+    def test_raid_aborts_on_housekeeping_timeout(self, tmp_project):
+        with patch("beat._housekeeping_phase", return_value="timeout"):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "aborted"
+        assert ticket is None
+
+    def test_raid_continues_on_deferred(self, tmp_project):
+        with (
+            patch("beat._housekeeping_phase", return_value="deferred"),
+            patch("beat.run_skill", return_value=(0, "IDLE: empty")),
+        ):
+            outcome, _ = beat._raid(beat.ProjectConfig(path=tmp_project))
+        assert outcome == "idle"  # not "aborted"
 
 
 # ── cross-project isolation (_claude_argv project_scoped) ─────────────────────
@@ -596,6 +731,7 @@ class TestProjectScopedIsolation:
 
         with (
             patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=_git_runner(commit_count=0)),
             patch("beat.run_skill", side_effect=fake_run_skill),
         ):
             beat._raid(beat.ProjectConfig(path=tmp_project))

--- a/tickets/0072-beat-housekeeping-distinct-pr.erg
+++ b/tickets/0072-beat-housekeeping-distinct-pr.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Beat housekeeping fixes go to a dedicated branch + distinct PR, verified+merged before continuation
-Status: open
+Status: closed
 Created: 2026-05-02
 Author: user
 
 --- log ---
 2026-05-02T07:08Z user created
+2026-05-02T07:30Z claude implemented — beat.py _housekeeping_phase + guard-no-push exception + 8 new tests
 
 --- body ---
 ## Context


### PR DESCRIPTION
Closes ticket 0072.

## Summary

`beat.py` now wraps `/housekeeping` in a new `_housekeeping_phase` that:

1. Cuts a fresh `claude/housekeeping-{YYYYMMDDTHHMMSSZ}` branch off `origin/main`
2. Runs the skill there with `BEAT_HOUSEKEEPING_BRANCH` exported (so the skill can detect beat-mode if needed)
3. Counts new commits — deletes the branch and restores `main` if zero
4. When `BEAT_HOUSEKEEPING_PR=1` and `gh` is on PATH: `git push`, `gh pr create`, polls `gh pr checks` until all settle, `gh pr merge --squash --delete-branch` when green, then `git pull --ff-only` on main
5. Otherwise: leaves the branch local for human review (today's default — preserves the human-in-the-loop contract)
6. Returns a structured outcome (`skipped` / `no-changes` / `merged` / `deferred` / `ci-failed` / `timeout` / `failed`)

`_raid` aborts the beat on `failed`, `timeout`, or `ci-failed` so `pick-ticket → raid` never runs against a known-bad main.

`scripts/guard-no-push.sh`: relaxed for the dedicated branch only when `BEAT_HOUSEKEEPING_PR=1` AND `BEAT_HOUSEKEEPING_BRANCH` matches the push target.

`skills/housekeeping/SKILL.md`: a "Beat mode" note documents the contract — skill stays simple, orchestration lives in `beat.py`. Interactive `/housekeeping` is unchanged.

## Test plan

- [x] `python3 -m pytest tests/` → 94 pass (8 new `TestHousekeepingPhase` cases + 1 raid-abort case adjusted)
- [x] `cd tickets/tools/go && go test ./...` → pass
- [x] `erg validate tickets/` → PASS (69 tickets)
- [x] `bash scripts/check-project-leak.sh` → clean
- [x] `set -euo pipefail` guard check → clean
- [ ] Operator step (out of scope for this PR): install + auth `gh` on the nightbeat host, then opt in via `BEAT_HOUSEKEEPING_PR=1`. Until then, beat-mode housekeeping commits land on a local branch and the morning review pushes them.

## Notes

The push/PR/merge step is opt-in to preserve today's "commits stay local; a human pushes" contract. Flipping `BEAT_HOUSEKEEPING_PR=1` activates the full automation. The guard-no-push exception is scoped to one specific branch name so the broader no-push rule still holds for everything else the beat does.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Nci18ZPcawCf87nmxzjD4)_