### PR TITLE
fix(state): reroll PR115 — five issues corrected

### DIFF
--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -49,16 +49,10 @@ def format_status(tickets, commits):
 
     lines = [STATUS_HEADING, f"<!-- generated {now} -->", ""]
 
-    if ready:
-        lines.append(f"**Ready ({len(ready)}):**")
-        for t in ready:
-            lines.append(f"  `{t['id']}` {t['title']}")
-
-    if blocked:
-        lines.append(f"**Blocked ({len(blocked)}):**")
-        for t in blocked:
-            deps = " ".join(f"→{b['id']}" for b in t["blocked_by"])
-            lines.append(f"  `{t['id']}` {t['title']} ({deps})")
+    # Summary counts only — full list via: erg ready tickets/
+    if ready or blocked:
+        summary = f"**Tickets:** {len(ready)} ready · {len(blocked)} blocked — `erg ready tickets/` for full list"
+        lines.append(summary)
 
     if commits:
         lines.append("**Recent commits:**")
@@ -69,11 +63,24 @@ def format_status(tickets, commits):
 
 
 def split_at_status(text):
-    """Return (preamble, discarded) split at the first ## Status heading."""
+    """Return (preamble, tail) split at the first ## Status heading.
+
+    tail includes everything from the Status heading onward so callers can
+    inspect sections that follow (Blockers, Next actions, Incident, etc.).
+    preamble is everything strictly before the Status heading.
+    """
     idx = text.find(f"\n{STATUS_HEADING}")
     if idx == -1:
-        return text.rstrip(), None
+        return text.rstrip(), ""
     return text[:idx], text[idx + 1 :]
+
+
+def _next_section_idx(text, start):
+    """Return index of the next ## heading after start, or len(text) if none."""
+    m = re.search(r"^## ", text[start:], re.MULTILINE)
+    if m:
+        return start + m.start()
+    return len(text)
 
 
 def refresh_last_updated(preamble, date_str):
@@ -89,9 +96,14 @@ def main():
         sys.exit(1)
 
     text = STATE_FILE.read_text()
-    preamble, _ = split_at_status(text)
+    preamble, tail = split_at_status(text)
 
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    # tail starts with "## Status\n..."; find where Status body ends
+    # (i.e. where the next ## heading begins) so we can preserve everything after it.
+    status_end = _next_section_idx(tail, len(STATUS_HEADING) + 1)
+    tail_after_status = tail[status_end:]  # sections after ## Status (may be empty)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     preamble = refresh_last_updated(preamble, today)
 
     commits = get_commits()
@@ -102,7 +114,12 @@ def main():
         status_lines = status_lines[:MAX_STATUS_LINES]
         status_lines.append(f"<!-- truncated to {MAX_STATUS_LINES} lines -->")
 
-    new_text = preamble.rstrip() + "\n\n" + "\n".join(status_lines) + "\n"
+    new_text = (
+        preamble.rstrip()
+        + "\n\n"
+        + "\n".join(status_lines)
+        + ("\n\n" + tail_after_status.lstrip() if tail_after_status.strip() else "\n")
+    )
     STATE_FILE.write_text(new_text)
 
     total = len(new_text.splitlines())

--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -25,7 +25,6 @@ STATE_FILE = REPO_ROOT / "STATE.md"
 TICKETS_DIR = REPO_ROOT / "tickets"
 ERG_BIN = TICKETS_DIR / "erg"
 STATUS_HEADING = "## Status"
-MAX_STATUS_LINES = 20
 
 
 def run(cmd):
@@ -39,7 +38,14 @@ def get_commits(n=5):
 
 
 def get_tickets():
-    return json.loads(run([str(ERG_BIN), "ready", str(TICKETS_DIR), "--json"]))
+    if not ERG_BIN.exists():
+        print(f"ERROR: erg binary not found at {ERG_BIN}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return json.loads(run([str(ERG_BIN), "ready", str(TICKETS_DIR), "--json"]))
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: erg ready failed: {e.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
 
 
 def format_status(tickets, commits):
@@ -87,6 +93,10 @@ def refresh_last_updated(preamble, date_str):
     pat = re.compile(r"^Last updated:.*$", re.MULTILINE)
     if pat.search(preamble):
         return pat.sub(f"Last updated: {date_str}", preamble)
+    print(
+        "WARNING: 'Last updated:' line not found in STATE.md preamble — add it manually.",
+        file=sys.stderr,
+    )
     return preamble
 
 
@@ -109,10 +119,6 @@ def main():
     commits = get_commits()
     tickets = get_tickets()
     status_lines = format_status(tickets, commits)
-
-    if len(status_lines) > MAX_STATUS_LINES:
-        status_lines = status_lines[:MAX_STATUS_LINES]
-        status_lines.append(f"<!-- truncated to {MAX_STATUS_LINES} lines -->")
 
     new_text = (
         preamble.rstrip()

--- a/skills/end-session/SKILL.md
+++ b/skills/end-session/SKILL.md
@@ -26,7 +26,7 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
 8. **Full test suite** — `make check` on main. New failures → open ticket. Known failures → confirm ticket still open.
 9. **Refresh STATE.md** on a throwaway branch:
    a. `git checkout -b housekeeping-state-YYYY-MM-DD main`
-   b. Rewrite STATE: current stats, blockers, next actions, milestones. No changelog.
+   b. Run `python3 "$HARNESS_DIR/scripts/refresh-STATE.py"` to regenerate `## Status` and bump `Last updated:`. Then hand-edit remaining sections (blockers, next actions, milestones) — no changelog.
    c. Prune: delete items checked off before this session.
    d. Commit, merge to main via fast-forward, delete branch.
 10. **Memory sweep** — follow `/memory` skill (includes staleness check + rule cross-reference).

--- a/skills/harness-rules/refresh-STATE.py
+++ b/skills/harness-rules/refresh-STATE.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Replace the ## Status section of STATE.md with fresh git + erg output."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    r = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    if r.returncode == 0:
+        return Path(r.stdout.strip())
+    return Path(__file__).parent.parent  # fallback: script is in scripts/ of project
+
+
+REPO_ROOT = _repo_root()
+STATE_FILE = REPO_ROOT / "STATE.md"
+TICKETS_DIR = REPO_ROOT / "tickets"
+ERG_BIN = TICKETS_DIR / "erg"
+STATUS_HEADING = "## Status"
+MAX_STATUS_LINES = 20
+
+
+def run(cmd):
+    return subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=REPO_ROOT
+    ).stdout.strip()
+
+
+def get_commits(n=5):
+    return run(["git", "log", "--oneline", f"-{n}"]).splitlines()
+
+
+def get_tickets():
+    return json.loads(run([str(ERG_BIN), "ready", str(TICKETS_DIR), "--json"]))
+
+
+def format_status(tickets, commits):
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+    ready = [t for t in tickets if t["ready"]]
+    blocked = [t for t in tickets if not t["ready"]]
+
+    lines = [STATUS_HEADING, f"<!-- generated {now} -->", ""]
+
+    if ready:
+        lines.append(f"**Ready ({len(ready)}):**")
+        for t in ready:
+            lines.append(f"  `{t['id']}` {t['title']}")
+
+    if blocked:
+        lines.append(f"**Blocked ({len(blocked)}):**")
+        for t in blocked:
+            deps = " ".join(f"→{b['id']}" for b in t["blocked_by"])
+            lines.append(f"  `{t['id']}` {t['title']} ({deps})")
+
+    if commits:
+        lines.append("**Recent commits:**")
+        for c in commits:
+            lines.append(f"  {c}")
+
+    return lines
+
+
+def split_at_status(text):
+    """Return (preamble, discarded) split at the first ## Status heading."""
+    idx = text.find(f"\n{STATUS_HEADING}")
+    if idx == -1:
+        return text.rstrip(), None
+    return text[:idx], text[idx + 1 :]
+
+
+def refresh_last_updated(preamble, date_str):
+    pat = re.compile(r"^Last updated:.*$", re.MULTILINE)
+    if pat.search(preamble):
+        return pat.sub(f"Last updated: {date_str}", preamble)
+    return preamble
+
+
+def main():
+    if not STATE_FILE.exists():
+        print(f"ERROR: {STATE_FILE} not found", file=sys.stderr)
+        sys.exit(1)
+
+    text = STATE_FILE.read_text()
+    preamble, _ = split_at_status(text)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    preamble = refresh_last_updated(preamble, today)
+
+    commits = get_commits()
+    tickets = get_tickets()
+    status_lines = format_status(tickets, commits)
+
+    if len(status_lines) > MAX_STATUS_LINES:
+        status_lines = status_lines[:MAX_STATUS_LINES]
+        status_lines.append(f"<!-- truncated to {MAX_STATUS_LINES} lines -->")
+
+    new_text = preamble.rstrip() + "\n\n" + "\n".join(status_lines) + "\n"
+    STATE_FILE.write_text(new_text)
+
+    total = len(new_text.splitlines())
+    print(f"STATE.md refreshed — {len(status_lines)} status lines, {total} total.")
+    if total > 40:
+        print(
+            f"WARNING: {total} lines exceeds 40-line cap — trim the hand-edited sections."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/harness-rules/state.md
+++ b/skills/harness-rules/state.md
@@ -10,42 +10,35 @@ Single orientation file, loaded at session start via hook. Hard cap: **40 lines 
 
 ## Structure
 
-Two hand-edited sections (short, stable, owned by the author):
+Hand-edited sections (stable, owned by the author):
 
 | Section | Content | Who edits |
 |---------|---------|-----------|
 | `## North star` | One paragraph — the core argument, rarely changes | Author |
-| `## Milestones` | Current + next milestone, `- [ ]` checkboxes, 5–8 lines max | Author |
+| Any additional `##` sections | Milestones, blockers, incidents, next actions, backlog — author adds as needed | Author |
 
 One mechanically generated section (replaced each session from `git log` + `git-erg`):
 
 | Section | Content | Who edits |
 |---------|---------|-----------|
-| `## Status` | Open tickets (git-erg), last 3–5 commits (git log --oneline), current blockers | Machine |
+| `## Status` | Ticket summary counts + last 3–5 commits | Machine |
 
-**Replace policy — no append.** Each session rewrites `## Status` in full from current git state. The hand-edited sections are touched only when the author explicitly updates them. No "Completed" or "Backlog" sections — git has the history, tickets have the backlog.
+**Replace policy — no append.** Each session rewrites `## Status` in full from current git state. All `##` sections after `## Status` are preserved verbatim — the script only replaces the Status body, not what follows. The hand-edited sections are touched only when the author explicitly updates them.
 
-**Line budget:** `## North star` ≤ 5 lines · `## Milestones` ≤ 10 lines · `## Status` ≤ 20 lines · header/whitespace ≤ 5 lines.
+**Line budget:** `## Status` ≤ 20 lines · total ≤ 40 lines. History lives in `git log`, full ticket list via `erg ready tickets/`.
 
-## Template
+## Minimal template
 
 ```markdown
-Last updated: YYYY-MM-DD
+Last updated: YYYY-MM-DDTHH:MMZ
 
 ## North star
 [One paragraph. Why this project exists, what success looks like. Author-maintained.]
 
-## Milestones
-### Current: [name]
-- [ ] item
-- [x] done item
-
-### Next: [name]
-- [ ] item
-
 ## Status
-<!-- generated: git log --oneline -5 + git-erg open -->
-**Open tickets:** 0NN title · 0NN title · …
-**Recent commits:** sha msg · sha msg · …
-**Blockers:** ticket or "None"
+<!-- generated YYYY-MM-DDTHH:MMZ -->
+**Tickets:** N ready · N blocked — `erg ready tickets/` for full list
+**Recent commits:**
+  sha msg
+  sha msg
 ```

--- a/skills/harness-rules/state.md
+++ b/skills/harness-rules/state.md
@@ -23,7 +23,7 @@ One mechanically generated section (replaced each session from `git log` + `git-
 |---------|---------|-----------|
 | `## Status` | Ticket summary counts + last 3–5 commits | Machine |
 
-**Replace policy — no append.** Each session rewrites `## Status` in full from current git state. All `##` sections after `## Status` are preserved verbatim — the script only replaces the Status body, not what follows. The hand-edited sections are touched only when the author explicitly updates them.
+**Replace policy — no append.** Each session rewrites `## Status` in full from current git state and bumps `Last updated:` in the preamble. All `##` sections after `## Status` are preserved verbatim. The other hand-edited sections are touched only when the author explicitly updates them.
 
 **Line budget:** `## Status` ≤ 20 lines · total ≤ 40 lines. History lives in `git log`, full ticket list via `erg ready tickets/`.
 

--- a/skills/harness-rules/state.md
+++ b/skills/harness-rules/state.md
@@ -1,22 +1,51 @@
 ---
 paths:
   - "STATE.md"
-last-reviewed: 2026-04-04
+last-reviewed: 2026-05-09
 ---
 
 # STATE.md
 
-Single orientation file, loaded at session start via hook. Keep it short and current (~40 lines max) — history lives in `git log`.
+Single orientation file, loaded at session start via hook. Hard cap: **40 lines total**. History lives in `git log`.
 
-| Section | Content |
-|---------|---------|
-| `Last updated:` | Date |
-| `## Status` | One-liner summary |
-| `## Blockers` | Current blockers or "None" |
-| `## Next actions` | 5–10 items, most urgent first |
-| `## North star` | One paragraph — the core argument |
-| `## Current milestone` | What we're working toward, with `- [ ]` checkboxes |
-| `## Next milestone` | What comes after |
-| `## Backlog` | Parked ideas, no checkboxes |
+## Structure
 
-**Pruning:** each update *replaces* sections, not appends. Completed items are deleted after one session. No "Completed" section — git has the history.
+Two hand-edited sections (short, stable, owned by the author):
+
+| Section | Content | Who edits |
+|---------|---------|-----------|
+| `## North star` | One paragraph — the core argument, rarely changes | Author |
+| `## Milestones` | Current + next milestone, `- [ ]` checkboxes, 5–8 lines max | Author |
+
+One mechanically generated section (replaced each session from `git log` + `git-erg`):
+
+| Section | Content | Who edits |
+|---------|---------|-----------|
+| `## Status` | Open tickets (git-erg), last 3–5 commits (git log --oneline), current blockers | Machine |
+
+**Replace policy — no append.** Each session rewrites `## Status` in full from current git state. The hand-edited sections are touched only when the author explicitly updates them. No "Completed" or "Backlog" sections — git has the history, tickets have the backlog.
+
+**Line budget:** `## North star` ≤ 5 lines · `## Milestones` ≤ 10 lines · `## Status` ≤ 20 lines · header/whitespace ≤ 5 lines.
+
+## Template
+
+```markdown
+Last updated: YYYY-MM-DD
+
+## North star
+[One paragraph. Why this project exists, what success looks like. Author-maintained.]
+
+## Milestones
+### Current: [name]
+- [ ] item
+- [x] done item
+
+### Next: [name]
+- [ ] item
+
+## Status
+<!-- generated: git log --oneline -5 + git-erg open -->
+**Open tickets:** 0NN title · 0NN title · …
+**Recent commits:** sha msg · sha msg · …
+**Blockers:** ticket or "None"
+```


### PR DESCRIPTION
Reroll of #115 (reverted). Five issues found in review, all fixed.

## Changes

1. **Script location** — moved `refresh-STATE.py` from `skills/harness-rules/` to `scripts/`. Rule files contain constraints, not executable code.

2. **Tail preservation** — `split_at_status` previously discarded everything after `## Status` (Open tickets, Incident, Blockers, Next actions, Backlog). Now only the Status body is replaced; all subsequent `##` sections are kept verbatim.

3. **Summary counts** — with 25+ open tickets the old per-ticket enumeration always hit `MAX_STATUS_LINES=20` and truncated. Replaced with a one-liner: `N ready · N blocked — erg ready tickets/ for full list`.

4. **Date format** — `strftime("%Y-%m-%d")` → `strftime("%Y-%m-%dT%H:%MZ")` to match the existing `Last updated:` convention and the generated comment timestamp.

5. **Rule file accuracy** — `state.md` rule updated to describe current STATE.md reality: `## Status` is machine-generated, all other `##` sections are author-maintained. Template updated to match actual output.

## Test plan
- [ ] Run `python3 scripts/refresh-STATE.py` on a live STATE.md with tail sections — verify tail is preserved
- [ ] Confirm `Last updated:` line uses ISO timestamp format
- [ ] Confirm `## Status` body shows summary counts, not per-ticket lines
- [ ] Verify script runs from `scripts/` (not old location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)