### PR TITLE
feat(0101): per-project beat config — ProjectConfig + interval skip

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -106,7 +106,9 @@ class ProjectConfig:
     path: Path
     budget_housekeeping: float = BUDGET_HOUSEKEEPING
     budget_pick_ticket: float = BUDGET_PICK_TICKET
+    budget_raid: float = BUDGET_RAID
     pick_ticket_model: str = MODEL_HAIKU  # model used when repo has no recent commits
+    interval_minutes: int = 0  # 0 = always run
 
 
 _BUILTIN_PROJECTS: list[ProjectConfig] = [
@@ -129,7 +131,30 @@ _BUILTIN_PROJECTS: list[ProjectConfig] = [
     ),
 ]
 
-_PROJ_KEYS = {"budget_housekeeping", "budget_pick_ticket", "pick_ticket_model"}
+_PROJ_KEYS = {
+    "budget_housekeeping",
+    "budget_pick_ticket",
+    "budget_raid",
+    "pick_ticket_model",
+    "interval_minutes",
+}
+
+
+def _apply_beat_json_overlay(config: ProjectConfig) -> None:
+    """Merge fields from <project>/.claude/beat.json into config, if present."""
+    beat_cfg = config.path / ".claude" / "beat.json"
+    if not beat_cfg.exists():
+        return
+    try:
+        overrides = json.loads(beat_cfg.read_text())
+        for k, v in overrides.items():
+            if k in _PROJ_KEYS:
+                setattr(config, k, v)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[beat] error loading {beat_cfg}: {exc}, ignoring overlay",
+            file=sys.stderr,
+        )
 
 
 def load_projects(config_path: Path) -> list[ProjectConfig]:
@@ -141,7 +166,7 @@ def load_projects(config_path: Path) -> list[ProjectConfig]:
         return list(_BUILTIN_PROJECTS)
     try:
         entries = json.loads(config_path.read_text())
-        return [
+        configs = [
             ProjectConfig(
                 path=Path(e["path"]).expanduser(),
                 **{k: e[k] for k in _PROJ_KEYS if k in e},
@@ -154,6 +179,9 @@ def load_projects(config_path: Path) -> list[ProjectConfig]:
             file=sys.stderr,
         )
         return list(_BUILTIN_PROJECTS)
+    for cfg in configs:
+        _apply_beat_json_overlay(cfg)
+    return configs
 
 
 PROJECTS: list[ProjectConfig] = load_projects(PROJECTS_CONFIG)
@@ -940,7 +968,7 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     _log(f"=== raid: running ticket {ticket_id} {_now_iso()} ===")
     oc_rc, oc_res = run_skill(
         f"/raid {ticket_id}\n\nRunning on: {hostname}",
-        budget=BUDGET_RAID,
+        budget=project.budget_raid,
         timeout_s=RAID_TIMEOUT_S,
         cwd=path,
         project_scoped=True,
@@ -1018,6 +1046,31 @@ def main() -> None:
     if not (path / ".git").is_dir():
         _log(f"ERROR: {path} is not a git repository. Aborting.")
         sys.exit(1)
+
+    # Interval skip: project can declare a minimum interval between beats.
+    if project.interval_minutes > 0:
+        last = read_last_beat_record(path)
+        if last and last.get("last_run_at"):
+            try:
+                last_epoch = datetime.fromisoformat(
+                    last["last_run_at"].replace("Z", "+00:00")
+                ).timestamp()
+                elapsed_s = time.time() - last_epoch
+                if elapsed_s < project.interval_minutes * 60:
+                    remaining = int(project.interval_minutes * 60 - elapsed_s)
+                    _log(
+                        f"=== interval-skip: {path.name} (next run in {remaining}s) ==="
+                    )
+                    _record_phase_outcome(
+                        path,
+                        "interval",
+                        "skip",
+                        detail=f"interval={project.interval_minutes}m, remaining={remaining}s",
+                    )
+                    lock_fh.close()
+                    sys.exit(0)
+            except (ValueError, TypeError):
+                pass
 
     (path / ".claude" / "sweep-state").mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1493,3 +1493,236 @@ class TestWeeklyPermissionsPrune:
 
         monkeypatch.setattr(beat, "PERMISSIONS_PRUNE_DAY_OF_WEEK", "monday")
         assert beat._is_prune_day() is False
+
+
+# ── Per-project beat config (ticket 0101) ────────────────────────────────────
+
+
+class TestProjectConfigFields:
+    def test_budget_raid_default(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"))
+        assert cfg.budget_raid == beat.BUDGET_RAID
+
+    def test_interval_minutes_default(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"))
+        assert cfg.interval_minutes == 0
+
+    def test_custom_budget_raid(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"), budget_raid=8.00)
+        assert cfg.budget_raid == 8.00
+
+    def test_custom_interval(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"), interval_minutes=30)
+        assert cfg.interval_minutes == 30
+
+
+class TestApplyBeatJsonOverlay:
+    def test_overlay_merges_known_keys(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "beat.json").write_text(
+            json.dumps({"budget_raid": 8.00, "interval_minutes": 30})
+        )
+        cfg = beat.ProjectConfig(path=tmp_path)
+        beat._apply_beat_json_overlay(cfg)
+        assert cfg.budget_raid == 8.00
+        assert cfg.interval_minutes == 30
+
+    def test_overlay_ignores_unknown_keys(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "beat.json").write_text(
+            json.dumps({"path": "/evil", "nonexistent_key": True})
+        )
+        cfg = beat.ProjectConfig(path=tmp_path)
+        original_path = cfg.path
+        beat._apply_beat_json_overlay(cfg)
+        assert cfg.path == original_path
+
+    def test_overlay_absent_is_noop(self, tmp_path):
+        cfg = beat.ProjectConfig(path=tmp_path)
+        beat._apply_beat_json_overlay(cfg)
+        assert cfg.budget_raid == beat.BUDGET_RAID
+
+    def test_overlay_malformed_json_warns(self, tmp_path, capsys):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "beat.json").write_text("not json{")
+        cfg = beat.ProjectConfig(path=tmp_path, budget_raid=3.00)
+        beat._apply_beat_json_overlay(cfg)
+        assert cfg.budget_raid == 3.00
+        assert "error" in capsys.readouterr().err.lower()
+
+
+class TestLoadProjectsOverlay:
+    def test_overlay_applied_during_load(self, tmp_path):
+        proj_dir = tmp_path / "myproject"
+        proj_dir.mkdir()
+        (proj_dir / ".claude").mkdir()
+        (proj_dir / ".claude" / "beat.json").write_text(
+            json.dumps({"interval_minutes": 45, "budget_raid": 7.50})
+        )
+        cfg_file = tmp_path / "projects.json"
+        cfg_file.write_text(json.dumps([{"path": str(proj_dir)}]))
+        projects = beat.load_projects(cfg_file)
+        assert len(projects) == 1
+        assert projects[0].interval_minutes == 45
+        assert projects[0].budget_raid == 7.50
+
+    def test_projects_json_budget_raid(self, tmp_path):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(json.dumps([{"path": "~/x", "budget_raid": 12.00}]))
+        projects = beat.load_projects(cfg)
+        assert projects[0].budget_raid == 12.00
+
+    def test_projects_json_interval_minutes(self, tmp_path):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(json.dumps([{"path": "~/x", "interval_minutes": 60}]))
+        projects = beat.load_projects(cfg)
+        assert projects[0].interval_minutes == 60
+
+
+class TestRaidBudgetPassthrough:
+    """budget_raid flows from ProjectConfig to the raid skill invocation."""
+
+    def setup_method(self):
+        beat.DRY_RUN = False
+
+    def test_raid_uses_project_budget(self, tmp_project):
+        recorded: list[dict] = []
+
+        def fake_run_skill(
+            skill,
+            *,
+            budget,
+            timeout_s,
+            cwd,
+            project_scoped=False,
+            model=beat.MODEL_SONNET,
+        ):
+            recorded.append({"skill": skill, "budget": budget})
+            if "pick-ticket" in skill:
+                return (0, beat._SkillResult(result_text="PICK: 0001"))
+            return (0, beat._SkillResult())
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat._sync_origin_main"),
+            patch("beat._default_branch", return_value="main"),
+            patch(
+                "beat._git", return_value=MagicMock(returncode=0, stdout="", stderr="")
+            ),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+        ):
+            beat._raid(beat.ProjectConfig(path=tmp_project, budget_raid=8.50))
+
+        raid_call = next(
+            r for r in recorded if "raid" in r["skill"] and "pick" not in r["skill"]
+        )
+        assert raid_call["budget"] == 8.50
+
+
+class TestIntervalSkip:
+    """interval_minutes causes main() to exit early when last run is too recent."""
+
+    def test_skips_when_interval_not_elapsed(self, tmp_project, tmp_path):
+        recent_ts = beat._now_iso()
+        beat_log = tmp_project / "beat-log.jsonl"
+        beat_log.write_text(
+            json.dumps({"outcome": "done", "last_run_at": recent_ts}) + "\n"
+        )
+
+        log_lines: list[str] = []
+        with (
+            patch("beat.signal.signal"),
+            patch("beat._setup_env"),
+            patch.object(beat, "LOGDIR", tmp_path / "logs"),
+            patch(
+                "beat._pick_project",
+                return_value=(
+                    0,
+                    beat.ProjectConfig(path=tmp_project, interval_minutes=30),
+                ),
+            ),
+            patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
+            patch("beat.fcntl.flock"),
+            patch("beat._log", side_effect=log_lines.append),
+            patch("beat.read_last_beat_record") as mock_read,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            mock_read.return_value = {
+                "outcome": "done",
+                "last_run_at": recent_ts,
+            }
+            beat.main()
+
+        assert exc_info.value.code == 0
+        assert any("interval-skip" in l for l in log_lines)
+
+    def test_runs_when_interval_elapsed(self, tmp_project, tmp_path):
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        beat_log = tmp_project / "beat-log.jsonl"
+        beat_log.write_text(
+            json.dumps({"outcome": "done", "last_run_at": old_ts}) + "\n"
+        )
+
+        with (
+            patch("beat.signal.signal"),
+            patch("beat._setup_env"),
+            patch.object(beat, "LOGDIR", tmp_path / "logs"),
+            patch(
+                "beat._pick_project",
+                return_value=(
+                    0,
+                    beat.ProjectConfig(path=tmp_project, interval_minutes=30),
+                ),
+            ),
+            patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
+            patch("beat.fcntl.flock"),
+            patch("beat._raid", return_value=("idle", None)) as mock_raid,
+            patch("beat.finalize_beat_log"),
+            patch("beat._cleanup_stale_in_progress"),
+            patch(
+                "beat.read_last_beat_record",
+                return_value={
+                    "outcome": "done",
+                    "last_run_at": old_ts,
+                },
+            ),
+            patch("beat.append_beat_log"),
+        ):
+            beat.main()
+
+        mock_raid.assert_called_once()
+
+    def test_no_skip_when_interval_zero(self, tmp_project, tmp_path):
+        recent_ts = beat._now_iso()
+
+        with (
+            patch("beat.signal.signal"),
+            patch("beat._setup_env"),
+            patch.object(beat, "LOGDIR", tmp_path / "logs"),
+            patch(
+                "beat._pick_project",
+                return_value=(
+                    0,
+                    beat.ProjectConfig(path=tmp_project, interval_minutes=0),
+                ),
+            ),
+            patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
+            patch("beat.fcntl.flock"),
+            patch("beat._raid", return_value=("idle", None)) as mock_raid,
+            patch("beat.finalize_beat_log"),
+            patch("beat._cleanup_stale_in_progress"),
+            patch(
+                "beat.read_last_beat_record",
+                return_value={
+                    "outcome": "done",
+                    "last_run_at": recent_ts,
+                },
+            ),
+            patch("beat.append_beat_log"),
+        ):
+            beat.main()
+
+        mock_raid.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `budget_raid` and `interval_minutes` fields to `ProjectConfig` dataclass with sensible defaults
- Add `.claude/beat.json` per-project overlay support in `load_projects()` — uses the same `_PROJ_KEYS` whitelist to prevent clobbering `path`
- Wire `project.budget_raid` through to the raid skill invocation (was hardcoded `BUDGET_RAID`)
- Add interval skip logic in `main()` after lock acquisition: projects with `interval_minutes > 0` skip when the last beat-log entry is too recent
- 15 new tests covering all new code paths; 0 regressions in existing tests

Closes ticket 0101. Unblocks ticket 0102 (migration of existing config to `.claude/beat.json`).

## Test plan

- [x] `ProjectConfig` has `budget_raid` and `interval_minutes` with correct defaults
- [x] `.claude/beat.json` overlay merges known keys, ignores unknown/path, handles malformed JSON
- [x] `load_projects()` applies overlay when `.claude/beat.json` is present
- [x] `projects.json` can set `budget_raid` and `interval_minutes`
- [x] `budget_raid` flows from `ProjectConfig` to the raid skill invocation
- [x] Interval skip fires when last run is recent, passes when elapsed, no-ops when interval=0
- [x] Full test suite: 94 pass (was 79), same 31 pre-existing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)