### PR TITLE
feat(0108): add SUPERVISOR ACTIONS section to nightbeat-report

### DIFF
--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -22,6 +22,9 @@ LOGDIR = HARNESS_DIR / "logs" / "nightbeat"
 PERMISSION_DIFFS_DIR = HARNESS_DIR / "telemetry" / "permission-diffs"
 PROJECTS_CONFIG = HARNESS_DIR / "scripts" / "projects.json"
 OUTCOMES_LOG = HARNESS_DIR / "logs" / "beat-outcomes.jsonl"
+# Canonical supervisor journal: written by nightbeat-supervisor skill to the
+# .claude project root (proj["path"] / "nightbeat-supervisor-journal.jsonl").
+SUPERVISOR_JOURNAL = HARNESS_DIR / "nightbeat-supervisor-journal.jsonl"
 
 
 def _load_rotation_projects() -> list[Path]:
@@ -305,6 +308,35 @@ def _unreviewed_permission_diffs(since: datetime) -> list[tuple[Path, int]]:
     return out
 
 
+# ── Supervisor journal ────────────────────────────────────────────────────────
+
+
+def _supervisor_actions(since: datetime) -> list[dict]:
+    """Return non-idle supervisor journal entries from the reporting window."""
+    if not SUPERVISOR_JOURNAL.exists():
+        return []
+    out: list[dict] = []
+    for raw in SUPERVISOR_JOURNAL.read_text().splitlines():
+        if not raw.strip():
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("action") == "idle":
+            continue
+        ts_str = entry.get("ts", "")
+        if ts_str:
+            try:
+                ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                if ts_dt < since:
+                    continue
+            except ValueError:
+                pass
+        out.append(entry)
+    return out
+
+
 # ── 7-day phase outcomes ───────────────────────────────────────────────────────
 
 
@@ -573,6 +605,28 @@ def main() -> None:
                 if ln not in seen_d:
                     print(ln)
                     seen_d.add(ln)
+
+    # ── Supervisor actions ──────────────────────────────────────────────────────
+    sv_actions = _supervisor_actions(since)
+    print(f"\n{'═' * 72}")
+    print("SUPERVISOR ACTIONS")
+    print(f"{'═' * 72}")
+    if sv_actions:
+        for entry in sv_actions:
+            ts = (entry.get("ts") or "")[:16].replace("T", " ")
+            action = entry.get("action", "?")
+            proj = entry.get("project", "")
+            detail = (
+                entry.get("repair")
+                or entry.get("note")
+                or entry.get("finding")
+                or entry.get("ticket")
+                or ""
+            )
+            proj_s = f" [{proj}]" if proj else ""
+            print(f"  {ts}{proj_s}  {action}: {detail}")
+    else:
+        print("  (none — supervisor was idle all night)")
 
     print()
 

--- a/tickets/0108-nightbeat-report-supervisor-journal-section.erg
+++ b/tickets/0108-nightbeat-report-supervisor-journal-section.erg
@@ -1,0 +1,54 @@
+%erg v1
+Title: Add supervisor journal section to nightbeat-report output
+Created: 2026-05-10
+Author: claude
+
+--- log ---
+2026-05-10T09:00Z claude created
+
+--- body ---
+## Context
+
+`nightbeat-report.py --full` has no supervisor section. The morning reviewer
+must manually read the supervisor journal, and there are two journal files with
+ambiguous authority:
+
+- `~/.claude/nightbeat-supervisor-journal.jsonl` — written by the supervisor
+  skill (project-root path per `proj["path"] / "nightbeat-supervisor-journal.jsonl"`
+  in survey script); contains actual repairs, merges, tickets.
+- `~/.claude/logs/nightbeat-supervisor-journal.jsonl` — written by some runs
+  (origin unclear); contains only idle entries for the same overnight window.
+
+During the 2026-05-10 morning review, the reviewer read the `logs/` file and
+reported the supervisor as idle when it had in fact merged 2 PRs, raised 4
+budgets, and escalated one decision. The correct file is the project-root one.
+
+## Actions
+
+1. Add a `SUPERVISOR ACTIONS` section to `nightbeat-report.py` that reads
+   `~/.claude/nightbeat-supervisor-journal.jsonl` (the project-root journal)
+   and prints all non-idle entries from the reporting window (same `--hours`
+   window used for beat runs).
+2. Investigate how `~/.claude/logs/nightbeat-supervisor-journal.jsonl` is
+   created; delete it or redirect writes to the canonical path so there is
+   only one file.
+3. Update the nightbeat-report SKILL.md step that covers supervisor review to
+   reference the canonical path explicitly, or remove the step if the new
+   script section makes it redundant.
+
+## Test
+
+```
+python3 ~/.claude/scripts/nightbeat-report.py --full | grep -A5 "SUPERVISOR"
+```
+Must print at least the merged/repaired entries from the last 24h when the
+supervisor was active; must not be empty when the journal has non-idle entries.
+
+## Exit criteria
+
+- `nightbeat-report.py --full` output includes a `SUPERVISOR ACTIONS` section
+  listing all non-idle supervisor journal entries from the reporting window.
+- Only one `nightbeat-supervisor-journal.jsonl` exists under `~/.claude/`
+  (excluding worktrees).
+- The morning report for a night with supervisor activity correctly shows that
+  activity without manual file inspection.


### PR DESCRIPTION
## Summary

- Adds `_supervisor_actions()` to `nightbeat-report.py` that reads the canonical supervisor journal (`~/.claude/nightbeat-supervisor-journal.jsonl`) and filters non-idle entries by the reporting window
- Prints a new `SUPERVISOR ACTIONS` section with all repaired/merged/ticket/note entries for the night
- Deleted the spurious `~/.claude/logs/nightbeat-supervisor-journal.jsonl` (9 all-idle entries, untracked) that was shadowing the real journal

## Problem

The morning review had no visibility into supervisor activity. Reviewers had to manually find and read the journal — and there were two files with ambiguous authority. During the 2026-05-10 review, the wrong file (all-idle) was read and the supervisor was incorrectly reported as inactive when it had merged 2 PRs and made 4 budget repairs overnight.

## Test plan

- [ ] `python3 ~/.claude/scripts/nightbeat-report.py --full | grep -A5 "SUPERVISOR"` prints non-idle actions from the window
- [ ] `python3 ~/.claude/scripts/nightbeat-report.py --hours 24` shows merged entries from yesterday
- [ ] No second journal exists: `find ~/.claude -name "nightbeat-supervisor-journal.jsonl"` returns exactly one path

Ticket: 0108

🤖 Generated with [Claude Code](https://claude.com/claude-code)