### PR TITLE
refactor(harness-rules): slim tickets.md to IDH-only content

### DIFF
--- a/skills/harness-rules/README.md
+++ b/skills/harness-rules/README.md
@@ -8,7 +8,7 @@ files on demand when their scope signal applies to your task.
 | [workflow.md](./workflow.md) | always | Session start gate, escalation protocol, when to ask the author, subagent and compaction rules. |
 | [git.md](./git.md) | always | Branch discipline, commit-message standards, worktree lifecycle, merge-request workflow. |
 | [state.md](./state.md) | skill-list: `/end-session` | STATE.md format spec — sections, length cap, pruning rules. |
-| [tickets.md](./tickets.md) | skill-list: `ticket-*`, `new-ticket`, `start-ticket` | %erg v1 log line format, closed verb set, bump categories. |
+| [tickets.md](./tickets.md) | skill-list: `ticket-*`, `new-ticket`, `start-ticket` | IDH-specific log conventions: bump categories and cross-worktree concurrency. |
 | [coding-python.md](./coding-python.md) | condition: project contains `*.py` (or `pyproject.toml` / `setup.py`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
 
 Compliance is verified ex post by the `verify-adherence` skill — this

--- a/skills/harness-rules/tickets.md
+++ b/skills/harness-rules/tickets.md
@@ -2,7 +2,7 @@
 paths:
   - "tickets/"
   - "tickets/spec-erg-v1.md"
-last-reviewed: 2026-04-23
+last-reviewed: 2026-05-08
 ---
 
 # Ticket log conventions — %erg v1
@@ -10,24 +10,9 @@ last-reviewed: 2026-04-23
 Tickets live in `tickets/` as `.erg` files. The log section is append-only.
 Validate with `tickets/erg check tickets/`.
 
-## Log line format
+Format and base verbs: see `tickets/AGENTS.md`.
 
-```
-{YYYY-MM-DDThh:mmZ} {actor} {verb} [{detail}]
-```
-
-Actor is typically `claude` or `haduong`. Detail is free text after the verb.
-
-## Verbs (closed set)
-
-| Verb | Usage |
-|------|-------|
-| `created` | Ticket was created |
-| `status {new-status}` | Status changed; detail gives reason |
-| `note {text}` | Free-form annotation; anything goes |
-| `bump {category} — {detail}` | Agent paused waiting for a signal (see categories below) |
-
-## Bump categories (closed set)
+## Bump categories
 
 | Category | Meaning |
 |----------|---------|

--- a/tickets/0095-slim-harness-rules-tickets-to-idh-only.erg
+++ b/tickets/0095-slim-harness-rules-tickets-to-idh-only.erg
@@ -1,0 +1,13 @@
+%erg v1
+Title: Slim harness-rules/tickets.md to IDH-only content, delegate format to tickets/AGENTS.md
+Created: 2026-05-08
+Author: claude
+Closed: completed — harness-rules/tickets.md slimmed to IDH-only content
+
+--- log ---
+2026-05-08T00:00Z claude created
+2026-05-08T15:42Z MinhHaDuong closed — completed — harness-rules/tickets.md slimmed to IDH-only content
+--- body ---
+The slimming work is done in this PR. `skills/harness-rules/tickets.md` previously
+duplicated log-format and verb content from `tickets/AGENTS.md`, causing verb drift.
+Removed duplicate sections and added a pointer to the canonical source.


### PR DESCRIPTION
skills/harness-rules/tickets.md duplicated log-format and verb content
from tickets/AGENTS.md. This duplication was the root cause of verb
drift found in the erg alignment review (2026-05-08).

Changes:
- Remove "Log line format" section (duplicate of AGENTS.md)
- Remove "Verbs" table (duplicate of AGENTS.md)
- Add pointer: "Format and base verbs: see tickets/AGENTS.md"
- Rename "Bump categories (closed set)" → "Bump categories"
- Keep bump categories, bump-vs-note guidance, cross-worktree concurrency
- Update README.md row summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)