### PR TITLE
fix(AGENTS.md): replace legacy status verb in example with note

### DIFF
--- a/tickets/0096-agents-md-stale-status-verb-example.erg
+++ b/tickets/0096-agents-md-stale-status-verb-example.erg
@@ -1,0 +1,33 @@
+%erg v1
+Title: Fix stale legacy status verb in AGENTS.md example log
+Created: 2026-05-08
+Author: claude-agent
+Closed: completed — example updated to use note verb
+
+--- log ---
+2026-05-08T00:00Z claude-agent created
+
+2026-05-08T15:37Z MinhHaDuong closed — completed — example updated to use note verb
+--- body ---
+## Context
+
+The example ticket log in `tickets/AGENTS.md` uses the legacy `status open`
+verb on the log line:
+
+    2026-05-04T14:22Z bob status open Was blocked, 0007 now merged
+
+The `status` verb predates the removal of the `Status:` header from the
+%erg v1 spec. The correct verb for an informational annotation is `note`.
+This stale example propagates the legacy pattern into new agents reading
+the file.
+
+## Actions
+
+Replace the `status open` log line with a `note` verb line:
+
+    2026-05-04T14:22Z bob note blocker 0007 merged — unblocked
+
+## Exit criteria
+
+- `tickets/AGENTS.md` example log uses `note` verb, not `status`
+- `erg check tickets/` passes

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -16,7 +16,7 @@ Blocked-by: 0007
 
 --- log ---
 2026-05-04T09:00Z alice created
-2026-05-04T14:22Z bob status open Was blocked, 0007 now merged
+2026-05-04T14:22Z bob note blocker 0007 merged — unblocked
 
 --- body ---
 ## Context


### PR DESCRIPTION
The AGENTS.md example log used the legacy status verb (status open)
which predates the removal of the Status: header from the %erg v1 spec.
This was propagating the legacy pattern into new agents reading the
example.

Replace with the note verb, which is the correct choice for an
informational annotation.

Ticket: 0096

🤖 Generated with [Claude Code](https://claude.com/claude-code)