### PR TITLE
fix(0110): correct is_closed check to use erg v1 log section

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -800,6 +800,23 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
     return "deferred"
 
 
+def _ticket_log_has_closed(ticket_path: Path) -> bool:
+    """Return True if the ticket's log section contains a 'closed' verb entry."""
+    in_log = False
+    for ln in ticket_path.read_text().splitlines():
+        if ln.strip() == "--- log ---":
+            in_log = True
+            continue
+        if ln.startswith("---"):
+            in_log = False
+            continue
+        if in_log:
+            parts = ln.split()
+            if len(parts) >= 3 and parts[2] == "closed":
+                return True
+    return False
+
+
 def _ticket_recently_picked(ticket_path: Path, within_hours: int = 8) -> bool:
     """True if a sweep-pick log line in this ticket is within cutoff.
 
@@ -1032,14 +1049,11 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
         )
         # Warn if raid exited cleanly but left the ticket open (double-pick risk).
         ticket_files = list(path.glob(f"tickets/{ticket_id}-*.erg"))
-        if ticket_files:
-            header_lines = ticket_files[0].read_text().splitlines()[:10]
-            is_closed = any(ln.startswith("Closed:") for ln in header_lines)
-            if not is_closed:
-                _log(
-                    f"=== warning: raid done but ticket {ticket_id}"
-                    f" not closed — double-pick risk ==="
-                )
+        if ticket_files and not _ticket_log_has_closed(ticket_files[0]):
+            _log(
+                f"=== warning: raid done but ticket {ticket_id}"
+                f" not closed — double-pick risk ==="
+            )
 
     _log(f"=== raid: outcome={outcome} {_now_iso()} ===")
     return outcome, ticket_id

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1288,9 +1288,12 @@ class TestRaidDoneButOpenWarning:
 
     def _make_ticket(self, tmp_project, ticket_id: str, status: str) -> None:
         (tmp_project / "tickets").mkdir(exist_ok=True)
+        log = "2026-01-01T00:00Z claude created\n"
+        if status == "closed":
+            log += "2026-01-02T00:00Z claude closed\n"
         (tmp_project / f"tickets/{ticket_id}-test-ticket.erg").write_text(
-            f"%erg v1\nTitle: test\nStatus: {status}\nCreated: 2026-01-01\nAuthor: claude\n"
-            f"\n--- log ---\n\n--- body ---\n"
+            f"%erg v1\nTitle: test\nCreated: 2026-01-01\nAuthor: claude\n"
+            f"\n--- log ---\n{log}\n--- body ---\n"
         )
 
     def test_warns_when_ticket_not_closed(self, tmp_project):
@@ -1342,12 +1345,16 @@ class TestRaidDoneButOpenWarning:
             max_turns=None,
         ):
             if "pick-ticket" in skill:
-                return (0, "PICK: 0002")
-            return (0, "")
+                return (0, beat._SkillResult(result_text="PICK: 0002"))
+            return (0, beat._SkillResult())
 
         with (
             patch("beat.housekeeping_needed", return_value=False),
             patch("beat._repo_active", return_value=False),
+            patch(
+                "beat._git",
+                return_value=MagicMock(returncode=0, stdout="", stderr=""),
+            ),
             patch("beat.run_skill", side_effect=fake_run_skill),
             patch("beat._log", side_effect=log_lines.append),
         ):


### PR DESCRIPTION
## Summary

- `_raid()` checked for a `Closed:` header field that does not exist in erg v1 format — tickets are closed via a `closed` verb in the log section
- Adds `_ticket_log_has_closed()` which scans the `--- log ---` section for a line whose third token is `closed`
- `test_no_warning_when_ticket_closed` now exercises the real code path (adds git patches so `_raid` reaches the warning check)

## Test plan

- [x] `python3 -m pytest tests/test_beat.py -q` → 126 passed (verified locally before creating this PR)

Closes #0110

🤖 Generated with [Claude Code](https://claude.com/claude-code)