### PR TITLE
refactor(scripts): extract _default_branch to git_utils.py

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -24,6 +24,8 @@ from datetime import UTC, datetime, timedelta
 from io import TextIOBase
 from pathlib import Path
 
+from git_utils import _default_branch
+
 # ── Constants ──────────────────────────────────────────────────────────────────
 
 HARNESS_DIR = Path.home() / ".claude"
@@ -571,22 +573,6 @@ def run_skill(
 
 
 # ── Origin sync ───────────────────────────────────────────────────────────────
-
-
-def _default_branch(project: Path) -> str:
-    """Return the remote default branch name, falling back to 'main'."""
-    result = subprocess.run(  # noqa: S603
-        ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=project,
-    )
-    return (
-        result.stdout.strip().removeprefix("origin/")
-        if result.returncode == 0
-        else "main"
-    )
 
 
 def _sync_origin_main(project: Path) -> None:

--- a/scripts/git_utils.py
+++ b/scripts/git_utils.py
@@ -1,0 +1,20 @@
+"""Shared git helpers for harness scripts."""
+
+import subprocess
+from pathlib import Path
+
+
+def _default_branch(project: Path) -> str:
+    """Return the remote default branch name, falling back to 'main'."""
+    result = subprocess.run(
+        ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=project,
+    )
+    return (
+        result.stdout.strip().removeprefix("origin/")
+        if result.returncode == 0
+        else "main"
+    )

--- a/scripts/git_utils.py
+++ b/scripts/git_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 def _default_branch(project: Path) -> str:
     """Return the remote default branch name, falling back to 'main'."""
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
         capture_output=True,
         text=True,

--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -8,16 +8,13 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from git_utils import _default_branch
+
 THRESHOLD_HOURS = 12.0
 
 
 def run(args, cwd):
     return subprocess.run(args, capture_output=True, text=True, check=False, cwd=cwd)
-
-
-def _default_branch(project):
-    r = run(["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"], project)
-    return r.stdout.strip().removeprefix("origin/") if r.returncode == 0 else "main"
 
 
 def git_state(project):

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,36 @@
+"""Tests for scripts/git_utils.py."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import git_utils  # noqa: E402
+
+
+class TestDefaultBranch:
+    def test_returns_branch_from_symbolic_ref(self, tmp_path):
+        with patch("git_utils.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="origin/develop\n", returncode=0)
+            assert git_utils._default_branch(tmp_path) == "develop"
+
+    def test_falls_back_to_main(self, tmp_path):
+        with patch("git_utils.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", returncode=128)
+            assert git_utils._default_branch(tmp_path) == "main"
+
+    def test_strips_origin_prefix(self, tmp_path):
+        with patch("git_utils.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="origin/main\n", returncode=0)
+            assert git_utils._default_branch(tmp_path) == "main"
+
+    def test_passes_project_as_cwd(self, tmp_path):
+        with patch("git_utils.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", returncode=128)
+            git_utils._default_branch(tmp_path)
+            mock_run.assert_called_once()
+            assert (
+                mock_run.call_args.kwargs.get("cwd") == tmp_path
+                or mock_run.call_args[1].get("cwd") == tmp_path
+            )


### PR DESCRIPTION
## Summary
- Extract duplicated `_default_branch(project)` helper from `beat.py` and `project-state.py` into shared `scripts/git_utils.py`
- Both scripts now import from the single source; fallback policy ("main") lives in one place
- 4 new unit tests for the extracted function

Closes ticket 0090.

## Test plan
- [x] `test_git_utils.py`: 4/4 pass (symbolic-ref parsing, fallback, prefix stripping, cwd passthrough)
- [x] `test_beat.py`: 79/110 pass (31 pre-existing failures on main, no regressions)
- [x] `beat.py` imports and runs without error
- [x] `project-state.py --help` prints help cleanly
- [x] `ruff check scripts/git_utils.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)