### PR TITLE
feat: nightbeat supervisor skill (ticket 0105)

### DIFF
--- a/skills/harness-rules/README.md
+++ b/skills/harness-rules/README.md
@@ -8,7 +8,7 @@ files on demand when their scope signal applies to your task.
 | [workflow.md](./workflow.md) | always | Session start gate, escalation protocol, when to ask the author, subagent and compaction rules. |
 | [git.md](./git.md) | always | Branch discipline, commit-message standards, worktree lifecycle, merge-request workflow. |
 | [state.md](./state.md) | skill-list: `/end-session` | STATE.md format spec — sections, length cap, pruning rules. |
-| [tickets.md](./tickets.md) | skill-list: `ticket-*`, `new-ticket`, `start-ticket` | IDH-specific log conventions: bump categories and cross-worktree concurrency. |
+| `tickets/AGENTS.md` (project-level) | skill-list: `ticket-*`, `new-ticket`, `start-ticket` | Ticket format rules injected via `@tickets/AGENTS.md` in project CLAUDE.md — no global rules file needed. |
 | [coding-python.md](./coding-python.md) | condition: project contains `*.py` (or `pyproject.toml` / `setup.py`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
 
 Compliance is verified ex post by the `verify-adherence` skill — this

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -51,8 +51,8 @@ within authority or open a ticket naming the root cause, not the symptom.
   touch the module-level constant; stop the timer first, restart after.
 - Root cause is a ticket too large to finish in one beat → read the body; if
   it has obvious split lines (independent deliverables, self-contained
-  sections), split into two child tickets and close the parent; otherwise
-  add a sweep-skip and open a repair ticket.
+  sections), split into one ticket per independent unit of work and close the
+  parent; otherwise add a sweep-skip and open a repair ticket.
 - Root cause is a dead timer → restart it.
 
 **Everything else**: open a ticket stating the root cause chain. Do not

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -35,41 +35,28 @@ For each entry in `prs_to_merge`:
 
 ## 3. Triage failures
 
-Failure types ordered by observed frequency across all projects and 200+
-beat-log entries. Read the nightbeat log for each failure, classify, and act:
+For each failure, read the log and ask **why** until you reach an actionable
+root cause. Do not stop at the signal — `error_max_budget_usd` is not a root
+cause, it is a symptom. Keep asking:
 
-**`aborted` with no diagnostics** (most common — 22 observed, usually a
-timer-stop cascade): check whether the main timer is still active. If stopped,
-restart it. If already running, this is noise from a mid-run kill; no action.
+> Why did it fail? → Why did that happen? → Why was that condition present?
 
-**`error_max_budget_usd`** (7 observed, always during housekeeping or raid):
-read the last 50 lines of the log to identify the sub-cause — observed
-triggers are `erg check` surprises, STATE.md scope creep, and stale worktree
-cleanup. Raise the per-project `ProjectConfig` field in `beat.py` by 20%,
-capped at 2× the module-level constant; never edit the module-level constant.
-Stop the main timer before editing, restart after.
+Stop when you reach something the harness can change. Then either repair
+within authority or open a ticket naming the root cause, not the symptom.
 
-**`aborted` with stale-in-progress diagnostics** (8 observed — SIGKILL
-recovery): self-resolving; beat.py handles this on the next run. Log it, no
-action unless it recurs more than twice in the same window.
+**Repair authority** (auto-apply without a ticket):
+- Root cause is a missing permission → add to `settings.json` allowlist.
+- Root cause is a scope that fit under a larger budget → raise the per-project
+  `ProjectConfig` field by 20%, capped at 2× the module-level constant; never
+  touch the module-level constant; stop the timer first, restart after.
+- Root cause is a ticket too large to finish in one beat → read the body; if
+  it has obvious split lines (independent deliverables, self-contained
+  sections), split into two child tickets and close the parent; otherwise
+  add a sweep-skip and open a repair ticket.
+- Root cause is a dead timer → restart it.
 
-**Same ticket failing repeatedly** (observed: chemin-de-voix ticket 0021,
-3× in a row): read the ticket body before acting. If it has obvious split
-lines — multiple independent deliverables, `##` sections that are each
-self-contained, or an Actions list spanning unrelated files — split it into
-two child tickets, close the parent with a log entry `closed: split → <id-a>
-<id-b>`, and commit. Otherwise add a sweep-skip (`erg note sweep-skip:
-scope-too-large`) and open a repair ticket naming the blocking issue.
-
-**`failed` with no ticket_id** (5 observed — housekeeping or pick-ticket died
-before a ticket was selected): read the log to identify which phase failed.
-Treat as `error_max_budget_usd` if the phase signal is budget; otherwise open
-a ticket.
-
-**`permission_denials` non-empty** (not yet observed, tracked in outcomes
-JSONL): add the denied command to `settings.json` allowlist.
-
-**Anything else**: open a ticket with the log excerpt; do not auto-repair.
+**Everything else**: open a ticket stating the root cause chain. Do not
+auto-repair.
 
 ## 4. Escalate
 

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -34,15 +34,22 @@ For each entry in `prs_to_merge`:
 
 ## 3. Triage failures
 
-Read the nightbeat log for each failure. Classify and repair:
+Read the nightbeat log for each failure. In practice, `error_max_budget_usd`
+is the only failure type observed across 60 runs (7/7 failures). Triage
+accordingly:
 
-| Category | Auto-repair |
-|---|---|
-| `permission_denial` | Add the denied command to `settings.json` allowlist |
-| `budget_exhaustion` | Raise per-project `ProjectConfig` field by 20%, capped at 2× the module-level constant; never edit the module-level constant |
-| `misplaced_tickets` | `git mv` closed tickets to `tickets/closed/` |
-| `crash` | Restart the main timer if stopped |
-| Anything else | Open a ticket with the log excerpt; stop |
+**`error_max_budget_usd`** (all observed failures): read the last 50 lines of
+the log to identify what consumed the budget — common sub-causes are `erg
+check` surprises, STATE.md scope creep, and stale worktree cleanup. Raise the
+per-project `ProjectConfig` field in `beat.py` by 20%, capped at 2× the
+module-level constant; never touch the module-level constant. Stop the main
+timer before editing, restart after.
+
+**`permission_denials` non-empty** (not yet observed, tracked in outcomes
+JSONL): add the denied command to `settings.json` allowlist.
+
+**Anything else**: open a ticket with the log excerpt and the result record's
+`subtype` and `stop_reason`; do not auto-repair.
 
 ## 4. Escalate
 

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -7,286 +7,55 @@ argument-hint: "[--since ISO-TS]"
 
 # Nightbeat Supervisor
 
-Autonomous night watchman. Runs on its own 15-min timer (separate from
-beat.py) and acts on every unprocessed outcome:
+Watch `~/.claude/logs/beat-outcomes.jsonl` for unprocessed entries and close
+the loop: merge PRs that are ready, diagnose failures, repair within authority,
+escalate when stuck.
 
-- **Happy path**: raid succeeded → PR open → verify-gate → merge.
-- **Failure path**: housekeeping/raid failed → diagnose → auto-repair or
-  ticket → escalate if stuck.
+**Non-negotiables**: never merge without `verdict: APPROVED`; auto-edit only
+`settings.json` permissions block and per-project `ProjectConfig` literals —
+everything else opens a ticket; stop the main timer before touching `beat.py`,
+restart after.
 
-**Persona constraints** (non-negotiable, never override):
-- Never merge without an explicit `verdict: APPROVED` from `/verify-gate`.
-- Auto-edit only: `settings.json` permissions block, per-project `ProjectConfig`
-  literals in `beat.py`. Everything else opens a ticket and stops.
-- Never touch `beat.py` without stopping the main timer first and restarting
-  it after.
-- Never force-push.
-- If the same failure type recurs ≥ 3 consecutive runs: escalate (Phase 6),
-  stop acting autonomously on that failure type.
-
----
-
-## Phase 1 — Lock + watermark load
-
-Acquire an exclusive lock before any reads or writes:
+## 1. Survey
 
 ```bash
-exec 9>"${HOME}/.claude/logs/.supervisor.lock"
-flock -n 9 || { echo "supervisor: already running, exiting"; exit 0; }
+python3 ~/.claude/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
 ```
 
-Read `~/.claude/logs/nightbeat-supervisor-watermark.json`. Extract `since`
-(ISO-8601 timestamp). If the file does not exist, default `since` to 24 hours
-ago. If `$ARGUMENTS` contains `--since <ts>`, use that value instead (allows
-manual backfill).
+Outputs `{prs_to_merge, failures}`. If both are empty, update the watermark
+and stop.
 
-```bash
-python3 ~/.claude/scripts/nightbeat-supervisor-survey.py \
-  --since "$SINCE" \
-  --outcomes ~/.claude/logs/beat-outcomes.jsonl
-```
+## 2. Merge ready PRs
 
-Parse the JSON output. It contains three lists:
-- `prs_to_merge` — `{project, ticket_id, pr_number, pr_sha, branch}`
-- `failures` — `{project, ticket_id, phase, outcome, ts, log_file}`
-- `idle` — informational only, skip
+For each entry in `prs_to_merge`:
 
-If both `prs_to_merge` and `failures` are empty: update the watermark to now
-and stop. Log one line: `supervisor: no pending actions since <since>`.
+1. Check the diff: `bash ~/.claude/skills/nightbeat-supervisor/check-pr-diff <pr> <repo>` — any non-zero exit is a HOLD; log the reason, skip to failures.
+2. `/verify-gate <pr>` — APPROVED → `/merge <pr>`. REROLL → note on the linked ticket. ESCALATE → go to step 4.
 
----
+## 3. Triage failures
 
-## Phase 2 — Destructive-diff check (for each PR)
+Read the nightbeat log for each failure. Classify and repair:
 
-For each entry in `prs_to_merge`, before calling verify-gate, run the diff
-check script:
-
-```bash
-bash ~/.claude/skills/nightbeat-supervisor/check-pr-diff "$PR_NUMBER" "$REPO"
-```
-
-The script exits 0 if the diff is clean, 1 if it contains a ticket deletion
-without a corresponding move to `tickets/closed/`. It prints a one-line
-reason to stdout.
-
-If exit code is non-zero (1 = ticket deletion detected, 2 = fetch failed):
-- Do NOT call verify-gate or merge regardless of reason.
-- Create a note in the supervisor log: `HOLD PR#<n>: <reason from script stdout>`.
-- Add it to the failures list for diagnosis in Phase 4.
-
-Continue to next PR.
-
----
-
-## Phase 3 — Merge loop
-
-Process each PR that passed the destructive-diff check.
-
-### 3a. Verify-gate
-
-```
-/verify-gate <pr_number>
-```
-
-Wait for verdict. Parse the last structured output block:
-- `verdict: APPROVED` → proceed to merge.
-- `verdict: REROLL` → do not merge. Log the failing criteria. If a ticket
-  exists for this PR's work, append a `note` to it with the REROLL reason.
-  If no ticket exists, create one.
-- `verdict: ESCALATE` → do not merge. Escalate (Phase 6) with the full
-  verify-gate output as context.
-
-### 3b. Merge
-
-```
-/merge <pr_number>
-```
-
-If merge fails (non-zero exit): log the error, do not retry. Create a repair
-note. Supervisor continues to next PR.
-
-Log one line per merged PR: `supervisor: merged PR#<n> ticket=<id> project=<project>`.
-
----
-
-## Phase 4 — Failure triage
-
-For each entry in `failures`, read the corresponding log file:
-
-```bash
-cat ~/.claude/logs/nightbeat/<log_file>
-```
-
-Classify the failure into one of these categories:
-
-| Category | Detection pattern |
+| Category | Auto-repair |
 |---|---|
-| `permission_denial` | `permission_denials` field non-empty, or "Permission denied" in log |
-| `budget_exhaustion` | `outcome=error_max_budget_usd`, or log ends mid-skill |
-| `misplaced_tickets` | `erg check` output listing closed tickets not in `tickets/closed/` |
-| `skill_bug` | Non-zero exit without budget/permission signal; log shows traceback or assertion |
-| `spec_gap` | Raid ends with a question, or ticket exit criteria ambiguous in the log |
-| `crash` | `aborted` outcome within CRASH_RECOVERY_WINDOW_S of `in_progress` |
-| `unknown` | None of the above |
+| `permission_denial` | Add the denied command to `settings.json` allowlist |
+| `budget_exhaustion` | Raise per-project `ProjectConfig` field by 20%, capped at 2× the module-level constant; never edit the module-level constant |
+| `misplaced_tickets` | `git mv` closed tickets to `tickets/closed/` |
+| `crash` | Restart the main timer if stopped |
+| Anything else | Open a ticket with the log excerpt; stop |
 
-Record the classification. Then apply the repair strategy below.
+## 4. Escalate
 
----
+When: ESCALATE verdict, unknown failure category, or the same failure type
+recurring ≥ 3 consecutive runs for a project.
 
-## Phase 5 — Auto-repair (bounded authority)
+Call `advisor` if available. Otherwise: `Agent(model="opus")` with the log
+context (no extended thinking in Agent mode — honest degradation). Create a
+ticket with the verdict if the fix is outside auto-apply authority.
 
-Apply only within the authority bounds defined below. Anything outside the
-bounds → create a ticket (see Phase 5d) and stop.
+## 5. Done
 
-### 5a. Permission denial
-
-Find the denied command in the log. Add it to the `allow` list in
-`~/.claude/settings.json` under the appropriate hook, following the existing
-allowlist structure.
-
-```bash
-python3 -c "import json,sys; d=json.load(open('${HOME}/.claude/settings.json')); print(json.dumps(d.get('permissions',{}), indent=2))"
+Update the watermark. End with:
 ```
-
-Edit the file directly. Commit: `chore: supervisor auto-allow <command>`.
-
-### 5b. Budget exhaustion
-
-Locate the project's per-project `ProjectConfig` entry in `beat.py`
-(search for `ProjectConfig(path=Path.home() / "<project-name>"`). Do not
-touch module-level constants (`BUDGET_HOUSEKEEPING`, `BUDGET_RAID`, etc.) —
-those affect every project.
-
-If no per-project `ProjectConfig` exists for the failing project: create one
-that copies the current global defaults, then raise only the relevant field
-(e.g., `budget_housekeeping=0.90`). Do not auto-raise otherwise.
-
-**Gate**: raise is at most 2× the module-level constant for that field. If
-the per-project value is already at or above 2× the module-level constant,
-do not auto-raise. Create a ticket instead.
-
-Before editing `beat.py`:
-```bash
-systemctl --user stop claude-nightbeat.timer
+supervisor: <ts> — merged: N, repaired: N, tickets: N, escalated: N
 ```
-
-Edit the `ProjectConfig` field only. Commit: `chore: supervisor raises budget for <project>`.
-
-After commit:
-```bash
-systemctl --user start claude-nightbeat.timer
-```
-
-If `start` fails: log the error, leave timer stopped, create a diagnostic
-ticket.
-
-### 5c. Misplaced tickets
-
-Run `erg check tickets/` to identify closed tickets not in `tickets/closed/`.
-For each:
-
-```bash
-git mv tickets/<id>-<slug>.erg tickets/closed/<id>-<slug>.erg
-```
-
-Commit: `chore: supervisor moves closed tickets to tickets/closed/`.
-
-Do not edit ticket content. Only move.
-
-### 5d. Skill bug / spec gap / unknown
-
-Do not auto-edit. Instead:
-
-Search open tickets for a related title (grep by category keyword). If none
-exists, create a new ticket using the erg binary:
-
-```bash
-ERG=${ERG:-tickets/erg}
-$ERG new "Supervisor-flagged: <category> in <project>/<phase>"
-```
-
-Then add the log excerpt and classification to the ticket body.
-
-Commit: `chore: supervisor creates repair ticket <id>`.
-
-### 5e. Crash
-
-Check if the main timer is currently stopped:
-
-```bash
-systemctl --user is-active claude-nightbeat.timer
-```
-
-If inactive: restart it.
-
-```bash
-systemctl --user start claude-nightbeat.timer
-```
-
-Log: `supervisor: restarted nightbeat timer after crash recovery`.
-
----
-
-## Phase 6 — Escalate
-
-Call this phase when:
-- `verdict: ESCALATE` from verify-gate.
-- `unknown` failure classification after Phase 4.
-- Same failure type recorded ≥ 3 consecutive times in `failures` for the
-  same project.
-
-Collect:
-1. The classification and log excerpt (last 100 lines of the log file).
-2. Recent beat-outcomes entries for the project (last 7 days).
-3. Any related open tickets.
-
-**If the `advisor` tool is available** (interactive session): call it. It
-forwards the full conversation transcript and uses a stronger reviewer with
-extended thinking — the strongest escalation path.
-
-**If `advisor` is not available** (typical for `claude -p bypassPermissions`
-launched from the systemd unit): spawn a sub-agent on Opus:
-
-```
-Agent(
-  subagent_type="general-purpose",
-  model="opus",
-  prompt="<assembled context above>"
-)
-```
-
-Note: the Agent tool does not expose an `effort` field — this gives Opus 4.7
-but without max-thinking mode. It is a degraded but useful fallback.
-
-Apply the recommendation if it falls within auto-apply authority (Phase 5).
-Otherwise: create a ticket capturing the diagnosis and recommended action.
-
-Log: `supervisor: escalated <project>/<phase> failure — advisor=<yes|sub-agent> verdict: <one-line summary>`.
-
----
-
-## Phase 7 — Watermark update
-
-After all phases complete (even if some items failed), write the watermark:
-
-```bash
-python3 -c "
-import json, datetime
-wm = {'since': datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ')}
-open('${HOME}/.claude/logs/nightbeat-supervisor-watermark.json', 'w').write(json.dumps(wm))
-print('supervisor: watermark updated to', wm['since'])
-"
-```
-
----
-
-## Summary line
-
-End every run with one structured line:
-
-```
-supervisor: <ts> — PRs merged: <N>, failures triaged: <N>, auto-repaired: <N>, tickets created: <N>, escalated: <N>
-```
-
-This line is parsed by `nightbeat-report.py` (future extension) for the
-morning summary.

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: nightbeat-supervisor
+description: Continuous autonomous supervisor for nightbeat. Watches beat outcomes, merges ready PRs, diagnoses and repairs failures, escalates when stuck.
+model: claude-opus-4-7
+effort: max
+user-invocable: true
+argument-hint: "[--dry-run]"
+---
+
+# Nightbeat Supervisor
+
+Autonomous night watchman. Runs after each beat cycle (or on its own
+15-minute timer) and acts on every unprocessed outcome:
+
+- **Happy path**: raid succeeded → PR open → verify-gate → merge.
+- **Failure path**: housekeeping/raid failed → diagnose → auto-repair or
+  ticket → escalate if stuck.
+
+**Persona constraints** (non-negotiable, never override):
+- Never merge without an explicit `verdict: APPROVED` from `/verify-gate`.
+- Never edit a skill's SKILL.md autonomously.
+- Never touch `beat.py` logic (beyond config constants) without stopping the
+  main timer first and restarting it after.
+- Never force-push.
+- If the same failure type recurs ≥ 3 consecutive runs: escalate to advisor,
+  stop acting autonomously on that failure type.
+
+---
+
+## Phase 1 — Watermark load
+
+Read `~/.claude/logs/nightbeat-supervisor-watermark.json`. Extract `since`
+(ISO-8601 timestamp). If the file does not exist, default `since` to 24 hours
+ago.
+
+```bash
+python3 ~/.claude/scripts/nightbeat-supervisor-survey.py \
+  --since "$SINCE" \
+  --outcomes ~/.claude/logs/beat-outcomes.jsonl
+```
+
+Parse the JSON output. It contains three lists:
+- `prs_to_merge` — `{project, ticket_id, pr_number, pr_sha, branch}`
+- `failures` — `{project, ticket_id, phase, outcome, ts, log_file}`
+- `idle` — informational only, skip
+
+If both `prs_to_merge` and `failures` are empty: update the watermark to now
+and stop. Log one line: `supervisor: no pending actions since <since>`.
+
+---
+
+## Phase 2 — Destructive-diff check (for each PR)
+
+For each entry in `prs_to_merge`, before calling verify-gate:
+
+```bash
+# leak-guard escape: forge CLI intentional
+gh pr diff <pr_number> --repo <repo> 2>/dev/null
+```
+
+Scan the diff for lines matching `^-` (deletions) that contain
+`tickets/[0-9]+-[^/]+\.erg` and do **not** have a corresponding `^+` line
+moving the same path to `tickets/closed/`.
+
+If any such deletion is found:
+- Do NOT call verify-gate or merge.
+- Append a comment to the PR explaining the hold.
+- Create a note in the supervisor log: `HOLD PR#<n>: deletes ticket file without closing`.
+- Add it to the failures list for diagnosis in Phase 4.
+
+Continue to next PR.
+
+---
+
+## Phase 3 — Merge loop
+
+Process each PR that passed the destructive-diff check.
+
+### 3a. Verify-gate
+
+```
+/verify-gate <pr_number>
+```
+
+Wait for verdict. Parse the last structured output block:
+- `verdict: APPROVED` → proceed to merge.
+- `verdict: REROLL` → do not merge. Log the failing criteria. If a ticket
+  exists for this PR's work, append a `note` to it with the REROLL reason.
+  If no ticket exists, create one.
+- `verdict: ESCALATE` → do not merge. Escalate to advisor (Phase 6) with the
+  full verify-gate output as context.
+
+### 3b. Merge
+
+```
+/merge <pr_number>
+```
+
+If merge fails (non-zero exit): log the error, do not retry. Create a repair
+note. Supervisor continues to next PR.
+
+Log one line per merged PR: `supervisor: merged PR#<n> ticket=<id> project=<project>`.
+
+---
+
+## Phase 4 — Failure triage
+
+For each entry in `failures`, read the corresponding log file:
+
+```bash
+cat ~/.claude/logs/nightbeat/<log_file>
+```
+
+Classify the failure into one of these categories:
+
+| Category | Detection pattern |
+|---|---|
+| `permission_denial` | `permission_denials` field non-empty, or "Permission denied" in log |
+| `budget_exhaustion` | `outcome=error_max_budget_usd`, or log ends mid-skill |
+| `misplaced_tickets` | `erg check` output listing closed tickets not in `tickets/closed/` |
+| `skill_bug` | Non-zero exit without budget/permission signal; log shows traceback or assertion |
+| `spec_gap` | Raid ends with a question, or ticket exit criteria ambiguous in the log |
+| `crash` | `aborted` outcome within CRASH_RECOVERY_WINDOW_S of `in_progress` |
+| `unknown` | None of the above |
+
+Record the classification. Then apply the repair strategy below.
+
+---
+
+## Phase 5 — Auto-repair (bounded authority)
+
+Apply only within the authority bounds defined below. Anything outside the
+bounds → create a ticket (see Phase 5d) and stop.
+
+### 5a. Permission denial
+
+Find the denied command in the log. Add it to the `allow` list in
+`~/.claude/settings.json` under the appropriate hook, following the existing
+allowlist structure.
+
+```bash
+# Example: check current structure first
+python3 -c "import json,sys; d=json.load(open('${HOME}/.claude/settings.json')); print(json.dumps(d.get('permissions',{}), indent=2))"
+```
+
+Edit the file directly. Commit: `chore: supervisor auto-allow <command>`.
+
+### 5b. Budget exhaustion
+
+Find the project's `ProjectConfig` in `beat.py`. If the observed cost is
+≤2× the current budget constant, raise the budget by 20% (round to 2 dp).
+
+**Gate**: budget raise is at most 2× the original constant. If the current
+budget is already at or above 2× original, do not auto-raise. Create a
+ticket instead.
+
+Before editing `beat.py`:
+```bash
+systemctl --user stop claude-nightbeat.timer
+```
+
+Edit the constant. Commit: `chore: supervisor raises budget for <project>`.
+
+After commit:
+```bash
+systemctl --user start claude-nightbeat.timer
+```
+
+If `start` fails: log the error, leave timer stopped, create a diagnostic
+ticket.
+
+### 5c. Misplaced tickets
+
+Run `erg check tickets/` to identify closed tickets not in `tickets/closed/`.
+For each:
+
+```bash
+git mv tickets/<id>-<slug>.erg tickets/closed/<id>-<slug>.erg
+```
+
+Commit: `chore: supervisor moves closed tickets to tickets/closed/`.
+
+Do not edit ticket content. Only move.
+
+### 5d. Skill bug / spec gap / unknown
+
+Do not auto-edit. Instead:
+
+Search open tickets for a related title (grep by category keyword). If none
+exists, create a new ticket using the erg binary:
+
+```bash
+ERG=${ERG:-tickets/erg}
+$ERG new "Supervisor-flagged: <category> in <project>/<phase>"
+```
+
+Then add the log excerpt and classification to the ticket body.
+
+Commit: `chore: supervisor creates repair ticket <id>`.
+
+### 5e. Crash
+
+Check if the main timer is currently stopped:
+
+```bash
+systemctl --user is-active claude-nightbeat.timer
+```
+
+If inactive: restart it.
+
+```bash
+systemctl --user start claude-nightbeat.timer
+```
+
+Log: `supervisor: restarted nightbeat timer after crash recovery`.
+
+---
+
+## Phase 6 — Escalate to advisor
+
+Call this phase when:
+- `verdict: ESCALATE` from verify-gate.
+- `unknown` failure classification after Phase 4.
+- Same failure type recorded ≥ 3 consecutive times in `failures` for the
+  same project.
+
+Collect:
+1. The classification and log excerpt (last 100 lines of the log file).
+2. Recent beat-outcomes entries for the project (last 7 days).
+3. Any related open tickets.
+
+Call the `advisor` tool with this context to get a second opinion.
+
+Apply the advisor's recommendation if it falls within auto-apply authority.
+Otherwise: create a ticket that captures the advisor's diagnosis and
+recommended action for human review.
+
+Log: `supervisor: escalated <project>/<phase> failure — advisor verdict: <summary>`.
+
+---
+
+## Phase 7 — Watermark update
+
+After all phases complete (even if some items failed), write the watermark:
+
+```bash
+python3 -c "
+import json, datetime
+wm = {'since': datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ')}
+open('${HOME}/.claude/logs/nightbeat-supervisor-watermark.json', 'w').write(json.dumps(wm))
+print('supervisor: watermark updated to', wm['since'])
+"
+```
+
+---
+
+## Summary line
+
+End every run with one structured line:
+
+```
+supervisor: <ts> — PRs merged: <N>, failures triaged: <N>, auto-repaired: <N>, tickets created: <N>, escalated: <N>
+```
+
+This line is parsed by `nightbeat-report.py` (future extension) for the
+morning summary.

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -54,8 +54,12 @@ recovery): self-resolving; beat.py handles this on the next run. Log it, no
 action unless it recurs more than twice in the same window.
 
 **Same ticket failing repeatedly** (observed: chemin-de-voix ticket 0021,
-3× in a row): the ticket is likely underspecified or blocked. Add a sweep-skip
-via `erg note sweep-skip: <reason>` and open a repair ticket.
+3× in a row): read the ticket body before acting. If it has obvious split
+lines — multiple independent deliverables, `##` sections that are each
+self-contained, or an Actions list spanning unrelated files — split it into
+two child tickets, close the parent with a log entry `closed: split → <id-a>
+<id-b>`, and commit. Otherwise add a sweep-skip (`erg note sweep-skip:
+scope-too-large`) and open a repair ticket naming the blocking issue.
 
 **`failed` with no ticket_id** (5 observed — housekeeping or pick-ticket died
 before a ticket was selected): read the log to identify which phase failed.

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -16,12 +16,12 @@ timer before editing `beat.py`, restart after; never edit skill SKILL.md files.
 ## 1. Survey
 
 ```bash
-python3 ~/.claude/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
+python3 $HARNESS_DIR/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
 ```
 
 If `--since` is absent from `$ARGUMENTS`, the script reads the watermark from
-`~/.claude/logs/nightbeat-supervisor-watermark.json` (defaults to 24h ago if
-the file is missing). Reads both `~/.claude/logs/beat-outcomes.jsonl` and each
+`$HARNESS_DIR/logs/nightbeat-supervisor-watermark.json` (defaults to 24h ago if
+the file is missing). Reads both `$HARNESS_DIR/logs/beat-outcomes.jsonl` and each
 project's `beat-log.jsonl`. Outputs `{prs_to_merge, failures, watermark_ts}`.
 If both lists are empty, write `watermark_ts` and stop.
 
@@ -30,7 +30,7 @@ If both lists are empty, write `watermark_ts` and stop.
 For each entry in `prs_to_merge` (which includes `pr_number` and `github_repo`
 derived by the survey script from the project's git remote):
 
-1. `bash ~/.claude/skills/nightbeat-supervisor/check-pr-diff <pr_number> <github_repo>` — non-zero exit is a HOLD; add to failures with the script's reason.
+1. `bash $HARNESS_DIR/skills/nightbeat-supervisor/check-pr-diff <pr_number> <github_repo>` — non-zero exit is a HOLD; add to failures with the script's reason.
 2. `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body) and move on. ESCALATE → go to step 4.
 
 ## 3. Diagnose and repair
@@ -68,8 +68,10 @@ ticket with the verdict if the fix is outside authority.
 
 ## 5. Done
 
-Write `watermark_ts` from the survey output to
-`~/.claude/logs/nightbeat-supervisor-watermark.json`. End with:
+Append one journal entry per action taken this cycle to
+`<project>/nightbeat-supervisor-journal.jsonl`. If no actions were taken,
+append a single `action=idle` entry — this serves as the watermark so the
+next cycle knows where to resume. End with:
 
 ```
 supervisor: <ts> — merged: N, repaired: N, tickets: N, escalated: N

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -2,7 +2,7 @@
 name: nightbeat-supervisor
 description: Continuous autonomous supervisor for nightbeat. Watches beat outcomes, merges ready PRs, diagnoses and repairs failures, escalates when stuck.
 user-invocable: true
-argument-hint: "[--dry-run]"
+argument-hint: "[--since ISO-TS]"
 ---
 
 # Nightbeat Supervisor
@@ -16,20 +16,29 @@ beat.py) and acts on every unprocessed outcome:
 
 **Persona constraints** (non-negotiable, never override):
 - Never merge without an explicit `verdict: APPROVED` from `/verify-gate`.
-- Never edit a skill's SKILL.md autonomously.
-- Never touch `beat.py` logic (beyond config constants) without stopping the
-  main timer first and restarting it after.
+- Auto-edit only: `settings.json` permissions block, per-project `ProjectConfig`
+  literals in `beat.py`. Everything else opens a ticket and stops.
+- Never touch `beat.py` without stopping the main timer first and restarting
+  it after.
 - Never force-push.
 - If the same failure type recurs ≥ 3 consecutive runs: escalate (Phase 6),
   stop acting autonomously on that failure type.
 
 ---
 
-## Phase 1 — Watermark load
+## Phase 1 — Lock + watermark load
+
+Acquire an exclusive lock before any reads or writes:
+
+```bash
+exec 9>"${HOME}/.claude/logs/.supervisor.lock"
+flock -n 9 || { echo "supervisor: already running, exiting"; exit 0; }
+```
 
 Read `~/.claude/logs/nightbeat-supervisor-watermark.json`. Extract `since`
 (ISO-8601 timestamp). If the file does not exist, default `since` to 24 hours
-ago.
+ago. If `$ARGUMENTS` contains `--since <ts>`, use that value instead (allows
+manual backfill).
 
 ```bash
 python3 ~/.claude/scripts/nightbeat-supervisor-survey.py \
@@ -60,9 +69,9 @@ The script exits 0 if the diff is clean, 1 if it contains a ticket deletion
 without a corresponding move to `tickets/closed/`. It prints a one-line
 reason to stdout.
 
-If exit code is 1:
-- Do NOT call verify-gate or merge.
-- Create a note in the supervisor log: `HOLD PR#<n>: <reason>`.
+If exit code is non-zero (1 = ticket deletion detected, 2 = fetch failed):
+- Do NOT call verify-gate or merge regardless of reason.
+- Create a note in the supervisor log: `HOLD PR#<n>: <reason from script stdout>`.
 - Add it to the failures list for diagnosis in Phase 4.
 
 Continue to next PR.
@@ -143,19 +152,25 @@ Edit the file directly. Commit: `chore: supervisor auto-allow <command>`.
 
 ### 5b. Budget exhaustion
 
-Find the project's `ProjectConfig` in `beat.py`. If the observed cost is
-≤2× the current budget constant, raise the budget by 20% (round to 2 dp).
+Locate the project's per-project `ProjectConfig` entry in `beat.py`
+(search for `ProjectConfig(path=Path.home() / "<project-name>"`). Do not
+touch module-level constants (`BUDGET_HOUSEKEEPING`, `BUDGET_RAID`, etc.) —
+those affect every project.
 
-**Gate**: budget raise is at most 2× the original constant. If the current
-budget is already at or above 2× original, do not auto-raise. Create a
-ticket instead.
+If no per-project `ProjectConfig` exists for the failing project: create one
+that copies the current global defaults, then raise only the relevant field
+(e.g., `budget_housekeeping=0.90`). Do not auto-raise otherwise.
+
+**Gate**: raise is at most 2× the module-level constant for that field. If
+the per-project value is already at or above 2× the module-level constant,
+do not auto-raise. Create a ticket instead.
 
 Before editing `beat.py`:
 ```bash
 systemctl --user stop claude-nightbeat.timer
 ```
 
-Edit the constant. Commit: `chore: supervisor raises budget for <project>`.
+Edit the `ProjectConfig` field only. Commit: `chore: supervisor raises budget for <project>`.
 
 After commit:
 ```bash
@@ -212,7 +227,7 @@ Log: `supervisor: restarted nightbeat timer after crash recovery`.
 
 ---
 
-## Phase 6 — Escalate (Opus 4.7 max thinking)
+## Phase 6 — Escalate
 
 Call this phase when:
 - `verdict: ESCALATE` from verify-gate.
@@ -225,10 +240,12 @@ Collect:
 2. Recent beat-outcomes entries for the project (last 7 days).
 3. Any related open tickets.
 
-Escalation uses a sub-agent on the stronger model. If the `advisor` tool is
-available in this session, call it first — it forwards the full transcript.
-Otherwise (e.g., running under `claude -p --permission-mode bypassPermissions`
-where the advisor tool may not be loaded), spawn a sub-agent explicitly:
+**If the `advisor` tool is available** (interactive session): call it. It
+forwards the full conversation transcript and uses a stronger reviewer with
+extended thinking — the strongest escalation path.
+
+**If `advisor` is not available** (typical for `claude -p bypassPermissions`
+launched from the systemd unit): spawn a sub-agent on Opus:
 
 ```
 Agent(
@@ -238,11 +255,13 @@ Agent(
 )
 ```
 
-Apply the recommendation if it falls within auto-apply authority (Phase 5).
-Otherwise: create a ticket that captures the diagnosis and recommended action
-for human review.
+Note: the Agent tool does not expose an `effort` field — this gives Opus 4.7
+but without max-thinking mode. It is a degraded but useful fallback.
 
-Log: `supervisor: escalated <project>/<phase> failure — verdict: <one-line summary>`.
+Apply the recommendation if it falls within auto-apply authority (Phase 5).
+Otherwise: create a ticket capturing the diagnosis and recommended action.
+
+Log: `supervisor: escalated <project>/<phase> failure — advisor=<yes|sub-agent> verdict: <one-line summary>`.
 
 ---
 

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -7,14 +7,11 @@ argument-hint: "[--since ISO-TS]"
 
 # Nightbeat Supervisor
 
-Watch `~/.claude/logs/beat-outcomes.jsonl` for unprocessed entries and close
-the loop: merge PRs that are ready, diagnose failures, repair within authority,
-escalate when stuck.
+Survey beat outcomes each cycle and close the loop: merge ready PRs, chase
+failures to their root cause, repair within authority, escalate when stuck.
 
-**Non-negotiables**: never merge without `verdict: APPROVED`; auto-edit only
-`settings.json` permissions block and per-project `ProjectConfig` literals —
-everything else opens a ticket; stop the main timer before touching `beat.py`,
-restart after.
+**Non-negotiables**: never merge without `verdict: APPROVED`; stop the main
+timer before editing `beat.py`, restart after; never edit skill SKILL.md files.
 
 ## 1. Survey
 
@@ -22,54 +19,58 @@ restart after.
 python3 ~/.claude/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
 ```
 
-Reads both `~/.claude/logs/beat-outcomes.jsonl` (phase-level signals) and
-each project's `beat-log.jsonl` (beat-level signals). Outputs
-`{prs_to_merge, failures}`. If both are empty, update the watermark and stop.
+If `--since` is absent from `$ARGUMENTS`, the script reads the watermark from
+`~/.claude/logs/nightbeat-supervisor-watermark.json` (defaults to 24h ago if
+the file is missing). Reads both `~/.claude/logs/beat-outcomes.jsonl` and each
+project's `beat-log.jsonl`. Outputs `{prs_to_merge, failures, watermark_ts}`.
+If both lists are empty, write `watermark_ts` and stop.
 
 ## 2. Merge ready PRs
 
-For each entry in `prs_to_merge`:
+For each entry in `prs_to_merge` (which includes `pr_number` and `github_repo`
+derived by the survey script from the project's git remote):
 
-1. Check the diff: `bash ~/.claude/skills/nightbeat-supervisor/check-pr-diff <pr> <repo>` — any non-zero exit is a HOLD; log the reason, skip to failures.
-2. `/verify-gate <pr>` — APPROVED → `/merge <pr>`. REROLL → note on the linked ticket. ESCALATE → go to step 4.
+1. `bash ~/.claude/skills/nightbeat-supervisor/check-pr-diff <pr_number> <github_repo>` — non-zero exit is a HOLD; add to failures with the script's reason.
+2. `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body) and move on. ESCALATE → go to step 4.
 
-## 3. Triage failures
+## 3. Diagnose and repair
 
-For each failure, read the log and ask **why** until you reach an actionable
-root cause. Do not stop at the signal — `error_max_budget_usd` is not a root
-cause, it is a symptom. Keep asking:
+For each failure, read the nightbeat log and ask **why** until you reach an
+actionable root cause:
 
 > Why did it fail? → Why did that happen? → Why was that condition present?
 
-Stop when you reach something the harness can change. Then either repair
-within authority or open a ticket naming the root cause, not the symptom.
+When you reach a root cause, repair if within authority:
 
-**Repair authority** (auto-apply without a ticket):
-- Root cause is a missing permission → add to `settings.json` allowlist.
-- Root cause is a scope that fit under a larger budget → raise the per-project
-  `ProjectConfig` field by 20%, capped at 2× the module-level constant; never
-  touch the module-level constant; stop the timer first, restart after.
-- Root cause is a ticket too large to finish in one beat → read the body; if
-  it has obvious split lines (independent deliverables, self-contained
-  sections), split into one ticket per independent unit of work and close the
-  parent; otherwise add a sweep-skip and open a repair ticket.
-- Root cause is a dead timer → restart it.
+- **Missing permission** → add to `settings.json` allowlist.
+- **Budget too small for the actual scope of work** → raise the per-project
+  `ProjectConfig` field in `beat.py` by 20%, capped at 2× the module-level
+  constant; never touch the module-level constant.
+- **Ticket too large to finish in one beat** → split into one ticket per
+  independent unit of work; convert the parent to an umbrella by adding
+  `Blocks: <id>...` and leaving it open (it may be blocking other tickets).
+- **Dead timer** → restart it.
 
-**Everything else**: open a ticket stating the root cause chain. Do not
+If the why-chain bottoms out without reaching anything repairable: escalate
+(step 4).
+
+**Anything else**: open a ticket stating the root cause chain; do not
 auto-repair.
 
 ## 4. Escalate
 
-When: ESCALATE verdict, unknown failure category, or the same failure type
-recurring ≥ 3 consecutive runs for a project.
+Triggers: ESCALATE from verify-gate, why-chain without a repairable finding,
+or the same root cause recurring ≥ 3 consecutive runs for a project.
 
-Call `advisor` if available. Otherwise: `Agent(model="opus")` with the log
+Call `advisor` if available. Otherwise `Agent(model="opus")` with the log
 context (no extended thinking in Agent mode — honest degradation). Create a
-ticket with the verdict if the fix is outside auto-apply authority.
+ticket with the verdict if the fix is outside authority.
 
 ## 5. Done
 
-Update the watermark. End with:
+Write `watermark_ts` from the survey output to
+`~/.claude/logs/nightbeat-supervisor-watermark.json`. End with:
+
 ```
 supervisor: <ts> — merged: N, repaired: N, tickets: N, escalated: N
 ```

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -22,8 +22,9 @@ restart after.
 python3 ~/.claude/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
 ```
 
-Outputs `{prs_to_merge, failures}`. If both are empty, update the watermark
-and stop.
+Reads both `~/.claude/logs/beat-outcomes.jsonl` (phase-level signals) and
+each project's `beat-log.jsonl` (beat-level signals). Outputs
+`{prs_to_merge, failures}`. If both are empty, update the watermark and stop.
 
 ## 2. Merge ready PRs
 
@@ -34,22 +35,37 @@ For each entry in `prs_to_merge`:
 
 ## 3. Triage failures
 
-Read the nightbeat log for each failure. In practice, `error_max_budget_usd`
-is the only failure type observed across 60 runs (7/7 failures). Triage
-accordingly:
+Failure types ordered by observed frequency across all projects and 200+
+beat-log entries. Read the nightbeat log for each failure, classify, and act:
 
-**`error_max_budget_usd`** (all observed failures): read the last 50 lines of
-the log to identify what consumed the budget — common sub-causes are `erg
-check` surprises, STATE.md scope creep, and stale worktree cleanup. Raise the
-per-project `ProjectConfig` field in `beat.py` by 20%, capped at 2× the
-module-level constant; never touch the module-level constant. Stop the main
-timer before editing, restart after.
+**`aborted` with no diagnostics** (most common — 22 observed, usually a
+timer-stop cascade): check whether the main timer is still active. If stopped,
+restart it. If already running, this is noise from a mid-run kill; no action.
+
+**`error_max_budget_usd`** (7 observed, always during housekeeping or raid):
+read the last 50 lines of the log to identify the sub-cause — observed
+triggers are `erg check` surprises, STATE.md scope creep, and stale worktree
+cleanup. Raise the per-project `ProjectConfig` field in `beat.py` by 20%,
+capped at 2× the module-level constant; never edit the module-level constant.
+Stop the main timer before editing, restart after.
+
+**`aborted` with stale-in-progress diagnostics** (8 observed — SIGKILL
+recovery): self-resolving; beat.py handles this on the next run. Log it, no
+action unless it recurs more than twice in the same window.
+
+**Same ticket failing repeatedly** (observed: chemin-de-voix ticket 0021,
+3× in a row): the ticket is likely underspecified or blocked. Add a sweep-skip
+via `erg note sweep-skip: <reason>` and open a repair ticket.
+
+**`failed` with no ticket_id** (5 observed — housekeeping or pick-ticket died
+before a ticket was selected): read the log to identify which phase failed.
+Treat as `error_max_budget_usd` if the phase signal is budget; otherwise open
+a ticket.
 
 **`permission_denials` non-empty** (not yet observed, tracked in outcomes
 JSONL): add the denied command to `settings.json` allowlist.
 
-**Anything else**: open a ticket with the log excerpt and the result record's
-`subtype` and `stop_reason`; do not auto-repair.
+**Anything else**: open a ticket with the log excerpt; do not auto-repair.
 
 ## 4. Escalate
 

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: nightbeat-supervisor
 description: Continuous autonomous supervisor for nightbeat. Watches beat outcomes, merges ready PRs, diagnoses and repairs failures, escalates when stuck.
-model: claude-opus-4-7
-effort: max
 user-invocable: true
 argument-hint: "[--dry-run]"
 ---
 
 # Nightbeat Supervisor
 
-Autonomous night watchman. Runs after each beat cycle (or on its own
-15-minute timer) and acts on every unprocessed outcome:
+Autonomous night watchman. Runs on its own 15-min timer (separate from
+beat.py) and acts on every unprocessed outcome:
 
 - **Happy path**: raid succeeded → PR open → verify-gate → merge.
 - **Failure path**: housekeeping/raid failed → diagnose → auto-repair or
@@ -22,7 +20,7 @@ Autonomous night watchman. Runs after each beat cycle (or on its own
 - Never touch `beat.py` logic (beyond config constants) without stopping the
   main timer first and restarting it after.
 - Never force-push.
-- If the same failure type recurs ≥ 3 consecutive runs: escalate to advisor,
+- If the same failure type recurs ≥ 3 consecutive runs: escalate (Phase 6),
   stop acting autonomously on that failure type.
 
 ---
@@ -51,21 +49,20 @@ and stop. Log one line: `supervisor: no pending actions since <since>`.
 
 ## Phase 2 — Destructive-diff check (for each PR)
 
-For each entry in `prs_to_merge`, before calling verify-gate:
+For each entry in `prs_to_merge`, before calling verify-gate, run the diff
+check script:
 
 ```bash
-# leak-guard escape: forge CLI intentional
-gh pr diff <pr_number> --repo <repo> 2>/dev/null
+bash ~/.claude/skills/nightbeat-supervisor/check-pr-diff "$PR_NUMBER" "$REPO"
 ```
 
-Scan the diff for lines matching `^-` (deletions) that contain
-`tickets/[0-9]+-[^/]+\.erg` and do **not** have a corresponding `^+` line
-moving the same path to `tickets/closed/`.
+The script exits 0 if the diff is clean, 1 if it contains a ticket deletion
+without a corresponding move to `tickets/closed/`. It prints a one-line
+reason to stdout.
 
-If any such deletion is found:
+If exit code is 1:
 - Do NOT call verify-gate or merge.
-- Append a comment to the PR explaining the hold.
-- Create a note in the supervisor log: `HOLD PR#<n>: deletes ticket file without closing`.
+- Create a note in the supervisor log: `HOLD PR#<n>: <reason>`.
 - Add it to the failures list for diagnosis in Phase 4.
 
 Continue to next PR.
@@ -87,8 +84,8 @@ Wait for verdict. Parse the last structured output block:
 - `verdict: REROLL` → do not merge. Log the failing criteria. If a ticket
   exists for this PR's work, append a `note` to it with the REROLL reason.
   If no ticket exists, create one.
-- `verdict: ESCALATE` → do not merge. Escalate to advisor (Phase 6) with the
-  full verify-gate output as context.
+- `verdict: ESCALATE` → do not merge. Escalate (Phase 6) with the full
+  verify-gate output as context.
 
 ### 3b. Merge
 
@@ -139,7 +136,6 @@ Find the denied command in the log. Add it to the `allow` list in
 allowlist structure.
 
 ```bash
-# Example: check current structure first
 python3 -c "import json,sys; d=json.load(open('${HOME}/.claude/settings.json')); print(json.dumps(d.get('permissions',{}), indent=2))"
 ```
 
@@ -216,7 +212,7 @@ Log: `supervisor: restarted nightbeat timer after crash recovery`.
 
 ---
 
-## Phase 6 — Escalate to advisor
+## Phase 6 — Escalate (Opus 4.7 max thinking)
 
 Call this phase when:
 - `verdict: ESCALATE` from verify-gate.
@@ -229,13 +225,24 @@ Collect:
 2. Recent beat-outcomes entries for the project (last 7 days).
 3. Any related open tickets.
 
-Call the `advisor` tool with this context to get a second opinion.
+Escalation uses a sub-agent on the stronger model. If the `advisor` tool is
+available in this session, call it first — it forwards the full transcript.
+Otherwise (e.g., running under `claude -p --permission-mode bypassPermissions`
+where the advisor tool may not be loaded), spawn a sub-agent explicitly:
 
-Apply the advisor's recommendation if it falls within auto-apply authority.
-Otherwise: create a ticket that captures the advisor's diagnosis and
-recommended action for human review.
+```
+Agent(
+  subagent_type="general-purpose",
+  model="opus",
+  prompt="<assembled context above>"
+)
+```
 
-Log: `supervisor: escalated <project>/<phase> failure — advisor verdict: <summary>`.
+Apply the recommendation if it falls within auto-apply authority (Phase 5).
+Otherwise: create a ticket that captures the diagnosis and recommended action
+for human review.
+
+Log: `supervisor: escalated <project>/<phase> failure — verdict: <one-line summary>`.
 
 ---
 

--- a/skills/nightbeat-supervisor/check-pr-diff
+++ b/skills/nightbeat-supervisor/check-pr-diff
@@ -10,10 +10,10 @@ PR_NUMBER=${1:?usage: check-pr-diff PR_NUMBER REPO}
 REPO=${2:?usage: check-pr-diff PR_NUMBER REPO}
 
 # <!-- harness-extension-point -->
-diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO" 2>/dev/null) || {
-  echo "check-pr-diff: could not fetch diff for PR#${PR_NUMBER}"
-  exit 0  # soft fail — don't block on network error
-}
+if ! diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO" 2>&1); then
+  echo "check-pr-diff: could not fetch diff for PR#${PR_NUMBER}: ${diff}"
+  exit 2  # unknown — SKILL.md Phase 2 treats any non-zero as HOLD
+fi
 
 # Find lines deleting ticket files: ^-  tickets/NNNN-slug.erg (not in closed/)
 deleted=$(echo "$diff" | grep -E '^-[^-].*tickets/[0-9]+-[^/]+\.erg' | grep -v 'tickets/closed/' || true)

--- a/skills/nightbeat-supervisor/check-pr-diff
+++ b/skills/nightbeat-supervisor/check-pr-diff
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# check-pr-diff — exit 0 if PR diff is clean, 1 if it deletes ticket files
+#                 without moving them to tickets/closed/.
+# Usage: check-pr-diff <pr_number> <repo>
+# Called by nightbeat-supervisor Phase 2 to guard against 2026-05-08-style
+# housekeeping branches that deleted ticket files from main.
+set -euo pipefail
+
+PR_NUMBER=${1:?usage: check-pr-diff PR_NUMBER REPO}
+REPO=${2:?usage: check-pr-diff PR_NUMBER REPO}
+
+# <!-- harness-extension-point -->
+diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO" 2>/dev/null) || {
+  echo "check-pr-diff: could not fetch diff for PR#${PR_NUMBER}"
+  exit 0  # soft fail — don't block on network error
+}
+
+# Find lines deleting ticket files: ^-  tickets/NNNN-slug.erg (not in closed/)
+deleted=$(echo "$diff" | grep -E '^-[^-].*tickets/[0-9]+-[^/]+\.erg' | grep -v 'tickets/closed/' || true)
+[ -z "$deleted" ] && exit 0
+
+# For each deleted path, check whether the same PR also adds it under tickets/closed/
+fail=0
+while IFS= read -r line; do
+  path=$(echo "$line" | grep -oE 'tickets/[0-9]+-[^/ ]+\.erg' | head -1)
+  filename=$(basename "$path")
+  if ! echo "$diff" | grep -qE "^\+[^+].*tickets/closed/${filename}"; then
+    echo "HOLD: PR#${PR_NUMBER} deletes ${path} without closing it"
+    fail=1
+  fi
+done <<< "$deleted"
+
+exit $fail

--- a/tickets/0105-nightbeat-supervisor.erg
+++ b/tickets/0105-nightbeat-supervisor.erg
@@ -1,0 +1,132 @@
+%erg v1
+Title: Nightbeat supervisor — autonomous post-beat merge + failure recovery agent
+Created: 2026-05-09
+Author: claude
+
+--- log ---
+2026-05-09T00:00Z claude created
+
+--- body ---
+## Context
+
+After each nightbeat run, two things can happen that currently require human
+morning review:
+
+1. **A raid succeeds and creates a PR.** The PR sits unmerged until the human
+   runs /nightbeat-report, reviews it, and manually triggers /merge. On
+   nights with 9 runs, a branch can wait 8 hours.
+
+2. **A housekeeping or raid fails.** The timer may stop (2026-05-08 incident)
+   or the same failure recurs all night, burning budget on something broken.
+   Root cause is not investigated until morning.
+
+The supervisor fills this gap: a continuously-running autonomous agent that
+watches beat-outcomes.jsonl, merges approved PRs, diagnoses failures, and
+applies bounded auto-repairs — all before the next beat fires.
+
+## Design decisions
+
+**Invocation**: separate systemd timer (`claude-nightbeat-supervisor.timer`),
+not a post-raid phase in beat.py. The supervisor must outlive the thing it
+supervises: if the main timer stops (as on 2026-05-08), a post-raid hook also
+stops. A separate timer can detect the outage and restart the main timer.
+
+**Watermark**: `~/.claude/logs/nightbeat-supervisor-watermark.json` — records
+the last beat-outcomes.jsonl timestamp the supervisor processed. Prevents
+re-merging or re-diagnosing on restart. Written atomically at the end of each
+supervisor run.
+
+**Repair authority** — two tiers:
+- *Auto-apply* (no ticket needed): add permission allowlist entries, raise
+  budget by ≤2x, move misplaced `tickets/*.erg` to `tickets/closed/`, restart
+  the main timer after a confirmed outage.
+- *Ticket-only* (never auto-edit): skill SKILL.md bodies, beat.py logic,
+  schema changes, anything requiring human judgment.
+
+**Destructive-diff brake**: before merging any PR, the supervisor checks the
+diff for deletions of `tickets/*.erg` files that are not simultaneously moved
+to `tickets/closed/`. Any such deletion → HOLD (do not merge, create a repair
+note). This catches the exact 2026-05-08 housekeeping branch incident.
+
+**Repair-while-running guard**: before touching beat.py, settings.json, or
+any skill file, the supervisor must stop the main timer
+(`systemctl --user stop claude-nightbeat.timer`), apply the fix, and restart
+it. Any failure in the apply step leaves the timer stopped and creates a
+diagnostic ticket.
+
+**Escalation**: call the `advisor` tool when:
+- The same failure type recurs ≥ 3 consecutive runs without a successful repair.
+- The root cause of a failure is ambiguous after reading the log.
+- A proposed repair is at the boundary of or outside auto-apply authority.
+
+**Model**: `claude-opus-4-7` with `effort: max`. The systemd ExecStart passes
+`--model claude-opus-4-7` explicitly (beat.py's run_skill() defaults to sonnet
+and must not be used to call the supervisor).
+
+## Relevant files
+
+- `~/.claude/logs/beat-outcomes.jsonl` — source of truth for beat outcomes
+- `~/.claude/logs/nightbeat/*.log` — per-run raw logs for diagnosis
+- `~/.claude/logs/nightbeat-supervisor-watermark.json` — new (idempotency)
+- `~/.claude/scripts/beat.py` — main timer controller; supervisor may restart it
+- `~/.claude/scripts/projects.json` — project list (for PR lookups)
+- `~/.claude/settings.json` — permission allowlist (auto-repair target)
+- `~/.claude/skills/nightbeat-supervisor/SKILL.md` — new skill persona
+- `~/.claude/scripts/nightbeat-supervisor-survey.py` — new helper (non-LLM
+  watermark reader + outcome classifier)
+- `/etc/systemd/user/claude-nightbeat-supervisor.{service,timer}` — new units
+
+## Actions
+
+1. **Write `skills/nightbeat-supervisor/SKILL.md`** — the full agent persona
+   (phases: watermark load → survey → merge loop → failure triage →
+   auto-repair → escalate → watermark update). Frontmatter:
+   `model: claude-opus-4-7`, `effort: max`.
+
+2. **Write `scripts/nightbeat-supervisor-survey.py`** — pure Python, stdlib
+   only:
+   - Reads `beat-outcomes.jsonl` from `--since <iso-ts>` (watermark).
+   - Classifies entries into: `prs_to_merge`, `failures`, `idle`.
+   - For each `raid outcome=success`, queries `gh pr list` (via subprocess)
+     to find the open PR for that project/ticket.
+   - Emits a JSON summary to stdout consumed by the skill.
+
+3. **Write systemd units** — `claude-nightbeat-supervisor.service` (one-shot,
+   `ExecStart=claude --model claude-opus-4-7 -p "/nightbeat-supervisor" ...`)
+   and `claude-nightbeat-supervisor.timer` (fires every 15 min during the
+   nightbeat window, plus on-boot).
+
+4. **Beat-outcomes watermark**: test that a duplicate supervisor run
+   (re-processing the same window) is a no-op (no double-merges, no
+   duplicate tickets).
+
+5. **Integration test**: simulate a budget-failure outcome entry in a test
+   beat-outcomes file → verify the supervisor creates a repair ticket (does
+   NOT attempt auto-repair on budget failures beyond budget-raise authority).
+
+## Test
+
+```bash
+# Red: survey script exists and classifies correctly
+python3 ~/.claude/scripts/nightbeat-supervisor-survey.py \
+  --outcomes-file tests/fixtures/beat-outcomes-sample.jsonl \
+  --since 2026-05-01T00:00:00Z | python3 -m json.tool
+# Should print {"prs_to_merge": [...], "failures": [...], "idle": [...]}
+# without error. Before implementation this file doesn't exist.
+```
+
+## Exit criteria
+
+- `scripts/nightbeat-supervisor-survey.py --help` exits 0.
+- Running the supervisor on an empty window (since=now) is a no-op and
+  updates the watermark.
+- A raid `outcome=success` with a matching open PR triggers verify-gate +
+  merge within one supervisor cycle.
+- A housekeeping `outcome=fail` triggers log-read + root-cause note
+  appended to the ticket (or a new ticket created) within one cycle.
+- The destructive-diff brake prevents merging the 2026-05-08-style
+  housekeeping branch (test with a synthetic PR diff).
+- Two consecutive supervisor failures on the same failure type escalate to
+  advisor output visible in the supervisor log.
+- Timer restart after repair is confirmed by `systemctl --user status
+  claude-nightbeat.timer` showing `active (waiting)`.

--- a/tickets/0105-nightbeat-supervisor.erg
+++ b/tickets/0105-nightbeat-supervisor.erg
@@ -85,11 +85,18 @@ and must not be used to call the supervisor).
 
 2. **Write `scripts/nightbeat-supervisor-survey.py`** — pure Python, stdlib
    only:
-   - Reads `beat-outcomes.jsonl` from `--since <iso-ts>` (watermark).
+   - Reads `~/.claude/logs/beat-outcomes.jsonl` (phase-level signals) from
+     `--since <iso-ts>` (watermark).
+   - Also reads each project's `beat-log.jsonl` (beat-level signals) for
+     `aborted`/`failed` outcomes and repeated-ticket patterns.
    - Classifies entries into: `prs_to_merge`, `failures`, `idle`.
    - For each `raid outcome=success`, queries `gh pr list` (via subprocess)
      to find the open PR for that project/ticket.
    - Emits a JSON summary to stdout consumed by the skill.
+   - Failure classification order matches observed frequency (empirically
+     derived from 200+ beat-log entries across 6 projects on padme):
+     aborted-no-diag (22) > budget-exhaustion (7) > stale-in-progress (8) >
+     repeated-ticket (1 ticket × 3 runs) > pre-ticket-fail (5).
 
 3. **Write `skills/nightbeat-supervisor/check-pr-diff`** — bash script that
    fetches a PR diff (forge CLI call, isolated from SKILL.md to satisfy

--- a/tickets/0105-nightbeat-supervisor.erg
+++ b/tickets/0105-nightbeat-supervisor.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-09T00:00Z claude created
+2026-05-09T00:00Z claude note body rewritten to reflect final design decisions
 
 --- body ---
 ## Context
@@ -13,142 +14,142 @@ After each nightbeat run, two things can happen that currently require human
 morning review:
 
 1. **A raid succeeds and creates a PR.** The PR sits unmerged until the human
-   runs /nightbeat-report, reviews it, and manually triggers /merge. On
-   nights with 9 runs, a branch can wait 8 hours.
+   runs /nightbeat-report, reviews it, and manually triggers /merge. On nights
+   with 9 runs, a branch can wait 8 hours.
 
 2. **A housekeeping or raid fails.** The timer may stop (2026-05-08 incident)
-   or the same failure recurs all night, burning budget on something broken.
-   Root cause is not investigated until morning.
+   or the same failure recurs all night. Root cause is not investigated until
+   morning.
 
-The supervisor fills this gap: a continuously-running autonomous agent that
-watches beat-outcomes.jsonl, merges approved PRs, diagnoses failures, and
-applies bounded auto-repairs — all before the next beat fires.
+The supervisor fills this gap: a skill invoked on its own 15-min timer that
+surveys beat outcomes, merges ready PRs, and chases failures to their root
+cause — all before the next beat fires.
 
 ## Design decisions
 
-**Invocation**: separate systemd timer (`claude-nightbeat-supervisor.timer`),
-not a post-raid phase in beat.py. The supervisor must outlive the thing it
-supervises: if the main timer stops (as on 2026-05-08), a post-raid hook also
-stops. A separate timer can detect the outage and restart the main timer.
+**Invocation**: separate systemd timer firing `claude -p "/nightbeat-supervisor"` every
+15 minutes. Not a post-raid phase in beat.py: the supervisor must outlive the
+thing it supervises (if the main timer stops, a post-raid hook also stops).
 
-**Watermark**: `~/.claude/logs/nightbeat-supervisor-watermark.json` — records
-the last beat-outcomes.jsonl timestamp the supervisor processed. Prevents
-re-merging or re-diagnosing on restart. Written atomically at the end of each
-supervisor run.
+**Session model**: stateless per cycle — fresh Claude session each invocation.
+Between-cycle memory lives in a per-project journal file, not in the agent
+context. Rationale: crash-safe, cost-bounded, context stays fresh. Judgment
+continuity comes from the survey script reading recent journal entries and
+including them in its output.
 
-**Repair authority** — two tiers:
-- *Auto-apply* (no ticket needed): add permission allowlist entries, raise
-  budget by ≤2x, move misplaced `tickets/*.erg` to `tickets/closed/`, restart
-  the main timer after a confirmed outage.
-- *Ticket-only* (never auto-edit): skill SKILL.md bodies, beat.py logic,
-  schema changes, anything requiring human judgment.
+**Journal**: `<project>/nightbeat-supervisor-journal.jsonl` — one record per
+supervisor action, appended by the skill after each cycle. Lives alongside
+`beat-log.jsonl` in the project root. Not under `$HARNESS_DIR` — IDH is
+agent-agnostic and runtime state belongs with the project it describes.
+Schema: `{ts, project, action, root_cause, ticket_id, pr_number, detail}`.
+Actions: `merge`, `budget_raise`, `allowlist_add`, `timer_restart`, `split`,
+`sweep_skip`, `ticket_created`, `escalate`.
 
-**Destructive-diff brake**: before merging any PR, the supervisor checks the
-diff for deletions of `tickets/*.erg` files that are not simultaneously moved
-to `tickets/closed/`. Any such deletion → HOLD (do not merge, create a repair
-note). This catches the exact 2026-05-08 housekeeping branch incident.
+**Watermark**: derived from the journal's last entry `ts` for that project.
+No separate watermark file.
 
-**Repair-while-running guard**: before touching beat.py, settings.json, or
-any skill file, the supervisor must stop the main timer
-(`systemctl --user stop claude-nightbeat.timer`), apply the fix, and restart
-it. Any failure in the apply step leaves the timer stopped and creates a
-diagnostic ticket.
+**Failure triage**: toyota-why — ask "why" until reaching an actionable root
+cause, not a symptom-to-action lookup table. Empirical baseline from 200+ beat-log
+entries across 6 projects: aborted-no-diag (22), error_max_budget_usd (7),
+stale-in-progress (8), repeated-ticket (1 ticket × 3 runs), pre-ticket-fail (5).
+These inform priors, not rules.
 
-**Escalation**: call the `advisor` tool when:
-- The same failure type recurs ≥ 3 consecutive runs without a successful repair.
-- The root cause of a failure is ambiguous after reading the log.
-- A proposed repair is at the boundary of or outside auto-apply authority.
+**Repair authority** (auto-apply without a ticket):
+- Missing permission → add to `settings.json` allowlist.
+- Budget too small for actual scope → raise per-project `ProjectConfig` field
+  in `beat.py` by 20%, capped at 2× the module-level constant; never edit
+  the module-level constant; stop timer first, restart after.
+- Ticket too large to finish in one beat → split into one ticket per
+  independent unit of work; convert parent to umbrella with `Blocks:` entries,
+  leave it open (may be blocking other tickets).
+- Dead timer → restart it.
 
-**Model**: `claude-opus-4-7` with `effort: max`. The systemd ExecStart passes
-`--model claude-opus-4-7` explicitly (beat.py's run_skill() defaults to sonnet
-and must not be used to call the supervisor).
+Everything else: open a ticket naming the root cause chain; do not auto-repair.
+
+**Destructive-diff brake**: before merging any PR, `check-pr-diff` exits
+non-zero if the diff deletes `tickets/*.erg` without a corresponding move to
+`tickets/closed/`. Any non-zero exit → HOLD. This catches the 2026-05-08
+incident pattern.
+
+**Escalation**: when the why-chain bottoms out without a repairable finding,
+or the same root cause recurs ≥ 3 consecutive runs. Use `advisor` tool if
+available; otherwise `Agent(model="opus")` — no extended thinking in Agent
+mode, honest degradation. Write verdict to journal.
+
+**Model**: Sonnet (supervisor loop); Opus 4.7 only for escalation.
+
+**Paths**: all `$HARNESS_DIR` references in skill and scripts, never
+`~/.claude`. Systemd units in `~/.config/systemd/user/`.
 
 ## Relevant files
 
-- `~/.claude/logs/beat-outcomes.jsonl` — source of truth for beat outcomes
-- `~/.claude/logs/nightbeat/*.log` — per-run raw logs for diagnosis
-- `~/.claude/logs/nightbeat-supervisor-watermark.json` — new (idempotency)
-- `~/.claude/scripts/beat.py` — main timer controller; supervisor may restart it
-- `~/.claude/scripts/projects.json` — project list (for PR lookups)
-- `~/.claude/settings.json` — permission allowlist (auto-repair target)
-- `~/.claude/skills/nightbeat-supervisor/SKILL.md` — new skill persona
-- `~/.claude/scripts/nightbeat-supervisor-survey.py` — new helper (non-LLM
-  watermark reader + outcome classifier)
-- `/etc/systemd/user/claude-nightbeat-supervisor.{service,timer}` — new units
+- `$HARNESS_DIR/skills/nightbeat-supervisor/SKILL.md` — skill persona (done)
+- `$HARNESS_DIR/skills/nightbeat-supervisor/check-pr-diff` — diff brake (done)
+- `$HARNESS_DIR/scripts/nightbeat-supervisor-survey.py` — survey helper (todo)
+- `$HARNESS_DIR/logs/beat-outcomes.jsonl` — phase-level signals (existing)
+- `$HARNESS_DIR/logs/nightbeat/*.log` — per-run raw logs (existing)
+- `<project>/beat-log.jsonl` — beat-level signals (existing, per-project)
+- `<project>/nightbeat-supervisor-journal.jsonl` — supervisor journal (new, per-project)
+- `~/.config/systemd/user/claude-nightbeat-supervisor.{service,timer}` — new units
+- `$HARNESS_DIR/scripts/nightbeat-report.py` — extend to render journal (todo)
 
 ## Actions
 
-1. **Write `skills/nightbeat-supervisor/SKILL.md`** — the full agent persona
-   (phases: watermark load → survey → merge loop → failure triage →
-   auto-repair → escalate → watermark update). Frontmatter:
-   `model: claude-opus-4-7`, `effort: max`.
+Already done:
+- [x] `skills/nightbeat-supervisor/SKILL.md`
+- [x] `skills/nightbeat-supervisor/check-pr-diff`
 
-2. **Write `scripts/nightbeat-supervisor-survey.py`** — pure Python, stdlib
-   only:
-   - Reads `~/.claude/logs/beat-outcomes.jsonl` (phase-level signals) from
-     `--since <iso-ts>` (watermark).
-   - Also reads each project's `beat-log.jsonl` (beat-level signals) for
-     `aborted`/`failed` outcomes and repeated-ticket patterns.
-   - Classifies entries into: `prs_to_merge`, `failures`, `idle`.
-   - For each `raid outcome=success`, queries `gh pr list` (via subprocess)
-     to find the open PR for that project/ticket.
-   - Emits a JSON summary to stdout consumed by the skill.
-   - Failure classification order matches observed frequency (empirically
-     derived from 200+ beat-log entries across 6 projects on padme):
-     aborted-no-diag (22) > budget-exhaustion (7) > stale-in-progress (8) >
-     repeated-ticket (1 ticket × 3 runs) > pre-ticket-fail (5).
+Remaining:
 
-3. **Write `skills/nightbeat-supervisor/check-pr-diff`** — bash script that
-   fetches a PR diff (forge CLI call, isolated from SKILL.md to satisfy
-   leak-guard) and exits 1 if any `tickets/*.erg` file is deleted without a
-   corresponding move to `tickets/closed/`.
+1. **`scripts/nightbeat-supervisor-survey.py`** — pure Python, stdlib only.
+   Reads `$HARNESS_DIR/logs/beat-outcomes.jsonl` and each project's
+   `beat-log.jsonl` (paths from `scripts/projects.json`). Derives
+   `github_repo` from each project's git remote (`git remote get-url origin`).
+   Reads the last 30 entries from each project's journal to build
+   `journal_context` (recent actions + root causes for pattern detection).
+   Derives `since` from journal's last entry ts (defaults to 24h ago if
+   journal absent). Accepts `--since ISO-TS` override from CLI.
+   Emits JSON: `{prs_to_merge, failures, watermark_ts, journal_context}`.
+   Each `prs_to_merge` entry: `{project, github_repo, ticket_id, pr_number, branch}`.
+   Each `failures` entry: `{project, ticket_id, phase, outcome, ts, log_file}`.
 
-4. **Write systemd units** — `claude-nightbeat-supervisor.service` (one-shot,
-   `ExecStart=claude -p "/nightbeat-supervisor" ...`, no explicit `--model`
-   flag so frontmatter governs) and `claude-nightbeat-supervisor.timer`
-   (fires every 15 min during the nightbeat window, plus on-boot).
+2. **Systemd units** — `claude-nightbeat-supervisor.service` (one-shot,
+   `ExecStart=claude -p "/nightbeat-supervisor"`) and
+   `claude-nightbeat-supervisor.timer` (OnCalendar=`*:0/15` during nightbeat
+   window; also on-boot via `[Install] WantedBy=timers.target`). Install to
+   `~/.config/systemd/user/`.
 
-5. **Create test fixture** `tests/fixtures/beat-outcomes-sample.jsonl` —
-   a representative sample with one `raid/success`, one `housekeeping/fail`,
-   and one `raid/budget` entry, each with a different project. Used by the
-   survey script test in the Test block below.
+3. **Test fixture** `tests/fixtures/beat-outcomes-sample.jsonl` — one
+   `raid/success`, one `housekeeping/fail`, one `raid/budget` entry across
+   three different projects. Used by the survey script test.
 
-6. **Beat-outcomes watermark**: test that a duplicate supervisor run
-   (re-processing the same window) is a no-op (no double-merges, no
-   duplicate tickets).
-
-7. **Integration test**: simulate a budget-failure outcome entry in a test
-   beat-outcomes file → verify the supervisor creates a repair ticket (does
-   NOT attempt auto-repair on budget failures beyond budget-raise authority).
-
-**Dependency note**: ticket 0104 (Prefect pipeline refactor) will replace
-`beat-outcomes.jsonl` with Prefect run history. If 0104 lands first, update
-this ticket: the survey script must read from Prefect's SQLite store, and the
-watermark contract (`--since`) must be preserved.
+4. **Extend `scripts/nightbeat-report.py`** — add a section rendering the
+   supervisor journal: actions taken, root causes identified, escalations.
+   Integrates into the existing morning report.
 
 ## Test
 
 ```bash
 # Red: survey script exists and classifies correctly
-python3 ~/.claude/scripts/nightbeat-supervisor-survey.py \
-  --outcomes-file tests/fixtures/beat-outcomes-sample.jsonl \
+python3 "$HARNESS_DIR/scripts/nightbeat-supervisor-survey.py" \
+  --outcomes tests/fixtures/beat-outcomes-sample.jsonl \
   --since 2026-05-01T00:00:00Z | python3 -m json.tool
-# Should print {"prs_to_merge": [...], "failures": [...], "idle": [...]}
-# without error. Before implementation this file doesn't exist.
+# Should print {prs_to_merge, failures, watermark_ts, journal_context}
+# Before implementation, this file does not exist.
 ```
 
 ## Exit criteria
 
-- `scripts/nightbeat-supervisor-survey.py --help` exits 0.
-- Running the supervisor on an empty window (since=now) is a no-op and
-  updates the watermark.
-- A raid `outcome=success` with a matching open PR triggers verify-gate +
-  merge within one supervisor cycle.
-- A housekeeping `outcome=fail` triggers log-read + root-cause note
-  appended to the ticket (or a new ticket created) within one cycle.
-- The destructive-diff brake prevents merging the 2026-05-08-style
-  housekeeping branch (test with a synthetic PR diff).
-- Two consecutive supervisor failures on the same failure type escalate to
-  advisor output visible in the supervisor log.
-- Timer restart after repair is confirmed by `systemctl --user status
-  claude-nightbeat.timer` showing `active (waiting)`.
+- Survey script: `--help` exits 0; classifies the test fixture correctly.
+- Empty window (since=now): supervisor runs, writes journal entry, emits
+  `merged: 0, repaired: 0, tickets: 0, escalated: 0`.
+- A `raid/success` with a matching open PR: verify-gate + merge within one cycle;
+  journal records `action=merge`.
+- A `housekeeping/fail`: why-chain reaches a root cause; journal records action
+  and root cause; timer restarted or repair ticket opened as appropriate.
+- Destructive-diff brake: `check-pr-diff` exits non-zero on a synthetic diff
+  that deletes a ticket file; supervisor records HOLD and does not call
+  verify-gate.
+- Same root cause ≥ 3 consecutive runs (verifiable from journal): supervisor
+  escalates rather than re-attempting auto-repair.
+- No `~/.claude` hardcoded in skill, survey script, or systemd units.

--- a/tickets/0105-nightbeat-supervisor.erg
+++ b/tickets/0105-nightbeat-supervisor.erg
@@ -91,18 +91,33 @@ and must not be used to call the supervisor).
      to find the open PR for that project/ticket.
    - Emits a JSON summary to stdout consumed by the skill.
 
-3. **Write systemd units** — `claude-nightbeat-supervisor.service` (one-shot,
-   `ExecStart=claude --model claude-opus-4-7 -p "/nightbeat-supervisor" ...`)
-   and `claude-nightbeat-supervisor.timer` (fires every 15 min during the
-   nightbeat window, plus on-boot).
+3. **Write `skills/nightbeat-supervisor/check-pr-diff`** — bash script that
+   fetches a PR diff (forge CLI call, isolated from SKILL.md to satisfy
+   leak-guard) and exits 1 if any `tickets/*.erg` file is deleted without a
+   corresponding move to `tickets/closed/`.
 
-4. **Beat-outcomes watermark**: test that a duplicate supervisor run
+4. **Write systemd units** — `claude-nightbeat-supervisor.service` (one-shot,
+   `ExecStart=claude -p "/nightbeat-supervisor" ...`, no explicit `--model`
+   flag so frontmatter governs) and `claude-nightbeat-supervisor.timer`
+   (fires every 15 min during the nightbeat window, plus on-boot).
+
+5. **Create test fixture** `tests/fixtures/beat-outcomes-sample.jsonl` —
+   a representative sample with one `raid/success`, one `housekeeping/fail`,
+   and one `raid/budget` entry, each with a different project. Used by the
+   survey script test in the Test block below.
+
+6. **Beat-outcomes watermark**: test that a duplicate supervisor run
    (re-processing the same window) is a no-op (no double-merges, no
    duplicate tickets).
 
-5. **Integration test**: simulate a budget-failure outcome entry in a test
+7. **Integration test**: simulate a budget-failure outcome entry in a test
    beat-outcomes file → verify the supervisor creates a repair ticket (does
    NOT attempt auto-repair on budget failures beyond budget-raise authority).
+
+**Dependency note**: ticket 0104 (Prefect pipeline refactor) will replace
+`beat-outcomes.jsonl` with Prefect run history. If 0104 lands first, update
+this ticket: the survey script must read from Prefect's SQLite store, and the
+watermark contract (`--since`) must be preserved.
 
 ## Test
 


### PR DESCRIPTION
## Summary

- New skill `skills/nightbeat-supervisor/SKILL.md` — autonomous post-beat supervisor: merges ready PRs, chases failures to root cause, repairs within authority, escalates when stuck
- New script `skills/nightbeat-supervisor/check-pr-diff` — diff brake that blocks merging PRs which delete ticket files without closing them (catches 2026-05-08 incident pattern)
- Ticket `0105-nightbeat-supervisor.erg` — full design spec with remaining implementation actions

## Key design decisions

- **Stateless per cycle** — fresh session each invocation; between-cycle memory lives in per-project `nightbeat-supervisor-journal.jsonl` (alongside `beat-log.jsonl`)
- **Agent-agnostic paths** — `$HARNESS_DIR` throughout, never `~/.claude`; journal lives in project root, systemd units in `~/.config/systemd/user/`
- **Toyota-why triage** — ask why until reaching an actionable root cause, not a symptom-to-action table; grounded in 200+ real beat-log entries across 6 projects
- **N-way ticket split** — oversized tickets split into one per independent unit of work; parent becomes umbrella with `Blocks:` entries, stays open
- **Sonnet base, Opus 4.7 for escalation only** — `advisor` tool if available, `Agent(model="opus")` fallback

## What remains (in ticket 0105)

- `scripts/nightbeat-supervisor-survey.py`
- Systemd units
- Test fixture
- `nightbeat-report.py` extension

## Test plan

- [ ] Leak-guard passes (`check-project-leak.sh skills/nightbeat-supervisor`)
- [ ] Ticket validates (`erg validate tickets/0105-nightbeat-supervisor.erg`)
- [ ] `check-pr-diff` exits non-zero on a diff that deletes a ticket file
- [ ] No `~/.claude` hardcoded in SKILL.md or check-pr-diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)