### PR TITLE
ticket(0043): weekly /fewer-permission-prompts via nightbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ systemctl --user daemon-reload
 systemctl --user enable --now claude-harness-pull.timer
 ```
 
+## Permissions
+
+The nightbeat folds in a weekly run of `/fewer-permission-prompts` (Sundays) that proposes an allowlist diff per project. Diffs are never auto-applied; review them at `~/.claude/telemetry/permission-diffs/` — `nightbeat-report` surfaces unreviewed entries each morning.
+
 ## Why not a plugin?
 
 Because it's **my** harness. IDH is my personal Claude config, cloned to `~/.claude` on every machine I use. The plugin system exists for shareable, redistributable tooling — that's not this. Fork the repo if you want your own.

--- a/STATE.md
+++ b/STATE.md
@@ -31,7 +31,6 @@ Level 4 (Hooks) + raid + `/verify` loop + git-erg tickets + bibliography pipelin
 - 0029 — beat dashboard blocker graph (blocked by 0028)
 - 0034 — housekeeping: split git-cleanup and ticket-scan into two phases
 - 0041 — investigate mid-session context reset between sub-skills
-- 0043 — weekly /fewer-permission-prompts run
 - 0044 — interactive session observer (blocked by 0042)
 - 0047 — auto early context compaction in beat and raid
 - 0049 — truth in ticket open status

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -62,6 +62,11 @@ MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
 
 PROJECTS_CONFIG: Path = HARNESS_DIR / "scripts" / "projects.json"
 
+# Weekly /fewer-permission-prompts cadence. Folded into nightbeat instead of
+# a dedicated systemd timer (ticket 0043). Lowercase weekday name; matched
+# against datetime.now().strftime("%A").lower().
+PERMISSIONS_PRUNE_DAY_OF_WEEK: str = "sunday"
+
 DRY_RUN: bool = os.environ.get("BEAT_DRY_RUN") == "1"
 
 
@@ -828,6 +833,41 @@ def _ticket_recently_picked(ticket_path: Path, within_hours: int = 8) -> bool:
     return False
 
 
+# ── Weekly /fewer-permission-prompts (ticket 0043) ────────────────────────────
+
+
+def _is_prune_day() -> bool:
+    """True when today's weekday matches PERMISSIONS_PRUNE_DAY_OF_WEEK."""
+    return datetime.now().strftime("%A").lower() == PERMISSIONS_PRUNE_DAY_OF_WEEK
+
+
+def _prune_permissions(project: Path) -> None:
+    """Run the /fewer-permission-prompts helper once a week.
+
+    Diff is written under ~/.claude/telemetry/permission-diffs/<date>.diff and
+    surfaced by nightbeat-report. Diffs are NEVER auto-applied; failure here is
+    benign and must not raise — beat must keep running.
+    """
+    if not _is_prune_day():
+        return
+    helper = HARNESS_DIR / "scripts" / "fewer-permission-prompts-helper.py"
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["python3", str(helper), str(project)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10 * 60,
+        )
+        diff_path = (result.stdout or "").strip().splitlines()[-1:] or [""]
+        _log(
+            f"=== permissions-prune: rc={result.returncode}"
+            f" diff={diff_path[0] or '(none)'} {_now_iso()} ==="
+        )
+    except Exception as exc:  # noqa: BLE001 — must never crash beat
+        _log(f"=== permissions-prune: failed silently: {exc} {_now_iso()} ===")
+
+
 def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     """Run the pick→raid sequence; return (outcome, ticket_id)."""
     ticket_id: str | None = None
@@ -852,6 +892,9 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     ):
         _log("=== pick-ticket: skipped (cooldown-recent-pick) ===")
         return "idle", None
+
+    # Weekly permission-allowlist diff (no-op except on prune day).
+    _prune_permissions(path)
 
     # Pick ticket. Loop on CLOSED (Tier 2 of ticket 0049): pick-ticket may
     # detect that a candidate's exit criteria are already met, close it, and

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -847,8 +847,19 @@ def _prune_permissions(project: Path) -> None:
     Diff is written under ~/.claude/telemetry/permission-diffs/<date>.diff and
     surfaced by nightbeat-report. Diffs are NEVER auto-applied; failure here is
     benign and must not raise — beat must keep running.
+
+    The helper is invoked at most once per host per day. Without this guard,
+    every project × every beat (~85 invocations on a weekend day across 5
+    projects × 17 beats) would each spawn its own ``/fewer-permission-prompts``
+    session.
     """
     if not _is_prune_day():
+        return
+    today_diff = (
+        HARNESS_DIR / "telemetry" / "permission-diffs"
+        / f"{datetime.now().strftime('%Y-%m-%d')}.diff"
+    )
+    if today_diff.exists():
         return
     helper = HARNESS_DIR / "scripts" / "fewer-permission-prompts-helper.py"
     try:

--- a/scripts/fewer-permission-prompts-helper.py
+++ b/scripts/fewer-permission-prompts-helper.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""fewer-permission-prompts-helper.py — emit a weekly allowlist-diff proposal.
+
+Spawns a non-interactive Claude Code session that invokes the Anthropic-shipped
+skill `/fewer-permission-prompts`. Writes the captured stdout (the proposed
+diff) to `~/.claude/telemetry/permission-diffs/<YYYY-MM-DD>.diff`. Diffs are
+NEVER auto-applied — they are surfaced read-only by `nightbeat-report.py`.
+
+Known caveat: bug `anthropics/claude-code#51057` strips environment-variable
+prefixes during extraction, so commands like
+    TEST_DATABASE_URL=... uv run pytest
+are missed. Verify diffs by hand before applying.
+
+Usage:
+    fewer-permission-prompts-helper.py <project-path>
+
+Exit codes:
+    0   — diff (or stub diff) written successfully
+    2   — usage error (missing project arg)
+
+Failure modes that fall back gracefully (still exit 0):
+    - `claude` CLI not on PATH                 → write stub-comment diff
+    - non-interactive flag rejected            → fall back to piping `\n` to stdin
+    - subprocess.TimeoutExpired                → write stub diff with timeout note
+
+This script must never crash the calling beat — see scripts/beat.py
+`_prune_permissions`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.tracebacklimit = 1
+
+
+HARNESS_DIR = Path(os.environ.get("HOME", str(Path.home()))) / ".claude"
+DIFF_DIR = HARNESS_DIR / "telemetry" / "permission-diffs"
+
+# Cap on the spawned `claude` invocation. The wrapper above (`beat.py`)
+# already caps the helper at 10 minutes; this is the inner soft limit.
+CLAUDE_TIMEOUT_S = 8 * 60
+
+PROMPT_SLASH = "/fewer-permission-prompts"
+
+
+def _today_diff_path() -> Path:
+    return DIFF_DIR / f"{datetime.now().strftime('%Y-%m-%d')}.diff"
+
+
+def _ensure_dirs() -> None:
+    DIFF_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _append_diff(content: str, *, header: str | None = None) -> Path:
+    path = _today_diff_path()
+    pieces: list[str] = []
+    if header:
+        pieces.append(f"# {header}\n")
+    if content and not content.endswith("\n"):
+        content = content + "\n"
+    pieces.append(content)
+    with path.open("a") as fh:
+        fh.write("".join(pieces))
+    return path
+
+
+def _claude_available() -> bool:
+    return shutil.which("claude") is not None
+
+
+def _spawn_claude(project: Path) -> tuple[int, str, str]:
+    """Try non-interactive first; fall back to piping stdin if needed.
+
+    Returns (returncode, stdout, stderr). Never raises for normal failure
+    modes (timeout, missing CLI) — the caller handles fallbacks.
+    """
+    # First attempt: --non-interactive (preferred path).
+    try:
+        proc = subprocess.run(  # noqa: S603, S607
+            [
+                "claude",
+                "--non-interactive",
+                "-p",
+                PROMPT_SLASH,
+                "--output-format",
+                "stream-json",
+            ],
+            cwd=str(project),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=CLAUDE_TIMEOUT_S,
+        )
+        # Older / current `claude` may not know `--non-interactive`. If it
+        # exited non-zero AND its stderr suggests the flag was rejected,
+        # fall through to the stdin fallback.
+        if proc.returncode == 0:
+            return proc.returncode, proc.stdout, proc.stderr
+        unknown_flag = (
+            "non-interactive" in (proc.stderr or "").lower()
+            or "unknown" in (proc.stderr or "").lower()
+            or "unrecognized" in (proc.stderr or "").lower()
+        )
+        if not unknown_flag:
+            return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as exc:
+        return 124, exc.stdout or "", f"timeout after {CLAUDE_TIMEOUT_S}s"
+    except FileNotFoundError:
+        return 127, "", "claude CLI not found"
+
+    # Fallback: pipe a confirm-no `\n` to stdin.
+    try:
+        proc = subprocess.run(  # noqa: S603, S607
+            ["claude", "-p", PROMPT_SLASH],
+            cwd=str(project),
+            input="\n",
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=CLAUDE_TIMEOUT_S,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as exc:
+        return 124, exc.stdout or "", f"timeout after {CLAUDE_TIMEOUT_S}s"
+    except FileNotFoundError:
+        return 127, "", "claude CLI not found"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(
+            "usage: fewer-permission-prompts-helper.py <project-path>",
+            file=sys.stderr,
+        )
+        return 2
+
+    project = Path(argv[1]).expanduser()
+    _ensure_dirs()
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    if not _claude_available():
+        path = _append_diff(
+            "",
+            header=(
+                f"{today} — claude CLI unavailable on this host;"
+                " no diff produced. See ticket 0043."
+            ),
+        )
+        print(path)
+        return 0
+
+    rc, stdout, stderr = _spawn_claude(project)
+    if rc == 0 and stdout.strip():
+        path = _append_diff(
+            stdout,
+            header=f"{today} — /fewer-permission-prompts (project: {project})",
+        )
+    elif rc == 124:
+        path = _append_diff(
+            "",
+            header=(
+                f"{today} — /fewer-permission-prompts timed out for {project}."
+                " Skipped this week."
+            ),
+        )
+    else:
+        path = _append_diff(
+            stderr or "(no output)",
+            header=(
+                f"{today} — /fewer-permission-prompts rc={rc} for {project};"
+                " see stderr below."
+            ),
+        )
+
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/fewer-permission-prompts-helper.py
+++ b/scripts/fewer-permission-prompts-helper.py
@@ -29,7 +29,6 @@ This script must never crash the calling beat — see scripts/beat.py
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys
@@ -39,7 +38,7 @@ from pathlib import Path
 sys.tracebacklimit = 1
 
 
-HARNESS_DIR = Path(os.environ.get("HOME", str(Path.home()))) / ".claude"
+HARNESS_DIR = Path.home() / ".claude"
 DIFF_DIR = HARNESS_DIR / "telemetry" / "permission-diffs"
 
 # Cap on the spawned `claude` invocation. The wrapper above (`beat.py`)
@@ -102,10 +101,18 @@ def _spawn_claude(project: Path) -> tuple[int, str, str]:
         # fall through to the stdin fallback.
         if proc.returncode == 0:
             return proc.returncode, proc.stdout, proc.stderr
-        unknown_flag = (
-            "non-interactive" in (proc.stderr or "").lower()
-            or "unknown" in (proc.stderr or "").lower()
-            or "unrecognized" in (proc.stderr or "").lower()
+        stderr_lc = (proc.stderr or "").lower()
+        unknown_flag = any(
+            phrase in stderr_lc
+            for phrase in (
+                "non-interactive",
+                "unknown",
+                "unrecognized",
+                "unrecognised",
+                "no such option",
+                "invalid option",
+                "invalid argument",
+            )
         )
         if not unknown_flag:
             return proc.returncode, proc.stdout, proc.stderr

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 HARNESS_DIR = Path.home() / ".claude"
 LOGDIR = HARNESS_DIR / "logs" / "nightbeat"
+PERMISSION_DIFFS_DIR = HARNESS_DIR / "telemetry" / "permission-diffs"
 PROJECTS: list[Path] = [
     Path.home() / "aedist-technical-report",
     Path.home() / "cadens",
@@ -271,6 +272,31 @@ def _beat_log_night_summary(proj: Path, since: datetime) -> dict:
     return {"counts": counts, "last": last}
 
 
+# ── Unreviewed permission diffs (ticket 0043) ─────────────────────────────────
+
+
+def _unreviewed_permission_diffs(since: datetime) -> list[tuple[Path, int]]:
+    """Return permission-diff files modified since the report window start.
+
+    These are weekly proposals from /fewer-permission-prompts that have not
+    been reviewed (we treat any file under the dir touched in the window as
+    unreviewed — review = move/delete the file).
+    """
+    if not PERMISSION_DIFFS_DIR.is_dir():
+        return []
+    cutoff = since.timestamp()
+    out: list[tuple[Path, int]] = []
+    for p in sorted(PERMISSION_DIFFS_DIR.glob("*.diff")):
+        try:
+            if p.stat().st_mtime < cutoff:
+                continue
+            line_count = sum(1 for _ in p.open())
+        except OSError:
+            continue
+        out.append((p, line_count))
+    return out
+
+
 # ── Default since ──────────────────────────────────────────────────────────────
 
 
@@ -403,6 +429,16 @@ def main() -> None:
             if issue not in seen:
                 print(f"  {issue}")
                 seen.add(issue)
+
+    # ── Unreviewed permission diffs (ticket 0043) ───────────────────────────────
+    pending = _unreviewed_permission_diffs(since)
+    if pending:
+        print(f"\n{'═' * 72}")
+        print("UNREVIEWED PERMISSION DIFFS")
+        print(f"{'═' * 72}")
+        for path, line_count in pending:
+            print(f"  UNREVIEWED PERMISSION DIFF: {path.name} ({line_count} lines)")
+        print(f"  review at: {PERMISSION_DIFFS_DIR}")
 
     # ── Totals ──────────────────────────────────────────────────────────────────
     n_done = sum(1 for r in runs if r.oc_status == "done")

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1427,6 +1427,7 @@ class TestWeeklyPermissionsPrune:
             return MagicMock(returncode=0, stdout=b"")
 
         monkeypatch.setattr(beat, "_is_prune_day", lambda: False)
+        monkeypatch.setattr(beat, "HARNESS_DIR", tmp_path)
         monkeypatch.setattr(beat.subprocess, "run", fake_run)
         beat._prune_permissions(tmp_path)
         assert called["v"] is False
@@ -1439,15 +1440,40 @@ class TestWeeklyPermissionsPrune:
             return MagicMock(returncode=0, stdout=b"")
 
         monkeypatch.setattr(beat, "_is_prune_day", lambda: True)
+        monkeypatch.setattr(beat, "HARNESS_DIR", tmp_path)
         monkeypatch.setattr(beat.subprocess, "run", fake_run)
         beat._prune_permissions(tmp_path)
         assert called["v"] is True
+
+    def test_skipped_when_today_diff_exists(self, tmp_path, monkeypatch):
+        """Once-per-day guard: helper not invoked if today's diff already exists."""
+        called = {"v": False}
+
+        def fake_run(*a, **k):
+            called["v"] = True
+            return MagicMock(returncode=0, stdout=b"")
+
+        monkeypatch.setattr(beat, "_is_prune_day", lambda: True)
+        monkeypatch.setattr(beat, "HARNESS_DIR", tmp_path)
+        monkeypatch.setattr(beat.subprocess, "run", fake_run)
+
+        diffs = tmp_path / "telemetry" / "permission-diffs"
+        diffs.mkdir(parents=True)
+        today = datetime.now().strftime("%Y-%m-%d")
+        (diffs / f"{today}.diff").write_text("# already produced earlier today\n")
+
+        beat._prune_permissions(tmp_path)
+        assert called["v"] is False, (
+            "second invocation on the same day must short-circuit before"
+            " spawning the helper"
+        )
 
     def test_failure_does_not_raise(self, tmp_path, monkeypatch):
         def boom(*a, **k):
             raise OSError("simulated failure")
 
         monkeypatch.setattr(beat, "_is_prune_day", lambda: True)
+        monkeypatch.setattr(beat, "HARNESS_DIR", tmp_path)
         monkeypatch.setattr(beat.subprocess, "run", boom)
         # Must not propagate.
         beat._prune_permissions(tmp_path)

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1413,3 +1413,57 @@ class TestRaidCooldownRecentPick:
         assert any("pick-ticket" in c for c in calls), (
             "pick-ticket should be invoked when no recent-pick cooldown applies"
         )
+
+
+# ── Weekly /fewer-permission-prompts (ticket 0043) ────────────────────────────
+
+
+class TestWeeklyPermissionsPrune:
+    def test_skipped_on_non_prune_day(self, tmp_path, monkeypatch):
+        called = {"v": False}
+
+        def fake_run(*a, **k):
+            called["v"] = True
+            return MagicMock(returncode=0, stdout=b"")
+
+        monkeypatch.setattr(beat, "_is_prune_day", lambda: False)
+        monkeypatch.setattr(beat.subprocess, "run", fake_run)
+        beat._prune_permissions(tmp_path)
+        assert called["v"] is False
+
+    def test_runs_on_prune_day(self, tmp_path, monkeypatch):
+        called = {"v": False}
+
+        def fake_run(*a, **k):
+            called["v"] = True
+            return MagicMock(returncode=0, stdout=b"")
+
+        monkeypatch.setattr(beat, "_is_prune_day", lambda: True)
+        monkeypatch.setattr(beat.subprocess, "run", fake_run)
+        beat._prune_permissions(tmp_path)
+        assert called["v"] is True
+
+    def test_failure_does_not_raise(self, tmp_path, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr(beat, "_is_prune_day", lambda: True)
+        monkeypatch.setattr(beat.subprocess, "run", boom)
+        # Must not propagate.
+        beat._prune_permissions(tmp_path)
+
+    def test_is_prune_day_uses_config(self, monkeypatch):
+        # Force the configured day to a deterministic weekday name.
+        from datetime import datetime as _dt
+
+        class _FakeDT(_dt):
+            @classmethod
+            def now(cls, tz=None):  # noqa: ARG002 — match signature
+                return _dt(2026, 5, 3)  # Sunday
+
+        monkeypatch.setattr(beat, "PERMISSIONS_PRUNE_DAY_OF_WEEK", "sunday")
+        monkeypatch.setattr(beat, "datetime", _FakeDT)
+        assert beat._is_prune_day() is True
+
+        monkeypatch.setattr(beat, "PERMISSIONS_PRUNE_DAY_OF_WEEK", "monday")
+        assert beat._is_prune_day() is False

--- a/tests/test_fewer_permission_prompts_helper.py
+++ b/tests/test_fewer_permission_prompts_helper.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/fewer-permission-prompts-helper.py.
+
+The helper invokes the `claude` CLI; here we shim it with a fake `claude`
+on PATH so the tests are hermetic and never touch the real CLI.
+"""
+
+import os
+import stat
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+HELPER = Path(__file__).parent.parent / "scripts" / "fewer-permission-prompts-helper.py"
+
+
+def _make_fake_claude(bin_dir: Path, *, stdout: str = "diff content\n", rc: int = 0) -> Path:
+    """Create a tiny shell stub that mimics the `claude` CLI."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    fake = bin_dir / "claude"
+    fake.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"printf '%s' {stdout!r}\n"
+        f"exit {rc}\n"
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return fake
+
+
+def _run_helper(project_path: Path, env: dict[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(HELPER), str(project_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_helper_writes_diff_file(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    _make_fake_claude(bin_dir, stdout="proposed allowlist diff\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env["HOME"] = str(home)
+
+    result = _run_helper(project, env)
+    assert result.returncode == 0, result.stderr
+
+    diffs_dir = home / ".claude" / "telemetry" / "permission-diffs"
+    assert diffs_dir.is_dir()
+    today = datetime.now().strftime("%Y-%m-%d")
+    diff_path = diffs_dir / f"{today}.diff"
+    assert diff_path.exists()
+    assert "proposed allowlist diff" in diff_path.read_text()
+
+
+def test_helper_does_not_crash_when_claude_missing(tmp_path):
+    """If the `claude` CLI is unavailable, helper must exit 0 with a stub diff."""
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    env = os.environ.copy()
+    # Strip PATH so `claude` cannot be found.
+    env["PATH"] = "/nonexistent"
+    env["HOME"] = str(home)
+
+    result = _run_helper(project, env)
+    assert result.returncode == 0, (
+        f"helper must not crash when claude missing; got rc={result.returncode}\n"
+        f"stderr={result.stderr}"
+    )
+
+    diffs_dir = home / ".claude" / "telemetry" / "permission-diffs"
+    today = datetime.now().strftime("%Y-%m-%d")
+    diff_path = diffs_dir / f"{today}.diff"
+    assert diff_path.exists()
+    # Stub diff should mention that the CLI was unavailable.
+    body = diff_path.read_text()
+    assert body.startswith("#") or "unavailable" in body.lower() or "claude" in body.lower()
+
+
+def test_helper_appends_when_run_twice_same_day(tmp_path):
+    bin_dir = tmp_path / "bin"
+    _make_fake_claude(bin_dir, stdout="first\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env["HOME"] = str(home)
+
+    r1 = _run_helper(project, env)
+    assert r1.returncode == 0, r1.stderr
+
+    # Second invocation on the same day should append, not clobber.
+    _make_fake_claude(bin_dir, stdout="second\n")
+    r2 = _run_helper(project, env)
+    assert r2.returncode == 0, r2.stderr
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    diff_path = home / ".claude" / "telemetry" / "permission-diffs" / f"{today}.diff"
+    body = diff_path.read_text()
+    assert "first" in body
+    assert "second" in body
+
+
+def test_helper_requires_project_arg(tmp_path):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(HELPER)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_nightbeat_report.py
+++ b/tests/test_nightbeat_report.py
@@ -57,3 +57,46 @@ def test_parser_accepts_mixed_labels_in_one_log(tmp_path):
     )
     run = nbr.parse_log(_write_log(tmp_path, body))
     assert run.oc_status == "aborted"
+
+
+# ── Unreviewed permission diffs (ticket 0043) ─────────────────────────────────
+
+
+def test_unreviewed_permission_diffs_picks_recent(tmp_path, monkeypatch):
+    diffs_dir = tmp_path / "permission-diffs"
+    diffs_dir.mkdir()
+    fresh = diffs_dir / "2026-05-03.diff"
+    fresh.write_text("line1\nline2\nline3\n")
+    monkeypatch.setattr(nbr, "PERMISSION_DIFFS_DIR", diffs_dir)
+
+    from datetime import datetime, timedelta, timezone
+
+    since = datetime.now(timezone.utc) - timedelta(hours=1)
+    found = nbr._unreviewed_permission_diffs(since)
+    assert len(found) == 1
+    assert found[0][0] == fresh
+    assert found[0][1] == 3
+
+
+def test_unreviewed_permission_diffs_ignores_old(tmp_path, monkeypatch):
+    import os
+    from datetime import datetime, timedelta, timezone
+
+    diffs_dir = tmp_path / "permission-diffs"
+    diffs_dir.mkdir()
+    old = diffs_dir / "2026-04-01.diff"
+    old.write_text("ancient\n")
+    # Backdate mtime by 30 days.
+    old_ts = (datetime.now() - timedelta(days=30)).timestamp()
+    os.utime(old, (old_ts, old_ts))
+    monkeypatch.setattr(nbr, "PERMISSION_DIFFS_DIR", diffs_dir)
+
+    since = datetime.now(timezone.utc) - timedelta(hours=8)
+    assert nbr._unreviewed_permission_diffs(since) == []
+
+
+def test_unreviewed_permission_diffs_no_dir(tmp_path, monkeypatch):
+    from datetime import datetime, timezone
+
+    monkeypatch.setattr(nbr, "PERMISSION_DIFFS_DIR", tmp_path / "missing")
+    assert nbr._unreviewed_permission_diffs(datetime.now(timezone.utc)) == []

--- a/tickets/0043-weekly-fewer-permission-prompts.erg
+++ b/tickets/0043-weekly-fewer-permission-prompts.erg
@@ -1,6 +1,6 @@
 %erg v1
 Title: Run /fewer-permission-prompts weekly via systemd timer
-Status: open
+Status: closed
 Created: 2026-04-28
 Author: claude
 
@@ -10,6 +10,7 @@ Author: claude
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:c3bfb0ede8f9 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:9f5957e07f6c expires:2026-04-30T09:21Z
 2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
+2026-05-03T12:55Z claude status closed — folded into nightbeat per Phase 2 refinement; weekly Sunday step writes diffs to ~/.claude/telemetry/permission-diffs/ and surfaces unreviewed entries in nightbeat-report
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Folds the weekly `/fewer-permission-prompts` run into nightbeat (Phase 2 refinement) instead of a dedicated systemd timer.
- New `_prune_permissions(project)` step runs in `_raid()` between housekeeping and pick-ticket. It is a no-op except on the configured weekday (`PERMISSIONS_PRUNE_DAY_OF_WEEK = "sunday"`).
- New `scripts/fewer-permission-prompts-helper.py` spawns the Anthropic-shipped skill, writes the proposed allowlist diff to `~/.claude/telemetry/permission-diffs/<date>.diff` (append within the same day), and never auto-applies.
- `nightbeat-report.py` gains an `UNREVIEWED PERMISSION DIFFS` section that lists files modified since the report window started, so review-or-discard becomes a daily morning prompt.
- Closes ticket 0043; STATE.md and README.md updated.

## Test plan

- [x] Red step landed first (`tests/test_beat.py::TestWeeklyPermissionsPrune` and `tests/test_fewer_permission_prompts_helper.py`).
- [x] `pytest tests/` — 107 passed.
- [x] Smoke test of the helper with `HOME` redirected to a tmp dir produced a real diff via the fallback (`--non-interactive` is unknown on `claude` 2.1.126; stdin-pipe fallback used as designed).
- [x] `./tickets/tools/go/erg validate tickets/` — PASS (73 tickets).
- [x] `bash scripts/check-project-leak.sh` — OK.
- [x] `pipefail-guard` (no new `*.sh`) — vacuously OK.

## Caveats

- **Bug `anthropics/claude-code#51057`** strips env-var prefixes during extraction, so commands like `TEST_DATABASE_URL=... uv run pytest` are missed. Documented in the helper header. Diffs must be reviewed by hand before applying.
- The current `claude` CLI (2.1.126) does not recognise `--non-interactive`. The helper detects this and falls back to piping a confirm-no `\n` to stdin (verified end-to-end on this branch).
- If the `claude` CLI is unavailable on a given host, the helper writes a single comment-line stub diff and returns 0 — `beat.py` never propagates the failure.
- No auto-apply: diffs are read-only artifacts; the human edits `settings.local.json` after review.

https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7sQrXTGU329U1i5DoPZ3p)_