### PR TITLE
Harness maintenance: beat/nightbeat fixes + ticket 0086

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -34,7 +34,6 @@ Level 4 (Hooks) + raid + `/verify` loop + git-erg tickets + bibliography pipelin
 - 0029 — beat dashboard blocker graph (blocked by 0028)
 - 0031 — housekeeping: replace grep-based scan with `erg ready --json`
 - 0034 — housekeeping: split git-cleanup and ticket-scan into two phases
-- 0041 — investigate mid-session context reset between sub-skills
 - 0044 — interactive session observer
 - 0047 — auto early context compaction in beat and raid
 - 0051 — beat should try another project when current one is idle or frozen

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -13,7 +13,6 @@ import json
 import os
 import re
 import secrets
-import shutil
 import signal
 import socket
 import subprocess
@@ -21,7 +20,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from io import TextIOBase
 from pathlib import Path
 
@@ -124,9 +123,7 @@ _PROJ_KEYS = {"budget_housekeeping", "budget_pick_ticket", "pick_ticket_model"}
 def load_projects(config_path: Path) -> list[ProjectConfig]:
     """Load project list from JSON; fall back to built-in defaults on any error."""
     if not config_path.exists():
-        print(
-            f"[beat] {config_path} not found, using built-in defaults", file=sys.stderr
-        )
+        print(f"[beat] {config_path} not found, using built-in defaults", file=sys.stderr)
         return list(_BUILTIN_PROJECTS)
     try:
         entries = json.loads(config_path.read_text())
@@ -152,7 +149,7 @@ PROJECTS: list[ProjectConfig] = load_projects(PROJECTS_CONFIG)
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _log(msg: str) -> None:
@@ -194,15 +191,11 @@ def _cleanup_stale_in_progress(project: Path) -> None:
                 rec = json.loads(line)
                 if rec.get("outcome") == "in_progress":
                     epoch = datetime.fromisoformat(
-                        rec.get("last_run_at", "1970-01-01T00:00:00Z").replace(
-                            "Z", "+00:00"
-                        )
+                        rec.get("last_run_at", "1970-01-01T00:00:00Z").replace("Z", "+00:00")
                     ).timestamp()
                     if epoch < cutoff:
                         rec["outcome"] = "aborted"
-                        rec["diagnostics"] = (
-                            "stale in_progress — cleaned on next beat start"
-                        )
+                        rec["diagnostics"] = "stale in_progress — cleaned on next beat start"
                         line = json.dumps(rec, separators=(",", ":"))
                         changed = True
             except (json.JSONDecodeError, ValueError, TypeError):
@@ -327,7 +320,7 @@ def housekeeping_needed(project: Path) -> bool:
     if age <= HOUSEKEEPING_INTERVAL_S:
         return False
     if age > HOUSEKEEPING_SAFETY_FLOOR_S:
-        last_hk_dt = datetime.fromtimestamp(int(parts[0]), tz=timezone.utc)
+        last_hk_dt = datetime.fromtimestamp(int(parts[0]), tz=UTC)
         if _repo_frozen_since(project, last_hk_dt):
             return False
         return True
@@ -528,9 +521,7 @@ def _sync_origin_main(project: Path) -> None:
         cwd=project,
     )
     default_branch = (
-        head_ref.stdout.strip().removeprefix("origin/")
-        if head_ref.returncode == 0
-        else "main"
+        head_ref.stdout.strip().removeprefix("origin/") if head_ref.returncode == 0 else "main"
     )
 
     # Fetch only the default branch; skip on network or auth failure.
@@ -584,9 +575,7 @@ def _sync_origin_main(project: Path) -> None:
             cwd=project,
         )
         if update.returncode == 0:
-            _log(
-                f"=== sync: {default_branch} updated from origin (HEAD on {branch}) ==="
-            )
+            _log(f"=== sync: {default_branch} updated from origin (HEAD on {branch}) ===")
         else:
             _log(
                 f"=== sync: {default_branch} update skipped — "
@@ -600,9 +589,7 @@ def _sync_origin_main(project: Path) -> None:
 
 
 def _setup_env() -> None:
-    os.environ["PATH"] = (
-        f"{Path.home() / '.local' / 'bin'}:/usr/local/bin:/usr/bin:/bin"
-    )
+    os.environ["PATH"] = f"{Path.home() / '.local' / 'bin'}:/usr/local/bin:/usr/bin:/bin"
     for var, val in {
         "GIT_AUTHOR_NAME": "claude-agent",
         "GIT_AUTHOR_EMAIL": "claude-agent@localhost",
@@ -639,69 +626,15 @@ def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
     )
 
 
-def _gh_available() -> bool:
-    return shutil.which("gh") is not None
-
-
-PR_CHECK_POLL_INTERVAL_S: int = 15
-PR_CHECK_TIMEOUT_S: int = 10 * 60
-PR_CHECK_TRANSIENT_RETRIES: int = 3
-
-
-def _wait_for_pr_checks(branch: str, *, cwd: Path) -> bool:
-    """Block until all PR checks settle. Return True iff all pass.
-
-    Tolerates a small number of transient `gh pr checks` failures
-    (rate limit, network blip) before giving up.
-    """
-    deadline = time.monotonic() + PR_CHECK_TIMEOUT_S
-    transient_failures = 0
-    while time.monotonic() < deadline:
-        result = subprocess.run(  # noqa: S603, S607
-            ["gh", "pr", "checks", branch, "--json", "name,bucket"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=cwd,
-        )
-        if result.returncode != 0:
-            transient_failures += 1
-            if transient_failures > PR_CHECK_TRANSIENT_RETRIES:
-                return False
-            time.sleep(PR_CHECK_POLL_INTERVAL_S)
-            continue
-        try:
-            checks = json.loads(result.stdout)
-        except json.JSONDecodeError:
-            transient_failures += 1
-            if transient_failures > PR_CHECK_TRANSIENT_RETRIES:
-                return False
-            time.sleep(PR_CHECK_POLL_INTERVAL_S)
-            continue
-        transient_failures = 0
-        if not checks:
-            time.sleep(PR_CHECK_POLL_INTERVAL_S)
-            continue
-        buckets = {c.get("bucket") for c in checks}
-        if "pending" in buckets:
-            time.sleep(PR_CHECK_POLL_INTERVAL_S)
-            continue
-        return buckets <= {"pass"}
-    return False
-
-
 def _housekeeping_phase(project: ProjectConfig) -> str:
-    """Run housekeeping on a dedicated branch; PR+merge if commits land.
+    """Run housekeeping on a dedicated branch cut from origin/main.
 
     Returns one of:
       "skipped"    — housekeeping_needed was False
       "no-changes" — skill ran clean, produced no commits
-      "merged"     — PR opened, CI green, squash-merged into main
-      "deferred"   — commits exist locally; PR/merge automation off (no gh
-                     or BEAT_HOUSEKEEPING_PR != 1) — branch left for human
-      "ci-failed"  — PR opened but at least one check failed
+      "deferred"   — commits on branch, left for human review
       "timeout"    — skill timed out
-      "failed"     — git/gh/skill error
+      "failed"     — git or skill error
     """
     path = project.path
     if not housekeeping_needed(path):
@@ -713,14 +646,12 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
         _log("=== housekeeping: cannot resolve origin/main ===")
         return "failed"
 
-    nonce = (
-        datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        + "-"
-        + secrets.token_hex(2)
-    )
+    nonce = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ") + "-" + secrets.token_hex(2)
     branch = f"claude/housekeeping-{nonce}"
-    if _git("checkout", "-B", branch, base, cwd=path).returncode != 0:
-        _log(f"=== housekeeping: failed to create {branch} ===")
+    r = _git("checkout", "-B", branch, base, cwd=path)
+    if r.returncode != 0:
+        detail = (r.stderr or r.stdout or "").strip().replace("\n", " | ")
+        _log(f"=== housekeeping: failed to create {branch}: {detail} ===")
         return "failed"
 
     _log(f"=== housekeeping: running on {branch} {_now_iso()} ===")
@@ -743,69 +674,14 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
         return "failed"
 
     n = _git("rev-list", "--count", f"{base}..HEAD", cwd=path).stdout.strip() or "0"
+    _git("checkout", "main", cwd=path)
     if int(n) == 0:
         _log("=== housekeeping: no commits, deleting branch ===")
-        _git("checkout", "main", cwd=path)
         _git("branch", "-D", branch, cwd=path)
         return "no-changes"
 
-    _log(f"=== housekeeping: {n} commit(s) on {branch} ===")
-
-    if not (os.environ.get("BEAT_HOUSEKEEPING_PR") == "1" and _gh_available()):
-        # Switch back to main so pick-ticket → raid don't run on the
-        # housekeeping branch and pick up its commits as their base.
-        _git("checkout", "main", cwd=path)
-        _log(f"=== housekeeping: deferred — branch {branch} ready for review ===")
-        return "deferred"
-
-    if _git("push", "-u", "origin", branch, cwd=path).returncode != 0:
-        return "failed"
-    log_lines = _git("log", "--format=- %s", f"{base}..HEAD", cwd=path).stdout.strip()
-    body = "Automated nightbeat housekeeping sweep.\n\n## Changes\n\n" + (
-        log_lines or "(none)"
-    )
-    pr = subprocess.run(  # noqa: S603, S607
-        [
-            "gh",
-            "pr",
-            "create",
-            "--base",
-            "main",
-            "--head",
-            branch,
-            "--title",
-            f"chore: housekeeping fixes (sweep) — {n} commit(s)",
-            "--body",
-            body,
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=path,
-    )
-    if pr.returncode != 0:
-        _log(f"=== housekeeping: gh pr create failed: {pr.stderr.strip()} ===")
-        return "failed"
-
-    if not _wait_for_pr_checks(branch, cwd=path):
-        _log(f"=== housekeeping: CI red on {branch} — aborting beat ===")
-        return "ci-failed"
-
-    merge = subprocess.run(  # noqa: S603, S607
-        ["gh", "pr", "merge", branch, "--squash", "--delete-branch"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=path,
-    )
-    if merge.returncode != 0:
-        _log(f"=== housekeeping: gh pr merge failed: {merge.stderr.strip()} ===")
-        return "failed"
-
-    _git("checkout", "main", cwd=path)
-    _git("pull", "--ff-only", "origin", "main", cwd=path)
-    _log(f"=== housekeeping: merged {branch} {_now_iso()} ===")
-    return "merged"
+    _log(f"=== housekeeping: deferred — {n} commit(s) on {branch} ready for review ===")
+    return "deferred"
 
 
 def _ticket_recently_picked(ticket_path: Path, within_hours: int = 8) -> bool:
@@ -816,7 +692,7 @@ def _ticket_recently_picked(ticket_path: Path, within_hours: int = 8) -> bool:
     log shows it was picked within ``within_hours`` should not be re-picked
     until the prior raid has had a chance to close it.
     """
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=within_hours)
+    cutoff = datetime.now(UTC) - timedelta(hours=within_hours)
     try:
         text = ticket_path.read_text()
     except (FileNotFoundError, OSError):
@@ -825,7 +701,7 @@ def _ticket_recently_picked(ticket_path: Path, within_hours: int = 8) -> bool:
         if "sweep-pick: selected" in line or "sweep-pick: picked" in line:
             try:
                 ts_str = line.split()[0].rstrip("Z")
-                ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+                ts = datetime.fromisoformat(ts_str).replace(tzinfo=UTC)
                 if ts > cutoff:
                     return True
             except (ValueError, IndexError):
@@ -890,10 +766,18 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     # see current ticket state from merged PRs.
     _sync_origin_main(path)
 
-    # Housekeeping (conditional). Aborts beat on failure/timeout/CI-red so
+    # Ensure working tree is on main before any read or write.
+    # Fails fast with a clear message if the tree is dirty.
+    r = _git("checkout", "main", cwd=path)
+    if r.returncode != 0:
+        detail = (r.stderr or r.stdout or "").strip().replace("\n", " | ")
+        _log(f"=== beat aborted: cannot checkout main: {detail} ===")
+        return "aborted", None
+
+    # Housekeeping (conditional). Aborts beat on failure/timeout so
     # pick-ticket → raid never runs against a known-bad main.
     hk_outcome = _housekeeping_phase(project)
-    if hk_outcome in ("failed", "timeout", "ci-failed"):
+    if hk_outcome in ("failed", "timeout"):
         return "aborted", None
 
     # Cooldown-recent-pick guard (ticket 0051 Layer 0). If any open ticket
@@ -953,12 +837,8 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
         return "idle", None
 
     if status == "idle":
-        last_result_line = (
-            pt_result.strip().splitlines()[-1] if pt_result.strip() else ""
-        )
-        _log(
-            f"=== pick-ticket: idle — {last_result_line or 'IDLE: no eligible tickets'} ==="
-        )
+        last_result_line = pt_result.strip().splitlines()[-1] if pt_result.strip() else ""
+        _log(f"=== pick-ticket: idle — {last_result_line or 'IDLE: no eligible tickets'} ===")
         return "idle", None
 
     _log(f"=== pick-ticket: picked {ticket_id} {_now_iso()} ===")
@@ -1009,7 +889,7 @@ def main() -> None:
 
     # Per-run logfile (opened before lock so startup messages are captured)
     LOGDIR.mkdir(parents=True, exist_ok=True)
-    logfile = LOGDIR / f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.log"
+    logfile = LOGDIR / f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}.log"
     _state.log_fh = logfile.open("a")
 
     # Rotate old logs
@@ -1049,9 +929,7 @@ def main() -> None:
     if last and last.get("outcome") == "in_progress":
         try:
             last_at = last.get("last_run_at", "1970-01-01T00:00:00Z")
-            last_epoch = datetime.fromisoformat(
-                last_at.replace("Z", "+00:00")
-            ).timestamp()
+            last_epoch = datetime.fromisoformat(last_at.replace("Z", "+00:00")).timestamp()
             if (time.time() - last_epoch) < CRASH_RECOVERY_WINDOW_S:
                 append_beat_log(
                     path,
@@ -1097,9 +975,7 @@ def main() -> None:
     ticket_label = ticket_id if ticket_id else "—"
     minutes, seconds = divmod(int(elapsed), 60)
     duration_str = f"{minutes}m {seconds}s" if minutes else f"{seconds}s"
-    print(
-        f"beat: {path.name} ticket={ticket_label} outcome={outcome} duration={duration_str}"
-    )
+    print(f"beat: {path.name} ticket={ticket_label} outcome={outcome} duration={duration_str}")
 
     _log(f"=== beat done elapsed={elapsed}s {_now_iso()} ===")
     if _state.log_fh is not None:

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -20,12 +20,19 @@ from pathlib import Path
 HARNESS_DIR = Path.home() / ".claude"
 LOGDIR = HARNESS_DIR / "logs" / "nightbeat"
 PERMISSION_DIFFS_DIR = HARNESS_DIR / "telemetry" / "permission-diffs"
-PROJECTS: list[Path] = [
-    Path.home() / "aedist-technical-report",
-    Path.home() / "cadens",
-    Path.home() / "Climate_finance",
-    Path.home() / "fuzzy-corpus",
-]
+PROJECTS_CONFIG = HARNESS_DIR / "scripts" / "projects.json"
+
+
+def _load_rotation_projects() -> list[Path]:
+    """Load project paths from projects.json (same source as beat.py)."""
+    if not PROJECTS_CONFIG.exists():
+        return []
+    try:
+        entries = json.loads(PROJECTS_CONFIG.read_text())
+        return [Path(e["path"]).expanduser() for e in entries]
+    except Exception:
+        return []
+
 
 _MARKER = re.compile(r"^=== (.+?) (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z) ===$")
 _RUN_RE = re.compile(r"^Run \d+\s+\S+\s+project slot \d+: (.+)$")
@@ -464,10 +471,11 @@ def main() -> None:
     )
 
     # ── Per-project beat-log summary ────────────────────────────────────────────
+    rotation = _load_rotation_projects()
     print(f"\n{'═' * 72}")
     print("PER-PROJECT SUMMARY  (from beat-log.jsonl)")
     print(f"{'═' * 72}")
-    for proj_path in PROJECTS:
+    for proj_path in rotation:
         summary = _beat_log_night_summary(proj_path, since)
         counts = summary["counts"]
         last = summary["last"]

--- a/tickets/0041-beat-mid-session-context-reset.erg
+++ b/tickets/0041-beat-mid-session-context-reset.erg
@@ -2,11 +2,13 @@
 Title: Force context reset between housekeeping and pick-ticket sub-sessions
 Created: 2026-04-27
 Author: claude
+Closed: beat.py spawns fresh claude CLI processes with --no-session-persistence; no context accumulates between sub-tasks. Hypothesis C (no-op) confirmed.
 
 --- log ---
 2026-04-27T12:30Z claude created
 
 2026-04-27T21:04Z claude note sweep-assess: not-picked hash:984bdefc447d scope:read beat.py and logs, potentially close as no-op risk:low
+2026-05-05T04:07Z claude closed — beat.py spawns fresh claude CLI processes with --no-session-persistence; no context accumulates between sub-tasks. Hypothesis C (no-op) confirmed.
 --- body ---
 ## Problem
 

--- a/tickets/0086-project-state-script.erg
+++ b/tickets/0086-project-state-script.erg
@@ -1,0 +1,120 @@
+%erg v1
+Title: Write project-state.py — mechanical per-project state probe
+Status: open
+Created: 2026-05-05
+Author: claude
+
+--- log ---
+2026-05-05T09:00Z haduong created
+
+--- body ---
+## Context
+
+Two upcoming skills need structured, LLM-free project state: `/eyes` (multi-project
+raid-readiness survey) and `/healthcheck` (deep per-project audit). Both share the
+same mechanical layer — git status, branch hygiene, housekeeping state, ticket
+readiness — but currently no script exposes this. `beat.py` duplicates some of
+it (`housekeeping_needed()`); the rest is assembled ad-hoc inside LLM sessions.
+
+This ticket produces the shared mechanical probe that both skills call. The LLM
+layer reads its structured output and applies judgment; it does not re-derive state
+from raw git commands.
+
+## What
+
+`~/.claude/scripts/project-state.py <project-path> [--full]`
+
+A single-project state probe. JSON output on stdout, exit 0 always (errors
+appear as fields, never as non-zero exit — callers must not break on a missing
+test runner or absent `erg` binary).
+
+**Fast mode (default)** — runs in under 1 s per project, safe to call across
+all projects in a beat:
+
+```json
+{
+  "path": "/home/haduong/aedist-technical-report",  <!-- harness-extension-point: illustrative path -->
+  "git": {
+    "clean": true,
+    "ahead": 0,
+    "behind": 0,
+    "branch": "main"
+  },
+  "housekeeping": {
+    "state": "clean | needed | tidying",
+    "branch": "claude/housekeeping-20260505T040423Z-27ce | null",
+    "last_commit_ts": "2026-05-04T21:00Z | null",
+    "age_hours": 12.3
+  },
+  "tickets": {
+    "ready": 3,
+    "open": 7,
+    "ready_ids": ["0150", "0156", "0160"]
+  }
+}
+```
+
+`housekeeping.state` derivation:
+- `tidying` — a `claude/housekeeping-*` local branch exists (housekeeping in
+  progress, not yet merged; caller should yield its turn)
+- `needed` — no tidying branch AND (`last_commit_ts` is null OR age > threshold)
+- `clean` — no tidying branch AND age ≤ threshold
+
+Threshold defaults to 12 h (matching `HOUSEKEEPING_INTERVAL_S` in beat.py)
+and can be overridden with `--threshold-hours N`.
+
+**Full mode (`--full`)** — adds test runner result and all open PRs; may take
+several seconds:
+
+```json
+{
+  ...,
+  "tests": {
+    "runner": "make | pytest | npm | none",
+    "status": "pass | fail | skip",
+    "detail": "12 passed / 0 failed"
+  },
+  "prs": {
+    "open": 2,
+    "items": [{"number": 42, "title": "...", "branch": "..."}]
+  }
+}
+```
+
+## How
+
+- Pure stdlib Python (no third-party imports).
+- Git queries via `subprocess` (same pattern as `beat.py`).
+- `erg ready --json` for ticket list; degrade gracefully if binary absent.
+- `gh pr list --json` for PR data; degrade gracefully if `gh` absent.
+- Test runner autodetection: `Makefile` → `make check-fast` (or `make test`),
+  `pyproject.toml`/`setup.py` → `pytest --tb=no -q`, `package.json` → `npm test`.
+- `housekeeping_needed()` in `beat.py` is **not** replaced here — that
+  refactor belongs in the beat redesign ticket once the script is proven.
+
+## Where
+
+- Script: `~/.claude/scripts/project-state.py`
+- Called by: `/eyes` skill (fast mode, all projects), `/healthcheck` skill
+  (full mode, current project). `beat.py` integration deferred to
+  beat-redesign ticket.
+
+## When / integration order
+
+1. Write and test `project-state.py` in isolation (this ticket).
+2. Update `/healthcheck` to call `project-state.py --full` as its data-collection
+   step (separate ticket).
+3. Write `/eyes` skill using fast mode output (separate ticket).
+4. Replace `housekeeping_needed()` in `beat.py` with a call to the script
+   (separate beat-redesign ticket — out of scope here).
+
+## Exit criteria
+
+- `python3 ~/.claude/scripts/project-state.py ~/.claude` outputs valid JSON.
+- `python3 ~/.claude/scripts/project-state.py ~/.claude --full` includes `tests`
+  and `prs` fields.
+- Running against a project with a dirty working tree sets `git.clean: false`.
+- Running against a project with a `claude/housekeeping-*` branch sets
+  `housekeeping.state: "tidying"`.
+- Running against a project with no `erg` binary sets `tickets.ready: null`
+  and includes `"error": "erg not found"` in the tickets object.


### PR DESCRIPTION
## Summary

- **nightbeat-report**: replaced hardcoded project list with `_load_rotation_projects()` reading `projects.json` — eliminates false-positive per-project summaries for projects no longer in rotation
- **beat.py**: removed dead `BEAT_HOUSEKEEPING_PR` flag and ~80 lines of PR auto-merge/CI-wait code; added explicit `git checkout main` gate in `_raid()` so stale branch state fails fast
- **ticket 0086**: new ticket specifying `project-state.py` — shared mechanical JSON probe for `/eyes` and `/healthcheck` skills

## Test plan

- [ ] `python3 ~/.claude/scripts/nightbeat-report.py --full` shows only projects in rotation (no cadens/Climate_finance/fuzzy-corpus if they were removed)
- [ ] Beat log shows `=== beat aborted: cannot checkout main: ... ===` when working tree is dirty at raid start
- [ ] `tickets/0086-project-state-script.erg` passes `erg validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)