### PR TITLE
refactor(ticket-new): delegate ID computation to erg next-id

### DIFF
--- a/skills/ticket-new/SKILL.md
+++ b/skills/ticket-new/SKILL.md
@@ -15,7 +15,8 @@ from a conversation. Extract the intent and normalize to `%erg v1`.
 
 1. Determine the next ID:
    ```bash
-   erg next-id tickets/
+   ERG=${ERG:-tickets/tools/go/erg}
+   $ERG next-id tickets/
    ```
 
 2. Choose a slug: lowercase kebab-case, ASCII only (`[a-z0-9-]`), derived from the title.

--- a/skills/ticket-new/SKILL.md
+++ b/skills/ticket-new/SKILL.md
@@ -13,17 +13,10 @@ from a conversation. Extract the intent and normalize to `%erg v1`.
 
 ## Steps
 
-1. Determine the next ID — take the maximum across local files **and** the cached
-   `origin/main` ref, then increment. No network call; uses whatever the last
-   `git fetch`/`pull`/`push` left in the local ref store.
+1. Determine the next ID:
    ```bash
-   LOCAL=$(ls tickets/*.erg tickets/archive/*.erg 2>/dev/null \
-     | sed 's|.*/||; s|-.*||' | sort -n | tail -1)
-   REMOTE=$(git ls-tree --name-only origin/main tickets/ 2>/dev/null \
-     | grep '\.erg$' | sed 's|-.*||' | sort -n | tail -1)
-   MAX=$(printf '%s\n%s\n' "$LOCAL" "$REMOTE" | grep -v '^$' | sort -n | tail -1)
+   erg next-id tickets/
    ```
-   Increment `MAX` by 1, zero-pad to 4 digits. If both are empty, start at `0001`.
 
 2. Choose a slug: lowercase kebab-case, ASCII only (`[a-z0-9-]`), derived from the title.
 

--- a/tickets/0074-ticket-new-use-erg-next-id.erg
+++ b/tickets/0074-ticket-new-use-erg-next-id.erg
@@ -1,0 +1,28 @@
+%erg v1
+Title: Simplify ticket-new skill to use erg next-id
+Status: open
+Created: 2026-05-02
+Author: MinhHaDuong
+
+--- log ---
+2026-05-02T23:00Z MinhHaDuong created
+
+--- body ---
+## Context
+The ticket-new skill embeds a 5-line bash pipeline to compute the next ticket
+ID by scanning local files and the cached origin/main ref. The erg binary
+already provides `erg next-id` for exactly this purpose. The inline script is
+redundant and contradicts the project principle that the LLM never computes
+hashes or scans ticket bodies.
+
+## Actions
+1. Replace the inline bash ID-computation block in skills/ticket-new/SKILL.md
+   with a single `erg next-id tickets/` call.
+
+## Test
+Read the updated SKILL.md and confirm the five-line bash block is gone and
+`erg next-id tickets/` appears in step 1.
+
+## Exit criteria
+skills/ticket-new/SKILL.md step 1 reads `erg next-id tickets/` with no inline
+shell pipeline.


### PR DESCRIPTION
Closes ticket 0074.

## Summary
- Replace the 5-line inline bash pipeline in `ticket-new/SKILL.md` step 1 with `erg next-id tickets/`
- The `erg` binary already provides this command; the inline script was redundant

## Test plan
- [ ] Read `skills/ticket-new/SKILL.md` — step 1 shows `erg next-id tickets/`, no bash pipeline
- [ ] `erg next-id` is available in the harness (`tickets/tools/go/erg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)