### PR TITLE
ticket(0051): move cooldown-recent-pick guard to beat.py (Layer 0)

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -21,7 +21,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from io import TextIOBase
 from pathlib import Path
 
@@ -803,6 +803,31 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
     return "merged"
 
 
+def _ticket_recently_picked(ticket_path: Path, within_hours: int = 8) -> bool:
+    """True if a sweep-pick log line in this ticket is within cutoff.
+
+    Implements the cooldown-recent-pick guard previously enforced by prose
+    in skills/pick-ticket/SKILL.md (ticket 0051 Layer 0). A ticket whose
+    log shows it was picked within ``within_hours`` should not be re-picked
+    until the prior raid has had a chance to close it.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=within_hours)
+    try:
+        text = ticket_path.read_text()
+    except (FileNotFoundError, OSError):
+        return False
+    for line in text.splitlines():
+        if "sweep-pick: selected" in line or "sweep-pick: picked" in line:
+            try:
+                ts_str = line.split()[0].rstrip("Z")
+                ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+                if ts > cutoff:
+                    return True
+            except (ValueError, IndexError):
+                continue
+    return False
+
+
 def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     """Run the pick→raid sequence; return (outcome, ticket_id)."""
     ticket_id: str | None = None
@@ -817,6 +842,16 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     hk_outcome = _housekeeping_phase(project)
     if hk_outcome in ("failed", "timeout", "ci-failed"):
         return "aborted", None
+
+    # Cooldown-recent-pick guard (ticket 0051 Layer 0). If any open ticket
+    # was picked within the last 8h, skip pick-ticket entirely — the prior
+    # raid hasn't had a chance to close it yet, and re-picking risks a
+    # double-raid.
+    if any(
+        _ticket_recently_picked(t) for t in path.glob("tickets/*.erg")
+    ):
+        _log("=== pick-ticket: skipped (cooldown-recent-pick) ===")
+        return "idle", None
 
     # Pick ticket. Loop on CLOSED (Tier 2 of ticket 0049): pick-ticket may
     # detect that a candidate's exit criteria are already met, close it, and

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -99,14 +99,13 @@ Select one ticket for the current sweep run.
    2. Then by lowest risk
    3. If risk is equal, prefer the simpler one
 
-6. **Write beat-skip updates.** Merge all new skip entries (from step 3) plus
-   a cooldown entry for the picked ticket into `.git/beat-skip.json`,
-   replacing any existing entry with the same `id`. No ticket files are
-   modified. No commit needed — beat-skip is machine-local state.
+6. **Write beat-skip updates.** Merge all new skip entries (from step 3)
+   into `.git/beat-skip.json`, replacing any existing entry with the same
+   `id`. No ticket files are modified. No commit needed — beat-skip is
+   machine-local state.
 
-   Always add a cooldown entry for the picked ticket (prevents re-picking on
-   the next beat before the raid has a chance to close it):
-   `{ "id": "...", "until": "{now+8h}", "reason": "cooldown-recent-pick" }`
+   Cooldown is enforced in beat.py via _ticket_recently_picked(); no
+   beat-skip entry needed for the picked ticket.
 
 7. If the candidate set is empty after all exclusions, output
    `IDLE: no eligible tickets` and stop.

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1311,3 +1312,104 @@ class TestRaidDoneButOpenWarning:
             beat._raid(beat.ProjectConfig(path=tmp_project))
 
         assert not any("warning" in l and "not closed" in l for l in log_lines)
+
+
+# ── Cooldown-recent-pick guard (ticket 0051 Layer 0) ──────────────────────────
+
+
+class TestTicketRecentlyPicked:
+    def test_fires_within_8h(self, tmp_path):
+        ticket = tmp_path / "0001-test.erg"
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+        ticket.write_text(
+            f"%erg v1\nTitle: T\nStatus: open\n\n--- log ---\n"
+            f"{now_iso} claude note sweep-pick: picked\n\n--- body ---\n"
+        )
+        assert beat._ticket_recently_picked(ticket, within_hours=8) is True
+
+    def test_clears_after_8h(self, tmp_path):
+        ticket = tmp_path / "0002-test.erg"
+        old = (datetime.now(timezone.utc) - timedelta(hours=9)).strftime(
+            "%Y-%m-%dT%H:%MZ"
+        )
+        ticket.write_text(
+            f"%erg v1\nTitle: T\nStatus: open\n\n--- log ---\n"
+            f"{old} claude note sweep-pick: picked\n\n--- body ---\n"
+        )
+        assert beat._ticket_recently_picked(ticket, within_hours=8) is False
+
+    def test_ignores_malformed_line(self, tmp_path):
+        ticket = tmp_path / "0003-test.erg"
+        ticket.write_text(
+            "%erg v1\nTitle: T\nStatus: open\n\n--- log ---\n"
+            "not-a-timestamp claude note sweep-pick: picked\n\n--- body ---\n"
+        )
+        assert beat._ticket_recently_picked(ticket, within_hours=8) is False
+
+
+class TestRaidCooldownRecentPick:
+    """Layer 0: when a ticket has a recent sweep-pick log entry, _raid()
+    short-circuits to idle before invoking pick-ticket."""
+
+    def setup_method(self):
+        beat.DRY_RUN = False
+
+    def test_skips_pick_ticket_when_recent_pick_exists(self, tmp_project):
+        (tmp_project / "tickets").mkdir(exist_ok=True)
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+        (tmp_project / "tickets" / "0042-recent.erg").write_text(
+            f"%erg v1\nTitle: recent\nStatus: open\n\n--- log ---\n"
+            f"{now_iso} claude note sweep-pick: picked\n\n--- body ---\n"
+        )
+
+        calls: list[str] = []
+
+        def fake_run_skill(skill, **kwargs):
+            calls.append(skill)
+            return (0, "")
+
+        log_lines: list[str] = []
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+            patch("beat._log", side_effect=log_lines.append),
+        ):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+
+        assert outcome == "idle"
+        assert ticket is None
+        assert not any("pick-ticket" in c for c in calls), (
+            "pick-ticket must not be invoked when a recent-pick cooldown applies"
+        )
+        assert any("cooldown-recent-pick" in l for l in log_lines)
+
+    def test_proceeds_when_no_recent_pick(self, tmp_project):
+        (tmp_project / "tickets").mkdir(exist_ok=True)
+        old = (datetime.now(timezone.utc) - timedelta(hours=9)).strftime(
+            "%Y-%m-%dT%H:%MZ"
+        )
+        (tmp_project / "tickets" / "0043-old.erg").write_text(
+            f"%erg v1\nTitle: old\nStatus: open\n\n--- log ---\n"
+            f"{old} claude note sweep-pick: picked\n\n--- body ---\n"
+        )
+
+        calls: list[str] = []
+
+        def fake_run_skill(skill, **kwargs):
+            calls.append(skill)
+            if "pick-ticket" in skill:
+                return (0, "IDLE: empty queue")
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+        ):
+            outcome, _ = beat._raid(beat.ProjectConfig(path=tmp_project))
+
+        assert outcome == "idle"
+        assert any("pick-ticket" in c for c in calls), (
+            "pick-ticket should be invoked when no recent-pick cooldown applies"
+        )


### PR DESCRIPTION
## Summary

Layer 0 of ticket 0051: lift the cooldown-recent-pick guard out of `skills/pick-ticket/SKILL.md` prose into a testable Python helper.

- New `_ticket_recently_picked(ticket_path, within_hours=8)` in `scripts/beat.py` parses ticket log lines for `sweep-pick: selected` / `sweep-pick: picked` and returns True when any timestamp is within the cutoff. Malformed lines and missing files are tolerated.
- `_raid()` now globs `tickets/*.erg` before the pick-ticket invocation; if any ticket is in cooldown it logs `=== pick-ticket: skipped (cooldown-recent-pick) ===` and returns `outcome=idle` without spending tokens.
- `skills/pick-ticket/SKILL.md` step 5 prose updated: the cooldown beat-skip rule is removed and replaced with a one-liner pointing at `_ticket_recently_picked()`.

Layers 1 (cross-project IDLE fallback) and 2 (pre-flight skip when nothing changed) remain open and are explicitly out of scope here.

## Test plan

- [x] New unit tests for `_ticket_recently_picked`: fires within 8h, clears after 8h, ignores malformed timestamp.
- [x] New integration tests: `_raid()` short-circuits to idle without invoking pick-ticket when a recent-pick exists; proceeds normally when only old picks exist.
- [x] `pytest tests/` — 101 passed.
- [x] `bash scripts/check-project-leak.sh` — exit 0.
- [x] `erg validate tickets/` — PASS (73 tickets).

https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p)_