### PR TITLE
feat(0086): project-state.py probe + healthcheck integration

### DIFF
--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Per-project state probe. JSON on stdout, exit 0 always."""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+THRESHOLD_HOURS = 12.0
+
+
+def run(args, cwd):
+    return subprocess.run(args, capture_output=True, text=True, check=False, cwd=cwd)
+
+
+def git_state(project):
+    branch_r = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], project)
+    branch = branch_r.stdout.strip() if branch_r.returncode == 0 else None
+
+    porcelain = run(["git", "status", "--porcelain"], project)
+    clean = porcelain.returncode == 0 and porcelain.stdout.strip() == ""
+
+    lr = run(["git", "rev-list", "--left-right", "--count", "HEAD...@{u}"], project)
+    ahead, behind = 0, 0
+    if lr.returncode == 0:
+        parts = lr.stdout.strip().split()
+        if len(parts) == 2:
+            ahead, behind = int(parts[0]), int(parts[1])
+
+    return {"branch": branch, "clean": clean, "ahead": ahead, "behind": behind}
+
+
+def housekeeping_state(project):
+    br = run(["git", "branch", "--list", "claude/housekeeping-*"], project)
+    branches = [
+        line.strip().lstrip("* ") for line in br.stdout.splitlines() if line.strip()
+    ]
+    hk_branch = branches[0] if branches else None
+
+    log_r = run(["git", "log", "--grep=housekeeping", "-1", "--format=%ct"], project)
+    ts_raw = log_r.stdout.strip()
+    last_ts = None
+    age_hours = None
+    if ts_raw:
+        try:
+            epoch = int(ts_raw)
+            last_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+            age_hours = round((time.time() - epoch) / 3600, 1)
+        except ValueError:
+            pass
+
+    if hk_branch:
+        state = "tidying"
+    elif last_ts is None or (age_hours is not None and age_hours > THRESHOLD_HOURS):
+        state = "needed"
+    else:
+        state = "clean"
+
+    return {
+        "state": state,
+        "branch": hk_branch,
+        "last_commit_ts": last_ts,
+        "age_hours": age_hours,
+    }
+
+
+def ticket_state(project):
+    tickets_dir = project / "tickets"
+    if not tickets_dir.is_dir():
+        return {
+            "ready": None,
+            "open": None,
+            "ready_ids": [],
+            "error": "no tickets/ directory",
+        }
+
+    try:
+        r = run(["erg", "ready", "--json", str(tickets_dir)], project)
+        if r.returncode != 0:
+            return {
+                "ready": None,
+                "open": None,
+                "ready_ids": [],
+                "error": f"erg failed: {r.stderr.strip()}",
+            }
+        ready_list = json.loads(r.stdout)
+    except FileNotFoundError:
+        erg_files = list(tickets_dir.glob("*.erg"))
+        open_count = 0
+        for f in erg_files:
+            text = f.read_text(errors="replace")
+            if not any(line.startswith("Closed:") for line in text.splitlines()[:10]):
+                open_count += 1
+        return {
+            "ready": None,
+            "open": open_count,
+            "ready_ids": [],
+            "error": "erg not found",
+        }
+
+    ready_ids = [t["id"] for t in ready_list]
+
+    erg_files = list(tickets_dir.glob("*.erg"))
+    open_count = 0
+    for f in erg_files:
+        text = f.read_text(errors="replace")
+        if not any(line.startswith("Closed:") for line in text.splitlines()[:10]):
+            open_count += 1
+
+    return {"ready": len(ready_ids), "open": open_count, "ready_ids": ready_ids}
+
+
+def test_state(project):
+    makefile = project / "Makefile"
+    if makefile.exists():
+        content = makefile.read_text(errors="replace")
+        if "check-fast" in content:
+            target = "check-fast"
+        elif "test" in content:
+            target = "test"
+        else:
+            return {
+                "runner": "none",
+                "status": "skip",
+                "detail": "no test target in Makefile",
+            }
+        r = run(["make", target], project)
+        return {
+            "runner": "make",
+            "status": "pass" if r.returncode == 0 else "fail",
+            "detail": r.stdout.strip().splitlines()[-1]
+            if r.stdout.strip()
+            else r.stderr.strip().splitlines()[-1]
+            if r.stderr.strip()
+            else "",
+        }
+
+    if (project / "pyproject.toml").exists() or (project / "setup.py").exists():
+        r = run(["pytest", "--tb=no", "-q"], project)
+        if r.returncode != 127:
+            last_line = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else ""
+            return {
+                "runner": "pytest",
+                "status": "pass" if r.returncode == 0 else "fail",
+                "detail": last_line,
+            }
+
+    if (project / "package.json").exists():
+        r = run(["npm", "test"], project)
+        return {
+            "runner": "npm",
+            "status": "pass" if r.returncode == 0 else "fail",
+            "detail": r.stdout.strip().splitlines()[-1] if r.stdout.strip() else "",
+        }
+
+    return {"runner": "none", "status": "skip", "detail": "no test runner detected"}
+
+
+def pr_state(project):
+    r = run(
+        ["gh", "pr", "list", "--json", "number,title,headRefName", "--limit", "50"],
+        project,
+    )
+    if r.returncode != 0:
+        return {
+            "open": None,
+            "items": [],
+            "error": f"gh unavailable: {r.stderr.strip()[:80]}",
+        }
+    try:
+        prs = json.loads(r.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return {"open": None, "items": [], "error": "gh output parse error"}
+    items = [
+        {"number": p["number"], "title": p["title"], "branch": p["headRefName"]}
+        for p in prs
+    ]
+    return {"open": len(items), "items": items}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "usage: project-state.py <project-path> [--full]"}))
+        sys.exit(0)
+
+    project = Path(sys.argv[1]).expanduser().resolve()
+    full = "--full" in sys.argv
+
+    out = {"path": str(project)}
+
+    try:
+        out["git"] = git_state(project)
+        out["housekeeping"] = housekeeping_state(project)
+        out["tickets"] = ticket_state(project)
+
+        if full:
+            out["tests"] = test_state(project)
+            out["prs"] = pr_state(project)
+    except Exception as e:
+        out["error"] = repr(e)
+
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -60,7 +60,7 @@ def housekeeping_state(project):
     return {
         "state": state,
         "branch": hk_branch,
-        "last_commit_ts": last_ts,
+        "last_housekeeping_ts": last_ts,
         "age_hours": age_hours,
     }
 
@@ -137,22 +137,27 @@ def test_state(project):
         }
 
     if (project / "pyproject.toml").exists() or (project / "setup.py").exists():
-        r = run(["pytest", "--tb=no", "-q"], project)
-        if r.returncode != 127:
+        try:
+            r = run(["pytest", "--tb=no", "-q"], project)
             last_line = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else ""
             return {
                 "runner": "pytest",
                 "status": "pass" if r.returncode == 0 else "fail",
                 "detail": last_line,
             }
+        except FileNotFoundError:
+            return {"runner": "pytest", "status": "skip", "detail": "pytest not found"}
 
     if (project / "package.json").exists():
-        r = run(["npm", "test"], project)
-        return {
-            "runner": "npm",
-            "status": "pass" if r.returncode == 0 else "fail",
-            "detail": r.stdout.strip().splitlines()[-1] if r.stdout.strip() else "",
-        }
+        try:
+            r = run(["npm", "test"], project)
+            return {
+                "runner": "npm",
+                "status": "pass" if r.returncode == 0 else "fail",
+                "detail": r.stdout.strip().splitlines()[-1] if r.stdout.strip() else "",
+            }
+        except FileNotFoundError:
+            return {"runner": "npm", "status": "skip", "detail": "npm not found"}
 
     return {"runner": "none", "status": "skip", "detail": "no test runner detected"}
 

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -12,24 +12,34 @@ Run a healthcheck on the current repository. Report results concisely — one li
 
 This skill is user-level and must **gracefully degrade**: each check runs only if its prerequisites are present. Missing prerequisites yield a `skip` status with a one-line reason, never a fail.
 
+## Data collection
+
+First, run the mechanical probe to collect structured state:
+
+```bash
+python3 ~/.claude/scripts/project-state.py "$(git rev-parse --show-toplevel)" --full
+```
+
+Parse the JSON output. Use its fields to populate checks 1–7 below without re-running git commands. If the script is missing or fails, fall back to ad-hoc commands per check.
+
 ## Checks
 
-1. **Recent activity** — commits in the last 12 hours, key themes
-2. **Open PRs** — list or confirm zero. Skip if `gh` unavailable.
-3. **Origin sync** — ahead/behind/synced. Skip if no remote.
+1. **Recent activity** — commits in the last 12 hours, key themes (use `git log --since`)
+2. **Open PRs** — from `prs.open` / `prs.items`. Skip if `prs.error`.
+3. **Origin sync** — from `git.ahead` / `git.behind`. Skip if no remote.
 4. **Branch hygiene** — list all, flag stale feature branches
 5. **Worktrees** — list all, flag orphaned ones
-6. **Working tree** — clean or list uncommitted changes
-7. **Tests green** — autodetect test runner (make/pytest/npm), report pass/fail
+6. **Working tree** — from `git.clean`. List uncommitted if dirty.
+7. **Tests green** — from `tests.status` / `tests.detail`. Skip if `tests.runner == "none"`.
 8. **Docs freshness (deep verification)** — cross-check status/directive docs (`STATE.md`, `README.md`, etc.):
    - **Staleness** — flag docs whose content predates recent repo activity
    - **Ticket cross-check** — references to tickets whose status contradicts
      the doc (todo but closed, done but open, broken ref). Skip if no `.erg` tickets.
-     (Use `erg ready --json` for the initial ticket list; only read specific tickets
+     (Use `tickets.ready_ids` for the initial ticket list; only read specific tickets
      whose status contradicts a doc reference.)
    - **PR cross-check** — PRs described as pending but already merged/closed.
-     Skip if `gh` unavailable.
-   - **Count consistency** — "N open tickets" claims vs actual count
+     Use `prs.items` from the probe. Skip if `prs.error`.
+   - **Count consistency** — "N open tickets" claims vs `tickets.open` from probe
 
 ## Output format
 

--- a/tickets/0086-project-state-script.erg
+++ b/tickets/0086-project-state-script.erg
@@ -15,30 +15,29 @@ ticket state per project, without LLM derivation. Extract the minimum probe.
 
 ## What
 
-`~/.claude/scripts/project-state.py <project-path>`
+`~/.claude/scripts/project-state.py <project-path> [--full]`
 
-JSON on stdout, exit 0 always (errors as fields). Runs in <1s.
+JSON on stdout, exit 0 always (errors as fields).
+
+**Fast mode (default)** — runs in <1s:
 
 ```json
 {
   "path": "/home/haduong/aedist-technical-report",
-  "git": {
-    "clean": true,
-    "ahead": 0,
-    "behind": 0,
-    "branch": "main"
-  },
-  "housekeeping": {
-    "state": "clean | needed | tidying",
-    "branch": "claude/housekeeping-20260505T040423Z-27ce | null",
-    "last_commit_ts": "2026-05-04T21:00Z | null",
-    "age_hours": 12.3
-  },
-  "tickets": {
-    "ready": 3,
-    "open": 7,
-    "ready_ids": ["0150", "0156", "0160"]
-  }
+  "git": { "clean": true, "ahead": 0, "behind": 0, "branch": "main" },
+  "housekeeping": { "state": "clean|needed|tidying", "branch": null,
+                    "last_commit_ts": "2026-05-04T21:00Z", "age_hours": 12.3 },
+  "tickets": { "ready": 3, "open": 7, "ready_ids": ["0150", "0156", "0160"] }
+}
+```
+
+**Full mode (`--full`)** — adds tests and PRs (may take seconds):
+
+```json
+{ ...,
+  "tests": { "runner": "make|pytest|npm|none", "status": "pass|fail|skip",
+             "detail": "12 passed / 0 failed" },
+  "prs": { "open": 2, "items": [{"number": 42, "title": "...", "branch": "..."}] }
 }
 ```
 
@@ -52,19 +51,29 @@ JSON on stdout, exit 0 always (errors as fields). Runs in <1s.
 - Pure stdlib Python (no third-party imports).
 - Git queries via `subprocess` (same pattern as `beat.py`).
 - `erg ready --json` for ticket list; degrade gracefully if binary absent.
+- `gh pr list --json` for PRs; degrade gracefully if `gh` absent.
+- Test runner autodetection: Makefile → `make check-fast` (fallback `make test`),
+  pyproject.toml → `pytest --tb=no -q`, package.json → `npm test`.
 - Threshold hardcoded to 12h (matches `HOUSEKEEPING_INTERVAL_S` in beat.py).
+
+## Skill integration
+
+Update `/healthcheck` skill to call `project-state.py --full` as its
+data-collection step instead of ad-hoc git commands.
 
 ## Exit criteria
 
 - `python3 ~/.claude/scripts/project-state.py ~/.claude` outputs valid JSON.
+- `python3 ~/.claude/scripts/project-state.py ~/.claude --full` includes `tests`
+  and `prs` fields.
 - Running against a project with a dirty working tree sets `git.clean: false`.
 - Running against a project with a `claude/housekeeping-*` branch sets
   `housekeeping.state: "tidying"`.
 - Running against a project with no `erg` binary sets `tickets.ready: null`
   and includes `"error": "erg not found"` in the tickets object.
+- `/healthcheck` skill calls `project-state.py --full`.
 
 ## Deferred (do not add without a caller)
 
-- `--full` mode (tests, PRs)
 - `--threshold-hours` flag
 - `beat.py` integration

--- a/tickets/0086-project-state-script.erg
+++ b/tickets/0086-project-state-script.erg
@@ -25,7 +25,7 @@ JSON on stdout, exit 0 always (errors as fields).
   "path": "/path/to/project",  <!-- harness-extension-point: illustrative -->
   "git": { "clean": true, "ahead": 0, "behind": 0, "branch": "main" },
   "housekeeping": { "state": "clean|needed|tidying", "branch": null,
-                    "last_commit_ts": "2026-05-04T21:00Z", "age_hours": 12.3 },
+                    "last_housekeeping_ts": "2026-05-04T21:00Z", "age_hours": 12.3 },
   "tickets": { "ready": 3, "open": 7, "ready_ids": ["0150", "0156", "0160"] }
 }
 ```

--- a/tickets/0086-project-state-script.erg
+++ b/tickets/0086-project-state-script.erg
@@ -10,30 +10,18 @@ Author: claude
 --- body ---
 ## Context
 
-Two upcoming skills need structured, LLM-free project state: `/eyes` (multi-project
-raid-readiness survey) and `/healthcheck` (deep per-project audit). Both share the
-same mechanical layer — git status, branch hygiene, housekeeping state, ticket
-readiness — but currently no script exposes this. `beat.py` duplicates some of
-it (`housekeeping_needed()`); the rest is assembled ad-hoc inside LLM sessions.
-
-This ticket produces the shared mechanical probe that both skills call. The LLM
-layer reads its structured output and applies judgment; it does not re-derive state
-from raw git commands.
+`/eyes` (future multi-project survey) needs structured git + housekeeping +
+ticket state per project, without LLM derivation. Extract the minimum probe.
 
 ## What
 
-`~/.claude/scripts/project-state.py <project-path> [--full]`
+`~/.claude/scripts/project-state.py <project-path>`
 
-A single-project state probe. JSON output on stdout, exit 0 always (errors
-appear as fields, never as non-zero exit — callers must not break on a missing
-test runner or absent `erg` binary).
-
-**Fast mode (default)** — runs in under 1 s per project, safe to call across
-all projects in a beat:
+JSON on stdout, exit 0 always (errors as fields). Runs in <1s.
 
 ```json
 {
-  "path": "/home/haduong/aedist-technical-report",  <!-- harness-extension-point: illustrative path -->
+  "path": "/home/haduong/aedist-technical-report",
   "git": {
     "clean": true,
     "ahead": 0,
@@ -55,66 +43,28 @@ all projects in a beat:
 ```
 
 `housekeeping.state` derivation:
-- `tidying` — a `claude/housekeeping-*` local branch exists (housekeeping in
-  progress, not yet merged; caller should yield its turn)
-- `needed` — no tidying branch AND (`last_commit_ts` is null OR age > threshold)
-- `clean` — no tidying branch AND age ≤ threshold
-
-Threshold defaults to 12 h (matching `HOUSEKEEPING_INTERVAL_S` in beat.py)
-and can be overridden with `--threshold-hours N`.
-
-**Full mode (`--full`)** — adds test runner result and all open PRs; may take
-several seconds:
-
-```json
-{
-  ...,
-  "tests": {
-    "runner": "make | pytest | npm | none",
-    "status": "pass | fail | skip",
-    "detail": "12 passed / 0 failed"
-  },
-  "prs": {
-    "open": 2,
-    "items": [{"number": 42, "title": "...", "branch": "..."}]
-  }
-}
-```
+- `tidying` — a `claude/housekeeping-*` local branch exists
+- `needed` — no tidying branch AND (no last commit OR age > 12h)
+- `clean` — no tidying branch AND age ≤ 12h
 
 ## How
 
 - Pure stdlib Python (no third-party imports).
 - Git queries via `subprocess` (same pattern as `beat.py`).
 - `erg ready --json` for ticket list; degrade gracefully if binary absent.
-- `gh pr list --json` for PR data; degrade gracefully if `gh` absent.
-- Test runner autodetection: `Makefile` → `make check-fast` (or `make test`),
-  `pyproject.toml`/`setup.py` → `pytest --tb=no -q`, `package.json` → `npm test`.
-- `housekeeping_needed()` in `beat.py` is **not** replaced here — that
-  refactor belongs in the beat redesign ticket once the script is proven.
-
-## Where
-
-- Script: `~/.claude/scripts/project-state.py`
-- Called by: `/eyes` skill (fast mode, all projects), `/healthcheck` skill
-  (full mode, current project). `beat.py` integration deferred to
-  beat-redesign ticket.
-
-## When / integration order
-
-1. Write and test `project-state.py` in isolation (this ticket).
-2. Update `/healthcheck` to call `project-state.py --full` as its data-collection
-   step (separate ticket).
-3. Write `/eyes` skill using fast mode output (separate ticket).
-4. Replace `housekeeping_needed()` in `beat.py` with a call to the script
-   (separate beat-redesign ticket — out of scope here).
+- Threshold hardcoded to 12h (matches `HOUSEKEEPING_INTERVAL_S` in beat.py).
 
 ## Exit criteria
 
 - `python3 ~/.claude/scripts/project-state.py ~/.claude` outputs valid JSON.
-- `python3 ~/.claude/scripts/project-state.py ~/.claude --full` includes `tests`
-  and `prs` fields.
 - Running against a project with a dirty working tree sets `git.clean: false`.
 - Running against a project with a `claude/housekeeping-*` branch sets
   `housekeeping.state: "tidying"`.
 - Running against a project with no `erg` binary sets `tickets.ready: null`
   and includes `"error": "erg not found"` in the tickets object.
+
+## Deferred (do not add without a caller)
+
+- `--full` mode (tests, PRs)
+- `--threshold-hours` flag
+- `beat.py` integration

--- a/tickets/0086-project-state-script.erg
+++ b/tickets/0086-project-state-script.erg
@@ -1,6 +1,5 @@
 %erg v1
 Title: Write project-state.py — mechanical per-project state probe
-Status: open
 Created: 2026-05-05
 Author: claude
 
@@ -23,7 +22,7 @@ JSON on stdout, exit 0 always (errors as fields).
 
 ```json
 {
-  "path": "/home/haduong/aedist-technical-report",
+  "path": "/path/to/project",  <!-- harness-extension-point: illustrative -->
   "git": { "clean": true, "ahead": 0, "behind": 0, "branch": "main" },
   "housekeeping": { "state": "clean|needed|tidying", "branch": null,
                     "last_commit_ts": "2026-05-04T21:00Z", "age_hours": 12.3 },


### PR DESCRIPTION
## Summary

- New `scripts/project-state.py <path> [--full]` — mechanical per-project state probe
  - Fast mode (<1s): git status, housekeeping state (tidying/needed/clean), ticket counts
  - Full mode: adds test runner autodetection and PR listing via `gh`
  - Pure stdlib Python, exit 0 always, errors as JSON fields
  - Graceful degradation: missing `erg` → error field, missing `gh` → error field
- Updated `/healthcheck` skill to call `project-state.py --full` as data-collection step

## Test plan

- [x] Fast mode: `python3 scripts/project-state.py ~/.claude` → valid JSON
- [x] Full mode: `python3 scripts/project-state.py ~/.claude --full` → includes tests + prs
- [x] Dirty tree → `git.clean: false`
- [x] Housekeeping branch → `housekeeping.state: "tidying"`
- [x] Missing erg → `tickets.error: "erg not found"`, `tickets.ready: null`
- [x] Cross-project: works on `~/aedist-technical-report`
- [ ] Run `/healthcheck` skill to verify integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)