### PR TITLE
ticket(0041): close as no-op — fresh sessions per sub-skill

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -34,7 +34,6 @@ Level 4 (Hooks) + raid + `/verify` loop + git-erg tickets + bibliography pipelin
 - 0029 — beat dashboard blocker graph (blocked by 0028)
 - 0031 — housekeeping: replace grep-based scan with `erg ready --json`
 - 0034 — housekeeping: split git-cleanup and ticket-scan into two phases
-- 0041 — investigate mid-session context reset between sub-skills
 - 0044 — interactive session observer
 - 0047 — auto early context compaction in beat and raid
 - 0051 — beat should try another project when current one is idle or frozen

--- a/tickets/0041-beat-mid-session-context-reset.erg
+++ b/tickets/0041-beat-mid-session-context-reset.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-04-27T12:30Z claude created
 
 2026-04-27T21:04Z claude note sweep-assess: not-picked hash:984bdefc447d scope:read beat.py and logs, potentially close as no-op risk:low
+2026-05-05T10:00Z claude closed — beat.py is pure Python orchestration; each sub-skill is a fresh subprocess with --no-session-persistence + --print, so no session accumulates context. H2 (sub-session bloat) is bounded by existing budget caps ($0.75) and timeouts (8–10 min). Solution candidates A/B unnecessary; closes as no-op per acceptance criteria.
 --- body ---
 ## Problem
 


### PR DESCRIPTION
## Summary

- Close ticket 0041 (mid-session context reset investigation) as no-op
- `beat.py` is pure Python orchestration — each sub-skill (`/housekeeping`, `/pick-ticket`, `/raid`) spawns a fresh `claude` subprocess with `--no-session-persistence` + `--print`
- Sub-session bloat (H2) bounded by existing budget caps ($0.75) and timeouts (8–10 min); no additional mitigation needed

## Test plan

- [x] Verified `_claude_argv` uses `--no-session-persistence` (line 416) and `--print` (line 412)
- [x] Verified `run_skill` spawns a new `subprocess.Popen` per invocation
- [x] No code changes — ticket closure only

🤖 Generated with [Claude Code](https://claude.com/claude-code)