### PR TITLE
fix(0138): erg-pr-merge waits for CI before merge API

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -95,14 +95,15 @@ if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; t
         git commit -m "ticket(${TICKET_ID}): close and archive — PR #${PR}"
     fi
     git push origin HEAD
-    echo "Waiting for CI after ticket-close commit..." # harness-extension-point
+    echo "Waiting for CI after ticket-close commit..."
+    # harness-extension-point
     timeout 600 gh pr checks "$PR" --watch --fail-fast \
-        || die "CI failed after ticket-close commit — aborting merge"
+        || die "CI did not pass within 600s (failed or timed out) — aborting merge"
 elif [[ -n "$TICKET_ID" ]]; then
     echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"
 fi
 
-# ── Step 3: squash-merge via GitHub API (works in worktrees and on VMs) ──────
+# ── Step 3: squash-merge via forge CLI (works in worktrees and on VMs) ───────
 
 echo "Merging PR #${PR}..."
 gh pr merge "$PR" --squash --delete-branch # harness-extension-point

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -14,7 +14,8 @@
 #   0. Verify: on PR head branch, CI green, no conflicts
 #   1. Find ticket ID from "Ticket: tickets/NNNN-..." in PR body (or title fallback)
 #   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push
-#   3. Squash-merge + delete remote branch via GitHub API (no local git ops)
+#   2a. Wait for CI to pass on ticket-close commit (timeout 600s)
+#   3. Squash-merge + delete remote branch via gh pr merge --squash --delete-branch
 #   4. If not in worktree: git checkout base && git pull --rebase
 
 set -euo pipefail
@@ -94,6 +95,9 @@ if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; t
         git commit -m "ticket(${TICKET_ID}): close and archive — PR #${PR}"
     fi
     git push origin HEAD
+    echo "Waiting for CI after ticket-close commit..."
+    timeout 600 gh pr checks "$PR" --watch --fail-fast \
+        || die "CI failed after ticket-close commit — aborting merge"
 elif [[ -n "$TICKET_ID" ]]; then
     echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"
 fi
@@ -101,12 +105,7 @@ fi
 # ── Step 3: squash-merge via GitHub API (works in worktrees and on VMs) ──────
 
 echo "Merging PR #${PR}..."
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner') # harness-extension-point
-gh api "repos/${REPO}/pulls/${PR}/merge" -X PUT -f merge_method=squash # harness-extension-point
-# harness-extension-point: GitHub API branch delete
-gh api "repos/${REPO}/git/refs/heads/${PR_BRANCH}" -X DELETE 2>/dev/null \
-    && echo "Deleted remote branch ${PR_BRANCH}" \
-    || echo "Note: remote branch ${PR_BRANCH} already gone"
+gh pr merge "$PR" --squash --delete-branch # harness-extension-point
 
 # ── Step 4: return to base branch (skipped inside a worktree) ────────────────
 

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -15,7 +15,7 @@
 #   1. Find ticket ID from "Ticket: tickets/NNNN-..." in PR body (or title fallback)
 #   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push
 #   2a. Wait for CI to pass on ticket-close commit (timeout 600s)
-#   3. Squash-merge + delete remote branch via gh pr merge --squash --delete-branch
+#   3. Squash-merge + delete remote branch (forge CLI — harness-extension-point)
 #   4. If not in worktree: git checkout base && git pull --rebase
 
 set -euo pipefail
@@ -95,7 +95,7 @@ if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; t
         git commit -m "ticket(${TICKET_ID}): close and archive — PR #${PR}"
     fi
     git push origin HEAD
-    echo "Waiting for CI after ticket-close commit..."
+    echo "Waiting for CI after ticket-close commit..." # harness-extension-point
     timeout 600 gh pr checks "$PR" --watch --fail-fast \
         || die "CI failed after ticket-close commit — aborting merge"
 elif [[ -n "$TICKET_ID" ]]; then

--- a/tickets/closed/0138-erg-pr-merge-wait-for-ci.erg
+++ b/tickets/closed/0138-erg-pr-merge-wait-for-ci.erg
@@ -2,10 +2,12 @@
 Title: erg-pr-merge: wait for CI before calling merge API
 Created: 2026-05-12
 Author: claude
+Closed: autoclosed — PR #157
 
 --- log ---
 2026-05-12T20:00Z claude created — perch follow-up after raid 120/129/133
 
+2026-05-12T21:07Z MinhHaDuong closed — autoclosed — PR #157
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes #0138

Ticket: tickets/0138-erg-pr-merge-wait-for-ci

## Changes

- After `git push origin HEAD` (ticket-close commit), wait for CI using `gh pr checks "$PR" --watch --fail-fast` wrapped in `timeout 600` — prevents the merge API from being called while checks are still in flight
- Replace raw `gh api repos/.../pulls/.../merge` call with `gh pr merge "$PR" --squash --delete-branch` — handles both merge and branch deletion atomically
- Remove the separate `gh api .../git/refs/heads/...` DELETE call (now handled by `--delete-branch`)
- Update header comment to document the new step 2a

Fixes the 405-on-re-trigger race: previously, the ticket-close push re-triggered CI which completed just as the raw merge API was called, causing a 405. Now the script explicitly waits for CI to settle before merging.

🤖 Generated with Claude Code