### PR TITLE
tickets(0079-0083): mechanization swarm — LLM→script for 5 skills

### DIFF
--- a/tickets/0079-mechanize-smoke-skill.erg
+++ b/tickets/0079-mechanize-smoke-skill.erg
@@ -1,0 +1,26 @@
+%erg v1
+Title: Mechanize smoke skill — extract shell steps to bash script
+Status: open
+Created: 2026-05-03
+Author: claude
+
+--- log ---
+2026-05-03T09:00Z claude created
+
+--- body ---
+## Context
+The smoke skill runs 7 shell commands (date, whoami, pwd, printenv, etc.)
+via Bash tool calls, then adds two hardcoded personality responses. Steps
+1-7 are pure data collection; they waste LLM tokens on tool calls that a
+bash script handles in milliseconds.
+
+## Actions
+1. Create `~/.claude/scripts/smoke.sh` that runs and prints items 1-7.
+2. Rewrite smoke skill body: call `smoke.sh` once, then ask the LLM only
+   for the two personality items (Truyện Kiều line, dog name).
+3. Update smoke frontmatter if needed.
+
+## Exit criteria
+- `~/.claude/scripts/smoke.sh` exists and is executable
+- Smoke skill makes exactly 1 Bash call (the script) + 0 additional tool calls for items 1-7
+- Personality items still answered by the LLM

--- a/tickets/0080-beat-skill-self-reporting.erg
+++ b/tickets/0080-beat-skill-self-reporting.erg
@@ -1,0 +1,27 @@
+%erg v1
+Title: Move beat run-summary into beat.py — eliminate JSONL parsing from skill
+Status: open
+Created: 2026-05-03
+Author: claude
+
+--- log ---
+2026-05-03T09:00Z claude created
+
+--- body ---
+## Context
+The beat skill calls beat.py, then reads the last line of beat-log.jsonl
+and formats a human-readable run report. beat.py already has all the data
+in memory when the run ends; printing its own summary removes the need for
+the skill to parse JSONL.
+
+## Actions
+1. Add a `_print_run_summary()` call at the end of the beat.py run loop,
+   printing: project, ticket_id, outcome, duration, cost.
+2. Redirect this output to stdout (not just the log file).
+3. Simplify the beat skill body: remove the JSONL-read and format steps.
+   The skill becomes: invoke beat.py, echo its stdout.
+
+## Exit criteria
+- beat.py prints a one-line summary on stdout at end of run
+- beat skill body contains no JSONL parsing
+- Output format matches what the nightbeat-report parser expects (or parser updated)

--- a/tickets/0081-mechanize-bib-merge-skill.erg
+++ b/tickets/0081-mechanize-bib-merge-skill.erg
@@ -1,0 +1,29 @@
+%erg v1
+Title: Mechanize bib-merge skill — extract deduplication to Python script
+Status: open
+Created: 2026-05-03
+Author: claude
+
+--- log ---
+2026-05-03T09:00Z claude created
+
+--- body ---
+## Context
+The bib-merge skill does bibtex deduplication: parse fence, match by
+author+year+DOI/title, dedupe, rename keys on collision, append to refs.bib,
+report diffs. This is deterministic string manipulation. The LLM adds no
+reasoning value; it just runs an algorithm that Python handles better.
+
+## Actions
+1. Implement `~/.claude/scripts/bib-merge.py`:
+   - Reads a bibtex block from stdin (or file arg)
+   - Parses with `bibtexparser` (or hand-rolled; entries are simple)
+   - Deduplicates against existing `refs.bib` on author+year, confirmed by DOI or title
+   - Renames key on collision (bump suffix), appends new entries
+   - Prints a diff-style report of added/skipped/renamed entries
+2. Rewrite bib-merge skill: pipe input to `bib-merge.py`, report its output.
+
+## Exit criteria
+- `~/.claude/scripts/bib-merge.py` exists, tested on ≥2 entries including a duplicate
+- Skill body makes one Bash call to the script
+- No LLM string-manipulation steps remain in the skill body

--- a/tickets/0082-mechanize-rwn-validate-skill.erg
+++ b/tickets/0082-mechanize-rwn-validate-skill.erg
@@ -1,0 +1,30 @@
+%erg v1
+Title: Mechanize related-work-note-validate — extract URL resolution to Python
+Status: open
+Created: 2026-05-03
+Author: claude
+
+--- log ---
+2026-05-03T09:00Z claude created
+
+--- body ---
+## Context
+The related-work-note-validate skill iterates bibliography entries, calls
+WebFetch for each DOI/URL/eprint, and reports PASS/WARN/FAIL. This is a
+mechanical HTTP-fetch loop with deterministic verdict logic. The LLM adds
+no value; it just makes N WebFetch calls and checks HTTP status codes.
+
+## Actions
+1. Implement `~/.claude/scripts/validate-refs.py`:
+   - Reads a related-work-note markdown file (path as arg)
+   - Extracts DOI/URL/arXiv eprint from the Bibliography section
+   - Resolves each via HTTP (requests library, follow doi.org redirects)
+   - Reports per-entry: identifier, resolved URL, HTTP status
+   - Exits with verdict: PASS / WARN (entries with no identifier) / FAIL (fetch failed)
+2. Rewrite skill: call `validate-refs.py <file>`, append provenance bullet on PASS,
+   surface failures for LLM to annotate.
+
+## Exit criteria
+- `~/.claude/scripts/validate-refs.py` exists, runs on a sample note
+- Skill makes one Bash call to the script
+- LLM only handles failure annotation, not the fetch loop

--- a/tickets/0083-mechanize-ticket-ready-skill.erg
+++ b/tickets/0083-mechanize-ticket-ready-skill.erg
@@ -1,0 +1,25 @@
+%erg v1
+Title: Mechanize ticket-ready skill — thin wrapper over erg ready
+Status: open
+Created: 2026-05-03
+Author: claude
+
+--- log ---
+2026-05-03T09:00Z claude created
+
+--- body ---
+## Context
+The ticket-ready skill calls `erg ready --json`, parses the JSON, and
+formats a list. This is a display shim with no LLM reasoning. The binary
+already produces the correct list; the skill adds no value beyond formatting.
+
+## Actions
+1. Check if `erg ready` (without --json) produces human-readable output.
+   If yes: replace skill body with `erg ready tickets/`.
+   If no: add a human-readable output mode to `erg ready` (git-erg ticket).
+2. If skill becomes a 1-liner, consider whether it warrants existence at all
+   vs. just documenting `erg ready` in the harness README.
+
+## Exit criteria
+- ticket-ready skill body is ≤5 lines OR skill is removed entirely
+- Running `/ticket-ready` produces the same list as `erg ready tickets/`


### PR DESCRIPTION
## Summary

- Add tickets 0079–0083 for the mechanization swarm (extract LLM steps to scripts)
- Drop ticket 0077 (superseded: `erg close` subcommand + ticket-close delegation already shipped in PRs #85/#92)
- Renumber old 0078 → 0083 to avoid ID collision with origin's closed 0078

## Tickets added

- **0079** — Mechanize smoke skill: extract shell steps to bash script
- **0080** — Move beat run-summary into beat.py (eliminate JSONL parsing from skill)
- **0081** — Mechanize bib-merge: extract deduplication to Python script
- **0082** — Mechanize related-work-note-validate: extract URL resolution to Python
- **0083** — Mechanize ticket-ready: thin wrapper over `erg ready` (human-readable output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)