### PR TITLE
ticket(0073): add unit test for hasBranch

### DIFF
--- a/tickets/tools/go/main_test.go
+++ b/tickets/tools/go/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -289,5 +290,147 @@ func TestValidateRejectsDuplicateLogSeparator(t *testing.T) {
 	}
 	if !strings.Contains(out, "--- log ---") || !strings.Contains(out, "expected 1") {
 		t.Errorf("error message missing duplicate-separator detail: %s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hasBranch — git branch claim-check
+// ---------------------------------------------------------------------------
+
+// runGit runs a git command in dir and fails the test if the command errors.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s in %s failed: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+}
+
+// newGitRepo creates a fresh temp git repo, configures user identity, and
+// chdirs into it. The returned cleanup restores the original cwd. Tests that
+// use this helper must not run in parallel — they all mutate process cwd.
+func newGitRepo(t *testing.T) (string, func()) {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q", "-b", "main")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "test")
+	runGit(t, repo, "config", "commit.gpgsign", "false")
+	runGit(t, repo, "config", "tag.gpgsign", "false")
+	runGit(t, repo, "commit", "--allow-empty", "-q", "-m", "init")
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir to %s: %v", repo, err)
+	}
+	cleanup := func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Errorf("restore cwd to %s: %v", prev, err)
+		}
+	}
+	t.Cleanup(cleanup)
+	return repo, cleanup
+}
+
+// TestHasBranchLocalMatch covers the happy path: a local branch whose name
+// contains the 4-digit ticket ID makes hasBranch return true.
+func TestHasBranchLocalMatch(t *testing.T) {
+	repo, _ := newGitRepo(t)
+	runGit(t, repo, "checkout", "-q", "-b", "0099-foo")
+
+	if !hasBranch("0099") {
+		t.Errorf("hasBranch(\"0099\") = false, want true (branch 0099-foo exists locally)")
+	}
+}
+
+// TestHasBranchLocalNoMatch covers two negative cases:
+//   1. No matching branch exists in a fresh repo.
+//   2. A matching branch existed but was deleted — hasBranch must return
+//      false again afterwards.
+func TestHasBranchLocalNoMatch(t *testing.T) {
+	repo, _ := newGitRepo(t)
+
+	// Pre-creation: nothing matches 0098.
+	if hasBranch("0098") {
+		t.Errorf("hasBranch(\"0098\") = true before any branch created, want false")
+	}
+
+	// Create then delete a matching branch; final state must report false.
+	runGit(t, repo, "checkout", "-q", "-b", "0098-bar")
+	runGit(t, repo, "checkout", "-q", "main")
+	runGit(t, repo, "branch", "-q", "-D", "0098-bar")
+
+	if hasBranch("0098") {
+		t.Errorf("hasBranch(\"0098\") = true after branch deleted, want false")
+	}
+}
+
+// TestHasBranchRemoteMatch verifies that a branch which exists only on a
+// remote (origin/0099-baz) is detected via the `git branch -r` fallback.
+func TestHasBranchRemoteMatch(t *testing.T) {
+	root := t.TempDir()
+	bare := filepath.Join(root, "bare.git")
+	clone := filepath.Join(root, "clone")
+
+	if err := os.MkdirAll(bare, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(clone, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, bare, "init", "-q", "--bare", "-b", "main")
+
+	runGit(t, clone, "init", "-q", "-b", "main")
+	runGit(t, clone, "config", "user.email", "test@example.com")
+	runGit(t, clone, "config", "user.name", "test")
+	runGit(t, clone, "config", "commit.gpgsign", "false")
+	runGit(t, clone, "config", "tag.gpgsign", "false")
+	runGit(t, clone, "commit", "--allow-empty", "-q", "-m", "init")
+	runGit(t, clone, "remote", "add", "origin", bare)
+	runGit(t, clone, "checkout", "-q", "-b", "0099-baz")
+	runGit(t, clone, "push", "-q", "origin", "0099-baz")
+	// Move local HEAD off the matching branch and delete it locally so the
+	// only place 0099 lives is on origin.
+	runGit(t, clone, "checkout", "-q", "main")
+	runGit(t, clone, "branch", "-q", "-D", "0099-baz")
+	runGit(t, clone, "fetch", "-q", "origin")
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := os.Chdir(clone); err != nil {
+		t.Fatalf("chdir clone: %v", err)
+	}
+
+	if !hasBranch("0099") {
+		t.Errorf("hasBranch(\"0099\") = false, want true (origin/0099-baz exists)")
+	}
+}
+
+// TestHasBranchOfflineFallback verifies that when there is no remote
+// configured (so `git branch -r` returns empty / does not error in a way
+// that propagates), hasBranch returns false rather than panicking. This
+// guards the offline-safe contract documented above the function.
+func TestHasBranchOfflineFallback(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("hasBranch panicked on offline/no-remote repo: %v", r)
+		}
+	}()
+
+	newGitRepo(t)
+	if hasBranch("0099") {
+		t.Errorf("hasBranch(\"0099\") = true on empty no-remote repo, want false")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds unit-test coverage for `hasBranch(id string) bool` in `tickets/tools/go/main.go`, the sole claim-check used by `cmdReady`/`cmdGraph` after the branch-as-claim migration (ticket 0066).
- Four cases covered:
  1. **Local match** — branch `0099-foo` exists locally, `hasBranch("0099")` returns `true`.
  2. **Local no-match** — asserts `false` *before* any matching branch is created, then again after a create+delete round-trip.
  3. **Remote match** — branch lives only on `origin` (bare repo + clone, push, local delete, fetch), `hasBranch` finds it via `git branch -r`.
  4. **Offline-safe fallback** — fresh repo with no remote configured: `hasBranch` returns `false` and does not panic.
- Adds a `newGitRepo` helper that creates a temp repo, sets local `user.email`/`user.name`, disables `commit.gpgsign`/`tag.gpgsign` locally so commits work in the sandbox, and chdirs in with a `t.Cleanup`-restored cwd.

## Test plan

- [x] `go test ./... -run TestHasBranchLocal -v` (module `tickets/tools/go`) — both local tests pass.
- [x] `go test ./... -v` (module `tickets/tools/go`) — full suite green, 11 existing tests untouched, 4 new tests pass.
- [x] `go build -o /tmp/erg . && /tmp/erg validate ../../../tickets/` — `ERG VALIDATION: PASS (73 tickets)`.
- [x] `bash scripts/check-project-leak.sh` — exit 0.

https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p)_