### PR TITLE
fix(0126): cwd contract for cross-repo verify-gate and merge

### DIFF
--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -12,4 +12,10 @@ Run:
 ~/.claude/skills/merge/erg-pr-merge $ARGUMENTS
 ```
 
+**Cross-repo prerequisite**: the caller must ensure cwd is the target
+project and the PR branch is checked out before invoking `/merge`. For
+cross-repo flows, this means `cd <project-path> && git fetch origin &&
+gh pr checkout <pr-number>` before the call. The script itself is
+cwd-based — it never takes a repo or path argument.
+
 Report stdout/stderr verbatim. If the script exits non-zero, stop and show the error.

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -14,8 +14,8 @@ Run:
 
 **Cross-repo prerequisite**: the caller must ensure cwd is the target
 project and the PR branch is checked out before invoking `/merge`. For
-cross-repo flows, this means `cd <project-path> && git fetch origin &&
-gh pr checkout <pr-number>` before the call. The script itself is
+cross-repo flows, this means `cd <project-path> && git fetch origin`
+and checking out the PR branch before the call. The script itself is
 cwd-based — it never takes a repo or path argument.
 
 Report stdout/stderr verbatim. If the script exits non-zero, stop and show the error.

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -6,6 +6,10 @@
 # Must be run from the PR's head branch. Works in git worktrees and on VMs.
 # GitHub-only: requires the GitHub CLI authenticated to the repo's GitHub remote.
 #
+# For cross-repo merges, the caller must cd into the target project and
+# `gh pr checkout <pr>` before invoking this script. See raid Phase 7
+# and nightbeat-supervisor Phase 2 for the caller contracts.
+#
 # Happy path:
 #   0. Verify: on PR head branch, CI green, no conflicts
 #   1. Find ticket ID from "Ticket: tickets/NNNN-..." in PR body (or title fallback)

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -7,7 +7,7 @@
 # GitHub-only: requires the GitHub CLI authenticated to the repo's GitHub remote.
 #
 # For cross-repo merges, the caller must cd into the target project and
-# `gh pr checkout <pr>` before invoking this script. See raid Phase 7
+# checkout the PR branch before invoking this script. See raid Phase 7
 # and nightbeat-supervisor Phase 2 for the caller contracts.
 #
 # Happy path:

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -28,11 +28,18 @@ If both lists are empty, write a journal `action=idle` entry and stop.
 
 ## 2. Merge ready PRs
 
-For each entry in `prs_to_merge` (which includes `pr_number` and `github_repo`
-derived by the survey script from the project's git remote):
+For each entry in `prs_to_merge` (which includes `pr_number`, `github_repo`,
+and `project_path` derived by the survey script from the project's git remote):
 
 1. `bash $HARNESS_DIR/skills/nightbeat-supervisor/check-pr-diff <pr_number> <github_repo>` — non-zero exit is a HOLD; add to failures with the script's reason.
-2. `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body) and move on. ESCALATE → go to step 4.
+2. Switch to the target project and check out the PR branch:
+   ```bash
+   cd <project_path>
+   git fetch origin
+   gh pr checkout <pr_number> --repo <github_repo>   # harness-extension-point
+   ```
+   Then: `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body) and move on. ESCALATE → go to step 4.
+   After verify-gate and merge complete, `cd $HARNESS_DIR` to return to the harness directory for the next PR.
 
 ## 3. Diagnose and repair
 

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -47,6 +47,12 @@ Either:
 Both paths produce the same verdict shape. Round is always derived from PR comment
 history (see "Standalone invocation"), never passed by the caller.
 
+**Cross-repo prerequisite**: the caller must ensure cwd is the target project
+before invoking `/verify-gate`. The gate uses `gh` and `git` commands that resolve
+against cwd — running from a different repo's worktree will produce wrong results.
+For cross-repo flows, the caller does `cd <project-path> && git fetch origin`
+before invoking the gate.
+
 ## Evidence discovery
 
 For each ticket exit criterion, the gate searches:

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -26,6 +26,9 @@ Merge is always the human's or the raid's call.
 - The fix loop between rounds makes commits on the PR branch; no changes to other branches.
 - `--force-approve` is supported for explicit human override; it is logged loudly in the
   PR comments and the skill transcript.
+- **Cross-repo prerequisite**: the caller must ensure cwd is the target project before
+  invoking `/verify`. The skill and its sub-skills (`/verify-gate`, `/simplify`, etc.)
+  use `gh` and `git` commands that resolve against cwd.
 
 ## Phases
 

--- a/tickets/0126-verify-gate-ignores-repo-arg-for-cross-r.erg
+++ b/tickets/0126-verify-gate-ignores-repo-arg-for-cross-r.erg
@@ -6,6 +6,7 @@ Author: MinhHaDuong
 --- log ---
 2026-05-11T23:37Z MinhHaDuong created
 2026-05-12T06:00Z MinhHaDuong note audit complete — scope wider than original ticket
+2026-05-12T09:00Z MinhHaDuong note design decision: cwd contract (forge-neutral) — caller cd's into target project before verify-gate/merge
 
 --- body ---
 ## Problem
@@ -32,26 +33,45 @@ Three layers are missing `--repo`:
 The survey (`nightbeat-supervisor-survey.py:135`) and `check-pr-diff`
 already use `--repo` correctly — the gap is downstream.
 
+## Design decision
+
+**Contract**: cwd-based. The caller (supervisor, raid) ensures cwd is the
+target project and the PR branch is checked out before invoking
+`/verify-gate` and `/merge`. No forge slug or project-path argument on
+skills or scripts.
+
+**Why cwd instead of project-path arg**: verify-gate runs `git log`,
+erg-pr-merge runs `git branch --show-current`, `git add tickets/`,
+`git push` — all cwd-dependent. Patching just the `gh` calls with
+`--repo` leaves dozens of `git` operations pointing at the wrong repo.
+The only clean fix is cwd.
+
+**Why forge-neutral**: the supervisor passes `project_path` (filesystem
+path) to `cd`, not a GitHub slug. The GitHub slug only appears in
+`check-pr-diff` and `gh pr checkout --repo`, behind
+`# harness-extension-point` lines.
+
+**Consistency with raid**: raid Phase 7 already does `gh pr checkout`
+before `/merge`. The supervisor now mirrors this pattern.
+
 ## Plan
 
 ### Layer 1: erg-pr-merge (shell script)
-- Accept optional `$GH_REPO` env var or positional arg for repo
-- Pass `--repo "$GH_REPO"` to `gh pr view` at lines 30, 36, 67
-- Fallback: if unset, derive from `git remote get-url origin` (current behavior)
+- No argument changes — script stays cwd-based
+- Update header comment to document the cross-repo caller contract
 
-### Layer 2: verify-gate SKILL.md
-- Add instruction: "When a repo argument is provided, pass `--repo <repo>`
-  to all `gh pr` and `gh api` calls"
-- Same for verify/SKILL.md and raid/SKILL.md line 142 (`/merge` invocation)
+### Layer 2: SKILL.md instructions
+- verify-gate, verify, merge: add cross-repo prerequisite note
+  (caller ensures cwd is target project)
+- raid: no change (already does `gh pr checkout` before `/merge`)
 
 ### Layer 3: Supervisor
-- nightbeat-supervisor SKILL.md line 35: pass repo when invoking
-  `/verify-gate` and `/merge`
-- Set `GH_REPO` env var before calling erg-pr-merge
+- Phase 2: add `cd <project_path> && git fetch && gh pr checkout`
+  before `/verify-gate` and `/merge`
 
 ## Exit criteria
 
-- `gh pr view` calls in erg-pr-merge use `--repo` when `GH_REPO` is set
-- verify-gate SKILL.md instructs agents to use `--repo` for cross-repo PRs
-- Supervisor passes repo context through the full verify-gate → merge chain
+- Supervisor SKILL.md instructs agents to cd + checkout before verify-gate/merge
+- verify-gate, verify, merge SKILL.md document the cwd prerequisite
+- erg-pr-merge header documents the cross-repo caller contract
 - Manual test: verify-gate a git-erg PR from a harness worktree succeeds

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -16,7 +16,7 @@ Blocked-by: 0007
 
 --- log ---
 2026-05-04T09:00Z alice created
-2026-05-04T14:22Z bob status open Was blocked, 0007 now merged
+2026-05-04T14:22Z bob note Was blocked, 0007 now merged
 
 --- body ---
 ## Context

--- a/tickets/closed/0126-verify-gate-ignores-repo-arg-for-cross-r.erg
+++ b/tickets/closed/0126-verify-gate-ignores-repo-arg-for-cross-r.erg
@@ -2,12 +2,14 @@
 Title: verify-gate ignores --repo arg for cross-repo PRs
 Created: 2026-05-12
 Author: MinhHaDuong
+Closed: autoclosed — PR #152
 
 --- log ---
 2026-05-11T23:37Z MinhHaDuong created
 2026-05-12T06:00Z MinhHaDuong note audit complete — scope wider than original ticket
 2026-05-12T09:00Z MinhHaDuong note design decision: cwd contract (forge-neutral) — caller cd's into target project before verify-gate/merge
 
+2026-05-12T18:42Z MinhHaDuong closed — autoclosed — PR #152
 --- body ---
 ## Problem
 


### PR DESCRIPTION
## Summary

- Supervisor Phase 2 now `cd`s into the target project and runs `gh pr checkout` before invoking `/verify-gate` and `/merge`, mirroring raid Phase 7's existing pattern
- verify-gate, verify, and merge SKILL.md document the cwd prerequisite for cross-repo callers
- erg-pr-merge header documents the cross-repo caller contract
- Ticket 0126 updated with design decision rationale (cwd contract vs project-path arg vs env var)

**Ticket:** tickets/0126-verify-gate-ignores-repo-arg-for-cross-r.erg

## Test plan

- [ ] Run supervisor survey against a multi-project config with at least one cross-repo PR
- [ ] Verify supervisor agent reads the cd + checkout instructions and switches to the target project before verify-gate
- [ ] Verify same-repo flows (raid, manual `/merge`) are unaffected (no new args required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)