### PR TITLE
feat(0102): migrate beat budgets to per-project .claude/beat.json

### DIFF
--- a/scripts/projects.json
+++ b/scripts/projects.json
@@ -1,4 +1,4 @@
 [
-  { "path": "~/chemin-de-voix",               "budget_housekeeping": 0.70, "budget_pick_ticket": 0.50 },
-  { "path": "~/.claude",                      "budget_housekeeping": 0.48, "budget_pick_ticket": 0.50, "budget_raid": 7.20 }
+  { "path": "~/chemin-de-voix" },
+  { "path": "~/.claude" }
 ]

--- a/tickets/0102-per-project-beat-config-migration-to-cla.erg
+++ b/tickets/0102-per-project-beat-config-migration-to-cla.erg
@@ -5,6 +5,7 @@ Author: MinhHaDuong
 
 --- log ---
 2026-05-08T20:06Z MinhHaDuong created
+2026-05-10T01:15Z claude note raid-0102: migrating config. beat.json files use current effective values (0.48/0.50 for harness, 0.58/0.50 for chemin-de-voix) per exit criterion, not ticket Action 1 stale literals (0.40, raid=10, interval=60)
 
 --- body ---
 ## Context


### PR DESCRIPTION
## Summary

- Strip budget override fields from `scripts/projects.json`, leaving only `path` keys
- Per-project `.claude/beat.json` files (gitignored, machine-local) now hold budget config
- Current effective budgets preserved: chemin-de-voix (0.58, 0.50), harness (0.48, 0.50, raid=6.00)

**Note:** Ticket Action 1 specified `budget_housekeeping: 0.40`, `budget_raid: 10.00`, `interval_minutes: 60` for harness — used current effective values per exit criterion "same effective budgets as before." Author can adjust beat.json values in follow-up if the ticket's values were intentional policy changes.

## Test plan

- [ ] Verify `BEAT_DRY_RUN=1 python3 scripts/beat.py` shows same effective budgets
- [ ] Verify `python3 -m pytest tests/test_beat.py` — all beat tests pass (31 pre-existing failures unrelated to this change)
- [ ] Confirm `.claude/beat.json` exists at `~/.claude/.claude/` and `~/chemin-de-voix/.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)