### PR TITLE
fix(0120): detect dirty working tree before beat checkout

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -954,6 +954,15 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     # Ensure working tree is on main before any read or write.
     # Fails fast with a clear message if the tree is dirty.
     default_branch = _default_branch(path)
+
+    status = _git("status", "--porcelain", cwd=path)
+    if status.stdout.strip():
+        dirty_files = status.stdout.strip().splitlines()[:5]
+        detail = f"{len(dirty_files)} file(s): {', '.join(dirty_files[:3])}"
+        _log(f"=== beat aborted: dirty working tree: {detail} ===")
+        _record_phase_outcome(path, "raid", "aborted-dirty-tree", detail=detail)
+        return "aborted-dirty-tree", None
+
     r = _git("checkout", default_branch, cwd=path)
     if r.returncode != 0:
         detail = (r.stderr or r.stdout or "").strip().replace("\n", " | ")

--- a/scripts/nightbeat-supervisor-survey.py
+++ b/scripts/nightbeat-supervisor-survey.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 HARNESS_DIR = Path(__file__).parent.parent
-FAILURE_OUTCOMES = {"fail", "budget", "timeout"}
+FAILURE_OUTCOMES = {"fail", "budget", "timeout", "aborted-dirty-tree"}
 
 
 def _expand(p: str) -> Path:

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -63,6 +63,10 @@ When you reach a root cause, repair if within authority:
   independent unit of work; convert the parent to an umbrella by adding
   `Blocks: <id>...` and leaving it open (it may be blocking other tickets).
 - **Dead timer** → restart it.
+- **Dirty working tree** (`outcome=aborted-dirty-tree`) → if the dirty files
+  are machine-local state (beat-outcomes.jsonl, STATE.md, build artifacts),
+  commit or stash them; otherwise open a ticket naming the dirty files and
+  their likely source.
 
 If the why-chain bottoms out without reaching anything repairable: escalate
 (step 4).

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -671,6 +671,37 @@ class TestRaidClosedLoop:
         assert ticket is None
 
 
+# ── _raid dirty-tree guard (ticket 0120) ──────────────────────────────────────
+
+
+class TestRaidDirtyTree:
+    """Ticket 0120: _raid returns ("aborted-dirty-tree", None) when the
+    working tree has uncommitted changes, and never proceeds to checkout."""
+
+    def test_dirty_tree_aborts_before_checkout(self, tmp_project):
+        checkout_called = []
+
+        def fake_git(*args, cwd):
+            sub = args[0] if args else ""
+            if sub == "status":
+                return MagicMock(returncode=0, stdout="M scripts/beat.py\n", stderr="")
+            if sub == "checkout":
+                checkout_called.append(args)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("beat._sync_origin_main"),
+            patch("beat._default_branch", return_value="main"),
+            patch("beat._git", side_effect=fake_git),
+            patch("beat._record_phase_outcome"),
+        ):
+            outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
+
+        assert outcome == "aborted-dirty-tree"
+        assert ticket is None
+        assert checkout_called == [], "checkout must not be called on a dirty tree"
+
+
 # ── housekeeping phase: dedicated branch + PR flow (ticket 0072) ──────────────
 
 

--- a/tickets/0120-dirty-tree-abort-code.erg
+++ b/tickets/0120-dirty-tree-abort-code.erg
@@ -5,6 +5,8 @@ Author: claude
 
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=12, sev=medium, score=24
+2026-05-12T00:00Z claude note imagine: fix belongs in _raid() line 957, not _sync_origin_main(); beat-outcomes.jsonl already exists via _record_phase_outcome()
+2026-05-12T00:00Z claude note implemented: dirty-tree guard in _raid() + supervisor repair rule
 
 2026-05-12T20:00Z note verify-gate round=2 APPROVED — all exit criteria addressed, round-1 blockers resolved in commit 5eb432c
 --- body ---

--- a/tickets/closed/0120-dirty-tree-abort-code.erg
+++ b/tickets/closed/0120-dirty-tree-abort-code.erg
@@ -2,6 +2,7 @@
 Title: skill-doctor: dirty tree blocks beat checkout — abort with structured error
 Created: 2026-05-11
 Author: claude
+Closed: autoclosed — PR #154
 
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=12, sev=medium, score=24
@@ -9,6 +10,7 @@ Author: claude
 2026-05-12T00:00Z claude note implemented: dirty-tree guard in _raid() + supervisor repair rule
 
 2026-05-12T20:00Z note verify-gate round=2 APPROVED — all exit criteria addressed, round-1 blockers resolved in commit 5eb432c
+2026-05-12T20:06Z MinhHaDuong closed — autoclosed — PR #154
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
- Adds `git status --porcelain` guard in `_raid()` (beat.py ~line 957) before git checkout
- Returns `aborted-dirty-tree` outcome for structured supervisor handling
- Documents dirty-tree repair rule in nightbeat-supervisor SKILL.md

## Test plan
- [ ] Dirty working tree → beat logs "aborted: dirty working tree" + returns `aborted-dirty-tree`
- [ ] Clean working tree → beat proceeds normally (no regression)
- [ ] Supervisor SKILL.md step 3 includes dirty-tree repair rule

Closes #0120
🤖 Generated with [Claude Code](https://claude.com/claude-code)