### PR TITLE
fix(0127): skip ticket-creation branches in survey PR discovery

### DIFF
--- a/scripts/nightbeat-supervisor-survey.py
+++ b/scripts/nightbeat-supervisor-survey.py
@@ -149,13 +149,16 @@ def _list_open_prs(project_path: Path, github_repo: str) -> list[dict]:
     prs = json.loads(r.stdout or "[]")
     results = []
     for pr in prs:
-        m = re.search(r"(\d{4})", pr["headRefName"])
+        branch = pr["headRefName"]
+        if re.match(r"^open-\d{4}", branch):
+            continue
+        m = re.search(r"(\d{4})", branch)
         if m:
             results.append(
                 {
                     "ticket_id": m.group(1),
                     "pr_number": pr["number"],
-                    "branch": pr["headRefName"],
+                    "branch": branch,
                 }
             )
     return results

--- a/tests/test_nightbeat_supervisor_survey.py
+++ b/tests/test_nightbeat_supervisor_survey.py
@@ -1,0 +1,61 @@
+"""Tests for nightbeat-supervisor-survey.py — branch filtering."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+spec = importlib.util.spec_from_file_location(
+    "nightbeat_supervisor_survey", SCRIPTS / "nightbeat-supervisor-survey.py"
+)
+nbs = importlib.util.module_from_spec(spec)
+sys.modules["nightbeat_supervisor_survey"] = nbs
+spec.loader.exec_module(nbs)
+
+
+def _mock_gh_pr_list(prs: list[dict]):
+    """Return a mock for subprocess.run that returns the given PR list."""
+
+    class FakeResult:
+        returncode = 0
+        stdout = json.dumps(prs)
+
+    return FakeResult()
+
+
+def test_skips_open_ticket_creation_branches():
+    prs = [
+        {"number": 133, "headRefName": "open-0130-0131"},
+        {"number": 134, "headRefName": "t0130-extract-helpers"},
+        {"number": 135, "headRefName": "open-0042"},
+    ]
+    with patch("subprocess.run", return_value=_mock_gh_pr_list(prs)):
+        results = nbs._list_open_prs(Path("/tmp"), "owner/repo")
+    assert len(results) == 1
+    assert results[0]["pr_number"] == 134
+    assert results[0]["ticket_id"] == "0130"
+    assert results[0]["branch"] == "t0130-extract-helpers"
+
+
+def test_keeps_regular_ticket_branches():
+    prs = [
+        {"number": 10, "headRefName": "t0099-fix-parser"},
+        {"number": 11, "headRefName": "t0100-add-tests"},
+    ]
+    with patch("subprocess.run", return_value=_mock_gh_pr_list(prs)):
+        results = nbs._list_open_prs(Path("/tmp"), "owner/repo")
+    assert len(results) == 2
+    ticket_ids = {r["ticket_id"] for r in results}
+    assert ticket_ids == {"0099", "0100"}
+
+
+def test_empty_when_all_are_ticket_creation():
+    prs = [
+        {"number": 50, "headRefName": "open-0200"},
+        {"number": 51, "headRefName": "open-0201-0202"},
+    ]
+    with patch("subprocess.run", return_value=_mock_gh_pr_list(prs)):
+        results = nbs._list_open_prs(Path("/tmp"), "owner/repo")
+    assert results == []

--- a/tickets/closed/0127-survey-matches-ticket-opening-prs-as-mer.erg
+++ b/tickets/closed/0127-survey-matches-ticket-opening-prs-as-mer.erg
@@ -2,10 +2,12 @@
 Title: survey matches ticket-opening PRs as merge candidates
 Created: 2026-05-12
 Author: MinhHaDuong
+Closed: autoclosed — PR #144
 
 --- log ---
 2026-05-11T23:37Z MinhHaDuong created
 
+2026-05-12T02:34Z MinhHaDuong closed — autoclosed — PR #144
 --- body ---
 ## Problem
 


### PR DESCRIPTION
## Summary

- `_list_open_prs()` matched `open-NNNN` branches (ticket-creation PRs) as merge candidates, causing the supervisor to repeatedly HOLD on git-erg PR #133 (3 consecutive cycles)
- Added `^open-\d{4}` filter to skip these branches before ticket ID extraction
- Added 3 unit tests covering: mixed branches, all-valid branches, all-filtered branches

**Ticket:** tickets/0127-survey-matches-ticket-opening-prs-as-mer.erg

## Test plan

- [x] `pytest tests/test_nightbeat_supervisor_survey.py` — 3/3 pass
- [x] Re-ran survey with fix: `prs_to_merge` no longer includes PR #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)