### PR TITLE
fix(beat): use _default_branch() at checkout step

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -847,10 +847,11 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
 
     # Ensure working tree is on main before any read or write.
     # Fails fast with a clear message if the tree is dirty.
-    r = _git("checkout", "main", cwd=path)
+    default_branch = _default_branch(path)
+    r = _git("checkout", default_branch, cwd=path)
     if r.returncode != 0:
         detail = (r.stderr or r.stdout or "").strip().replace("\n", " | ")
-        _log(f"=== beat aborted: cannot checkout main: {detail} ===")
+        _log(f"=== beat aborted: cannot checkout {default_branch}: {detail} ===")
         return "aborted", None
 
     # Housekeeping (conditional). Aborts beat on failure/timeout so

--- a/tickets/0092-beat-checkout-hardcoded-main.erg
+++ b/tickets/0092-beat-checkout-hardcoded-main.erg
@@ -1,0 +1,42 @@
+%erg v1
+Title: Fix beat.py checkout step hardcodes "main" instead of calling _default_branch()
+Created: 2026-05-07
+Author: claude-agent
+
+--- log ---
+2026-05-07T21:15Z claude-agent created
+
+--- body ---
+## Context
+
+`scripts/beat.py` line 850 calls `git checkout main` unconditionally, but
+`chemin-de-voix` (and any other project with a `master` default branch) does
+not have a `main` branch. This causes the beat to abort every time it
+selects that project slot:
+
+```
+=== beat aborted: cannot checkout main: error: le spécificateur de chemin
+'main' ne correspond à aucun fichier connu de git ===
+```
+
+`_default_branch(path)` already exists and is already called correctly in
+`_sync_origin_main` (line 599) and `_housekeeping_phase` (line 722). The
+checkout step just missed it.
+
+## Actions
+
+1. In `scripts/beat.py`, replace the hardcoded `"main"` at the checkout
+   step (~line 850) with `_default_branch(path)`.
+2. Update the error message string on the next line to use the branch name
+   variable instead of the literal "main".
+
+## Test
+
+Run `python3 scripts/beat.py --help` to confirm the script still loads.
+Verify `_default_branch` is called, not "main" literal, at the checkout step.
+
+## Exit criteria
+
+- `git grep '"main"' scripts/beat.py` does not match the checkout step
+- Beat no longer aborts on `chemin-de-voix`
+- Existing tests pass (`make test` or equivalent)


### PR DESCRIPTION
## Summary

- Fixes ticket 0092: `beat.py` checkout step hardcoded `"main"`, causing beat to abort on repositories whose default branch is `master` or any other non-`main` name.
- `_default_branch(path)` already existed and was used correctly in `_sync_origin_main` (line 599) and `_housekeeping_phase` (line 722); the checkout step simply missed it.
- The fix is 3 lines: introduce a `default_branch` variable and use it for both the `git checkout` call and the error log message.

## Test plan

- [ ] `python3 scripts/beat.py --help` exits without error
- [ ] `git grep '"main"' scripts/beat.py` shows only the fallback inside `_default_branch()` itself (line 588), not in the checkout path
- [ ] Manual beat run on a `master`-branch project no longer aborts with "cannot checkout main"

🤖 Generated with [Claude Code](https://claude.com/claude-code)