### PR TITLE
ticket(0042): refine design — index-based lazy load, portable, 0021 gates

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -51,6 +51,7 @@ Level 4 (Hooks) + raid + `/verify` loop + git-erg tickets + bibliography pipelin
 - 0069 — per-project beat config (.claude/beat.json) with interval_minutes
 - 0070 — /dream skill — autonomous nightly memory consolidation
 - 0073 — hasBranch unit test (gap found in PR #81 review)
+- 0075 — audit disable-model-invocation in ticket-* skills
 - 0054 — [discussion] restore Five-Claws phase announcement at session start
 - 0055 — [discussion] milestone/epic layer above tickets
 - 0056 — [discussion] mid-session pause/resume checkpoints

--- a/tickets/0042-replace-harness-rules-with-hooks.erg
+++ b/tickets/0042-replace-harness-rules-with-hooks.erg
@@ -1,5 +1,5 @@
 %erg v1
-Title: Replace harness-rules skill with context-aware hook injection
+Title: Replace harness-rules skill with index-based lazy load
 Status: open
 Created: 2026-04-28
 Author: claude
@@ -66,7 +66,8 @@ follow-up exchange for the architectural rationale.
 ## Dependencies
 
 - Ticket 0021 (verify-adherence stack-agnostic) — mechanical ex-post
-  compliance check; this ticket's behavioral safety net.
+  compliance check; this ticket's behavioral safety net. Already closed
+  (PR #59); referenced here as the delivered mechanism, not open work.
 
 ## Test
 

--- a/tickets/0042-replace-harness-rules-with-hooks.erg
+++ b/tickets/0042-replace-harness-rules-with-hooks.erg
@@ -10,6 +10,7 @@ Author: claude
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:7aedbe92df8c expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:edaeb529c775 expires:2026-04-30T09:21Z
 2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
+2026-05-03T09:00Z haduong note design refined: session start loads only a rules index (harness-rules/README.md); agents read rule files on demand; verify-adherence (ticket 0021) is the mechanical ex-post check. Portability goal: plain markdown, not Claude Code-specific mechanisms like .claude/rules/ globs.
 --- body ---
 ## Context
 
@@ -21,9 +22,14 @@ not a runtime guarantee. The pattern also fights Anthropic's progressive
 disclosure model: the body loads unconditionally, occupying ~1500 tokens
 of every session whether or not the rules apply to the task.
 
-Hooks are the deterministic mechanism for unconditional injection.
-Rules that must always fire belong in hooks, not in a skill description
-that hopes the model reads it.
+**Refined design (2026-05-03)**: rather than injecting rule content via
+hooks, session start injects only a lightweight index
+(`skills/harness-rules/README.md`) that names each rule file and its
+scope. The agent reads individual rule files on demand. Compliance is
+verified ex post by the verify-adherence step (ticket 0021), not by
+trusting that the agent internalized context at load time. This keeps
+the mechanism agent-portable — plain markdown files, no Claude
+Code-specific frontmatter.
 
 See `docs/2026-04-28-metaskill-panorama.md` §F4 and the harness-rules
 follow-up exchange for the architectural rationale.
@@ -31,79 +37,74 @@ follow-up exchange for the architectural rationale.
 ## Relevant files
 
 - `skills/harness-rules/SKILL.md` — the umbrella, to be removed
-- `skills/harness-rules/workflow.md` — unconditional, → hook
-- `skills/harness-rules/git.md` — unconditional, → hook
-- `skills/harness-rules/state.md` — only used by `/end-session`, → fold into that skill
-- `skills/harness-rules/tickets.md` — used by `/new-ticket` + `/ticket-*`, → reference file shared across those skills
-- `skills/harness-rules/coding-python.md` — conditional on Python project, → PreToolUse hook on Edit/Write when `pyproject.toml` exists
-- `scripts/on-start.sh` — SessionStart hook, target for workflow.md + git.md content
-- `settings.json` — register the new PreToolUse hook for coding-python
+- `skills/harness-rules/README.md` — **new**: lightweight index, injected at session start via hook
+- `skills/harness-rules/workflow.md` — unconditional, listed in index
+- `skills/harness-rules/git.md` — unconditional, listed in index
+- `skills/harness-rules/state.md` — scoped to `/end-session`, listed in index
+- `skills/harness-rules/tickets.md` — scoped to ticket-* skills, listed in index
+- `skills/harness-rules/coding-python.md` — conditional on Python project, listed in index
+- `scripts/on-start.sh` — SessionStart hook; emit the index (not full rule bodies)
+- `settings.json` — remove hook for harness-rules invocation if any
 
 ## Actions
 
-1. Audit each companion file: classify as **unconditional** (every
-   session), **scoped** (only N skills), or **conditional** (project
-   shape). Decision table goes in the PR description.
-2. **Unconditional** rules (workflow.md, git.md) → emit from
-   `on-start.sh` as additional context on session start. Keep the lines
-   above the `exec >/dev/null` cutoff so they actually reach the
-   conversation.
-3. **Scoped** rules (state.md, tickets.md) → move into the bodies (or
-   shared `references/` directory) of the skills that use them.
-   `/end-session` references state.md; `/new-ticket`, `/ticket-new`,
-   `/ticket-claim`, `/ticket-close`, `/ticket-release`, `/ticket-ready`
-   reference tickets.md.
-4. **Conditional** rules (coding-python.md) → register a PreToolUse
-   hook in `settings.json` that injects the file when:
-   - tool is Edit/Write/NotebookEdit, AND
-   - target path matches `*.py`, OR project root has `pyproject.toml`
-5. Delete `skills/harness-rules/` once all consumers are converted.
-6. Update `README.md` (lists harness-rules in the structure tree) and
-   `STATE.md` (mentions auto-invoked rules implicitly).
+1. Write `skills/harness-rules/README.md` as a one-screen index:
+   one row per rule file, with its scope signal (always / skill-list /
+   condition). This is what the hook emits — nothing else.
+2. Update `on-start.sh` to `cat skills/harness-rules/README.md` above
+   the `exec >/dev/null` cutoff so it reaches the conversation.
+   Remove any existing full-body injection of harness-rules content.
+3. Remove `skills/harness-rules/SKILL.md` (the persuasion-phrase
+   wrapper is replaced by the deterministic hook).
+4. Keep the individual rule files (`workflow.md`, `git.md`, etc.) in
+   place — agents read them on demand via the index pointers.
+5. Update `README.md` and `STATE.md` to reflect the new structure.
+6. Confirm ticket 0021 (verify-adherence stack-agnostic) covers
+   mechanical ex-post checking of the rules that matter most;
+   add any gaps to 0021 rather than here.
+
+## Dependencies
+
+- Ticket 0021 (verify-adherence stack-agnostic) — mechanical ex-post
+  compliance check; this ticket's behavioral safety net.
 
 ## Test
 
-Red step: a test that the rules content is reachable when expected and
-absent when not.
-
 - `tests/test_harness_rules_injection.sh`:
-  - Spawn a Claude Code session in a non-Python project. Assert
-    coding-python.md content does **not** appear in the session
-    transcript.
-  - Spawn a session in a Python project (`pyproject.toml` present)
-    and trigger an Edit on a `.py` file. Assert coding-python.md
-    content **does** appear before the edit completes.
-  - Spawn any session. Assert workflow.md and git.md content appears
-    in the SessionStart hook output (verifiable via a fixture session).
+  - Spawn any session. Assert `README.md` index content appears in
+    the SessionStart hook output; assert individual rule file bodies
+    do **not** appear unless the agent reads them explicitly.
+  - Spawn a Python project session, trigger an Edit on `.py`. Assert
+    the agent reads `coding-python.md` before editing (transcript check).
 
 ## Verification
 
-- [ ] `find skills/harness-rules` returns nothing
-- [ ] `grep -r "harness-rules" skills/ scripts/ settings.json README.md` returns no matches
-- [ ] Non-Python project session does not load coding-python.md
-- [ ] Python project Edit on `.py` triggers coding-python.md injection
+- [ ] `find skills/harness-rules -name SKILL.md` returns nothing
+- [ ] `on-start.sh` emits only the index, not rule bodies
+- [ ] `grep -r "harness-rules" skills/ scripts/ settings.json README.md` returns no spurious matches
 - [ ] `nightbeat-report` for the week after the change shows no spike
-      in rule-violation patterns (baseline comparison)
+      in rule-violation patterns (baseline comparison against 0021 output)
 - [ ] CI green: `validate-tickets`, `skill-lint`, `leak-guard`,
       `pipefail-guard`
 
 ## Invariants
 
 - The Five Claws workflow phases remain documented somewhere reachable
-  (probably README.md or a single `docs/workflow.md` reference).
+  (probably in `workflow.md` via the index).
 - `/orchestrator`, `/verify`, `/celebrate` continue to read consistent
-  rules (they currently inherit from harness-rules being always loaded;
-  they may need explicit references after the change).
+  rules — they can now do so explicitly via the index.
 - No behavioral regression on the autonomous nightbeat channel — the
   weekly comparison above gates this.
+- Mechanism is agent-portable: plain markdown, no `.claude/rules/`
+  globs or other Claude Code-specific injection.
 
 ## Exit criteria
 
-- `skills/harness-rules/` removed.
-- Rules previously in companion files are injected by hooks (always)
-  or referenced explicitly by the skills that need them (scoped).
+- `skills/harness-rules/SKILL.md` removed; `README.md` index in place.
+- `on-start.sh` emits only the index at session start.
+- Individual rule files remain readable on demand.
+- Ticket 0021 verify-adherence covers the rules that matter most.
 - One week of nightbeat runs after merge shows no rule-adherence
   regression vs. the prior week.
 - Token budget per session reduced by the size of harness-rules
-  bodies on tasks that don't need them (measurable via session-end
-  token counts in telemetry).
+  bodies on tasks that don't need them.


### PR DESCRIPTION
## Summary

- **STATE.md**: add missing ticket 0075 to open tickets list (healthcheck fix-now)
- **ticket 0042**: redesign harness-rules replacement — session start emits a lightweight `harness-rules/README.md` index; agents read rule files on demand; verify-adherence (0021) provides mechanical ex-post checking

## Design change in 0042

Old approach: hooks inject full rule file content into every session (~1500 tokens unconditionally).

New approach:
- `on-start.sh` emits only `harness-rules/README.md` (index of rule files + their scope)
- Agent reads individual rule files on demand from the index
- Compliance checked ex post by ticket 0021 (verify-adherence stack-agnostic)
- Mechanism is agent-portable: plain markdown, no `.claude/rules/` globs or Claude Code-specific frontmatter

## Test plan

- [ ] Confirm `STATE.md` open tickets list now includes 0075
- [ ] Confirm ticket 0042 body reflects index-based design and names 0021 as dependency

🤖 Generated with [Claude Code](https://claude.ai/claude-code)