### PR TITLE
feat(0132): raid merges APPROVED PRs after verify-gate + scope check

### DIFF
--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -137,7 +137,7 @@ the PR — it stays open for human review.
 
 For each eligible PR, sequentially within the wave:
 1. `git fetch origin` to pick up any prior merges.
-2. `gh pr checkout <pr-number>` — `/merge` requires being on the PR head branch.
+2. `gh pr checkout <pr-number>` — `/merge` requires being on the PR head branch. <!-- harness-extension-point -->
 3. Check PR is still mergeable (no conflicts from earlier merges in this wave).
 4. Run `/merge <pr-number>`. This atomically closes the ticket and squash-merges via GitHub API.
 5. If merge fails (conflict, CI regression), ESCALATE — leave a PR comment and move to the next PR.

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: raid
-description: Run an Imperial Dragon raid across multiple tickets. Picks targets, manages waves, enforces isolation. Always autonomous — never merges.
+description: Run an Imperial Dragon raid across multiple tickets. Picks targets, manages waves, enforces isolation. Merges APPROVED PRs after verify-gate clears.
 disable-model-invocation: false
 user-invocable: true
 argument-hint: [ticket-ids or "all open"]
@@ -12,8 +12,7 @@ effort: max
 
 A raid does not redefine skills. It calls `/start-ticket`,
 `/review-pr`, `/celebrate`, etc. Its job is sequencing, wave management,
-and enforcing invariants. It never merges — all work lands as merge requests
-for the author to review.
+and enforcing invariants.
 
 ## Balance rule
 
@@ -52,6 +51,16 @@ For each ticket, launch an agent (background, no isolation needed — read-only)
   Annotate any hits with the proposed fix.
 
 Wait for all. Commit reimagined tickets. Report scorecard.
+
+**Drift guard**: For each reimagined ticket, compare against the original:
+- Exit criteria dropped or reworded to change intent → ESCALATE.
+- New exit criteria added that weren't implied by the original → ESCALATE.
+- Scope narrowed to a strict subset of the original → allowed (simplification).
+- Implementation approach changed but exit criteria preserved → allowed (that's the point).
+
+Reimagination refines *how* to deliver, not *what* to deliver. Any ticket that
+fails the drift guard is pulled from the raid and left for human review with
+a comment explaining what the Imagine agent proposed to change and why.
 
 ## Phase 3: Plan (parallel)
 
@@ -97,8 +106,8 @@ Mood: Be strict, skeptical, nit-picky, detail-oriented. Aim for code excellence 
 5. `/verify-gate` — anti-rubber-stamp merge gate: APPROVED / REROLL / ESCALATE.
 6. On REROLL (round 1 only), `/verify` spawns a fix agent and re-gates; round 2 escalates.
 
-`/verify` never merges. The raid does not either — merges are always the
-author's call (interactive) or the `/celebrate` flow's call (autonomous).
+`/verify` never merges. Merges happen in Phase 7 after verify-gate clears
+(including its scope-containment check).
 
 **Per-wave:** after all per-ticket `/verify` runs complete, launch one integration-review
 subagent (read-only) to check:
@@ -110,28 +119,37 @@ subagent (read-only) to check:
 Wave-level findings go to the human as a wave-summary comment; they do not block
 individual `/verify` verdicts.
 
-## Phase 7: Scope audit
-
-Check each merge request for scope creep — did Execute exceed the Plan?
-
-**Inspect the branch, not a range.** Use two-dot `git log origin/main..origin/<branch> --stat`. Never use three-dot `origin/main...origin/<branch>` — that's the symmetric difference, so commits another session pushes to main while the raid runs will appear in the output and get falsely flagged as on-PR scope creep.
+## Phase 7: Merge (sequential per-wave)
 
 **Token economy rule**: Any time a ticket must be created in any phase, invoke
 `/ticket-new` — never write the file directly or compute the next ID manually.
 `/ticket-new` calls `erg next-id` and `erg validate <file>` (file arg, not
 directory), keeping mechanical work inside the tool where it belongs.
 
-For each out-of-scope finding, choose one outcome:
+For each wave, merge APPROVED PRs one at a time. A PR is merge-eligible if:
+- `/verify-gate` verdict is APPROVED (one REROLL allowed — Phase 6 handles this), AND
+- `scope_overflow` in the verdict is empty or all entries have suggested disposition
+  TICKETED (caller creates tickets via `/ticket-new` and adds `Scope overflow:
+  tickets/NNNN` to the PR body before merging).
 
-- **CLEAN** — no scope creep found; continue.
-- **TICKETED** — create a new ticket via `/ticket-new` for the out-of-scope work.
-  Leave commits in the PR. Add a line to the PR body: `Scope overflow: #NNNN`.
-  Do not rewrite git history.
-- **ESCALATE** — scope creep is present but cannot be cleanly ticketed (ambiguous
-  ownership, no clear ticket boundary, or you are uncertain). Stop. Leave a
-  comment on the merge request explaining what was found. Human decides.
+Any ESCALATE verdict (from exit criteria, review comments, or scope overflow) stops
+the PR — it stays open for human review.
 
-**Never** rebase or amend commits to excise scope creep.
+For each eligible PR, sequentially within the wave:
+1. `git fetch origin` to pick up any prior merges.
+2. `gh pr checkout <pr-number>` — `/merge` requires being on the PR head branch.
+3. Check PR is still mergeable (no conflicts from earlier merges in this wave).
+4. Run `/merge <pr-number>`. This atomically closes the ticket and squash-merges via GitHub API.
+5. If merge fails (conflict, CI regression), ESCALATE — leave a PR comment and move to the next PR.
+
+After all waves: `git checkout main && git pull --rebase origin main`, then
+`make check`. New failures → revert last merge + ticket.
+
+## Phase 8: Celebrate (per-merged-PR)
+
+After all merges, from the updated main branch, run `/celebrate` for each
+successfully merged PR. The celebrate pre-check (`git merge-base --is-ancestor
+HEAD origin/main`) passes because HEAD is main after the pull.
 
 ## Mid-session checkpoint (~50% effort)
 
@@ -150,8 +168,7 @@ Autonomous mode: ralph loop to next wave.
     grep -h ' bump ' tickets/*.erg | awk '{print $4}' | sort | uniq -c | sort -rn
     ```
     Format as: `Ticket NNNN: N bumps (X permission, Y verify-reroll, …) → Z% trivial`
-2a. Interactive mode: All work pushed, merge requests open.
-2b. Autonomous mode: All merge requests merged, main green.
+2. All merged PRs confirmed on main. Any ESCALATED PRs listed with reasons.
 3. Write briefing (session log + merge request list + test delta).
 4. Do NOT run `/end-session`.
 

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -67,6 +67,21 @@ For each review comment, the gate searches:
 
 A comment is UNRESOLVED if none of the above applies.
 
+## Scope containment
+
+After verifying exit criteria (completeness), the gate checks containment:
+does the diff include work not attributable to any exit criterion?
+
+Inspect the branch with `git log origin/main..origin/<branch> --stat` (two-dot,
+never three-dot — three-dot is symmetric difference and catches unrelated commits
+pushed to main during the raid). For each changed file, trace it to an exit
+criterion or a necessary dependency (e.g., a test file for a new function).
+
+The gate reports findings in the `scope_overflow` section of the verdict. It does
+not create tickets or edit the PR body — the caller handles disposition.
+
+Never rebase or amend commits to excise scope creep.
+
 ## Verdict shape
 
 ```yaml
@@ -104,6 +119,11 @@ unresolved_adherence_violations:
     line: <n>
     severity: blocking | nit
 
+scope_overflow:
+  - file: <path>
+    reason: "<why this change is not traceable to any exit criterion>"
+    suggested_disposition: TICKETED | ESCALATE
+
 rationale: |
   <one paragraph: what is the strongest remaining reviewer attack on this PR?
    if APPROVED, state why the evidence holds up to adversarial reading.>
@@ -129,6 +149,9 @@ second_round_needed:
 - Any `NOT_APPLIED` must-fix simplify finding without rationale → REROLL (round 1) /
   ESCALATE (round 2).
 - Any `blocking` adherence violation → REROLL (round 1) / ESCALATE (round 2).
+- Any `scope_overflow` entry with suggested disposition ESCALATE → ESCALATE.
+- `scope_overflow` entries with all suggested dispositions TICKETED → does not block
+  APPROVED. Caller handles ticket creation and PR annotation.
 - All lists empty AND all criteria ADDRESSED → APPROVED.
 
 **On REROLL**: append to the ticket file at `~/.claude/tickets/{ticket-id}-*.erg`:
@@ -169,7 +192,7 @@ blocker or a `verifiable:` minor) or files it as `consider:`.
 | "Simplify ran, no findings" | Simplify finds nits, not ticket completion; orthogonal |
 | "Reviewer concern filed as follow-up" with no ticket ID | Unverifiable; ticket must exist |
 | "Addressed in PR body" without commit | PR body is narrative; need the actual change |
-| "Edge case out of scope" without Scope audit confirmation | The Scope phase is Phase 7; gate cannot waive unilaterally |
+| "Edge case out of scope" without scope evidence | Gate must trace each changed file to an exit criterion; untraced files go in `scope_overflow` |
 | "X might break" / "could cause Y" as a minor | Ambiguous hypothesis with no reproducible evidence. |
 
 ## Standalone invocation
@@ -202,6 +225,7 @@ by invocation mode:
    Review comments: <n_unresolved> unresolved
    Simplify: <n_unresolved> must-fix not applied
    Adherence: <n_blocking> blocking violations
+   Scope overflow: <n_files> files (<n_ticketed> ticketed, <n_escalate> escalate)
 
    Minors:
    - verifiable: <count> (<n_unresolved> unresolved, blocker-adjacent)
@@ -229,4 +253,4 @@ by invocation mode:
 
 - **Merging.** The gate never merges.
 - **Re-running tests.** The gate reads results; phase 1 of `/verify-adherence` runs them.
-- **Scope audit.** That's Phase 7 of the raid, handled separately.
+- **Acting on scope overflow.** The gate detects and reports; the caller tickets and annotates.

--- a/tickets/0131-raid-token-economy-review.erg
+++ b/tickets/0131-raid-token-economy-review.erg
@@ -1,0 +1,46 @@
+%erg v1
+Title: Review token economy across raid cycle skills
+Created: 2026-05-12
+Author: claude
+
+--- log ---
+2026-05-12T10:00Z claude created
+
+--- body ---
+## Context
+
+The raid pipeline chains 8+ skills (start-ticket, verify-adherence, review,
+review-pr, simplify, verify-gate, merge, celebrate) plus the raid orchestrator
+itself. Each skill loads its full SKILL.md into context, and several repeat
+preambles, verdict shapes, or anti-pattern tables that the caller already
+injected. The cumulative token spend across a multi-ticket raid is high —
+especially on REROLL cycles where verify runs twice.
+
+## Actions
+
+1. Measure baseline: instrument a dry-run raid to log token counts per skill
+   invocation. Identify the top 3 token-heavy skills.
+2. Audit each skill's SKILL.md for repeated content — shared definitions
+   (minor tag table, verdict shape, anti-pattern lists) that appear in
+   multiple skills. Factor into a shared reference if net savings > 20%.
+3. Check whether context is cleared between raid phases. Identify phases
+   where stale context from prior phases persists without being used.
+4. Review verbose output shapes (verify-gate YAML, review-pr comment
+   templates) — can they be compacted without losing information for the
+   next consumer in the chain?
+5. Check the raid SKILL.md itself (190 lines) — can phase descriptions be
+   tightened without losing precision?
+6. Propose concrete changes with estimated token savings per raid run.
+
+## Test
+
+Run `wc -c` on all skill files in the raid pipeline before and after changes.
+Total character count should decrease by at least 15% without losing any
+decision-relevant information (verify by re-running /verify on an existing PR
+and comparing verdict quality).
+
+## Exit criteria
+
+- Token audit report with per-skill measurements
+- At least one concrete compaction applied and verified
+- No regression in verify-gate verdict quality on a test PR

--- a/tickets/0132-raid-merge-celebrate-phases.erg
+++ b/tickets/0132-raid-merge-celebrate-phases.erg
@@ -1,0 +1,48 @@
+%erg v1
+Title: Add merge and celebrate phases to raid, fold scope audit into verify-gate
+Created: 2026-05-12
+Author: claude
+
+--- log ---
+2026-05-12T10:15Z claude created
+
+--- body ---
+## Context
+
+Raid sequenced work through verify-gate but never merged — PRs were left for
+human review or nightbeat-supervisor. With growing trust in the pipeline,
+raid should close the loop: verify-gate APPROVED → merge → celebrate.
+
+Scope audit (old Phase 7) duplicated work that verify-gate could do natively
+as a scope-containment check on the diff. Folding it in simplifies the
+pipeline and keeps the per-ticket lifecycle self-contained.
+
+## Actions
+
+1. verify-gate: add scope-containment section — detect overflow, report in
+   `scope_overflow` verdict field with `suggested_disposition` (TICKETED or
+   ESCALATE). Gate stays a pure detector (context: fork).
+2. verify-gate: add `scope_overflow` to verdict shape and decision rules.
+3. raid: remove Phase 7 (scope audit) — now handled by verify-gate.
+4. raid: add Phase 7 (Merge) — sequential per-wave, `gh pr checkout` before
+   each `/merge`, handle scope_overflow ticketing before merge.
+5. raid: add Phase 8 (Celebrate) — from updated main after all merges.
+6. raid: add drift guard after Phase 2 (Imagine) — exit criteria changes
+   ESCALATE, implementation approach changes allowed.
+7. raid: remove interactive/autonomous mode split in wrap-up.
+
+## Test
+
+Diff review: verify that verify-gate verdict shape includes `scope_overflow`,
+decision rules handle TICKETED vs ESCALATE, raid Phase 7 merge flow checks
+out PR branch before `/merge`, and drift guard criteria are precise.
+
+## Exit criteria
+
+- verify-gate has scope-containment section with `scope_overflow` in verdict shape
+- verify-gate decision rules: all TICKETED does not block APPROVED, any ESCALATE → ESCALATE
+- raid Phase 7 merges sequentially per-wave with `gh pr checkout` before `/merge`
+- raid Phase 8 runs `/celebrate` from updated main
+- drift guard after Imagine: dropped/reworded exit criteria → ESCALATE
+- No stale "Phase 7 = scope audit" references remain
+- All `gh` calls annotated with harness-extension-point comment

--- a/tickets/closed/0132-raid-merge-celebrate-phases.erg
+++ b/tickets/closed/0132-raid-merge-celebrate-phases.erg
@@ -2,10 +2,12 @@
 Title: Add merge and celebrate phases to raid, fold scope audit into verify-gate
 Created: 2026-05-12
 Author: claude
+Closed: autoclosed — PR #146
 
 --- log ---
 2026-05-12T10:15Z claude created
 
+2026-05-12T06:53Z MinhHaDuong closed — autoclosed — PR #146
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0132-raid-merge-celebrate-phases.erg

## Summary

- Fold scope audit (old Phase 7) into verify-gate as a scope-containment check — the gate detects overflow and reports `suggested_disposition` (TICKETED/ESCALATE); the caller handles ticketing and PR annotation
- Add Phase 7 (Merge): sequential per-wave merge of APPROVED PRs, with `gh pr checkout` before each `/merge` call
- Add Phase 8 (Celebrate): runs `/celebrate` from updated main after all merges
- Add drift guard after Phase 2 (Imagine): exit criteria changes → ESCALATE, implementation approach changes → allowed
- Remove interactive/autonomous mode split — raid always merges now
- One REROLL allowed per PR (existing Phase 6 behavior, unchanged)
- Ticket 0131 (token economy review) rides along as a follow-up

## Test plan

- [ ] verify-gate verdict shape includes `scope_overflow` section
- [ ] verify-gate decision rules handle TICKETED vs ESCALATE scope overflow
- [ ] raid Phase 7 merge flow: checkout → mergeable check → `/merge` → error handling
- [ ] drift guard criteria after Imagine phase
- [ ] No stale "Phase 7 = scope audit" references remain
- [ ] All `gh` calls have harness-extension-point annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)