### PR TITLE
fix(pick-ticket): remove stale status verb from log examples

### DIFF
--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -57,7 +57,7 @@ Select one ticket for the current sweep run.
    - `git log --since=<last-pick-ts> -- <relevant-files>` returns matches
      (recent commits touched files the ticket talks about). Use the
      timestamp of the most recent `sweep-pick:` log line or
-     `status closed — already-done` log line in the ticket as
+     `closed — already-done` log line in the ticket as
      `<last-pick-ts>`; if none, default to 7 days ago.
 
    Skip the check on cache-hit tickets with no recent relevant commits —
@@ -79,7 +79,7 @@ Select one ticket for the current sweep run.
 
    1. Call `/ticket-close <id> already-done` — `erg close` writes the
       `Status: closed` header change and appends the audit log line
-      `{ts} claude status closed — already-done` in one step.
+      `{ts} claude closed — already-done` in one step.
    2. Output `CLOSED: <id>` and stop processing this candidate (do not
       rank it). beat.py will loop back and pick again.
 

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -78,7 +78,7 @@ Select one ticket for the current sweep run.
    pass:
 
    1. Call `/ticket-close <id> already-done` — `erg close` writes the
-      `Status: closed` header change and appends the audit log line
+      `Closed:` header and appends the audit log line
       `{ts} claude closed — already-done` in one step.
    2. Output `CLOSED: <id>` and stop processing this candidate (do not
       rank it). beat.py will loop back and pick again.


### PR DESCRIPTION
## Summary
- Remove stale `status` verb from two log examples in `skills/pick-ticket/SKILL.md`
- `status closed — already-done` → `closed — already-done` (lines 60, 82)
- Same anti-pattern fixed in ticket 0096 (AGENTS.md)

Ticket: 0098

## Test plan
- [x] `grep 'status closed' skills/pick-ticket/SKILL.md` returns no matches
- [x] `erg check tickets/` passes (98 tickets, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)