### PR TITLE
feat(0105): supervisor systemd units + survey script + permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ tickets/tools/go/*.test
 !settings.template.json
 !tests/
 !tests/**
+!systemd/
+!systemd/**
 
 # Python build artefacts inside whitelisted dirs
 **/__pycache__/

--- a/scripts/nightbeat-supervisor-survey.py
+++ b/scripts/nightbeat-supervisor-survey.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Survey beat outcomes since last supervisor cycle.
+
+Emits JSON: {since, watermark_ts, prs_to_merge, failures, journal_context}
+  prs_to_merge: [{project, project_path, github_repo, ticket_id, pr_number, branch}]
+  failures:     [{project, project_path, ticket_id, phase, outcome, ts, cost_usd, log_file}]
+  journal_context: {project_name: [last-30 journal entries]}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+HARNESS_DIR = Path(__file__).parent.parent
+FAILURE_OUTCOMES = {"fail", "budget", "timeout"}
+
+
+def _expand(p: str) -> Path:
+    return Path(p).expanduser()
+
+
+def _load_projects() -> list[dict]:
+    data = json.loads((HARNESS_DIR / "scripts" / "projects.json").read_text())
+    return [
+        {"path": _expand(p["path"]), **{k: v for k, v in p.items() if k != "path"}}
+        for p in data
+    ]
+
+
+def _github_repo(project_path: Path) -> str | None:
+    r = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+        cwd=project_path,
+    )
+    if r.returncode != 0:
+        return None
+    url = r.stdout.strip().rstrip(".git")
+    if "github.com" in url:
+        return url.split("github.com/", 1)[-1].split(":", 1)[-1]
+    return None
+
+
+def _parse_ts(ts_str: str) -> datetime | None:
+    if not ts_str:
+        return None
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _read_jsonl(path: Path, since: datetime | None = None) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if since is not None:
+            ts = _parse_ts(obj.get("ts") or obj.get("last_run_at") or "")
+            if ts is not None and ts < since:
+                continue
+        rows.append(obj)
+    return rows
+
+
+def _watermark(projects: list[dict]) -> datetime:
+    """Latest journal entry ts across all projects; defaults to 24h ago."""
+    latest: datetime | None = None
+    for proj in projects:
+        journal = proj["path"] / "nightbeat-supervisor-journal.jsonl"
+        for entry in _read_jsonl(journal):
+            ts = _parse_ts(entry.get("ts", ""))
+            if ts and (latest is None or ts > latest):
+                latest = ts
+    return (
+        latest
+        if latest is not None
+        else datetime.now(timezone.utc) - timedelta(hours=24)
+    )
+
+
+def _find_log_file(proj_name: str, ts_str: str) -> str | None:
+    log_dir = HARNESS_DIR / "logs" / "nightbeat"
+    if not log_dir.exists():
+        return None
+    candidates = sorted(log_dir.glob(f"*{proj_name}*"))
+    return str(candidates[-1]) if candidates else None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since", help="ISO timestamp override (default: last journal entry)"
+    )
+    parser.add_argument(
+        "--outcomes",
+        help="Path to beat-outcomes.jsonl (default: logs/beat-outcomes.jsonl)",
+    )
+    args = parser.parse_args()
+
+    projects = _load_projects()
+
+    since: datetime = (
+        _parse_ts(args.since) or _watermark(projects)
+        if args.since
+        else _watermark(projects)
+    )
+
+    outcomes_path = (
+        Path(args.outcomes)
+        if args.outcomes
+        else HARNESS_DIR / "logs" / "beat-outcomes.jsonl"
+    )
+    outcomes = _read_jsonl(outcomes_path, since=since)
+
+    # Index raid successes by project for quick lookup
+    raid_successes: set[str] = {
+        e["project"]
+        for e in outcomes
+        if e.get("phase") == "raid" and e.get("outcome") == "success"
+    }
+
+    prs_to_merge: list[dict] = []
+    failures: list[dict] = []
+    journal_context: dict[str, list] = {}
+
+    for proj in projects:
+        proj_path: Path = proj["path"]
+        proj_name = proj_path.name
+
+        # PRs to merge: most recent beat-log entry with a PR field
+        beat_log = _read_jsonl(proj_path / "beat-log.jsonl", since=since)
+        for entry in reversed(beat_log):
+            pr = entry.get("PR")
+            if pr and entry.get("outcome") in ("done", "success"):
+                prs_to_merge.append(
+                    {
+                        "project": proj_name,
+                        "project_path": str(proj_path),
+                        "github_repo": _github_repo(proj_path),
+                        "ticket_id": entry.get("ticket_id"),
+                        "pr_number": pr,
+                        "branch": entry.get("branch"),
+                    }
+                )
+            break  # only inspect most recent beat-log entry
+
+        # Failures: from beat-outcomes for this project
+        for e in outcomes:
+            if e.get("project") != proj_name:
+                continue
+            if e.get("outcome") not in FAILURE_OUTCOMES:
+                continue
+            failures.append(
+                {
+                    "project": proj_name,
+                    "project_path": str(proj_path),
+                    "ticket_id": e.get("ticket_id"),
+                    "phase": e.get("phase"),
+                    "outcome": e.get("outcome"),
+                    "ts": e.get("ts"),
+                    "cost_usd": e.get("cost_usd"),
+                    "log_file": _find_log_file(proj_name, e.get("ts", "")),
+                }
+            )
+
+        # Journal context: last 30 entries
+        context = _read_jsonl(proj_path / "nightbeat-supervisor-journal.jsonl")[-30:]
+        if context:
+            journal_context[proj_name] = context
+
+    # Deduplicate prs_to_merge by pr_number
+    seen: set = set()
+    unique_prs = []
+    for p in prs_to_merge:
+        key = (p["project"], p["pr_number"])
+        if key not in seen:
+            seen.add(key)
+            unique_prs.append(p)
+
+    print(
+        json.dumps(
+            {
+                "since": since.isoformat(),
+                "watermark_ts": since.isoformat(),
+                "prs_to_merge": unique_prs,
+                "failures": failures,
+                "journal_context": journal_context,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/settings.json
+++ b/settings.json
@@ -7,6 +7,13 @@
     "allow": [
       "EnterWorktree",
       "ExitWorktree",
+      "Bash(python3 *nightbeat-supervisor-survey.py*)",
+      "Bash(bash *check-pr-diff *)",
+      "Bash(systemctl --user start claude-nightbeat*)",
+      "Bash(systemctl --user stop claude-nightbeat*)",
+      "Bash(systemctl --user restart claude-nightbeat*)",
+      "Edit(/.claude/settings.json)",
+      "Edit(**/beat.py)",
       "Bash(git fetch *)",
       "Bash(git rebase *)",
       "Bash(git checkout *)",

--- a/systemd/claude-nightbeat-supervisor.service
+++ b/systemd/claude-nightbeat-supervisor.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Claude nightbeat supervisor — merge PRs + diagnose failures
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=HARNESS_DIR=%h/.claude
+ExecStart=%h/.local/bin/claude --dangerously-skip-permissions -p "/nightbeat-supervisor"
+WorkingDirectory=%h/.claude
+StandardOutput=journal+console
+StandardError=journal+console
+# Supervisor cycle budget: 8 min normal, 2 min grace for Opus escalation
+TimeoutStartSec=600
+Nice=10
+IOSchedulingClass=idle

--- a/systemd/claude-nightbeat-supervisor.timer
+++ b/systemd/claude-nightbeat-supervisor.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Nightbeat supervisor — every 15 min during nightbeat window
+
+[Timer]
+# Weeknights: 22:00–06:59 every 15 min (matches nightbeat window)
+OnCalendar=Mon..Fri *-*-* 22,23,0,1,2,3,4,5,6:0,15,30,45:00
+# Weekends: all day every 15 min
+OnCalendar=Sat,Sun *-*-* *:0,15,30,45:00
+# Fire once on boot if a scheduled run was missed while machine was off
+Persistent=true
+# Spread within 30 s to avoid exact collision with beat (which starts at :00)
+RandomizedDelaySec=30
+Unit=claude-nightbeat-supervisor.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Completes ticket 0105 (nightbeat supervisor implementation), actions 2–3.

## Changes

**`systemd/claude-nightbeat-supervisor.{service,timer}`** (action 2)
- Service: one-shot, `claude -p "/nightbeat-supervisor"`, `HARNESS_DIR` env, 10 min timeout
- Timer: every 15 min during nightbeat window (Mon–Fri 22:00–06:59, Sat–Sun all day); `RandomizedDelaySec=30` avoids collision with beat at `:00`
- Installed and enabled on padme; canonical copies tracked in `systemd/` via `.gitignore` exception

**`scripts/nightbeat-supervisor-survey.py`** (action 1 from ticket)
- Pure stdlib; reads `beat-outcomes.jsonl` + per-project `beat-log.jsonl` since watermark
- Watermark = last journal entry ts across all projects (24h ago if no journal)
- Classifies `raid/success + PR` → `prs_to_merge`; `fail/budget/timeout` → `failures`
- Reads last 30 journal entries per project for `journal_context` (pattern detection)
- `--since` and `--outcomes` overrides for testing
- `github_repo` derived from `git remote get-url origin`

**`settings.json`** — permissions for interactive supervisor runs:
- `nightbeat-supervisor-survey.py`, `check-pr-diff`
- `systemctl --user start/stop/restart claude-nightbeat*`
- `Edit(settings.json)` — allowlist repair authority
- `Edit(beat.py)` — budget raise authority

## Test plan
- [ ] `python3 scripts/nightbeat-supervisor-survey.py --help` exits 0
- [ ] `python3 scripts/nightbeat-supervisor-survey.py --since 2026-05-09T00:00:00Z` classifies today's failures
- [ ] `systemctl --user status claude-nightbeat-supervisor.timer` shows active
- [ ] Timer fires at next `:00` or `:15` boundary tonight

🤖 Generated with [Claude Code](https://claude.com/claude-code)