### PR TITLE
feat: skill-doctor survey and 4 hardening tickets

### DIFF
--- a/scripts/skill-doctor-survey.py
+++ b/scripts/skill-doctor-survey.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Skill-doctor survey — mine journals, logs, and git history for recurring failure patterns.
+
+Emits JSON: {window, patterns}
+  window: {since, until, days}
+  patterns: [{signature, frequency, severity, score, evidence, affected_skill, candidate_patch}]
+
+Patterns are ranked by score = frequency × severity_weight.
+Severity weights: high=3, medium=2, low=1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+def _resolve_harness_dir() -> Path:
+    """Resolve the real harness directory, following worktree symlinks."""
+    script_dir = Path(__file__).resolve().parent.parent
+    env = os.environ.get("HARNESS_DIR")
+    if env:
+        return Path(env)
+    git_file = script_dir / ".git"
+    if git_file.is_file():
+        gitdir_line = git_file.read_text().strip()
+        if gitdir_line.startswith("gitdir:"):
+            worktree_git = Path(gitdir_line.split(":", 1)[1].strip()).resolve()
+            commondir = worktree_git / "commondir"
+            if commondir.is_file():
+                real_gitdir = (worktree_git / commondir.read_text().strip()).resolve()
+                return real_gitdir.parent
+    return script_dir
+
+
+HARNESS_DIR = _resolve_harness_dir()
+
+
+def _parse_ts(ts_str: str) -> datetime | None:
+    if not ts_str:
+        return None
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _read_jsonl(path: Path, since: datetime | None = None) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if since is not None:
+            ts = _parse_ts(obj.get("ts", ""))
+            if ts is not None and ts < since:
+                continue
+        rows.append(obj)
+    return rows
+
+
+def _git_log_grep(pattern: str, since: datetime) -> list[str]:
+    r = subprocess.run(
+        [
+            "git",
+            "log",
+            "--all",
+            "--oneline",
+            f"--since={since.isoformat()}",
+            f"--grep={pattern}",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=HARNESS_DIR,
+    )
+    return r.stdout.strip().splitlines() if r.returncode == 0 else []
+
+
+def _scan_nightbeat_logs(since: datetime) -> list[str]:
+    """Extract failure signature lines from nightbeat logs."""
+    log_dir = HARNESS_DIR / "logs" / "nightbeat"
+    if not log_dir.exists():
+        return []
+    lines = []
+    for logfile in sorted(log_dir.glob("*.log")):
+        stem = logfile.stem[:15]
+        try:
+            file_dt = datetime.strptime(stem, "%Y%m%dT%H%M%S").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            continue
+        if file_dt < since:
+            continue
+        try:
+            content = logfile.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in content.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("{"):
+                continue
+            low = stripped.lower()
+            if any(
+                kw in low
+                for kw in (
+                    "aborted",
+                    "error",
+                    "fail",
+                    "denied",
+                    "budget",
+                    "timeout",
+                    "max-turns",
+                    "outcome=",
+                )
+            ):
+                lines.append(stripped)
+    return lines
+
+
+def _cluster_budget_raises(
+    journal: list[dict], repair_commits: list[str]
+) -> dict | None:
+    """Detect repeated budget raises for the same project+phase."""
+    raises: list[dict] = []
+    for entry in journal:
+        action = entry.get("action", "")
+        note = entry.get("note", "")
+        if action == "repair" and "budget" in note.lower():
+            raises.append(entry)
+    seen_msgs: set[str] = set()
+    for commit in repair_commits:
+        if "raise" in commit.lower() and "budget" in commit.lower():
+            # Deduplicate: same commit message from different branches
+            msg = commit.split(" ", 1)[1] if " " in commit else commit
+            if msg not in seen_msgs:
+                seen_msgs.add(msg)
+                raises.append({"source": "git", "line": commit})
+
+    if len(raises) < 2:
+        return None
+
+    by_project: dict[str, int] = Counter()
+    for r in raises:
+        proj = r.get("project", "unknown")
+        by_project[proj] += 1
+
+    return {
+        "signature": "budget-cap-repeated-raises",
+        "frequency": len(raises),
+        "severity": "medium",
+        "score": len(raises) * 2,
+        "evidence": [r.get("note") or r.get("line", "") for r in raises[:6]],
+        "affected_skill": "nightbeat-supervisor",
+        "candidate_patch": (
+            "After 3 consecutive budget raises for the same project+phase "
+            "within 7 days, escalate to a ticket instead of raising again. "
+            "Log a warning when a raise would exceed 1.5x the module-level constant."
+        ),
+    }
+
+
+def _cluster_dirty_tree(log_lines: list[str]) -> dict | None:
+    """Detect dirty working tree blocking checkout."""
+    dirty = [
+        ln
+        for ln in log_lines
+        if "cannot checkout" in ln
+        and ("modifications locales" in ln or "local changes" in ln.lower())
+    ]
+    if len(dirty) < 2:
+        return None
+
+    files_mentioned: set[str] = set()
+    for ln in dirty:
+        for m in re.findall(r"\t(\S+)", ln):
+            files_mentioned.add(m)
+
+    return {
+        "signature": "dirty-tree-blocks-checkout",
+        "frequency": len(dirty),
+        "severity": "medium",
+        "score": len(dirty) * 2,
+        "evidence": [ln[:200] for ln in dirty[:4]],
+        "dirty_files": sorted(files_mentioned)[:10],
+        "affected_skill": "beat.py (_sync_origin_main)",
+        "candidate_patch": (
+            "In _sync_origin_main(), check `git status --porcelain` first. "
+            "If dirty, log the dirty files and abort with error code "
+            "'aborted-dirty-tree' so the supervisor can open a ticket."
+        ),
+    }
+
+
+def _cluster_watermark_redetection(journal: list[dict]) -> dict | None:
+    """Detect watermark/journal issues causing re-detection loops."""
+    redetect = []
+    for entry in journal:
+        note = entry.get("note", "").lower()
+        if any(kw in note for kw in ("already repaired", "re-detect", "watermark")):
+            redetect.append(entry)
+
+    if len(redetect) < 2:
+        return None
+
+    return {
+        "signature": "watermark-redetection-loop",
+        "frequency": len(redetect),
+        "severity": "high",
+        "score": len(redetect) * 3,
+        "evidence": [r.get("note", "")[:200] for r in redetect[:4]],
+        "affected_skill": "nightbeat-supervisor-survey.py",
+        "candidate_patch": (
+            "Add a startup assertion to the survey script: verify the canonical "
+            "journal path exists and no non-canonical duplicate exists independently. "
+            "Fail loud if both exist."
+        ),
+    }
+
+
+def _cluster_umbrella_not_closed(
+    journal: list[dict], log_lines: list[str]
+) -> dict | None:
+    """Detect umbrella tickets staying open after children complete."""
+    umbrella_events = []
+    for entry in journal:
+        note = entry.get("note", "").lower()
+        if "umbrella" in note and (
+            "open" in note or "closed" in note or "never closed" in note
+        ):
+            umbrella_events.append(entry)
+    for ln in log_lines:
+        if "umbrella" in ln.lower() and "closed" in ln.lower():
+            umbrella_events.append({"source": "log", "note": ln[:200]})
+
+    if len(umbrella_events) < 2:
+        return None
+
+    return {
+        "signature": "umbrella-not-auto-closed",
+        "frequency": len(umbrella_events),
+        "severity": "medium",
+        "score": len(umbrella_events) * 2,
+        "evidence": [e.get("note", "")[:200] for e in umbrella_events[:4]],
+        "affected_skill": "pick-ticket",
+        "candidate_patch": (
+            "In pick-ticket step 3: if a ticket has Blocks: entries, check "
+            "whether all referenced tickets are closed. If yes, auto-close "
+            "as already-done."
+        ),
+    }
+
+
+def _cluster_ticket_line_format(repair_commits: list[str]) -> dict | None:
+    """Detect plain Ticket: vs **Ticket:** format mismatches."""
+    ticket_line_issues = [
+        c
+        for c in repair_commits
+        if "ticket:" in c.lower() and ("tolerate" in c.lower() or "plain" in c.lower())
+    ]
+    if len(ticket_line_issues) < 1:
+        return None
+
+    freq = len(ticket_line_issues)
+    return {
+        "signature": "ticket-line-format-mismatch",
+        "frequency": freq,
+        "severity": "high",
+        "score": freq * 3,
+        "evidence": ticket_line_issues[:4],
+        "affected_skill": "merge (erg-pr-merge)",
+        "candidate_patch": (
+            "Loosen the grep in erg-pr-merge to accept Ticket:, **Ticket:**, "
+            "and **Ticket**: at line start (case-insensitive). If no ticket line "
+            "is found at all, exit non-zero."
+        ),
+    }
+
+
+def _cluster_max_turns(journal: list[dict], log_lines: list[str]) -> dict | None:
+    """Detect max-turns exhaustion events."""
+    events = []
+    for entry in journal:
+        note = entry.get("note", "").lower()
+        if "max-turns" in note or "max_turns" in note:
+            events.append(entry)
+    for ln in log_lines:
+        if "max-turns" in ln.lower() or "max_turns" in ln.lower():
+            events.append({"source": "log", "note": ln[:200]})
+
+    if len(events) < 2:
+        return None
+
+    return {
+        "signature": "max-turns-exhaustion",
+        "frequency": len(events),
+        "severity": "medium",
+        "score": len(events) * 2,
+        "evidence": [e.get("note", "")[:200] for e in events[:4]],
+        "affected_skill": "beat.py (pick-ticket/raid)",
+        "candidate_patch": (
+            "Per-project max_turns_pick_ticket already landed (ticket 0115). "
+            "Monitor for recurrence; if still hitting, consider dynamic turn "
+            "allocation based on ticket complexity."
+        ),
+    }
+
+
+def _cluster_crash_recovery(log_lines: list[str]) -> dict | None:
+    """Detect crash recovery events."""
+    crashes = [ln for ln in log_lines if "crash recovery" in ln.lower()]
+    if len(crashes) < 2:
+        return None
+    return {
+        "signature": "beat-crash-recovery",
+        "frequency": len(crashes),
+        "severity": "low",
+        "score": len(crashes) * 1,
+        "evidence": [ln[:200] for ln in crashes[:4]],
+        "affected_skill": "beat.py",
+        "candidate_patch": (
+            "Investigate crash root causes from log context. "
+            "Add structured crash reason to beat-outcomes.jsonl."
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Look-back window in days (default: 30)",
+    )
+    parser.add_argument(
+        "--min-frequency",
+        type=int,
+        default=2,
+        help="Minimum occurrences to report a pattern (default: 2)",
+    )
+    args = parser.parse_args()
+
+    since = datetime.now(timezone.utc) - timedelta(days=args.days)
+    until = datetime.now(timezone.utc)
+
+    # Collect evidence from all sources
+    journal_path = HARNESS_DIR / "logs" / "nightbeat-supervisor-journal.jsonl"
+    journal_alt = HARNESS_DIR / "nightbeat-supervisor-journal.jsonl"
+    journal = _read_jsonl(journal_path, since)
+    if journal_alt.exists() and journal_alt != journal_path:
+        journal.extend(_read_jsonl(journal_alt, since))
+
+    repair_commits = _git_log_grep("repair:", since)
+    ticket_commits = _git_log_grep("ticket(", since)
+    log_lines = _scan_nightbeat_logs(since)
+
+    # Run all clusterers
+    patterns = []
+    for clusterer in (
+        lambda: _cluster_budget_raises(journal, repair_commits),
+        lambda: _cluster_dirty_tree(log_lines),
+        lambda: _cluster_watermark_redetection(journal),
+        lambda: _cluster_umbrella_not_closed(journal, log_lines),
+        lambda: _cluster_ticket_line_format(repair_commits + ticket_commits),
+        lambda: _cluster_max_turns(journal, log_lines),
+        lambda: _cluster_crash_recovery(log_lines),
+    ):
+        result = clusterer()
+        if result and result["frequency"] >= args.min_frequency:
+            patterns.append(result)
+
+    patterns.sort(key=lambda p: p["score"], reverse=True)
+
+    print(
+        json.dumps(
+            {
+                "window": {
+                    "since": since.isoformat(),
+                    "until": until.isoformat(),
+                    "days": args.days,
+                },
+                "pattern_count": len(patterns),
+                "patterns": patterns,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: skill-doctor
+description: Weekly failure-pattern analysis across journals, logs, and git history. Clusters recurring failures and opens tickets with proposed patches. Never auto-applies fixes.
+user-invocable: true
+argument-hint: "[--days N]"
+model: sonnet
+---
+
+# Skill Doctor $ARGUMENTS
+
+Analyze recurring failure patterns across the harness automation and propose
+hardening patches via tickets. Run weekly or on-demand.
+
+**Authority boundary**: propose only — open tickets with diffs, never
+auto-apply patches. Same boundary as nightbeat-supervisor's "anything else →
+open a ticket."
+
+## 1. Survey
+
+```bash
+python3 $HARNESS_DIR/scripts/skill-doctor-survey.py $ARGUMENTS
+```
+
+Parse the JSON output. If `pattern_count` is 0, report "no recurring patterns
+found" and stop.
+
+## 2. Cross-reference existing tickets
+
+For each pattern in `patterns`, search open tickets for the `signature` keyword:
+
+```bash
+ERG=$(command -v erg 2>/dev/null || echo "tickets/erg")
+$ERG ready --json tickets/ 2>/dev/null || true
+```
+
+Also check closed tickets for recent fixes:
+
+```bash
+grep -rl "<signature>" tickets/closed/ 2>/dev/null | tail -5
+```
+
+Mark each pattern as `covered` (open ticket exists), `recently-fixed`
+(closed ticket within 14 days), or `uncovered`.
+
+## 3. Report
+
+Present the ranked patterns as a table:
+
+| Rank | Signature | Freq | Sev | Score | Status | Affected Skill |
+|------|-----------|------|-----|-------|--------|----------------|
+
+For each `uncovered` pattern, show:
+- **Evidence**: the `evidence` array from the survey (verbatim log/journal excerpts)
+- **Candidate patch**: the proposed fix from the survey
+- **Expected impact**: estimated failure-rate reduction
+
+Ask the user which patterns to ticket before proceeding.
+
+## 4. Open tickets
+
+For each approved pattern, create a ticket via `/ticket-new`:
+
+- **Title**: `skill-doctor: {signature} — {one-line fix summary}`
+- **Context**: evidence from the survey, frequency × severity score,
+  affected skill/script
+- **Actions**: the candidate patch, broken into concrete steps
+- **Test**: how to verify the fix prevents recurrence (ideally a
+  grep-able assertion or a test case)
+- **Exit criteria**: the specific condition that makes this pattern
+  stop recurring
+
+Commit all new tickets in a single commit:
+`chore(skill-doctor): open N tickets from weekly survey`
+
+## 5. Done
+
+Report:
+```
+skill-doctor: surveyed {days}d window — {pattern_count} patterns, {uncovered} uncovered, {ticketed} tickets opened
+```

--- a/tickets/0119-budget-raise-convergence-guard.erg
+++ b/tickets/0119-budget-raise-convergence-guard.erg
@@ -2,12 +2,10 @@
 Title: skill-doctor: budget-raise convergence guard — escalate after 3 consecutive raises
 Created: 2026-05-11
 Author: claude
-Closed: autoclosed — PR #139
 
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=9, sev=medium, score=18
-
-2026-05-11T16:47Z MinhHaDuong closed — autoclosed — PR #139
+2026-05-11T16:52Z claude note — reverted erroneous auto-close (PR #139 opens this ticket, does not implement it)
 --- body ---
 ## Context
 

--- a/tickets/0119-budget-raise-convergence-guard.erg
+++ b/tickets/0119-budget-raise-convergence-guard.erg
@@ -1,0 +1,55 @@
+%erg v1
+Title: skill-doctor: budget-raise convergence guard — escalate after 3 consecutive raises
+Created: 2026-05-11
+Author: claude
+
+--- log ---
+2026-05-11T16:00Z claude created — skill-doctor survey: freq=9, sev=medium, score=18
+
+--- body ---
+## Context
+
+The nightbeat-supervisor raises per-project budgets by 20% on each
+`error_max_budget_usd` failure, but the 20% rule is reactive and slow to
+converge when scope grows faster than increments can track. Evidence from the
+last 30 days:
+
+- chemin-de-voix `budget_housekeeping`: 0.48 → 0.58 → 0.70 → 0.84 → 0.90 → 1.08
+  across 6 supervisor cycles (7 repair commits, some duplicated across branches)
+- `.claude` `budget_raid`: 5.00 → 6.00 → 7.20, committed twice
+- Ticket 0116's watermark bug amplified this — same failure re-detected 4 times
+
+The supervisor never stops raising because no convergence check exists.
+
+## Actions
+
+1. In `skills/nightbeat-supervisor/SKILL.md`, add a convergence guard to
+   step 3 (Diagnose and repair):
+
+   > Before raising a budget, count how many `action=repair` journal entries
+   > exist for the same project+phase in the last 7 days. If ≥ 3: do not
+   > raise. Instead, open a ticket: "budget not converging for {project}
+   > {phase} — {N} raises in 7 days, current={current}, started={first}."
+
+2. Add a warning threshold: if the proposed raise would exceed 1.5× the
+   module-level constant, log a warning and include it in the ticket.
+
+3. Update the survey script's budget clusterer to track per-project+phase
+   counts for more precise scoring.
+
+## Test
+
+```bash
+# Simulate: add 3 budget_raise journal entries for the same project+phase
+# within 7 days, then run a supervisor cycle with a new budget failure.
+# Expected: supervisor opens a ticket instead of raising.
+python3 scripts/skill-doctor-survey.py --days 7
+# Should show budget-cap-repeated-raises with freq >= 3
+```
+
+## Exit criteria
+
+- Supervisor SKILL.md contains the convergence guard (3 raises / 7 days).
+- A supervisor cycle with 3+ prior raises for the same project+phase opens
+  a ticket instead of raising the budget.
+- The 1.5× warning threshold is documented in the SKILL.md.

--- a/tickets/0120-dirty-tree-abort-code.erg
+++ b/tickets/0120-dirty-tree-abort-code.erg
@@ -1,0 +1,59 @@
+%erg v1
+Title: skill-doctor: dirty tree blocks beat checkout — abort with structured error
+Created: 2026-05-11
+Author: claude
+
+--- log ---
+2026-05-11T16:00Z claude created — skill-doctor survey: freq=12, sev=medium, score=24
+
+--- body ---
+## Context
+
+12+ beat cycles aborted with "cannot checkout main/master" because a previous
+session left uncommitted changes. Dirty files included STATE.md, scripts/beat.py,
+scripts/nightbeat-supervisor-survey.py, and chemin-de-voix ticket files.
+
+`beat.py`'s `_sync_origin_main()` calls `git checkout <default_branch>` without
+checking working tree state first. When dirty, git prints a French error message
+and exits non-zero. Beat logs this as a generic `beat aborted` but the supervisor
+has no structured signal to act on — it just sees the abort in the next log scan.
+
+Pattern: interactive session or previous beat leaves uncommitted changes →
+next hourly beat can't sync → repeats every hour until human intervenes.
+
+## Actions
+
+1. In `_sync_origin_main()` in `scripts/beat.py`, before the checkout:
+
+   ```python
+   r = _git("status", "--porcelain", cwd=path)
+   if r.stdout.strip():
+       dirty = r.stdout.strip().splitlines()[:5]
+       _log(f"aborted-dirty-tree: {len(dirty)} dirty files: {dirty}")
+       return "aborted-dirty-tree"
+   ```
+
+2. Add `"aborted-dirty-tree"` as a recognized outcome in `beat-outcomes.jsonl`
+   so the supervisor can match on it.
+
+3. In the supervisor SKILL.md step 3, add a repair rule:
+
+   > **Dirty working tree** → commit or stash the changes if they are
+   > machine-local state (beat.json, STATE.md regen); otherwise open a
+   > ticket naming the dirty files.
+
+## Test
+
+```bash
+# In a project repo, create an uncommitted file, then run beat:
+echo "dirty" > /tmp/test-dirty && cp /tmp/test-dirty STATE.md
+python3 scripts/beat.py --dry-run
+# Expected: log line contains "aborted-dirty-tree"
+```
+
+## Exit criteria
+
+- `_sync_origin_main()` checks `git status --porcelain` before checkout.
+- A dirty working tree produces `outcome=aborted-dirty-tree` in beat outcomes.
+- The supervisor SKILL.md documents the dirty-tree repair rule.
+- No more generic `beat aborted: cannot checkout` lines in nightbeat logs.

--- a/tickets/0121-journal-path-startup-assertion.erg
+++ b/tickets/0121-journal-path-startup-assertion.erg
@@ -1,0 +1,56 @@
+%erg v1
+Title: skill-doctor: journal path startup assertion — prevent re-detection loops
+Created: 2026-05-11
+Author: claude
+
+--- log ---
+2026-05-11T16:00Z claude created — skill-doctor survey: freq=3, sev=high, score=9
+
+--- body ---
+## Context
+
+Ticket 0116 fixed the root cause: the supervisor SKILL.md used an ambiguous
+journal path that some cycles resolved to `logs/` instead of the project root.
+But no guard prevents the same class of bug from recurring — if a future skill
+edit reintroduces the ambiguity, the re-detection loop restarts silently.
+
+Evidence: 3 journal entries documenting re-detection, 4 unnecessary budget
+raises ($0.70 → $1.08) for the same chemin-de-voix housekeeping failure.
+
+## Actions
+
+1. In `scripts/nightbeat-supervisor-survey.py`, add a startup assertion
+   after loading projects:
+
+   ```python
+   for proj in projects:
+       canonical = proj["path"] / "nightbeat-supervisor-journal.jsonl"
+       alt = proj["path"] / "logs" / "nightbeat-supervisor-journal.jsonl"
+       if alt.exists() and canonical.exists() and not alt.is_symlink():
+           sys.exit(f"ERROR: dual journal for {proj['path'].name}: "
+                    f"both {canonical} and {alt} exist independently. "
+                    f"Merge entries and remove or symlink the non-canonical file.")
+   ```
+
+2. Add the same check to the supervisor SKILL.md step 1 (Survey):
+
+   > Before running the survey, verify no dual-journal state exists.
+   > If both `<project>/nightbeat-supervisor-journal.jsonl` and
+   > `<project>/logs/nightbeat-supervisor-journal.jsonl` exist as
+   > independent files, stop and open a ticket.
+
+## Test
+
+```bash
+# Create a dual-journal scenario:
+touch /tmp/test-journal-canonical.jsonl
+touch /tmp/test-journal-alt.jsonl
+# Mock the survey to check both paths exist → expected: non-zero exit
+```
+
+## Exit criteria
+
+- Survey script exits non-zero if both canonical and non-canonical journal
+  files exist independently (not symlinked).
+- Error message names both paths and the project.
+- Supervisor SKILL.md documents the pre-flight check.

--- a/tickets/0122-umbrella-auto-close-in-pick-ticket.erg
+++ b/tickets/0122-umbrella-auto-close-in-pick-ticket.erg
@@ -1,0 +1,55 @@
+%erg v1
+Title: skill-doctor: auto-close umbrella tickets when all children are closed
+Created: 2026-05-11
+Author: claude
+
+--- log ---
+2026-05-11T16:00Z claude created — skill-doctor survey: freq=2, sev=medium, score=4
+
+--- body ---
+## Context
+
+Umbrella tickets (those with `Blocks:` entries) remain open after all their
+children complete. pick-ticket treats them as valid candidates and wastes turns
+assessing them — chemin-de-voix 0071 stayed open after 0080+0081 completed,
+consuming all 30 max-turns during the exit-criteria check. The supervisor
+had to close it manually across 2 cycles.
+
+Ticket 0061 was also closed as meta (split into 0115/0116/0117) — same pattern
+of an umbrella needing manual intervention.
+
+## Actions
+
+1. In `skills/pick-ticket/SKILL.md` step 3 (Assess remaining candidates),
+   add an umbrella check before the scope/risk assessment:
+
+   > **Umbrella check**: if the ticket body contains `Blocks:` entries,
+   > extract the referenced ticket IDs. For each, check whether
+   > `tickets/closed/<id>-*.erg` exists (or `erg status <id>` reports closed).
+   > If ALL referenced tickets are closed, auto-close the umbrella via
+   > `/ticket-close <id> already-done` and output `CLOSED: <id>`.
+   > Skip scope assessment for this ticket.
+
+2. This is a grep-able check — no LLM judgment required:
+
+   ```bash
+   # Extract Blocks: IDs from ticket body
+   grep -oP 'Blocks:\s*\K[\d,\s]+' tickets/NNNN-*.erg | tr ',' '\n'
+   # For each ID, check if closed
+   test -n "$(ls tickets/closed/${ID}-*.erg 2>/dev/null)"
+   ```
+
+## Test
+
+```bash
+# Create an umbrella ticket with Blocks: 0001, 0002
+# Ensure both 0001 and 0002 exist in tickets/closed/
+# Run pick-ticket
+# Expected: CLOSED: <umbrella-id>
+```
+
+## Exit criteria
+
+- pick-ticket auto-closes umbrella tickets whose Blocks: targets are all closed.
+- The auto-close outputs `CLOSED: <id>` (not `PICK:`) so beat.py loops.
+- No more max-turns exhaustion on completed umbrella tickets.

--- a/tickets/closed/0119-budget-raise-convergence-guard.erg
+++ b/tickets/closed/0119-budget-raise-convergence-guard.erg
@@ -2,10 +2,12 @@
 Title: skill-doctor: budget-raise convergence guard — escalate after 3 consecutive raises
 Created: 2026-05-11
 Author: claude
+Closed: autoclosed — PR #139
 
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=9, sev=medium, score=18
 
+2026-05-11T16:47Z MinhHaDuong closed — autoclosed — PR #139
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add `scripts/skill-doctor-survey.py` — mines nightbeat journals, beat logs, and git history to cluster recurring automation failures by signature (freq × severity ranking)
- Add `skills/skill-doctor/SKILL.md` — user-invocable skill that runs the survey, cross-references existing tickets, and opens new tickets for unaddressed patterns
- Open 4 tickets from the first survey run (30-day window):
  - **0119**: budget-raise convergence guard — escalate after 3 consecutive raises
  - **0120**: dirty-tree abort code — `git status --porcelain` before checkout in beat.py
  - **0121**: journal-path startup assertion — fail loud on dual-journal state
  - **0122**: umbrella auto-close in pick-ticket — close when all `Blocks:` targets done

## Design choices

- Survey resolves worktree paths via git `commondir` so it works from any worktree
- 7 clusterers cover the failure signatures observed in the last 30 days of operation
- Git commit deduplication in budget-cap clusterer prevents inflation from same change on multiple branches
- Skill boundary: propose-only — opens tickets with diffs, never auto-applies patches

## Test plan

- [x] `python3 -m pytest tests/ -x -q` — 145 passed
- [x] `python3 scripts/skill-doctor-survey.py --days 30` — 5 patterns detected with correct frequencies
- [x] Syntax check passes
- [ ] Manual: run `/skill-doctor` and verify interactive flow

**Ticket:** tickets/0119, tickets/0120, tickets/0121, tickets/0122

🤖 Generated with [Claude Code](https://claude.com/claude-code)