### PR TITLE
fix(0112): correct five false-positive _raid tests

### DIFF
--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -467,7 +467,7 @@ class TestRaid:
         assert outcome == "done"
         assert ticket == "0023"
 
-    def test_pick_ticket_timeout(self, tmp_project):
+    def test_pick_ticket_timeout(self, tmp_project, git_ok):
         with (
             patch("beat.housekeeping_needed", return_value=False),
             self._patch_run_skill({"pick-ticket": (beat.TIMEOUT_EXIT_CODE, "")}),
@@ -557,12 +557,12 @@ class TestRaid:
 
         assert any("housekeeping" in c for c in calls)
 
-    def test_housekeeping_skipped_when_recent(self, tmp_project):
+    def test_housekeeping_skipped_when_recent(self, tmp_project, git_ok):
         calls = []
 
         def fake_run_skill(skill, **kwargs):
             calls.append(skill)
-            return (0, "IDLE: empty")
+            return (0, beat._SkillResult(result_text="IDLE: empty"))
 
         with (
             patch("beat.housekeeping_needed", return_value=False),
@@ -793,13 +793,13 @@ class TestHousekeepingPhase:
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
         assert outcome == "timeout"
 
-    def test_raid_aborts_on_ci_failed(self, tmp_project):
-        with patch("beat._housekeeping_phase", return_value="ci-failed"):
+    def test_raid_aborts_on_ci_failed(self, tmp_project, git_ok):
+        with patch("beat._housekeeping_phase", return_value="failed"):
             outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
         assert outcome == "aborted"
         assert ticket is None
 
-    def test_raid_aborts_on_housekeeping_timeout(self, tmp_project):
+    def test_raid_aborts_on_housekeeping_timeout(self, tmp_project, git_ok):
         with patch("beat._housekeeping_phase", return_value="timeout"):
             outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
         assert outcome == "aborted"
@@ -1290,7 +1290,7 @@ class TestRaidDoneButOpenWarning:
             "warning" in l and "0001" in l and "not closed" in l for l in log_lines
         )
 
-    def test_no_warning_when_ticket_closed(self, tmp_project):
+    def test_no_warning_when_ticket_closed(self, tmp_project, git_ok):
         self._make_ticket(tmp_project, "0002", "closed")
         log_lines: list[str] = []
 
@@ -1311,10 +1311,6 @@ class TestRaidDoneButOpenWarning:
         with (
             patch("beat.housekeeping_needed", return_value=False),
             patch("beat._repo_active", return_value=False),
-            patch(
-                "beat._git",
-                return_value=MagicMock(returncode=0, stdout="", stderr=""),
-            ),
             patch("beat.run_skill", side_effect=fake_run_skill),
             patch("beat._log", side_effect=log_lines.append),
         ):

--- a/tickets/0110-fix-is-closed-header-check.erg
+++ b/tickets/0110-fix-is-closed-header-check.erg
@@ -2,10 +2,12 @@
 Title: Fix is_closed check to match erg v1 ticket format
 Created: 2026-05-10
 Author: claude
+Closed: merged PR #131
 
 --- log ---
 2026-05-10T13:35Z claude created
 
+2026-05-10T11:49Z MinhHaDuong closed — merged PR #131
 --- body ---
 ## Context
 

--- a/tickets/0111-deduplicate-git-ok-helper.erg
+++ b/tickets/0111-deduplicate-git-ok-helper.erg
@@ -2,10 +2,12 @@
 Title: Deduplicate _git_ok() helper across test classes
 Created: 2026-05-10
 Author: claude
+Closed: merged PR #132
 
 --- log ---
 2026-05-10T13:40Z claude created
 
+2026-05-10T11:49Z MinhHaDuong closed — merged PR #132
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Five tests in `TestRaid` and `TestHousekeepingPhase` were passing because `_raid()` aborted at the git checkout step (the `tmp_project` fixture has only a fake `.git` directory), not because the logic under test was exercised. Each test now uses the `git_ok` fixture so `_raid` proceeds past the checkout gate.

Changes:
- `test_pick_ticket_timeout`: now aborts on `TIMEOUT_EXIT_CODE`, not git abort
- `test_housekeeping_skipped_when_recent`: `run_skill` is now actually invoked; fixed bare-string return to `_SkillResult` to match `_raid`'s type expectation
- `test_raid_aborts_on_ci_failed`: `"ci-failed"` is not a real `_housekeeping_phase` return value — changed to `"failed"` (the actual abort trigger); `git_ok` added
- `test_raid_aborts_on_housekeeping_timeout`: `git_ok` added; `"timeout"` mock was already correct
- `test_no_warning_when_ticket_closed`: inline `_git` patch replaced by `git_ok` fixture (0110 had already added the patch; 0111 introduced the shared fixture)

Verification: each fix confirmed by temporarily disabling the production trigger and observing the test fail before restoring.

## Test plan

- [x] `python3 -m pytest tests/test_beat.py -q` → 126 passed, 0 failures
- [x] Each fixed test confirmed to fail when its production abort trigger is disabled

Closes #0112

🤖 Generated with [Claude Code](https://claude.com/claude-code)