### PR TITLE
ticket(0077): mechanize ticket-close — delegate to erg close

### DIFF
--- a/skills/ticket-close/SKILL.md
+++ b/skills/ticket-close/SKILL.md
@@ -3,17 +3,11 @@ name: ticket-close
 description: Close a local ticket.
 disable-model-invocation: false
 user-invocable: true
-argument-hint: <ticket-id>
+argument-hint: <ticket-id> [reason]
 ---
 
 # Close ticket $ARGUMENTS
 
-## Steps
-
-1. Find the ticket file: `tickets/$ARGUMENTS-*.erg`
-
-2. Update the ticket:
-   - Change `Status:` line to `Status: closed` (works from any prior status)
-   - Append log line: `{timestamp} {agent} status closed — {reason}`
-
-3. Commit the ticket status change.
+1. Parse `$ARGUMENTS`: first word is `<id>`, rest is `<reason>` (default: `done`).
+2. Run: `${ERG:-erg} close <id> <reason>`
+3. Commit: `git add tickets/ && git commit -m "ticket(<id>): close — <reason>"`


### PR DESCRIPTION
## Summary
- Replaces LLM file-editing in ticket-close skill with `erg close` delegation
- Adds default reason ("done") when only ticket id is provided  
- Updates argument-hint to document optional reason parameter
- Skill body reduced to 3 lines (from ~10)

## Exit criteria (from ticket)
- [x] ticket-close skill body is ≤10 lines
- [x] No LLM file-editing steps remain in the skill body
- [ ] Invoking `/ticket-close 0001` calls `erg close 0001 done` and exits cleanly (manual test needed)

## Test plan
- [ ] Verify `erg close` is called correctly when reason is provided
- [ ] Verify default reason "done" is used when reason omitted
- [ ] Verify commit message follows convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)