### PR TITLE
ticket(0075): document why ticket-new is model-invocable

### DIFF
--- a/skills/ticket-new/SKILL.md
+++ b/skills/ticket-new/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: ticket-new
 description: Create a local %erg v1 file for agent coordination.
+# Model-invocable: parses free-form input (title, sentence, gh JSON, paste) into %erg v1.
+# Side effects are file-only — no branch, no PR — so autonomous capture is safe.
+# Contrast start-ticket (disable-model-invocation: true), which creates worktree + branch + PR.
 disable-model-invocation: false
 user-invocable: true
 argument-hint: [title]

--- a/tickets/0075-ticket-new-disable-model-invocation.erg
+++ b/tickets/0075-ticket-new-disable-model-invocation.erg
@@ -1,11 +1,12 @@
 %erg v1
 Title: Audit disable-model-invocation setting in ticket-* skills
-Status: open
+Status: closed
 Created: 2026-05-02
 Author: claude
 
 --- log ---
 2026-05-02T23:10Z claude created
+2026-05-03T16:00Z claude status closed — audit-complete
 
 --- body ---
 ## Context


### PR DESCRIPTION
Audit conclusion: ticket-new (false) and start-ticket (true) differ
intentionally — ticket-new only writes a file (cheap, idea-capture-friendly,
safe for autonomous invocation), start-ticket creates a worktree + branch + PR
(big side effects, must be user-initiated). Other ticket-* skills (close,
ready, new-ticket) keep false as cheap model-invocable wrappers. Added a YAML
comment in ticket-new's frontmatter explaining the contrast.

https://claude.ai/code/session_01UD2DQKdHansTaKRqgK65ba