### PR TITLE
feat(0106): per-project raid_timeout_s in ProjectConfig

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -101,7 +101,14 @@ class _SkillResult:
 
 @dataclass
 class ProjectConfig:
-    """Per-project beat settings; budget fields default to the global constants."""
+    """Per-project beat settings; budget fields default to the global constants.
+
+    Fields (all optional except path):
+        budget_housekeeping, budget_pick_ticket, budget_raid — USD caps.
+        pick_ticket_model — model used when repo has no recent commits.
+        interval_minutes — minimum minutes between beats (0 = always run).
+        raid_timeout_s — seconds before the raid subprocess is killed.
+    """
 
     path: Path
     budget_housekeeping: float = BUDGET_HOUSEKEEPING
@@ -109,6 +116,7 @@ class ProjectConfig:
     budget_raid: float = BUDGET_RAID
     pick_ticket_model: str = MODEL_HAIKU  # model used when repo has no recent commits
     interval_minutes: int = 0  # 0 = always run
+    raid_timeout_s: int = RAID_TIMEOUT_S
 
 
 _BUILTIN_PROJECTS: list[ProjectConfig] = [
@@ -137,6 +145,7 @@ _PROJ_KEYS = {
     "budget_raid",
     "pick_ticket_model",
     "interval_minutes",
+    "raid_timeout_s",
 }
 
 
@@ -969,7 +978,7 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     oc_rc, oc_res = run_skill(
         f"/raid {ticket_id}\n\nRunning on: {hostname}",
         budget=project.budget_raid,
-        timeout_s=RAID_TIMEOUT_S,
+        timeout_s=project.raid_timeout_s,
         cwd=path,
         project_scoped=True,
     )

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -47,6 +47,11 @@ When you reach a root cause, repair if within authority:
 - **Budget too small for the actual scope of work** → raise the per-project
   `ProjectConfig` field in `beat.py` by 20%, capped at 2× the module-level
   constant; never touch the module-level constant.
+- **Raid timeout during verify/review** (`outcome=timeout` AND why-chain
+  shows verify/review slowness, not implementation slowness) → raise
+  `raid_timeout_s` in the per-project config by 20%, capped at
+  2× `RAID_TIMEOUT_S` (3600 s). Implementation slowness is a "ticket too
+  large" signal — do not raise the timeout for that.
 - **Ticket too large to finish in one beat** → split into one ticket per
   independent unit of work; convert the parent to an umbrella by adding
   `Blocks: <id>...` and leaving it open (it may be blocking other tickets).

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -505,6 +505,32 @@ class TestRaid:
         assert outcome == "failed"
         assert ticket == "0005"
 
+    def test_raid_uses_per_project_timeout(self, tmp_project):
+        captured = {}
+
+        def spy_run_skill(skill, **kwargs):
+            if "raid" in skill and "pick" not in skill:
+                captured.update(kwargs)
+            if "pick-ticket" in skill:
+                return (0, beat._SkillResult(result_text="PICK: 0042"))
+            return (0, beat._SkillResult())
+
+        custom_timeout = 2700
+        config = beat.ProjectConfig(path=tmp_project, raid_timeout_s=custom_timeout)
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat._sync_origin_main"),
+            patch("beat._default_branch", return_value="main"),
+            patch(
+                "beat._git",
+                return_value=MagicMock(returncode=0, stdout="", stderr=""),
+            ),
+            patch("beat.run_skill", side_effect=spy_run_skill),
+        ):
+            beat._raid(config)
+        assert captured["timeout_s"] == custom_timeout
+
     def test_housekeeping_runs_when_needed(self, tmp_project):
         calls = []
 

--- a/tickets/0106-raid-timeout-verify-review-cycle.erg
+++ b/tickets/0106-raid-timeout-verify-review-cycle.erg
@@ -4,6 +4,7 @@ Created: 2026-05-09
 Author: claude
 
 --- log ---
+2026-05-10T12:00Z claude note — implementing: raid_timeout_s field in ProjectConfig, wired to raid call site, supervisor repair rule added, discriminating test written
 2026-05-09T16:00Z claude created — opened by nightbeat-supervisor; root cause from chemin-de-voix raid on 0071 (2026-05-09T10:33Z)
 
 --- body ---


### PR DESCRIPTION
## Summary

- Add `raid_timeout_s: int = RAID_TIMEOUT_S` field to `ProjectConfig`, registered in `_PROJ_KEYS` so it's settable via `projects.json` and per-project `beat.json` overlay
- Wire `project.raid_timeout_s` into the raid `run_skill()` call (replaces hardcoded `RAID_TIMEOUT_S`)
- Add supervisor repair rule: raise `raid_timeout_s` by 20% (capped at 3600s) when `outcome=timeout` root cause is verify/review slowness
- Discriminating test: captures `timeout_s` kwarg and asserts it matches custom config value (2700), not the module default (1800)

Closes #0106

## Test plan

- [x] New test `test_raid_uses_per_project_timeout` passes
- [ ] Existing test suite passes (pre-existing `TestRunSkillDryRun.test_pick_ticket_returns_pick_sentinel` failure is unrelated — `_SkillResult` mock mismatch)
- [ ] Manual: verify `projects.json` accepts `raid_timeout_s` field
- [ ] Manual: verify `beat.json` overlay applies `raid_timeout_s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)