### PR TITLE
fix(0129): remove restated verify pipeline from raid Phase 6

### DIFF
--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -97,17 +97,7 @@ Wait for wave to complete.
 
 Mood: Be strict, skeptical, nit-picky, detail-oriented. Aim for code excellence and integrity.
 
-**Per-ticket:** invoke `/verify <pr-number>` on each merge request. The skill runs:
-
-1. `/verify-adherence` — mechanical-first rule check (tests + grep ratchet before LLM).
-2. `/review` (built-in) — standard review.
-3. `/review-pr` or `/review-pr-prose` — file-type heuristic.
-4. `/simplify` — reuse/quality/efficiency, applies fixes.
-5. `/verify-gate` — anti-rubber-stamp merge gate: APPROVED / REROLL / ESCALATE.
-6. On REROLL (round 1 only), `/verify` spawns a fix agent and re-gates; round 2 escalates.
-
-`/verify` never merges. Merges happen in Phase 7 after verify-gate clears
-(including its scope-containment check).
+**Per-ticket:** invoke `/verify <pr-number>` on each merge request.
 
 **Per-wave:** after all per-ticket `/verify` runs complete, launch one integration-review
 subagent (read-only) to check:

--- a/tickets/0120-dirty-tree-abort-code.erg
+++ b/tickets/0120-dirty-tree-abort-code.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=12, sev=medium, score=24
 
+2026-05-12T20:00Z note verify-gate round=2 APPROVED — all exit criteria addressed, round-1 blockers resolved in commit 5eb432c
 --- body ---
 ## Context
 

--- a/tickets/0129-deduplicate-verify-chain-in-raid.erg
+++ b/tickets/0129-deduplicate-verify-chain-in-raid.erg
@@ -5,6 +5,8 @@ Author: claude
 
 --- log ---
 2026-05-12T08:00Z claude created
+2026-05-12T00:00Z claude note imagine: lines to remove are 100-110 (not 91-98); mood line 98 and integration review 112-120 preserved
+2026-05-12T00:00Z claude note implemented: removed 9-line verify pipeline restatement from Phase 6
 
 --- body ---
 ## Context

--- a/tickets/closed/0129-deduplicate-verify-chain-in-raid.erg
+++ b/tickets/closed/0129-deduplicate-verify-chain-in-raid.erg
@@ -2,12 +2,14 @@
 Title: Remove restated verify pipeline from raid Phase 6
 Created: 2026-05-12
 Author: claude
+Closed: autoclosed — PR #155
 
 --- log ---
 2026-05-12T08:00Z claude created
 2026-05-12T00:00Z claude note imagine: lines to remove are 100-110 (not 91-98); mood line 98 and integration review 112-120 preserved
 2026-05-12T00:00Z claude note implemented: removed 9-line verify pipeline restatement from Phase 6
 
+2026-05-12T20:04Z MinhHaDuong closed — autoclosed — PR #155
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
- Removes 9-line verify pipeline restatement from raid/SKILL.md Phase 6 (lines 100-110)
- Replaces with single delegation line: invoke `/verify <pr-number>`
- Mood line (98) and per-wave integration review (112-120) preserved

## Test plan
- [ ] Phase 6 section ≤15 lines after edit
- [ ] No pipeline steps 1-6 remain in Phase 6
- [ ] Per-wave integration review block unchanged

Closes #0129
🤖 Generated with [Claude Code](https://claude.com/claude-code)