### PR TITLE
feat(0099): CI guard against legacy status verb

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,33 @@ jobs:
           fi
           echo "OK: escape hatch suppressed leak"
 
+  status-verb-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No legacy status verb in skill log examples
+        run: bash scripts/check-status-verb.sh
+      - name: Self-test — guard must catch a deliberate violation
+        run: |
+          tmp=$(mktemp -d)
+          mkdir -p "$tmp/skills/fake"
+          echo '2026-05-01T10:00Z claude status closed — done' > "$tmp/skills/fake/SKILL.md"
+          if bash scripts/check-status-verb.sh "$tmp/skills"; then
+            echo "FAIL: guard did not catch the deliberate violation"
+            exit 1
+          fi
+          echo "OK: deliberate violation caught"
+      - name: Self-test — guard must pass on clean file
+        run: |
+          tmp=$(mktemp -d)
+          mkdir -p "$tmp/skills/fake"
+          echo '2026-05-01T10:00Z claude closed — done' > "$tmp/skills/fake/SKILL.md"
+          if ! bash scripts/check-status-verb.sh "$tmp/skills"; then
+            echo "FAIL: guard reported false positive on clean file"
+            exit 1
+          fi
+          echo "OK: guard passes clean file"
+
   pipefail-guard:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,6 +86,16 @@ jobs:
             exit 1
           fi
           echo "OK: guard passes clean file"
+      - name: Self-test — guard must not false-positive on substring match
+        run: |
+          tmp=$(mktemp -d)
+          mkdir -p "$tmp/skills/fake"
+          echo 'check status openings for this quarter' > "$tmp/skills/fake/SKILL.md"
+          if ! bash scripts/check-status-verb.sh "$tmp/skills"; then
+            echo "FAIL: guard false-positived on substring 'status openings'"
+            exit 1
+          fi
+          echo "OK: guard ignores substring matches"
 
   pipefail-guard:
     runs-on: ubuntu-latest

--- a/scripts/check-status-verb.sh
+++ b/scripts/check-status-verb.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Guard against legacy %erg "status <state>" verb in skill log examples.
+# Valid verbs: created, closed, note. The "status" verb was removed in %erg v1.
+# Usage: check-status-verb.sh [file-or-dir ...]   (default: skills/ tickets/AGENTS.md)
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+    TARGETS=(skills/ tickets/AGENTS.md)
+else
+    TARGETS=("$@")
+fi
+
+PATTERN='status open\|status closed\|status doing\|status pending'
+
+fail=0
+for target in "${TARGETS[@]}"; do
+    [ -e "$target" ] || continue
+    while IFS= read -r match; do
+        [ -z "$match" ] && continue
+        echo "FAIL [legacy status verb]: $match"
+        fail=1
+    done < <(grep -rn "$PATTERN" "$target" 2>/dev/null || true)
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "OK: no legacy status verbs found"
+fi
+exit $fail

--- a/scripts/check-status-verb.sh
+++ b/scripts/check-status-verb.sh
@@ -10,11 +10,11 @@ else
     TARGETS=("$@")
 fi
 
-PATTERN='status open\|status closed\|status doing\|status pending'
+PATTERN='\bstatus open\b\|\bstatus closed\b\|\bstatus doing\b\|\bstatus pending\b'
 
 fail=0
 for target in "${TARGETS[@]}"; do
-    [ -e "$target" ] || continue
+    [ -e "$target" ] || { echo "WARN: $target not found" >&2; continue; }
     while IFS= read -r match; do
         [ -z "$match" ] && continue
         echo "FAIL [legacy status verb]: $match"

--- a/tickets/0099-ci-guard-status-verb-in-skill-examples.erg
+++ b/tickets/0099-ci-guard-status-verb-in-skill-examples.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-08T16:15Z claude created
+2026-05-09T17:00Z claude note raid-0099: scripts/check-status-verb.sh + CI job; scans skills/ + tickets/AGENTS.md
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Adds `scripts/check-status-verb.sh` — grep guard against the legacy `status open|closed|doing|pending` verb pattern in `skills/` and `tickets/AGENTS.md`
- Adds `status-verb-guard` CI job with two self-tests (catch violation + pass clean file)
- Scope deliberately limited to skills/ + AGENTS.md to avoid false positives from historical closed-ticket logs

## Exit criteria (from ticket 0099)

- [x] CI step runs the guard (`status-verb-guard` job in CI.yml)
- [x] Guard fails on file containing `status closed` in a log example (self-test verified)
- [x] Guard passes on current clean tree (local + self-test verified)

## Test plan

- [ ] CI passes on this PR (5 jobs: validate-tickets, skill-lint, status-verb-guard, leak-guard, pipefail-guard)
- [ ] Plant `status closed` in a skill file on a test branch → CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)