### PR TITLE
fix(security): stop leaking API keys in ps -ef

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: All hook scripts must have set -euo pipefail
         run: |
-          missing=$(grep -L 'set -euo pipefail' scripts/*.sh | grep -v 'shell-init\.sh' || true)
+          missing=$(grep -L 'set -euo pipefail' scripts/*.sh | grep -Ev 'shell-init\.sh|bash-env\.sh' || true)
           if [ -n "$missing" ]; then
             echo "FAIL: missing set -euo pipefail in:"
             echo "$missing"

--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Loaded via BASH_ENV — sourced at startup of every Claude Code bash subprocess.
+# Exports .env secrets into the process environment without inlining them in argv
+# (inlining in argv leaks secrets to ps -ef, which is visible to all local users).
+#
+# BASH_ENV is honored by non-interactive bash (i.e. "bash -c ..."), which is
+# exactly what Claude Code uses for Bash tool calls.
+
+set -a  # mark all subsequent assignments for export
+
+[ -f "$HOME/.claude/.env" ] && source "$HOME/.claude/.env"
+
+# Project-level .env, identified by PWD (Claude Code sets PWD to the project dir
+# for each subprocess). Skip if it resolves to the same file as the user-level one.
+if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
+    _be_proj="$(realpath "$PWD/.env" 2>/dev/null)"
+    _be_user="$(realpath "$HOME/.claude/.env" 2>/dev/null)"
+    [ "$_be_proj" != "$_be_user" ] && source "$PWD/.env"
+    unset _be_proj _be_user
+fi
+
+set +a

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
 set -euo pipefail
-# SessionStart hook: load env vars, enforce worktree isolation.
+# SessionStart hook: enforce worktree isolation.
 # Runs at the beginning of every Claude Code session.
-
-# Persist .env vars to CLAUDE_ENV_FILE so Bash subprocesses (uv run, etc.) see them.
-# Claude itself auto-loads .env, but child processes don't inherit its environment.
-persist_env() {
-    local envfile="$1"
-    [ -f "$envfile" ] || return 0
-    [ -n "${CLAUDE_ENV_FILE:-}" ] || return 0
-    grep -v '^\s*#' "$envfile" | grep -v '^\s*$' | sed 's/^export //' >> "$CLAUDE_ENV_FILE" || true
-}
-
-# User-level env
-persist_env "$HOME/.claude/.env"
+#
+# NOTE: env vars (.env secrets) are injected into bash subprocesses via BASH_ENV
+# (settings.json → env.BASH_ENV → scripts/bash-env.sh). Do NOT use CLAUDE_ENV_FILE
+# for secrets: that mechanism inlines KEY=VALUE in argv, leaking to ps -ef.
 
 # Worktree instruction — skip in automated night-sweep runs
 if [[ -z "${CLAUDE_NIGHT_SWEEP:-}" ]]; then
@@ -41,11 +33,6 @@ exec >/dev/null 2>&1
 
 # Everything below requires a project directory
 [ -n "${CLAUDE_PROJECT_DIR:-}" ] && cd "$CLAUDE_PROJECT_DIR" || exit 0
-
-# Project-level env (skip if same as user-level to avoid duplication)
-if [ "$(readlink -f "${CLAUDE_PROJECT_DIR:-}/.env" 2>/dev/null)" != "$(readlink -f "$HOME/.claude/.env" 2>/dev/null)" ]; then
-    persist_env "$CLAUDE_PROJECT_DIR/.env"
-fi
 
 # Activate project git hooks if a pre-commit hook exists
 if [ -f hooks/pre-commit ]; then

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "UV_ENV_FILE": "/home/haduong/.claude/.env"
+    "UV_ENV_FILE": "/home/haduong/.claude/.env",
+    "BASH_ENV": "/home/haduong/.claude/scripts/bash-env.sh"
   },
   "permissions": {
     "allow": [

--- a/tickets/0076-stop-ps-leak-api-keys.erg
+++ b/tickets/0076-stop-ps-leak-api-keys.erg
@@ -1,0 +1,40 @@
+%erg v1
+Title: Stop leaking API keys in ps -ef via CLAUDE_ENV_FILE
+Status: open
+Created: 2026-05-03
+Author: claude
+
+--- log ---
+2026-05-03T10:00Z claude created
+2026-05-03T10:00Z claude linked gh#83
+
+--- body ---
+## Problem
+
+`on-start.sh` wrote `KEY=VALUE` pairs to `CLAUDE_ENV_FILE`. Claude Code inlines those as
+shell variable assignments before every Bash tool call:
+
+    /bin/bash -c "source snapshot.sh && KEY=val eval 'command'"
+
+The secrets end up in argv, which is world-readable via `ps -ef`. Multiple orphaned bash
+processes (PIDs 1258886, 1806318, 2246411, 2329898, 2330495) were discovered with all API
+keys exposed since 2026-04-30 — ~3 days.
+
+## Fix (implemented in gh#83)
+
+Switch to `BASH_ENV`: bash sources the file before each non-interactive invocation,
+exporting secrets into the process environment block (not argv). Environment blocks
+are only readable by the process owner and root.
+
+Changes:
+- `scripts/bash-env.sh` — new script: `set -a`, sources `~/.claude/.env` and `$PWD/.env`, `set +a`
+- `settings.json` — added `"BASH_ENV": ".../bash-env.sh"` to `env` section
+- `scripts/on-start.sh` — removed `persist_env` function and all calls
+
+Also swept 689 stale `session-env/*/sessionstart-hook-*.sh` files containing plaintext secrets.
+
+## Exit criteria
+
+- [ ] PR #83 merged
+- [ ] CI green (pipefail-guard excludes `bash-env.sh` — same rationale as `shell-init.sh`)
+- [ ] Fresh session: `ps -ef | grep -E 'sk-ant|HAL_PASSWORD'` returns empty


### PR DESCRIPTION
## Summary

- **Root cause**: `on-start.sh` wrote `KEY=VALUE` pairs to `CLAUDE_ENV_FILE`; Claude Code inlines those as shell assignments before every Bash tool call (`bash -c "KEY=val eval 'cmd'"`), exposing secrets in argv — visible to all local users via `ps -ef`.
- **Fix**: switch to `BASH_ENV` — bash sources the file before each non-interactive invocation, exporting secrets into the process environment block (not argv).
- **Cleanup**: removed 689 stale `session-env/*/sessionstart-hook-*.sh` files that contained plaintext secrets.

## Changes

| File | Change |
|------|--------|
| `scripts/bash-env.sh` | New: sources `~/.claude/.env` and `$PWD/.env` with `set -a`/`set +a` — exports vars without touching argv |
| `settings.json` | Added `"BASH_ENV": ".../bash-env.sh"` to the `env` section |
| `scripts/on-start.sh` | Removed `persist_env` function and all calls; added comment explaining why `CLAUDE_ENV_FILE` must not be used for secrets |

## Test plan

- [x] `BASH_ENV=/tmp/be-test.sh bash -c 'echo $VAR'` confirmed working before implementation
- [x] `BASH_ENV` honored even with the snapshot-sourcing preamble (`bash -c "source snapshot.sh && eval '...'"`)
- [ ] After merging: start a fresh session, run a Bash command, then `ps -ef | grep -E 'sk-ant|sk-proj|HAL_PASSWORD'` from another terminal — should be empty

## Security note

Keys were exposed in `ps -ef` from April 30 to May 3 (≈3 days). This fix prevents future exposure; key rotation is still recommended for all keys that were visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)