### PR TITLE
fix(project-state): wrap make runner in FileNotFoundError guard

### DIFF
--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -227,16 +227,19 @@ def test_state(project):
                 "status": "skip",
                 "detail": "no test target in Makefile",
             }
-        r = run(["make", target], project)
-        return {
-            "runner": "make",
-            "status": "pass" if r.returncode == 0 else "fail",
-            "detail": r.stdout.strip().splitlines()[-1]
-            if r.stdout.strip()
-            else r.stderr.strip().splitlines()[-1]
-            if r.stderr.strip()
-            else "",
-        }
+        try:
+            r = run(["make", target], project)
+            return {
+                "runner": "make",
+                "status": "pass" if r.returncode == 0 else "fail",
+                "detail": r.stdout.strip().splitlines()[-1]
+                if r.stdout.strip()
+                else r.stderr.strip().splitlines()[-1]
+                if r.stderr.strip()
+                else "",
+            }
+        except FileNotFoundError:
+            return {"runner": "make", "status": "skip", "detail": "make not found"}
 
     if (project / "pyproject.toml").exists() or (project / "setup.py").exists():
         try:

--- a/tickets/0087-project-state-make-fnf.erg
+++ b/tickets/0087-project-state-make-fnf.erg
@@ -2,6 +2,7 @@
 Title: project-state.py: wrap make runner in try/except FileNotFoundError
 Created: 2026-05-05
 Author: claude
+Closed: 2026-05-06 claude fixed
 
 --- log ---
 2026-05-05T13:45Z claude created — residual gap from PR #100 verify-gate


### PR DESCRIPTION
## Summary

- Wraps the `make` runner invocation in `test_state()` with `try/except FileNotFoundError`, returning `{"runner": "make", "status": "skip", "detail": "make not found"}` when `make` is absent.
- Aligns the `make` runner with the `pytest` and `npm` runners that already handle missing executables gracefully.
- Closes ticket #0087.

## Test plan

- [ ] On a system without `make`: verify `test_state()` returns `{"runner": "make", "status": "skip", "detail": "make not found"}` instead of raising `FileNotFoundError`.
- [ ] On a system with `make`: verify the `make` runner still works normally (pass/fail based on exit code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)