### PR TITLE
feat(state): replace-policy STATE.md rule + refresh-STATE.py script

### DIFF
--- a/skills/harness-rules/refresh-STATE.py
+++ b/skills/harness-rules/refresh-STATE.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Replace the ## Status section of STATE.md with fresh git + erg output."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    r = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    if r.returncode == 0:
+        return Path(r.stdout.strip())
+    return Path(__file__).parent.parent  # fallback: script is in scripts/ of project
+
+
+REPO_ROOT = _repo_root()
+STATE_FILE = REPO_ROOT / "STATE.md"
+TICKETS_DIR = REPO_ROOT / "tickets"
+ERG_BIN = TICKETS_DIR / "erg"
+STATUS_HEADING = "## Status"
+MAX_STATUS_LINES = 20
+
+
+def run(cmd):
+    return subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=REPO_ROOT
+    ).stdout.strip()
+
+
+def get_commits(n=5):
+    return run(["git", "log", "--oneline", f"-{n}"]).splitlines()
+
+
+def get_tickets():
+    return json.loads(run([str(ERG_BIN), "ready", str(TICKETS_DIR), "--json"]))
+
+
+def format_status(tickets, commits):
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    ready = [t for t in tickets if t["ready"]]
+    blocked = [t for t in tickets if not t["ready"]]
+
+    lines = [STATUS_HEADING, f"<!-- generated {now} -->", ""]
+
+    if ready:
+        lines.append(f"**Ready ({len(ready)}):**")
+        for t in ready:
+            lines.append(f"  `{t['id']}` {t['title']}")
+
+    if blocked:
+        lines.append(f"**Blocked ({len(blocked)}):**")
+        for t in blocked:
+            deps = " ".join(f"→{b['id']}" for b in t["blocked_by"])
+            lines.append(f"  `{t['id']}` {t['title']} ({deps})")
+
+    if commits:
+        lines.append("**Recent commits:**")
+        for c in commits:
+            lines.append(f"  {c}")
+
+    return lines
+
+
+def split_at_status(text):
+    """Return (preamble, discarded) split at the first ## Status heading."""
+    idx = text.find(f"\n{STATUS_HEADING}")
+    if idx == -1:
+        return text.rstrip(), None
+    return text[:idx], text[idx + 1 :]
+
+
+def refresh_last_updated(preamble, date_str):
+    pat = re.compile(r"^Last updated:.*$", re.MULTILINE)
+    if pat.search(preamble):
+        return pat.sub(f"Last updated: {date_str}", preamble)
+    return preamble
+
+
+def main():
+    if not STATE_FILE.exists():
+        print(f"ERROR: {STATE_FILE} not found", file=sys.stderr)
+        sys.exit(1)
+
+    text = STATE_FILE.read_text()
+    preamble, _ = split_at_status(text)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    preamble = refresh_last_updated(preamble, today)
+
+    commits = get_commits()
+    tickets = get_tickets()
+    status_lines = format_status(tickets, commits)
+
+    if len(status_lines) > MAX_STATUS_LINES:
+        status_lines = status_lines[:MAX_STATUS_LINES]
+        status_lines.append(f"<!-- truncated to {MAX_STATUS_LINES} lines -->")
+
+    new_text = preamble.rstrip() + "\n\n" + "\n".join(status_lines) + "\n"
+    STATE_FILE.write_text(new_text)
+
+    total = len(new_text.splitlines())
+    print(f"STATE.md refreshed — {len(status_lines)} status lines, {total} total.")
+    if total > 40:
+        print(
+            f"WARNING: {total} lines exceeds 40-line cap — trim the hand-edited sections."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/harness-rules/state.md
+++ b/skills/harness-rules/state.md
@@ -1,22 +1,51 @@
 ---
 paths:
   - "STATE.md"
-last-reviewed: 2026-04-04
+last-reviewed: 2026-05-09
 ---
 
 # STATE.md
 
-Single orientation file, loaded at session start via hook. Keep it short and current (~40 lines max) — history lives in `git log`.
+Single orientation file, loaded at session start via hook. Hard cap: **40 lines total**. History lives in `git log`.
 
-| Section | Content |
-|---------|---------|
-| `Last updated:` | Date |
-| `## Status` | One-liner summary |
-| `## Blockers` | Current blockers or "None" |
-| `## Next actions` | 5–10 items, most urgent first |
-| `## North star` | One paragraph — the core argument |
-| `## Current milestone` | What we're working toward, with `- [ ]` checkboxes |
-| `## Next milestone` | What comes after |
-| `## Backlog` | Parked ideas, no checkboxes |
+## Structure
 
-**Pruning:** each update *replaces* sections, not appends. Completed items are deleted after one session. No "Completed" section — git has the history.
+Two hand-edited sections (short, stable, owned by the author):
+
+| Section | Content | Who edits |
+|---------|---------|-----------|
+| `## North star` | One paragraph — the core argument, rarely changes | Author |
+| `## Milestones` | Current + next milestone, `- [ ]` checkboxes, 5–8 lines max | Author |
+
+One mechanically generated section (replaced each session from `git log` + `git-erg`):
+
+| Section | Content | Who edits |
+|---------|---------|-----------|
+| `## Status` | Open tickets (git-erg), last 3–5 commits (git log --oneline), current blockers | Machine |
+
+**Replace policy — no append.** Each session rewrites `## Status` in full from current git state. The hand-edited sections are touched only when the author explicitly updates them. No "Completed" or "Backlog" sections — git has the history, tickets have the backlog.
+
+**Line budget:** `## North star` ≤ 5 lines · `## Milestones` ≤ 10 lines · `## Status` ≤ 20 lines · header/whitespace ≤ 5 lines.
+
+## Template
+
+```markdown
+Last updated: YYYY-MM-DD
+
+## North star
+[One paragraph. Why this project exists, what success looks like. Author-maintained.]
+
+## Milestones
+### Current: [name]
+- [ ] item
+- [x] done item
+
+### Next: [name]
+- [ ] item
+
+## Status
+<!-- generated: git log --oneline -5 + git-erg open -->
+**Open tickets:** 0NN title · 0NN title · …
+**Recent commits:** sha msg · sha msg · …
+**Blockers:** ticket or "None"
+```


### PR DESCRIPTION
## Summary

- **Rewrites `skills/harness-rules/state.md`** to enforce the replace (not append) contract that keeps STATE.md under 40 lines. Codifies two hand-edited sections (north star, milestones) and one machine-generated `## Status` section with a 20-line budget.
- **Adds `skills/harness-rules/refresh-STATE.py`** — run from any project root to atomically replace `## Status` with a live snapshot from `git log --oneline -5` and `erg ready --json`. Works whether invoked from IDH or a project-local copy; detects repo root via `git rev-parse --show-toplevel`.

## Why

The old rule prescribed replace policy but the actual STATE.md had grown to 80+ lines of append-style entries. The new rule makes the contract explicit: only `## North star` and `## Milestones` are hand-edited; everything else is mechanically generated and replaced each session.

## Test plan

- [ ] Run `python3 ~/.claude/skills/harness-rules/refresh-STATE.py` from a project root with `tickets/erg`
- [ ] Verify `## Status` replaced, hand-edited sections preserved
- [ ] Verify total line count reported; warning fires if > 40

🤖 Generated with [Claude Code](https://claude.com/claude-code)