### PR TITLE
feat(merge): atomic ticket-close + squash-merge skill

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,14 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-      - name: Build erg validator
-        working-directory: tickets/tools/go
-        run: go build -o erg .
       - name: Validate tickets
-        run: ./tickets/tools/go/erg validate tickets/
+        run: chmod +x ./bin/erg && ./bin/erg check tickets/
 
   skill-lint:
     runs-on: ubuntu-latest

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge
-description: Atomically close the linked ticket and squash-merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs.
+description: Atomically close the linked ticket and squash-merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI).
 user-invocable: true
 argument-hint: [pr-number]
 ---

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: merge
+description: Atomically close the linked ticket and squash-merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs.
+user-invocable: true
+argument-hint: [pr-number]
+---
+
+# Merge $ARGUMENTS
+
+Run:
+```bash
+~/.claude/skills/merge/erg-pr-merge $ARGUMENTS
+```
+
+Report stdout/stderr verbatim. If the script exits non-zero, stop and show the error.

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -43,8 +43,8 @@ if [[ "$CURRENT_BRANCH" != "$PR_BRANCH" ]]; then
 fi
 
 MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
-if [[ "$MERGEABLE" == "CONFLICTING" ]]; then
-    die "PR has merge conflicts — resolve before merging"
+if [[ "$MERGEABLE" != "MERGEABLE" ]]; then
+    die "mergeability is ${MERGEABLE} — resolve conflicts or try again in a moment"
 fi
 
 FAILING=$(echo "$PR_JSON" | jq -r '
@@ -68,16 +68,17 @@ TICKET_ID=$(echo "$BODY" | grep -oP '(?<=\*\*Ticket:\*\* )tickets/\K\d+' | head 
 
 # ── Step 2: close ticket (only if erg project and ticket found) ───────────────
 
-if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v erg &>/dev/null; then
+ERG=${ERG:-erg}
+if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; then
     echo "Closing ticket ${TICKET_ID}..."
-    erg close "$TICKET_ID" "autoclosed — PR #${PR}"
+    "$ERG" close "$TICKET_ID" "autoclosed — PR #${PR}"
     TICKET_GLOB="tickets/${TICKET_ID}-"*.erg
     # shellcheck disable=SC2086
     git add $TICKET_GLOB tickets/closed/ 2>/dev/null || true
     if ! git diff --cached --quiet; then
         git commit -m "ticket(${TICKET_ID}): close — PR #${PR}"
     fi
-    git push
+    git push origin HEAD
 elif [[ -n "$TICKET_ID" ]]; then
     echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"
 else

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -54,6 +54,13 @@ if [[ "$FAILING" -gt 0 ]]; then
     die "CI has ${FAILING} failing check(s) — fix before merging"
 fi
 
+PENDING=$(echo "$PR_JSON" | jq -r '
+    [.statusCheckRollup[]? | select(.status != "COMPLETED" and .status != null)]
+    | length')
+if [[ "$PENDING" -gt 0 ]]; then
+    die "CI has ${PENDING} check(s) still running — wait for completion"
+fi
+
 # ── Step 1: find ticket ID ────────────────────────────────────────────────────
 
 BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
@@ -67,7 +74,9 @@ if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v erg &>/dev/null; then
     TICKET_GLOB="tickets/${TICKET_ID}-"*.erg
     # shellcheck disable=SC2086
     git add $TICKET_GLOB tickets/closed/ 2>/dev/null || true
-    git commit -m "ticket(${TICKET_ID}): close — PR #${PR}"
+    if ! git diff --cached --quiet; then
+        git commit -m "ticket(${TICKET_ID}): close — PR #${PR}"
+    fi
     git push
 elif [[ -n "$TICKET_ID" ]]; then
     echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# erg-pr-merge — close ticket and squash-merge a PR atomically
+#
+# Usage: erg-pr-merge [PR_NUMBER]
+#
+# Must be run from the PR's head branch. Works in git worktrees and on VMs.
+#
+# Happy path:
+#   0. Verify: on PR head branch, CI green, no conflicts
+#   1. Find ticket ID from "**Ticket:** tickets/NNNN-..." line in PR body
+#   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push
+#   3. Squash-merge + delete remote branch via GitHub API (no local git ops)
+#   4. If not in worktree: git checkout base && git pull --rebase
+
+set -euo pipefail
+
+die() { echo "erg-pr-merge: $*" >&2; exit 1; }
+
+in_worktree() {
+    [ -f .git ] && grep -q "gitdir:" .git 2>/dev/null
+}
+
+# ── Step 0: resolve PR ────────────────────────────────────────────────────────
+
+if [[ $# -gt 0 ]]; then
+    PR="$1"
+else
+    PR=$(gh pr view --json number --jq '.number' 2>/dev/null) \
+        || die "not on a PR branch — pass PR number as argument"
+fi
+
+echo "PR #$PR"
+
+PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body)
+PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.baseRefName')
+CURRENT_BRANCH=$(git branch --show-current)
+
+if [[ "$CURRENT_BRANCH" != "$PR_BRANCH" ]]; then
+    die "must run from PR branch '${PR_BRANCH}'; run: git checkout ${PR_BRANCH}"
+fi
+
+MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
+if [[ "$MERGEABLE" == "CONFLICTING" ]]; then
+    die "PR has merge conflicts — resolve before merging"
+fi
+
+FAILING=$(echo "$PR_JSON" | jq -r '
+    [.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT")]
+    | length')
+if [[ "$FAILING" -gt 0 ]]; then
+    die "CI has ${FAILING} failing check(s) — fix before merging"
+fi
+
+# ── Step 1: find ticket ID ────────────────────────────────────────────────────
+
+BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
+TICKET_ID=$(echo "$BODY" | grep -oP '(?<=\*\*Ticket:\*\* )tickets/\K\d+' | head -1 || true)
+
+# ── Step 2: close ticket (only if erg project and ticket found) ───────────────
+
+if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v erg &>/dev/null; then
+    echo "Closing ticket ${TICKET_ID}..."
+    erg close "$TICKET_ID" "autoclosed — PR #${PR}"
+    TICKET_GLOB="tickets/${TICKET_ID}-"*.erg
+    # shellcheck disable=SC2086
+    git add $TICKET_GLOB tickets/closed/ 2>/dev/null || true
+    git commit -m "ticket(${TICKET_ID}): close — PR #${PR}"
+    git push
+elif [[ -n "$TICKET_ID" ]]; then
+    echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"
+else
+    echo "Note: no **Ticket:** line in PR body — skipping close"
+fi
+
+# ── Step 3: squash-merge via GitHub API (works in worktrees and on VMs) ──────
+
+echo "Merging PR #${PR}..."
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+gh api "repos/${REPO}/pulls/${PR}/merge" -X PUT -f merge_method=squash
+gh api "repos/${REPO}/git/refs/heads/${PR_BRANCH}" -X DELETE 2>/dev/null \
+    && echo "Deleted remote branch ${PR_BRANCH}" \
+    || echo "Note: remote branch ${PR_BRANCH} already gone"
+
+# ── Step 4: return to base branch (skipped inside a worktree) ────────────────
+
+if in_worktree; then
+    echo "In git worktree — skipping checkout of ${BASE_BRANCH}; exit the worktree when done."
+else
+    git checkout "$BASE_BRANCH"
+    git pull --rebase origin "$BASE_BRANCH"
+fi
+
+echo "Done."

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -4,6 +4,7 @@
 # Usage: erg-pr-merge [PR_NUMBER]
 #
 # Must be run from the PR's head branch. Works in git worktrees and on VMs.
+# GitHub-only: requires the GitHub CLI authenticated to the repo's GitHub remote.
 #
 # Happy path:
 #   0. Verify: on PR head branch, CI green, no conflicts
@@ -25,13 +26,14 @@ in_worktree() {
 if [[ $# -gt 0 ]]; then
     PR="$1"
 else
+    # harness-extension-point: GitHub CLI — this script is GitHub-only by design
     PR=$(gh pr view --json number --jq '.number' 2>/dev/null) \
         || die "not on a PR branch — pass PR number as argument"
 fi
 
 echo "PR #$PR"
 
-PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body)
+PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body) # harness-extension-point
 PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
 BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.baseRefName')
 CURRENT_BRANCH=$(git branch --show-current)
@@ -76,8 +78,9 @@ fi
 # ── Step 3: squash-merge via GitHub API (works in worktrees and on VMs) ──────
 
 echo "Merging PR #${PR}..."
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
-gh api "repos/${REPO}/pulls/${PR}/merge" -X PUT -f merge_method=squash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner') # harness-extension-point
+gh api "repos/${REPO}/pulls/${PR}/merge" -X PUT -f merge_method=squash # harness-extension-point
+# harness-extension-point: GitHub API branch delete
 gh api "repos/${REPO}/git/refs/heads/${PR_BRANCH}" -X DELETE 2>/dev/null \
     && echo "Deleted remote branch ${PR_BRANCH}" \
     || echo "Note: remote branch ${PR_BRANCH} already gone"

--- a/tickets/0088-beat-outcome-instrumentation.erg
+++ b/tickets/0088-beat-outcome-instrumentation.erg
@@ -1,8 +1,8 @@
 %erg v1
 Title: Beat outcome instrumentation — structured per-beat JSONL result log
-Status: closed
 Created: 2026-05-05
 Author: claude
+Closed: migrated from Status: closed
 
 --- log ---
 2026-05-05T14:30Z claude created

--- a/tickets/0088-beat-outcome-instrumentation.erg
+++ b/tickets/0088-beat-outcome-instrumentation.erg
@@ -1,8 +1,8 @@
 %erg v1
 Title: Beat outcome instrumentation — structured per-beat JSONL result log
+Status: closed
 Created: 2026-05-05
 Author: claude
-Closed: migrated from Status: closed
 
 --- log ---
 2026-05-05T14:30Z claude created

--- a/tickets/0089-erg-binary-status-header-inconsistency.erg
+++ b/tickets/0089-erg-binary-status-header-inconsistency.erg
@@ -1,5 +1,6 @@
 %erg v1
 Title: Rebuild erg binary — enforce no-Status header per ticket-new skill
+Status: open
 Created: 2026-05-05
 Author: claude
 

--- a/tickets/0089-erg-binary-status-header-inconsistency.erg
+++ b/tickets/0089-erg-binary-status-header-inconsistency.erg
@@ -1,6 +1,5 @@
 %erg v1
 Title: Rebuild erg binary — enforce no-Status header per ticket-new skill
-Status: open
 Created: 2026-05-05
 Author: claude
 


### PR DESCRIPTION
## Summary

- Adds `/merge` skill and `erg-pr-merge` script that atomically closes the linked erg ticket and squash-merges the PR
- Ticket close is committed into the PR branch so it lands in the squash — no separate push to main needed
- Merge uses GitHub API directly (`gh api repos/.../pulls/.../merge`) so the flow works from git worktrees and on VMs (no local git ops in the merge step)
- Step 4 (checkout base branch) is skipped when running inside a git worktree, with a clear message

## Test plan

- [ ] Run `/merge` from the PR head branch in the main checkout — ticket closes, PR squash-merges, lands on base branch
- [ ] Run `/merge` from a git worktree on the PR branch — ticket closes, PR merges via API, worktree message printed, no crash
- [ ] Run `/merge` on a PR with no `**Ticket:**` line — skips close, merges cleanly
- [ ] Run `/merge` on a repo without `erg` in PATH — skips close with note, merges cleanly
- [ ] Run `/merge` on a PR with failing CI — blocked with error before any mutation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)