### PR TITLE
fix(0116): eliminate dual-journal path mismatch in nightbeat-supervisor

### DIFF
--- a/scripts/migrate-supervisor-journal.py
+++ b/scripts/migrate-supervisor-journal.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""One-time migration: merge logs/nightbeat-supervisor-journal.jsonl into root.
+
+Run once to consolidate entries that a supervisor cycle mistakenly wrote to
+~/.claude/logs/ instead of ~/.claude/ (ticket 0116).
+
+After running, the logs/ file is left in place but can be removed safely:
+  rm ~/.claude/logs/nightbeat-supervisor-journal.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+HARNESS_DIR = Path(__file__).parent.parent
+ROOT_JOURNAL = HARNESS_DIR / "nightbeat-supervisor-journal.jsonl"
+LOGS_JOURNAL = HARNESS_DIR / "logs" / "nightbeat-supervisor-journal.jsonl"
+
+
+def _load(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows: list[dict] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            print(f"Warning: skipping malformed line in {path}: {line!r}")
+    return rows
+
+
+def main() -> None:
+    root_entries = _load(ROOT_JOURNAL)
+    logs_entries = _load(LOGS_JOURNAL)
+
+    if not logs_entries:
+        print(f"Nothing to migrate: {LOGS_JOURNAL} is empty or absent.")
+        return
+
+    # Dedup key: (ts, action) — enough to identify duplicates
+    existing_keys: set[tuple[str, str]] = {
+        (e.get("ts", ""), e.get("action", "")) for e in root_entries
+    }
+
+    new_entries = [
+        e
+        for e in logs_entries
+        if (e.get("ts", ""), e.get("action", "")) not in existing_keys
+    ]
+
+    if not new_entries:
+        print(f"All {len(logs_entries)} logs/ entries already present in root journal.")
+        return
+
+    # Append new entries to root journal
+    with ROOT_JOURNAL.open("a") as f:
+        for entry in new_entries:
+            f.write(json.dumps(entry) + "\n")
+
+    print(
+        f"Migrated {len(new_entries)} of {len(logs_entries)} entries from\n"
+        f"  {LOGS_JOURNAL}\n  → {ROOT_JOURNAL}\n"
+        f"({len(logs_entries) - len(new_entries)} already present, skipped)"
+    )
+    print(f"\nYou may now remove the stale logs/ file:\n  rm {LOGS_JOURNAL}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -22,8 +22,8 @@ LOGDIR = HARNESS_DIR / "logs" / "nightbeat"
 PERMISSION_DIFFS_DIR = HARNESS_DIR / "telemetry" / "permission-diffs"
 PROJECTS_CONFIG = HARNESS_DIR / "scripts" / "projects.json"
 OUTCOMES_LOG = HARNESS_DIR / "logs" / "beat-outcomes.jsonl"
-# Canonical supervisor journal: written by nightbeat-supervisor skill to the
-# .claude project root (proj["path"] / "nightbeat-supervisor-journal.jsonl").
+# Canonical supervisor journal: $HARNESS_DIR/nightbeat-supervisor-journal.jsonl.
+# The nightbeat-supervisor skill writes ALL entries here (never to logs/ subdirs).
 SUPERVISOR_JOURNAL = HARNESS_DIR / "nightbeat-supervisor-journal.jsonl"
 
 

--- a/scripts/nightbeat-supervisor-survey.py
+++ b/scripts/nightbeat-supervisor-survey.py
@@ -77,7 +77,12 @@ def _read_jsonl(path: Path, since: datetime | None = None) -> list[dict]:
 
 
 def _watermark(projects: list[dict]) -> datetime:
-    """Latest journal entry ts across all projects; defaults to 24h ago."""
+    """Latest journal entry ts across all projects; defaults to 24h ago.
+
+    Canonical journal path: <proj["path"]>/nightbeat-supervisor-journal.jsonl.
+    For the harness project this resolves to $HARNESS_DIR/nightbeat-supervisor-journal.jsonl.
+    The nightbeat-supervisor skill writes ALL entries there (not to logs/ subdirs).
+    """
     latest: datetime | None = None
     for proj in projects:
         journal = proj["path"] / "nightbeat-supervisor-journal.jsonl"

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -20,7 +20,7 @@ python3 $HARNESS_DIR/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
 ```
 
 If `--since` is absent from `$ARGUMENTS`, the script derives the watermark from
-the latest `ts` in each project's `nightbeat-supervisor-journal.jsonl` (defaults
+the latest `ts` in `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl` (defaults
 to 24h ago if no journal exists). Reads `$HARNESS_DIR/logs/beat-outcomes.jsonl`
 and finds open PRs for raid-success tickets via remote branch lookup and forge API.
 Outputs `{prs_to_merge, failures, watermark_ts, journal_context}`.
@@ -75,7 +75,7 @@ ticket with the verdict if the fix is outside authority.
 ## 5. Done
 
 Append one journal entry per action taken this cycle to
-`<project>/nightbeat-supervisor-journal.jsonl`. If no actions were taken,
+`$HARNESS_DIR/nightbeat-supervisor-journal.jsonl`. If no actions were taken,
 append a single `action=idle` entry — this serves as the watermark so the
 next cycle knows where to resume. End with:
 

--- a/tickets/0116-fix-dual-journal-path-mismatch.erg
+++ b/tickets/0116-fix-dual-journal-path-mismatch.erg
@@ -1,0 +1,51 @@
+%erg v1
+Title: Fix dual-journal path mismatch in nightbeat-supervisor
+Created: 2026-05-11
+Author: claude
+
+--- log ---
+2026-05-11T04:10Z claude created
+2026-05-11T05:00Z claude note — root cause confirmed: SKILL.md used ambiguous `<project>/nightbeat-supervisor-journal.jsonl`; agent interpreted as logs/ on some cycles. No code hardcodes the wrong path. Fix: make path explicit as `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl` at both SKILL.md sites. Add migration script for lost entries and docstring clarifications.
+
+--- body ---
+## Context
+
+Two `nightbeat-supervisor-journal.jsonl` files exist:
+- `~/.claude/nightbeat-supervisor-journal.jsonl` (root) — read by the survey script
+- `~/.claude/logs/nightbeat-supervisor-journal.jsonl` (logs) — written by some supervisor cycles
+
+The survey's `_watermark()` reads `proj["path"] / "nightbeat-supervisor-journal.jsonl"`,
+which for the `.claude` project resolves to the root file. But supervisor cycles (at least
+those run between 01:15Z–01:49Z on 2026-05-11) wrote their journal entries to the logs
+file. The watermark therefore never advanced past the last root-file entry (01:00:57Z),
+causing the same chemin-de-voix housekeeping failure to be re-detected and the budget
+raised repeatedly: $0.70 → $0.84 → $0.90 → $1.08 across four cycles.
+
+Root cause discovered while processing chemin-de-voix housekeeping fail at 01:07:10Z
+(error_max_budget_usd, cost=$0.706). Budget in beat.json is already at $1.08 and
+subsequent beat succeeded — no additional repair needed.
+
+## Actions
+
+1. Decide canonical path: `~/.claude/nightbeat-supervisor-journal.jsonl` (matches
+   survey expectation) or `~/.claude/logs/nightbeat-supervisor-journal.jsonl` (matches
+   logging convention). Recommendation: root file, since that's what the survey reads.
+
+2. Migrate existing entries from the logs journal to the root journal (dedup by ts+action).
+
+3. Remove (or make a symlink of) the logs journal so both paths resolve to the same file,
+   OR update the supervisor skill to always write to the root file.
+
+4. Update the survey script comment / docstring to name the canonical path explicitly.
+
+## Test
+
+After fix: run `python3 scripts/nightbeat-supervisor-survey.py` and verify that
+`watermark_ts` equals the latest entry across BOTH current files (currently 01:49:50Z).
+
+## Exit criteria
+
+- Single canonical journal path used by both the supervisor skill and the survey script.
+- Running the survey after a repair cycle produces a watermark that reflects the repair,
+  so the next cycle does not re-detect the same failure.
+- Existing entries from the logs journal are preserved (not lost).


### PR DESCRIPTION
## Summary

- **Root cause**: `SKILL.md` step 5 used `<project>/nightbeat-supervisor-journal.jsonl` while step 1 used `$HARNESS_DIR`. Agents in some cycles interpreted `<project>` as the logs/ directory, writing to `~/.claude/logs/nightbeat-supervisor-journal.jsonl` instead of the canonical `~/.claude/nightbeat-supervisor-journal.jsonl`. The survey reads from the root, so its watermark never advanced past the misrouted entries, causing repeated re-detection of already-repaired failures.
- **SKILL.md**: both sites now explicitly name `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl`
- **Survey + report**: docstrings/comments updated to name the canonical path
- **Migration script**: `scripts/migrate-supervisor-journal.py` merges the stale `logs/` entries into root (dedup by ts+action)

## Test plan

- [ ] Verify SKILL.md no longer contains `<project>/nightbeat-supervisor-journal.jsonl`
- [ ] `python3 -m py_compile scripts/nightbeat-supervisor-survey.py scripts/nightbeat-report.py scripts/migrate-supervisor-journal.py` — no errors
- [ ] Run migration once: `python3 ~/.claude/scripts/migrate-supervisor-journal.py` — should report migrated entries
- [ ] `python3 ~/.claude/scripts/nightbeat-supervisor-survey.py | jq .watermark_ts` — should equal the latest entry across both current journal files
- [ ] Confirm only one `nightbeat-supervisor-journal.jsonl` under `~/.claude/` after `rm ~/.claude/logs/nightbeat-supervisor-journal.jsonl`

Closes #0116

🤖 Generated with [Claude Code](https://claude.com/claude-code)