### PR TITLE
feat(0115): per-project max_turns_pick_ticket

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -111,6 +111,7 @@ class ProjectConfig:
         pick_ticket_model — model used when repo has no recent commits.
         interval_minutes — minimum minutes between beats (0 = always run).
         raid_timeout_s — seconds before the raid subprocess is killed.
+        max_turns_pick_ticket — max agent turns for pick-ticket (default 30).
     """
 
     path: Path

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -120,6 +120,7 @@ class ProjectConfig:
     pick_ticket_model: str = MODEL_HAIKU  # model used when repo has no recent commits
     interval_minutes: int = 0  # 0 = always run
     raid_timeout_s: int = RAID_TIMEOUT_S
+    max_turns_pick_ticket: int = MAX_TURNS_PICK_TICKET
 
 
 _BUILTIN_PROJECTS: list[ProjectConfig] = [
@@ -149,6 +150,7 @@ _PROJ_KEYS = {
     "pick_ticket_model",
     "interval_minutes",
     "raid_timeout_s",
+    "max_turns_pick_ticket",
 }
 
 
@@ -953,7 +955,7 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
             cwd=path,
             project_scoped=True,
             model=pick_model,
-            max_turns=MAX_TURNS_PICK_TICKET,
+            max_turns=project.max_turns_pick_ticket,
         )
 
         if pt_rc == TIMEOUT_EXIT_CODE:
@@ -961,7 +963,7 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
             return "aborted", None
         if pt_res.subtype == "error_max_turns":
             _log(
-                f"=== pick-ticket: max-turns ({MAX_TURNS_PICK_TICKET}) reached — context cap hit {_now_iso()} ==="
+                f"=== pick-ticket: max-turns ({project.max_turns_pick_ticket}) reached — context cap hit {_now_iso()} ==="
             )
         if pt_rc != 0:
             _record_phase_outcome(path, "pick_ticket", "fail", skill_result=pt_res)

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1547,6 +1547,14 @@ class TestProjectConfigFields:
         cfg = beat.ProjectConfig(path=Path("/tmp/p"), interval_minutes=30)
         assert cfg.interval_minutes == 30
 
+    def test_max_turns_pick_ticket_default(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"))
+        assert cfg.max_turns_pick_ticket == beat.MAX_TURNS_PICK_TICKET
+
+    def test_custom_max_turns_pick_ticket(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_pick_ticket=50)
+        assert cfg.max_turns_pick_ticket == 50
+
 
 class TestApplyBeatJsonOverlay:
     def test_overlay_merges_known_keys(self, tmp_path):
@@ -1610,6 +1618,23 @@ class TestLoadProjectsOverlay:
         projects = beat.load_projects(cfg)
         assert projects[0].interval_minutes == 60
 
+    def test_projects_json_max_turns_pick_ticket(self, tmp_path):
+        cfg = tmp_path / "projects.json"
+        cfg.write_text(json.dumps([{"path": "~/x", "max_turns_pick_ticket": 50}]))
+        projects = beat.load_projects(cfg)
+        assert projects[0].max_turns_pick_ticket == 50
+
+    def test_beat_json_overlay_max_turns_pick_ticket(self, tmp_path):
+        proj_dir = tmp_path / "myproject"
+        proj_dir.mkdir()
+        (proj_dir / ".claude").mkdir()
+        (proj_dir / ".claude" / "beat.json").write_text(
+            json.dumps({"max_turns_pick_ticket": 45})
+        )
+        cfg = beat.ProjectConfig(path=proj_dir)
+        beat._apply_beat_json_overlay(cfg)
+        assert cfg.max_turns_pick_ticket == 45
+
 
 class TestRaidBudgetPassthrough:
     """budget_raid flows from ProjectConfig to the raid skill invocation."""
@@ -1648,6 +1673,43 @@ class TestRaidBudgetPassthrough:
             r for r in recorded if "raid" in r["skill"] and "pick" not in r["skill"]
         )
         assert raid_call["budget"] == 8.50
+
+
+class TestPickTicketMaxTurnsPassthrough:
+    """max_turns_pick_ticket flows from ProjectConfig to the pick-ticket invocation."""
+
+    def setup_method(self):
+        beat.DRY_RUN = False
+
+    def test_pick_ticket_uses_project_max_turns(self, tmp_project, git_ok):
+        recorded: list[dict] = []
+
+        def fake_run_skill(
+            skill,
+            *,
+            budget,
+            timeout_s,
+            cwd,
+            project_scoped=False,
+            model=beat.MODEL_SONNET,
+            max_turns=None,
+        ):
+            recorded.append({"skill": skill, "max_turns": max_turns})
+            if "pick-ticket" in skill:
+                return (0, beat._SkillResult(result_text="IDLE: empty"))
+            return (0, beat._SkillResult())
+
+        with (
+            patch("beat.housekeeping_needed", return_value=False),
+            patch("beat._repo_active", return_value=False),
+            patch("beat._sync_origin_main"),
+            patch("beat._default_branch", return_value="main"),
+            patch("beat.run_skill", side_effect=fake_run_skill),
+        ):
+            beat._raid(beat.ProjectConfig(path=tmp_project, max_turns_pick_ticket=50))
+
+        pick_call = next(r for r in recorded if "pick-ticket" in r["skill"])
+        assert pick_call["max_turns"] == 50
 
 
 class TestIntervalSkip:


### PR DESCRIPTION
## Summary
- Add `max_turns_pick_ticket: int` field to `ProjectConfig` (default: `MAX_TURNS_PICK_TICKET`)
- Register in `_PROJ_KEYS` so `beat.json` overlays and `projects.json` entries can override it
- Wire `project.max_turns_pick_ticket` into the `run_skill()` call for pick-ticket (was hardcoded to the module constant)

## Root cause
chemin-de-voix `pick_ticket` hit the 30-turn cap checking ticket 0071 exit criteria (2026-05-10T19:05Z). No per-project knob existed.

## Test plan
- [x] `TestProjectConfigFields.test_max_turns_pick_ticket_default` — default equals constant
- [x] `TestProjectConfigFields.test_custom_max_turns_pick_ticket` — custom value sticks
- [x] `TestLoadProjectsOverlay.test_projects_json_max_turns_pick_ticket` — JSON round-trip
- [x] `TestLoadProjectsOverlay.test_beat_json_overlay_max_turns_pick_ticket` — overlay round-trip
- [x] `TestPickTicketMaxTurnsPassthrough.test_pick_ticket_uses_project_max_turns` — value reaches `run_skill`
- [x] All 131 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)