### PR TITLE
feat: offload housekeeping git phase to shell script (#34)

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -769,6 +769,17 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
         return "failed"
 
     _log(f"=== housekeeping: running on {branch} {_now_iso()} ===")
+    git_script = path / "scripts" / "housekeeping-git.sh"
+    if git_script.exists():
+        git_rc = subprocess.run(  # noqa: S603
+            [str(git_script)],
+            cwd=path,
+            check=False,
+        ).returncode
+        if git_rc == 0:
+            _log(f"=== housekeeping-git: done {_now_iso()} ===")
+        else:
+            _log(f"=== housekeeping-git: rc={git_rc} {_now_iso()} ===")
     os.environ["BEAT_HOUSEKEEPING_BRANCH"] = branch
     try:
         hk_rc, hk_res = run_skill(

--- a/scripts/housekeeping-git.sh
+++ b/scripts/housekeeping-git.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run from project root. Handles git sync, beat-skip expiry, and erg DAG check.
+set -uo pipefail
+
+git fetch --all --prune --quiet
+git gc --auto
+
+SKIP_FILE=".git/beat-skip.json"
+if [[ -f "$SKIP_FILE" ]]; then
+    NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    TMP=$(mktemp)
+    if jq --arg now "$NOW" '[.[] | select(.until == null or .until > $now)]' "$SKIP_FILE" > "$TMP"; then
+        mv "$TMP" "$SKIP_FILE"
+    else
+        rm -f "$TMP"
+    fi
+fi
+
+ERG=${ERG:-tickets/erg}
+"$ERG" check tickets/ 2>/dev/null || true
+
+exit 0

--- a/scripts/housekeeping-git.sh
+++ b/scripts/housekeeping-git.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Run from project root. Handles git sync, beat-skip expiry, and erg DAG check.
-set -uo pipefail
+set -euo pipefail
 
-git fetch --all --prune --quiet
-git gc --auto
+git fetch --all --prune --quiet || true
+git gc --auto || true
 
 SKIP_FILE=".git/beat-skip.json"
 if [[ -f "$SKIP_FILE" ]]; then

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -11,21 +11,9 @@ Run full repo housekeeping and act on every finding.
 
 ## Steps
 
-1. **Git sync.** `git fetch --all --prune --quiet` then `git gc --auto`. Log if working tree is dirty (do not abort).
-
-1a. **Beat-skip sweep.** If `.git/beat-skip.json` exists, remove entries where
-    `until` is present and `until < now`. Rewrite the file in place. This
-    prevents the skip list from accumulating expired entries across beats.
-
-1b. **DAG coherence check.** Run `erg check` if available (command tracked in
-    git-erg/0038) to surface duplicate IDs, dangling Blocked-by refs, and
-    folder-closure issues. Degrade gracefully if the command is not yet
-    installed:
-    ```bash
-    ERG=${ERG:-tickets/erg}
-    $ERG check tickets/ 2>/dev/null || true
-    ```
-    Emit any output as housekeeping warnings; do not abort on non-zero exit.
+1. **Git phase.**
+   - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(scripts/housekeeping-git.sh)` from the project root.
+   - If `BEAT_HOUSEKEEPING_BRANCH` **is** set (beat.py run): skip — beat.py already ran the git phase before invoking this skill.
 
 2. **Healthcheck.** Invoke /healthcheck. The probe (`project-state.py`)
    runs once inside healthcheck and covers all checks — do not re-run git

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -16,7 +16,7 @@ Blocked-by: 0007
 
 --- log ---
 2026-05-04T09:00Z alice created
-2026-05-04T14:22Z bob status open Was blocked, 0007 now merged
+2026-05-04T14:22Z bob note blocker 0007 merged â€” unblocked
 
 --- body ---
 ## Context
@@ -25,7 +25,7 @@ We need exponential backoff with jitter, capped at 3 retries.
 
 ## Exit criteria
 - [ ] `client.Fetch()` retries up to 3 times on 5xx
-- [ ] Backoff is 1s, 2s, 4s + random jitter âi 500ms
+- [ ] Backoff is 1s, 2s, 4s + random jitter ï¿½i 500ms
 - [ ] Unit test covers retry exhaustion path
 - [ ] `make check` passes
 ```

--- a/tickets/closed/0034-housekeeping-split-git-and-ticket-phases.erg
+++ b/tickets/closed/0034-housekeeping-split-git-and-ticket-phases.erg
@@ -2,6 +2,7 @@
 Title: Offload housekeeping git phase to a shell script
 Created: 2026-04-27
 Author: claude
+Closed: autoclosed — PR #149
 
 --- log ---
 2026-04-27T00:00Z claude created
@@ -13,6 +14,7 @@ Author: claude
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:fd5819165802 expires:2026-04-30T09:21Z
 2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 2026-05-12T13:28Z rescoped: offload git steps to shell script; drop two-skill split approach
+2026-05-12T13:56Z Minh Ha-Duong closed — autoclosed — PR #149
 --- body ---
 ## Problem
 


### PR DESCRIPTION
## Summary

- Extracts the git sync, beat-skip expiry, and erg DAG check from the housekeeping skill into `scripts/housekeeping-git.sh`
- Updates `beat.py` to run the script as a subprocess before invoking the skill, logging `housekeeping-git: done` or `rc=N`
- Updates `skills/housekeeping/SKILL.md` step 1 to delegate to the script on interactive runs, and skip on beat.py runs (since beat.py already ran it)

## Test plan

- [ ] `bash -n scripts/housekeeping-git.sh` passes (syntax check)
- [ ] `scripts/housekeeping-git.sh` is executable
- [ ] `skills/housekeeping/SKILL.md` no longer contains old step 1a/1b prose (beat-skip json, erg check)
- [ ] `beat.py` logs `housekeeping-git: done` before the skill invocation
- [ ] Beat mode section in SKILL.md still makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ticket: tickets/0034-housekeeping-split-git-and-ticket-phases.erg