### PR TITLE
ticket(0049): Tier 2 - lightweight exit-criteria check + CLOSED loop

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -46,6 +46,9 @@ HOUSEKEEPING_SAFETY_FLOOR_S: int = 24 * 3600
 HOUSEKEEPING_TIMEOUT_S: int = 10 * 60
 PICK_TICKET_TIMEOUT_S: int = 8 * 60
 RAID_TIMEOUT_S: int = 30 * 60
+# Max consecutive CLOSED:<id> repicks per beat before aborting to idle.
+# Tier 2 of ticket 0049: bound prevents flaky exit-criteria from looping forever.
+MAX_CLOSED_REPICKS: int = 3
 CRASH_RECOVERY_WINDOW_S: int = 55 * 60
 LOG_RETAIN_COUNT: int = 60
 TIMEOUT_EXIT_CODE: int = 124  # matches bash `timeout` convention
@@ -364,12 +367,29 @@ def _repo_active(project: Path) -> bool:
 # ── Pick-ticket output parser ─────────────────────────────────────────────────
 
 
-def parse_pick(result_text: str) -> str | None:
-    """Return 4-digit ticket ID from PICK: line, or None for IDLE / no match."""
+def parse_pick(result_text: str) -> tuple[str, str | None]:
+    """Classify pick-ticket output.
+
+    Returns a (status, ticket_id) tuple where status is one of:
+      - "pick":   `PICK: <id>` matched; ticket_id is the 4-digit string.
+      - "closed": `CLOSED: <id>` matched (Tier 2, ticket 0049) — pick-ticket
+                  detected the ticket's exit criteria are already met and
+                  closed it; caller should re-pick. ticket_id is the 4-digit
+                  string of the closed ticket.
+      - "idle":   No eligible candidate, or unparseable output. ticket_id
+                  is None.
+
+    Precedence: IDLE > CLOSED > PICK. IDLE always wins (safety bias).
+    """
     if re.search(r"\bIDLE\b", result_text, re.IGNORECASE):
-        return None
-    m = re.search(r"\bPICK:\s*(\d{4})\b", result_text)
-    return m.group(1) if m else None
+        return ("idle", None)
+    closed = re.search(r"\bCLOSED:\s*(\d{4})\b", result_text)
+    if closed:
+        return ("closed", closed.group(1))
+    pick = re.search(r"\bPICK:\s*(\d{4})\b", result_text)
+    if pick:
+        return ("pick", pick.group(1))
+    return ("idle", None)
 
 
 # ── Claude subprocess ──────────────────────────────────────────────────────────
@@ -798,26 +818,52 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     if hk_outcome in ("failed", "timeout", "ci-failed"):
         return "aborted", None
 
-    # Pick ticket
+    # Pick ticket. Loop on CLOSED (Tier 2 of ticket 0049): pick-ticket may
+    # detect that a candidate's exit criteria are already met, close it, and
+    # emit `CLOSED: <id>` — re-pick rather than raid a stale ticket. Bound
+    # at MAX_CLOSED_REPICKS to prevent flaky exit-criteria from looping
+    # forever (abort to idle so the next beat can try again).
     hostname = socket.gethostname()
     pick_model = MODEL_SONNET if _repo_active(path) else project.pick_ticket_model
-    _log(f"=== pick-ticket: running model={pick_model} {_now_iso()} ===")
-    pt_rc, pt_result = run_skill(
-        f"/pick-ticket\n\nRunning on: {hostname}",
-        budget=project.budget_pick_ticket,
-        timeout_s=PICK_TICKET_TIMEOUT_S,
-        cwd=path,
-        project_scoped=True,
-        model=pick_model,
-    )
+    closed_attempts = 0
+    ticket_id = None
+    pt_result = ""
+    while closed_attempts < MAX_CLOSED_REPICKS:
+        _log(f"=== pick-ticket: running model={pick_model} {_now_iso()} ===")
+        pt_rc, pt_result = run_skill(
+            f"/pick-ticket\n\nRunning on: {hostname}",
+            budget=project.budget_pick_ticket,
+            timeout_s=PICK_TICKET_TIMEOUT_S,
+            cwd=path,
+            project_scoped=True,
+            model=pick_model,
+        )
 
-    if pt_rc == TIMEOUT_EXIT_CODE:
-        return "aborted", None
-    if pt_rc != 0:
-        return "failed", None
+        if pt_rc == TIMEOUT_EXIT_CODE:
+            return "aborted", None
+        if pt_rc != 0:
+            return "failed", None
 
-    ticket_id = parse_pick(pt_result)
-    if ticket_id is None:
+        status, ticket_id = parse_pick(pt_result)
+        if status == "closed":
+            closed_attempts += 1
+            _log(
+                f"=== pick-ticket: closed {ticket_id}, repicking"
+                f" (attempt {closed_attempts}/{MAX_CLOSED_REPICKS}) ==="
+            )
+            continue
+        break
+    else:
+        # while-else: ran MAX_CLOSED_REPICKS times without breaking → all
+        # attempts returned CLOSED. Abort to idle so the orchestrator never
+        # raids a ticket that may be already done.
+        _log(
+            f"=== pick-ticket: idle — {MAX_CLOSED_REPICKS} consecutive CLOSED"
+            " picks; aborting beat to avoid loop ==="
+        )
+        return "idle", None
+
+    if status == "idle":
         last_result_line = (
             pt_result.strip().splitlines()[-1] if pt_result.strip() else ""
         )

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pick-ticket
-description: Pick the lowest-risk available ticket for an autonomous sweep run. Returns PICK:<id> or IDLE.
+description: Pick the lowest-risk available ticket for an autonomous sweep run. Returns PICK:<id>, CLOSED:<id>, or IDLE.
 user-invocable: true
 argument-hint:
 ---
@@ -46,12 +46,60 @@ Select one ticket for the current sweep run.
    If the `## Attempt log` section has 3 or more entries regardless of outcome:
    write a beat-skip entry `{ "id": "...", "reason": "three-strikes: needs human review" }` (no `until`)
 
-4. **Rank remaining candidates:**
+4. **Lightweight exit-criteria check (Tier 2 of ticket 0049).** For each
+   remaining candidate, check whether its exit criteria are *already* met
+   in the codebase. The point: don't burn a ~$5 raid on a ticket whose
+   work is already done (e.g. fixed as a side effect of another ticket).
+
+   **Trigger gate** — only run this check on a candidate when *either*:
+   - the ticket's `cache` field is `miss` in `erg ready --json` (body
+     changed since last sweep), *or*
+   - `git log --since=<last-pick-ts> -- <relevant-files>` returns matches
+     (recent commits touched files the ticket talks about). Use the
+     timestamp of the most recent `sweep-pick:` or `sweep-close:` log
+     line in the ticket as `<last-pick-ts>`; if none, default to 7 days
+     ago.
+
+   Skip the check on cache-hit tickets with no recent relevant commits —
+   nothing about them has changed, the answer is still "open."
+
+   **Allowed checks** — only consider exit criteria expressible as one of
+   these three crisp grep-able shapes. Vague exits ("works correctly",
+   "no regressions", "user-friendly") → leave open, do not attempt.
+
+   1. **String absence**: `! grep -F "<literal>" <file>` — exit criterion
+      reads "string X does not appear in file F."
+   2. **File absence**: `test ! -f <path>` — exit criterion reads
+      "file F does not exist."
+   3. **Symbol presence**: `grep -E '^(def|class|func) <name>' <file>` —
+      exit criterion reads "function/class/func `name` is defined in F."
+
+   If *all* of a ticket's exit criteria reduce to these checks AND all
+   pass:
+
+   1. Compute the body hash: `bodyhash=$(${ERG} ready --json tickets/ \
+      | jq -r '.[] | select(.id=="<id>") | .hash')`
+   2. Call `/ticket-close <id>` (no reason argument — the close skill
+      records the status change; the sweep-close note records why).
+   3. Append a sweep-close log line to `tickets/<id>-*.erg` immediately
+      below the most recent log entry, before `--- body ---`:
+      `{now-iso} claude note sweep-close: already-done hash:<bodyhash>`
+      Use UTC minute precision: `date -u +%Y-%m-%dT%H:%MZ`.
+   4. Output `CLOSED: <id>` and stop processing this candidate (do not
+      rank it). beat.py will loop back and pick again.
+
+   If *any* exit criterion is vague or fails its check → leave the
+   candidate open and proceed to ranking.
+
+   Process candidates one at a time. The first `CLOSED:` is sufficient —
+   beat.py loops on it. Do not batch-close multiple tickets in one run.
+
+5. **Rank remaining candidates:**
    1. Tickets with `fix-tests` in their slug first
    2. Then by lowest risk
    3. If risk is equal, prefer the simpler one
 
-5. **Write beat-skip updates.** Merge all new skip entries (from step 3) plus
+6. **Write beat-skip updates.** Merge all new skip entries (from step 3) plus
    a cooldown entry for the picked ticket into `.git/beat-skip.json`,
    replacing any existing entry with the same `id`. No ticket files are
    modified. No commit needed — beat-skip is machine-local state.
@@ -60,13 +108,15 @@ Select one ticket for the current sweep run.
    the next beat before the raid has a chance to close it):
    `{ "id": "...", "until": "{now+8h}", "reason": "cooldown-recent-pick" }`
 
-6. If the candidate set is empty after all exclusions, output
+7. If the candidate set is empty after all exclusions, output
    `IDLE: no eligible tickets` and stop.
 
 ## Output
 
 Exactly one line:
-- `PICK: <ticket-id>`
+- `PICK: <ticket-id>` — picked a ticket; raid will run.
+- `CLOSED: <ticket-id>` — closed an already-done ticket; beat.py loops
+  back to pick again. Bounded at 3 consecutive CLOSEDs per beat.
 - `IDLE: no eligible tickets`
 
 ## Cross-worktree concurrency

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -47,43 +47,72 @@ def beat_log(tmp_project):
 
 class TestParsePick:
     def test_pick_exact(self):
-        assert beat.parse_pick("PICK: 0023") == "0023"
+        assert beat.parse_pick("PICK: 0023") == ("pick", "0023")
 
     def test_pick_with_leading_prose(self):
-        assert beat.parse_pick("After reviewing tickets, PICK: 0111") == "0111"
+        assert beat.parse_pick("After reviewing tickets, PICK: 0111") == (
+            "pick",
+            "0111",
+        )
 
     def test_pick_multiline(self):
-        assert beat.parse_pick("Thinking...\nPICK: 0042\nDone.") == "0042"
+        assert beat.parse_pick("Thinking...\nPICK: 0042\nDone.") == ("pick", "0042")
 
     def test_pick_no_space(self):
         # "PICK:0023" without space — regex requires \s* so this matches
-        assert beat.parse_pick("PICK:0023") == "0023"
+        assert beat.parse_pick("PICK:0023") == ("pick", "0023")
 
     def test_idle_keyword(self):
-        assert beat.parse_pick("IDLE: no eligible tickets") is None
+        assert beat.parse_pick("IDLE: no eligible tickets") == ("idle", None)
 
     def test_idle_case_insensitive(self):
-        assert beat.parse_pick("idle: nothing to do") is None
+        assert beat.parse_pick("idle: nothing to do") == ("idle", None)
 
     def test_idle_takes_precedence_over_pick(self):
         # If both appear, IDLE wins (safety bias)
-        assert beat.parse_pick("IDLE: queue empty\nPICK: 0007") is None
+        assert beat.parse_pick("IDLE: queue empty\nPICK: 0007") == ("idle", None)
 
     def test_ambiguous_no_keyword(self):
-        assert beat.parse_pick("I reviewed the tickets and found nothing") is None
+        assert beat.parse_pick("I reviewed the tickets and found nothing") == (
+            "idle",
+            None,
+        )
 
     def test_empty_string(self):
-        assert beat.parse_pick("") is None
+        assert beat.parse_pick("") == ("idle", None)
 
     def test_pick_must_be_four_digits(self):
         # Three-digit ID should not match \d{4}
-        assert beat.parse_pick("PICK: 042") is None
+        assert beat.parse_pick("PICK: 042") == ("idle", None)
 
     def test_pick_five_digits_no_match(self):
-        assert beat.parse_pick("PICK: 00042") is None
+        assert beat.parse_pick("PICK: 00042") == ("idle", None)
 
     def test_dry_run_sentinel(self):
-        assert beat.parse_pick("PICK: 9999") == "9999"
+        assert beat.parse_pick("PICK: 9999") == ("pick", "9999")
+
+    def test_closed_signal_parsing(self):
+        # Tier 2 (ticket 0049): pick-ticket emits CLOSED: <id> when it
+        # detects a ticket whose exit criteria are already met.
+        status, ticket_id = beat.parse_pick("CLOSED: 0049")
+        assert status == "closed"
+        assert ticket_id == "0049"
+
+    def test_closed_with_prose(self):
+        status, ticket_id = beat.parse_pick(
+            "Exit criteria already met.\nCLOSED: 0039\nMoving on."
+        )
+        assert status == "closed"
+        assert ticket_id == "0039"
+
+    def test_closed_must_be_four_digits(self):
+        # Mirror PICK behavior: only 4-digit IDs match.
+        assert beat.parse_pick("CLOSED: 042") == ("idle", None)
+
+    def test_idle_takes_precedence_over_closed(self):
+        # If pick-ticket emits both CLOSED and IDLE, IDLE wins (safety bias):
+        # treat as idle so beat.py doesn't loop on a malformed transcript.
+        assert beat.parse_pick("CLOSED: 0049\nIDLE: nothing left") == ("idle", None)
 
 
 # ── housekeeping_needed ────────────────────────────────────────────────────────
@@ -507,6 +536,103 @@ class TestRaid:
             beat._raid(beat.ProjectConfig(path=tmp_project))
 
         assert not any("housekeeping" in c for c in calls)
+
+
+# ── _raid CLOSED-loop (ticket 0049 Tier 2) ────────────────────────────────────
+
+
+class TestRaidClosedLoop:
+    """Tier 2 of ticket 0049: pick-ticket may emit `CLOSED: <id>` when it
+    detects an already-done ticket. _raid must loop and re-pick rather than
+    invoking the orchestrator on a stale pick. A bound prevents flaky exit
+    criteria from looping forever."""
+
+    def setup_method(self):
+        beat.DRY_RUN = False
+
+    def test_closed_then_pick_loops_back(self, tmp_project):
+        """First pick-ticket call returns CLOSED; second returns PICK.
+        _raid must call pick-ticket twice, then proceed to raid."""
+        pick_results = iter(
+            [
+                (0, "CLOSED: 0049"),
+                (0, "PICK: 0050"),
+            ]
+        )
+        calls: list[str] = []
+
+        def fake_run_skill(skill, **kwargs):
+            calls.append(skill)
+            if "pick-ticket" in skill:
+                return next(pick_results)
+            if "raid" in skill:
+                return (0, "")
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+        ):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+
+        pick_calls = [c for c in calls if "pick-ticket" in c]
+        assert len(pick_calls) == 2
+        assert outcome == "done"
+        assert ticket == "0050"
+
+    def test_consecutive_closed_aborts_to_idle(self, tmp_project):
+        """Three consecutive CLOSED picks → idle (loop guard).
+
+        Bound: max 3 consecutive CLOSED before aborting. Prevents flaky
+        exit-criteria checks from looping forever."""
+        calls: list[str] = []
+
+        def fake_run_skill(skill, **kwargs):
+            calls.append(skill)
+            if "pick-ticket" in skill:
+                return (0, "CLOSED: 0049")
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+        ):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+
+        pick_calls = [c for c in calls if "pick-ticket" in c]
+        # 3 attempts max
+        assert len(pick_calls) == 3
+        # No raid invocation — never reached PICK
+        assert not any("raid" in c and "pick-ticket" not in c for c in calls)
+        assert outcome == "idle"
+        assert ticket is None
+
+    def test_closed_then_idle_returns_idle(self, tmp_project):
+        """CLOSED on first call, IDLE on second → idle (no raid)."""
+        pick_results = iter(
+            [
+                (0, "CLOSED: 0049"),
+                (0, "IDLE: nothing left"),
+            ]
+        )
+        calls: list[str] = []
+
+        def fake_run_skill(skill, **kwargs):
+            calls.append(skill)
+            if "pick-ticket" in skill:
+                return next(pick_results)
+            return (0, "")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+        ):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+
+        pick_calls = [c for c in calls if "pick-ticket" in c]
+        assert len(pick_calls) == 2
+        assert outcome == "idle"
+        assert ticket is None
 
 
 # ── housekeeping phase: dedicated branch + PR flow (ticket 0072) ──────────────


### PR DESCRIPTION
## Summary

Implements **Tier 2 only** of ticket 0049 (Truth in ticket open status).
When pick-ticket detects an open ticket whose exit criteria are already
met in the codebase, it closes the ticket and emits `CLOSED: <id>`.
beat.py loops back and picks again — no orchestrator burn on a stale ticket.

- `parse_pick()` → `tuple[str, str | None]` with status in `{pick, idle, closed}`. Precedence: IDLE > CLOSED > PICK.
- `_raid()` wraps pick-ticket in a bounded while-loop. `MAX_CLOSED_REPICKS = 3` consecutive CLOSEDs → abort to idle (loop guard against flaky exit-criteria).
- `skills/pick-ticket/SKILL.md` step 4 adds a lightweight exit-criteria check with a trigger gate (cache:miss OR recent relevant commits) and three crisp grep-able check shapes: string absence, file absence, symbol presence. No DSL — three hardcoded shapes only.

## Scope

- **Tier 1** (housekeeping integration): deferred to ticket 0034. Not touched.
- **Tier 2** (this PR): lightweight exit-criteria check + CLOSED loop.
- **Tier 3** (start-ticket exit-criteria verify): preexisting since 2026-04-29. Not touched.

## Adjusted plan

The original 0049 body called for `/ticket-close <id> already-done`, but
`/ticket-close` does not accept a reason argument. Adjusted: pick-ticket
calls plain `/ticket-close <id>` and writes a separate
`sweep-close: already-done hash:<bodyhash>` `note` log line into the ticket
file, mirroring the existing `sweep-skip:` log-line pattern.

## Test plan

- [x] `python3 -m pytest tests/test_beat.py::TestParsePick -v` — 16 tests pass (12 refactored to tuple shape; 4 new for CLOSED parsing)
- [x] `python3 -m pytest tests/test_beat.py::TestRaidClosedLoop -v` — 3 new tests pass (CLOSED→PICK loops back; 3 consecutive CLOSED → idle; CLOSED→IDLE)
- [x] `python3 -m pytest tests/ -x -v` — 103 / 103 pass
- [x] `bash scripts/check-project-leak.sh` — clean
- [x] `grep -L 'set -euo pipefail' scripts/*.sh | grep -Ev 'shell-init\.sh|bash-env\.sh'` — clean
- [x] `./tickets/tools/go/erg validate tickets/` — PASS (73 tickets)
- [x] SKILL.md frontmatter lint — clean
- [x] `go test ./tickets/tools/go/...` — pass

## Files changed

- `scripts/beat.py` (+58 / −20)
- `skills/pick-ticket/SKILL.md` (+57 / −3)
- `tests/test_beat.py` (+136 / −14)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p)_