### PR TITLE
fix(beat): PR #78 follow-up — deferred-checkout bug + 4 nits

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -12,6 +12,8 @@ import fcntl
 import json
 import os
 import re
+import secrets
+import shutil
 import signal
 import socket
 import subprocess
@@ -526,21 +528,22 @@ def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
 
 
 def _gh_available() -> bool:
-    return (
-        subprocess.run(  # noqa: S603, S607
-            ["sh", "-c", "command -v gh"], capture_output=True, check=False
-        ).returncode
-        == 0
-    )
+    return shutil.which("gh") is not None
 
 
 PR_CHECK_POLL_INTERVAL_S: int = 15
 PR_CHECK_TIMEOUT_S: int = 10 * 60
+PR_CHECK_TRANSIENT_RETRIES: int = 3
 
 
 def _wait_for_pr_checks(branch: str, *, cwd: Path) -> bool:
-    """Block until all PR checks settle. Return True iff all pass."""
+    """Block until all PR checks settle. Return True iff all pass.
+
+    Tolerates a small number of transient `gh pr checks` failures
+    (rate limit, network blip) before giving up.
+    """
     deadline = time.monotonic() + PR_CHECK_TIMEOUT_S
+    transient_failures = 0
     while time.monotonic() < deadline:
         result = subprocess.run(  # noqa: S603, S607
             ["gh", "pr", "checks", branch, "--json", "name,bucket"],
@@ -550,11 +553,20 @@ def _wait_for_pr_checks(branch: str, *, cwd: Path) -> bool:
             cwd=cwd,
         )
         if result.returncode != 0:
-            return False
+            transient_failures += 1
+            if transient_failures > PR_CHECK_TRANSIENT_RETRIES:
+                return False
+            time.sleep(PR_CHECK_POLL_INTERVAL_S)
+            continue
         try:
             checks = json.loads(result.stdout)
         except json.JSONDecodeError:
-            return False
+            transient_failures += 1
+            if transient_failures > PR_CHECK_TRANSIENT_RETRIES:
+                return False
+            time.sleep(PR_CHECK_POLL_INTERVAL_S)
+            continue
+        transient_failures = 0
         if not checks:
             time.sleep(PR_CHECK_POLL_INTERVAL_S)
             continue
@@ -589,7 +601,11 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
         _log("=== housekeeping: cannot resolve origin/main ===")
         return "failed"
 
-    nonce = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    nonce = (
+        datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        + "-"
+        + secrets.token_hex(2)
+    )
     branch = f"claude/housekeeping-{nonce}"
     if _git("checkout", "-B", branch, base, cwd=path).returncode != 0:
         _log(f"=== housekeeping: failed to create {branch} ===")
@@ -624,11 +640,21 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
     _log(f"=== housekeeping: {n} commit(s) on {branch} ===")
 
     if not (os.environ.get("BEAT_HOUSEKEEPING_PR") == "1" and _gh_available()):
+        # Switch back to main so pick-ticket → raid don't run on the
+        # housekeeping branch and pick up its commits as their base.
+        _git("checkout", "main", cwd=path)
         _log(f"=== housekeeping: deferred — branch {branch} ready for review ===")
         return "deferred"
 
     if _git("push", "-u", "origin", branch, cwd=path).returncode != 0:
         return "failed"
+    log_lines = _git(
+        "log", "--format=- %s", f"{base}..HEAD", cwd=path
+    ).stdout.strip()
+    body = (
+        "Automated nightbeat housekeeping sweep.\n\n## Changes\n\n"
+        + (log_lines or "(none)")
+    )
     pr = subprocess.run(  # noqa: S603, S607
         [
             "gh",
@@ -639,9 +665,9 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
             "--head",
             branch,
             "--title",
-            "chore: housekeeping fixes (sweep)",
+            f"chore: housekeeping fixes (sweep) — {n} commit(s)",
             "--body",
-            "Automated nightbeat housekeeping sweep.",
+            body,
         ],
         capture_output=True,
         text=True,

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -550,20 +550,27 @@ class TestHousekeepingPhase:
         ):
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
         assert outcome == "no-changes"
-        # Branch must be created then deleted; main must be checked out
-        subcommands = [call.args[0] for call in mock_git.call_args_list]
-        assert "checkout" in subcommands
-        assert "branch" in subcommands
+        calls = [call.args for call in mock_git.call_args_list]
+        # Branch deletion must specifically run `git branch -D <branch>`
+        delete_calls = [c for c in calls if c[:2] == ("branch", "-D")]
+        assert len(delete_calls) == 1
+        assert delete_calls[0][2].startswith("claude/housekeeping-")
+        # And `git checkout main` must run before the delete
+        assert ("checkout", "main") in [c[:2] for c in calls]
 
     def test_deferred_when_pr_opt_in_off(self, tmp_project, monkeypatch):
         monkeypatch.delenv("BEAT_HOUSEKEEPING_PR", raising=False)
         with (
             patch("beat.housekeeping_needed", return_value=True),
-            patch("beat._git", side_effect=_git_runner(commit_count=2)),
+            patch("beat._git", side_effect=_git_runner(commit_count=2)) as mock_git,
             patch("beat.run_skill", return_value=(0, "")),
         ):
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
         assert outcome == "deferred"
+        # Bug regression: deferred must checkout main so pick-ticket / raid
+        # don't run on the housekeeping branch (PR #78 review finding).
+        calls = [call.args for call in mock_git.call_args_list]
+        assert ("checkout", "main") in [c[:2] for c in calls]
 
     def test_merged_when_pr_opt_in_and_ci_green(self, tmp_project, monkeypatch):
         monkeypatch.setenv("BEAT_HOUSEKEEPING_PR", "1")
@@ -573,14 +580,13 @@ class TestHousekeepingPhase:
             if argv and argv[0] == "gh":
                 gh_calls.append(argv)
                 return MagicMock(returncode=0, stdout='[{"bucket":"pass"}]', stderr="")
-            if argv == ["sh", "-c", "command -v gh"]:
-                return MagicMock(returncode=0)
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with (
             patch("beat.housekeeping_needed", return_value=True),
             patch("beat._git", side_effect=_git_runner(commit_count=2)),
             patch("beat.run_skill", return_value=(0, "")),
+            patch("beat._gh_available", return_value=True),
             patch("beat.subprocess.run", side_effect=fake_subprocess_run),
         ):
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
@@ -592,8 +598,6 @@ class TestHousekeepingPhase:
         monkeypatch.setenv("BEAT_HOUSEKEEPING_PR", "1")
 
         def fake_subprocess_run(argv, **kwargs):
-            if argv == ["sh", "-c", "command -v gh"]:
-                return MagicMock(returncode=0)
             if argv and argv[:3] == ["gh", "pr", "checks"]:
                 return MagicMock(
                     returncode=0,
@@ -608,10 +612,34 @@ class TestHousekeepingPhase:
             patch("beat.housekeeping_needed", return_value=True),
             patch("beat._git", side_effect=_git_runner(commit_count=1)),
             patch("beat.run_skill", return_value=(0, "")),
+            patch("beat._gh_available", return_value=True),
             patch("beat.subprocess.run", side_effect=fake_subprocess_run),
         ):
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
         assert outcome == "ci-failed"
+
+    def test_wait_for_pr_checks_tolerates_transient_failures(self, tmp_path):
+        # First two calls fail (returncode=1), third returns a green check.
+        responses = [
+            MagicMock(returncode=1, stdout="", stderr="rate limited"),
+            MagicMock(returncode=1, stdout="", stderr="network blip"),
+            MagicMock(returncode=0, stdout='[{"bucket":"pass"}]', stderr=""),
+        ]
+        with (
+            patch("beat.subprocess.run", side_effect=responses),
+            patch("beat.time.sleep"),  # don't actually sleep in the test
+        ):
+            result = beat._wait_for_pr_checks("claude/housekeeping-x", cwd=tmp_path)
+        assert result is True
+
+    def test_wait_for_pr_checks_gives_up_after_too_many_failures(self, tmp_path):
+        always_fail = MagicMock(returncode=1, stdout="", stderr="auth error")
+        with (
+            patch("beat.subprocess.run", return_value=always_fail),
+            patch("beat.time.sleep"),
+        ):
+            result = beat._wait_for_pr_checks("claude/housekeeping-x", cwd=tmp_path)
+        assert result is False
 
     def test_skill_timeout_returns_timeout(self, tmp_project):
         with (


### PR DESCRIPTION
Post-merge review of PR #78 surfaced one real bug and four quality nits. This PR fixes them.

## Bug

`_housekeeping_phase` `deferred` return path now checks out `main` before returning. Previously left the dedicated `claude/housekeeping-*` branch checked out, so the subsequent pick-ticket / raid ran on it and would carry the unreviewed housekeeping commits into the feature branch — the exact pollution ticket 0072 was meant to prevent. The `no-changes` and `merged` paths already did this; `deferred` was the odd one out.

## Nits

- **`_gh_available`**: `shutil.which("gh") is not None` instead of shelling out to `sh -c command -v gh`. Clearer, faster, no shell.
- **`_wait_for_pr_checks`**: tolerate up to 3 transient `gh pr checks` failures (rate limits, JSON parse blips, network) before declaring CI failed. Previously a single non-zero `gh` exit aborted the beat.
- **PR title and body**: title carries commit count (`chore: housekeeping fixes (sweep) — N commit(s)`); body lists the actual commit subjects between `origin/main` and the branch, so a reviewer can see what's being changed without opening the diff.
- **Nonce**: append 4 hex chars from `secrets.token_hex(2)` so two beats in the same second cannot collide on the same branch name.

## Tests

- `test_no_changes_deletes_branch`: tightened to assert the specific `git branch -D <branch>` call (was loose — passed even if cleanup was removed).
- `test_deferred_when_pr_opt_in_off`: now also asserts `git checkout main` runs (regression guard for the bug above).
- New `test_wait_for_pr_checks_tolerates_transient_failures` (3 transient 1-exits, then green → True).
- New `test_wait_for_pr_checks_gives_up_after_too_many_failures` (always 1-exit → False).
- `test_merged_when_pr_opt_in_and_ci_green` and `test_ci_failed_blocks_merge`: patch `beat._gh_available` directly now (the `sh -c command -v gh` shellout is gone).

## Test plan

- [x] `python3 -m pytest tests/` → 96 pass
- [x] `cd tickets/tools/go && go test ./...` → pass
- [x] `erg validate tickets/` → PASS (69 tickets)
- [x] `bash scripts/check-project-leak.sh` → clean
- [x] `set -euo pipefail` guard → clean

---
_Generated by [Claude Code](https://claude.ai/code/session_016Nci18ZPcawCf87nmxzjD4)_