### PR TITLE
feat(0128): anchor raid briefings with git ground truth

### DIFF
--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -12,11 +12,13 @@ Usage:
 import argparse
 import json
 import re
-import subprocess  # noqa: E402 — used in _resolve_branch/_git_log_oneline
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from git_utils import _default_branch
 
 HARNESS_DIR = Path.home() / ".claude"
 LOGDIR = HARNESS_DIR / "logs" / "nightbeat"
@@ -66,15 +68,24 @@ def _resolve_branch(project: Path, ticket_id: str) -> str | None:
 
 
 def _git_log_oneline(project: Path, branch: str, max_commits: int = 5) -> list[str]:
-    """Return oneline commit subjects for branch vs origin/main."""
+    """Return oneline commit subjects for branch vs the project's default branch."""
+    default = _default_branch(project)
     try:
         out = subprocess.run(
-            ["git", "-C", str(project), "log", "--oneline", f"origin/main..{branch}"],
+            [
+                "git",
+                "-C",
+                str(project),
+                "log",
+                "--oneline",
+                f"-{max_commits}",
+                f"origin/{default}..{branch}",
+            ],
             capture_output=True,
             text=True,
             timeout=5,
         )
-        return out.stdout.splitlines()[:max_commits]
+        return out.stdout.splitlines()
     except (subprocess.TimeoutExpired, OSError):
         return []
 

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -529,7 +529,7 @@ def main() -> None:
                             print(f"    {c}")
                     else:
                         print(f"  {'─' * 40}")
-                        print("  Git: branch exists but no commits ahead of main")
+                        print("  Git: branch exists but no new commits vs default")
                 else:
                     print(f"  {'─' * 40}")
                     print("  Git: branch not found (merged or deleted)")

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -12,6 +12,7 @@ Usage:
 import argparse
 import json
 import re
+import subprocess  # noqa: E402 — used in _resolve_branch/_git_log_oneline
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -35,6 +36,46 @@ def _load_rotation_projects() -> list[Path]:
         entries = json.loads(PROJECTS_CONFIG.read_text())
         return [Path(e["path"]).expanduser() for e in entries]
     except Exception:
+        return []
+
+
+def _resolve_branch(project: Path, ticket_id: str) -> str | None:
+    """Find remote branch matching t{ticket_id}-* for a project."""
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(project),
+                "branch",
+                "-r",
+                "--list",
+                f"origin/t{ticket_id}-*",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        for line in out.stdout.splitlines():
+            branch = line.strip()
+            if branch:
+                return branch
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def _git_log_oneline(project: Path, branch: str, max_commits: int = 5) -> list[str]:
+    """Return oneline commit subjects for branch vs origin/main."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(project), "log", "--oneline", f"origin/main..{branch}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return out.stdout.splitlines()[:max_commits]
+    except (subprocess.TimeoutExpired, OSError):
         return []
 
 
@@ -465,6 +506,22 @@ def main() -> None:
                 )
             for ln in text.splitlines():
                 print(f"  {ln}")
+
+            if run.project and run.ticket_id:
+                branch = _resolve_branch(run.project, run.ticket_id)
+                if branch:
+                    commits = _git_log_oneline(run.project, branch)
+                    if commits:
+                        print(f"  {'─' * 40}")
+                        print("  Git (ground truth):")
+                        for c in commits:
+                            print(f"    {c}")
+                    else:
+                        print(f"  {'─' * 40}")
+                        print("  Git: branch exists but no commits ahead of main")
+                else:
+                    print(f"  {'─' * 40}")
+                    print("  Git: branch not found (merged or deleted)")
 
     # ── Issues ──────────────────────────────────────────────────────────────────
     issues: list[str] = []

--- a/tests/test_nightbeat_report.py
+++ b/tests/test_nightbeat_report.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
 spec = importlib.util.spec_from_file_location(
     "nightbeat_report", SCRIPTS / "nightbeat-report.py"
 )

--- a/tickets/0126-verify-gate-ignores-repo-arg-for-cross-r.erg
+++ b/tickets/0126-verify-gate-ignores-repo-arg-for-cross-r.erg
@@ -5,6 +5,7 @@ Author: MinhHaDuong
 
 --- log ---
 2026-05-11T23:37Z MinhHaDuong created
+2026-05-12T06:00Z MinhHaDuong note audit complete — scope wider than original ticket
 
 --- body ---
 ## Problem
@@ -19,19 +20,38 @@ Every cross-repo PR the survey discovers will hit this wall until fixed.
 
 ## Root cause
 
-The verify-gate skill (and likely the merge skill) invokes `gh pr view`
-without `--repo <owner/repo>`, so the GitHub CLI defaults to the current
-working directory's git remote.
+Three layers are missing `--repo`:
+
+1. **erg-pr-merge script** (`skills/merge/erg-pr-merge`) — 3 `gh pr view`
+   calls at lines 30, 36, 67 lack `--repo`. These are the hardest failures.
+2. **verify-gate SKILL.md** — prose instructions tell the agent to run
+   `gh pr view` but don't mention `--repo`. The agent inherits cwd context.
+3. **Supervisor wiring** — supervisor knows `github_repo` from the survey
+   but doesn't pass it when invoking `/verify-gate` or `/merge`.
+
+The survey (`nightbeat-supervisor-survey.py:135`) and `check-pr-diff`
+already use `--repo` correctly — the gap is downstream.
 
 ## Plan
 
-1. Audit the verify-gate SKILL.md and any helper scripts for `gh pr` or
-   `gh api` calls that lack `--repo`.
-2. Thread the repo argument through all GitHub CLI calls.
-3. Add a test case: verify-gate from a different repo's worktree against
-   a cross-repo PR number.
+### Layer 1: erg-pr-merge (shell script)
+- Accept optional `$GH_REPO` env var or positional arg for repo
+- Pass `--repo "$GH_REPO"` to `gh pr view` at lines 30, 36, 67
+- Fallback: if unset, derive from `git remote get-url origin` (current behavior)
+
+### Layer 2: verify-gate SKILL.md
+- Add instruction: "When a repo argument is provided, pass `--repo <repo>`
+  to all `gh pr` and `gh api` calls"
+- Same for verify/SKILL.md and raid/SKILL.md line 142 (`/merge` invocation)
+
+### Layer 3: Supervisor
+- nightbeat-supervisor SKILL.md line 35: pass repo when invoking
+  `/verify-gate` and `/merge`
+- Set `GH_REPO` env var before calling erg-pr-merge
 
 ## Exit criteria
 
-- `gh pr view` calls in verify-gate use `--repo` when a repo arg is provided.
-- Supervisor can verify-gate a git-erg PR from a harness worktree.
+- `gh pr view` calls in erg-pr-merge use `--repo` when `GH_REPO` is set
+- verify-gate SKILL.md instructs agents to use `--repo` for cross-repo PRs
+- Supervisor passes repo context through the full verify-gate → merge chain
+- Manual test: verify-gate a git-erg PR from a harness worktree succeeds

--- a/tickets/0128-anchor-raid-briefings-with-git-ground-tr.erg
+++ b/tickets/0128-anchor-raid-briefings-with-git-ground-tr.erg
@@ -1,0 +1,46 @@
+%erg v1
+Title: Anchor raid briefings with git ground truth in nightbeat report
+Created: 2026-05-12
+Author: MinhHaDuong
+
+--- log ---
+2026-05-12T05:30Z MinhHaDuong created
+
+--- body ---
+## Problem
+
+nightbeat-report.py displays raid briefings verbatim from the agent's
+`result_text`. These briefings can misrepresent the actual fix — t0124
+said "added harness-extension-point annotation" but the commit removed
+the gh reference instead. No ground truth is shown alongside the briefing.
+
+## Root cause
+
+The report has `project` (repo path) and `ticket_id` but never queries
+git. Line 460 of nightbeat-report.py prints result_text as-is.
+
+## Plan
+
+In the RAID RESULTS section of nightbeat-report.py (~line 460), after
+printing the briefing text, resolve the actual branch and append a
+"Git (ground truth)" block:
+
+1. From `run.project` and `run.ticket_id`, find branches matching
+   `t{ticket_id}-*` via `git -C <project> branch -r --list 'origin/t{id}-*'`
+2. If a branch is found, run `git -C <project> log --oneline origin/main..origin/<branch>`
+   (capped at 5 commits)
+3. Print the result indented under a `Git` separator, below the
+   briefing text
+4. If no branch is found (already merged/deleted), print a note
+
+This is ~20 lines in nightbeat-report.py. No changes to beat.py or raid
+SKILL.md.
+
+## Exit criteria
+
+- `nightbeat-report.py --full` shows actual commit subjects alongside
+  each raid briefing that has a resolvable branch
+- When the branch is gone (merged+deleted), a note says so rather than
+  silently omitting
+- No new dependencies; git is already available in the nightbeat
+  environment

--- a/tickets/closed/0128-anchor-raid-briefings-with-git-ground-tr.erg
+++ b/tickets/closed/0128-anchor-raid-briefings-with-git-ground-tr.erg
@@ -2,10 +2,12 @@
 Title: Anchor raid briefings with git ground truth in nightbeat report
 Created: 2026-05-12
 Author: MinhHaDuong
+Closed: autoclosed — PR #147
 
 --- log ---
 2026-05-12T05:30Z MinhHaDuong created
 
+2026-05-12T07:28Z MinhHaDuong closed — autoclosed — PR #147
 --- body ---
 ## Problem
 


### PR DESCRIPTION
## Summary

- Raid briefings are LLM-authored prose that can misrepresent the actual fix — t0124 said "added harness-extension-point" but the commit removed the `gh` reference instead
- `nightbeat-report.py` now resolves the branch for each raid result and appends actual commit subjects as a ground-truth anchor below the briefing
- When a branch is already merged/deleted, a note says so rather than silently omitting

## Test plan

- [x] `nightbeat-report.py --full` shows git commits under raid briefings with resolvable branches
- [x] Merged/deleted branches show "branch not found (merged or deleted)"
- [x] Non-`--full` mode works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)