### PR TITLE
fix: erg binary commits under tickets/tools/go/, not bin/

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate tickets
-        run: chmod +x ./bin/erg && ./bin/erg check tickets/
+        run: chmod +x ./tickets/tools/go/erg && ./tickets/tools/go/erg check tickets/
 
   skill-lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@
 !docs/**
 !tickets/
 !tickets/**
-# Exclude compiled Go binaries from ticket tools
-tickets/tools/go/git-erg
-tickets/tools/go/erg
 tickets/tools/go/*.test
 
 # settings.json: universal config (hooks, effortLevel, universal permissions) — tracked

--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -76,7 +76,7 @@ def ticket_state(project):
             "error": "no tickets/ directory",
         }
 
-    erg_bin = shutil.which("erg") or str(project / "bin/erg")
+    erg_bin = shutil.which("erg") or str(project / "tickets/tools/go/erg")
 
     try:
         r = run([erg_bin, "ready", "--json", str(tickets_dir)], project)

--- a/skills/harness-rules/tickets.md
+++ b/skills/harness-rules/tickets.md
@@ -8,7 +8,7 @@ last-reviewed: 2026-04-23
 # Ticket log conventions — %erg v1
 
 Tickets live in `tickets/` as `.erg` files. The log section is append-only.
-Validate with `bin/erg check tickets/`.
+Validate with `tickets/tools/go/erg check tickets/`.
 
 ## Log line format
 

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -28,7 +28,7 @@ Run full repo housekeeping and act on every finding.
     folder-closure issues. Degrade gracefully if the command is not yet
     installed:
     ```bash
-    ERG=${ERG:-bin/erg}
+    ERG=${ERG:-tickets/tools/go/erg}
     $ERG check tickets/ 2>/dev/null || true
     ```
     Emit any output as housekeeping warnings; do not abort on non-zero exit.

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -13,7 +13,7 @@ Select one ticket for the current sweep run.
 
 0. Resolve the `erg` binary once:
    ```bash
-   ERG=$(command -v erg 2>/dev/null || echo "bin/erg")
+   ERG=$(command -v erg 2>/dev/null || echo "tickets/tools/go/erg")
    ```
    Use `$ERG` for every subsequent call. Never search for the binary again.
 

--- a/skills/ticket-new/SKILL.md
+++ b/skills/ticket-new/SKILL.md
@@ -18,7 +18,7 @@ from a conversation. Extract the intent and normalize to `%erg v1`.
 
 1. Determine the next ID:
    ```bash
-   ERG=${ERG:-bin/erg}
+   ERG=${ERG:-tickets/tools/go/erg}
    $ERG next-id tickets/
    ```
    Always use `erg next-id` — never compute or guess the ID manually.


### PR DESCRIPTION
## Summary

- Removes `tickets/tools/go/erg` from `.gitignore` — the binary commits with the project, it is not a build artifact
- Renames `bin/erg` → `tickets/tools/go/erg` (same binary, correct location per the `tickets/` convention)
- Restores all `$ERG` fallbacks in skills and scripts to `tickets/tools/go/erg`
- Updates CI to use `./tickets/tools/go/erg check tickets/`

**Why:** `erg` is tied to the repo it serves and travels under `tickets/`. The old gitignore exclusion was left over from when `main.go` was the source and the binary was a transient build output. Now that the source is gone and the binary is the artifact, it commits directly.

## Test plan

- [ ] All four CI checks pass
- [ ] `tickets/tools/go/erg version` works in CI (binary is present and executable)
- [ ] `bin/` directory is empty / removed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)