### PR TITLE
chore: remove git-erg from nightbeat targets

### DIFF
--- a/scripts/projects.json
+++ b/scripts/projects.json
@@ -1,5 +1,4 @@
 [
   { "path": "~/chemin-de-voix" },
-  { "path": "~/.claude" },
-  { "path": "~/git-erg" }
+  { "path": "~/.claude" }
 ]

--- a/tickets/0136-remove-git-erg-from-nightbeat-targets.erg
+++ b/tickets/0136-remove-git-erg-from-nightbeat-targets.erg
@@ -1,0 +1,12 @@
+%erg 0.1
+Title: remove git-erg from nightbeat targets
+Created: 2026-05-12
+Author: MinhHaDuong
+
+--- log ---
+2026-05-12T14:48Z MinhHaDuong created
+
+--- body ---
+No open tickets in git-erg repo — remove it from `scripts/projects.json` to avoid wasting beat budget.
+
+Exit criteria: `scripts/projects.json` lists only `chemin-de-voix` and `~/.claude`.


### PR DESCRIPTION
Ticket: tickets/0136-remove-git-erg-from-nightbeat-targets.erg

## Summary
- Remove \`~/git-erg\` from \`scripts/projects.json\` — no open tickets in that repo, no point spending beat budget there.

## Test plan
- [x] \`scripts/projects.json\` lists only \`chemin-de-voix\` and \`~/.claude\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)