### PR TITLE
feat(0122): auto-close umbrella tickets when all children done

### DIFF
--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -28,8 +28,22 @@ Select one ticket for the current sweep run.
    Log each excluded id and reason to beat output. Do not read ticket bodies
    for excluded tickets.
 
-3. **Assess remaining candidates.** For each remaining ticket, read its body
-   and assess scope and risk:
+3. **Assess remaining candidates.** For each remaining ticket:
+
+   **Umbrella check**: Before assessing scope, grep the ticket file header for
+   `^Blocks:` (anchored to line start). If found, extract the space/comma-separated
+   ticket IDs. For each ID, check whether `tickets/closed/<NNNN>-*.erg` exists.
+   If ALL referenced tickets are closed, run `/ticket-close <id> already-done`
+   and output `CLOSED: <id>`. Skip scope assessment for this ticket.
+
+   Shell reference:
+   ```bash
+   grep -oP '^Blocks:\s*\K[\d,\s]+' ticket.erg | tr ',' '\n' | tr -d ' '
+   # Close check:
+   ls tickets/closed/${ID}-*.erg 2>/dev/null
+   ```
+
+   Read the ticket body and assess scope and risk:
    - **Scope:** estimated time and files touched (e.g. `30m/3f`)
    - **Risk:** `low`, `medium`, or `high` — prefer tickets that touch few
      files, change docs/config/tests rather than core logic, are easily

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -31,14 +31,16 @@ Select one ticket for the current sweep run.
 3. **Assess remaining candidates.** For each remaining ticket:
 
    **Umbrella check**: Before assessing scope, grep the ticket file header for
-   `^Blocks:` (anchored to line start). If found, extract the space/comma-separated
-   ticket IDs. For each ID, check whether `tickets/closed/<NNNN>-*.erg` exists.
+   `^Blocks:` (anchored to line start). If found, extract the referenced ticket
+   IDs (one per `Blocks:` line — the header is repeatable). For each ID, check
+   whether `tickets/closed/<NNNN>-*.erg` exists.
    If ALL referenced tickets are closed, run `/ticket-close <id> already-done`
    and output `CLOSED: <id>`. Skip scope assessment for this ticket.
 
    Shell reference:
    ```bash
-   grep -oP '^Blocks:\s*\K[\d,\s]+' ticket.erg | tr ',' '\n' | tr -d ' '
+   # Each Blocks: line yields one ID (repeatable header — one ref per line):
+   grep -oP '^Blocks:\s*\K\S+' ticket.erg
    # Close check:
    ls tickets/closed/${ID}-*.erg 2>/dev/null
    ```

--- a/tickets/0140-erg-binary-accept-blocks-header.erg
+++ b/tickets/0140-erg-binary-accept-blocks-header.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Update erg binary to accept Blocks: as a valid v1 header
+Created: 2026-05-12
+Author: claude
+
+--- log ---
+2026-05-12T20:49Z claude created — unblocks PR #159 umbrella auto-close feature
+
+--- body ---
+## Context
+
+`tickets/spec-erg-v1.md` (updated in PR #159) defines `Blocks:` as a valid v1
+header (repeatable, type `ref`, inverse of `Blocked-by:`). However, the `erg`
+binary at `tickets/erg` hardcodes its accepted header set and currently rejects
+`Blocks:` with "unknown header 'Blocks' (not in v1 closed set)".
+
+This means any ticket file using `Blocks:` to mark children will fail the
+`validate-tickets` CI job before the pick-ticket umbrella-close logic can run.
+The feature added in PR #159 is doc-complete but non-functional until this fix.
+
+## Actions
+
+1. Update the `erg` binary source (git-erg repo) to add `Blocks:` to the
+   accepted v1 header set: repeatable, type `ref`, same grammar as `Blocked-by:`.
+2. Rebuild and recommit `tickets/erg` in the harness repo.
+3. Verify `erg validate` accepts a ticket file with `Blocks: 0042`.
+
+## Exit criteria
+
+- [ ] `tickets/erg validate` accepts a ticket file with `Blocks: 0042` (exit 0).
+- [ ] `validate-tickets` CI job passes on a branch with a `Blocks:`-bearing ticket.
+- [ ] `make check` (or equivalent) passes.

--- a/tickets/closed/0122-umbrella-auto-close-in-pick-ticket.erg
+++ b/tickets/closed/0122-umbrella-auto-close-in-pick-ticket.erg
@@ -2,11 +2,13 @@
 Title: skill-doctor: auto-close umbrella tickets when all children are closed
 Created: 2026-05-11
 Author: claude
+Closed: autoclosed — PR #159
 
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=2, sev=medium, score=4
 2026-05-12T21:00Z claude note — reimagine: Blocks: header not in spec-erg-v1.md; add it as prerequisite in same PR. Anchor grep to ^Blocks: to avoid prose false positives.
 
+2026-05-12T21:10Z MinhHaDuong closed — autoclosed — PR #159
 --- body ---
 ## Context
 

--- a/tickets/spec-erg-v1.md
+++ b/tickets/spec-erg-v1.md
@@ -64,6 +64,7 @@ format literals.
 | `Author` | yes | no | line | Agent or human identifier (non-empty) |
 | `Closed` | no | no | line | Closure reason (PR ref, supersession note, etc.); non-empty |
 | `Blocked-by` | no | yes | ref | Local `NNNN`, path-ref `module/NNNN`, or forge ref `host/owner/repo#N` (see grammar) |
+| `Blocks` | no | yes | ref | Inverse of `Blocked-by`: parent/umbrella ticket lists child IDs it blocks; used by pick-ticket to auto-close when all children are closed |
 | `Tag` | no | yes | enum | Configurable via `.ergrc [tags]`; defaults: `needs-human`, `deferred` |
 
 **All header values are line-strings — single line, no embedded newlines.**

--- a/tickets/spec-erg-v1.md
+++ b/tickets/spec-erg-v1.md
@@ -83,7 +83,7 @@ content belongs in the body section.
 Required headers (`Title`, `Created`, `Author`) must have a non-empty
 value; an empty value is a validation error.
 
-No other headers are valid in v1. No `X-` extensions.
+No headers outside this table are valid in v1. No `X-` extensions.
 
 `Tag:` is repeatable; each occurrence adds one tag value. The validator enforces the closed value set per occurrence; see the validate rules.
 

--- a/tickets/spec-erg-v1.md
+++ b/tickets/spec-erg-v1.md
@@ -124,6 +124,10 @@ default. One `Blocked-by:` line per dependency; remove the line once the depende
 **Resolution and cycle detection** for path-refs are deferred to a follow-up implementation ticket.
 Tools that cannot resolve a path-ref treat it as blocking (same behaviour as offline forge refs).
 
+**`Blocks:` references** use the same ref grammar as `Blocked-by:`. The auto-close logic in
+`pick-ticket` resolves local refs only (`[0-9]{4}`); path-refs and forge-refs in `Blocks:` lines
+are ignored by the auto-close check (treated as unresolvable — the umbrella stays open).
+
 There is no pending or doing header. If two agents need to avoid stepping on each other, they should
 coordinate via out-of-band signals — typically a git branch whose name contains the ticket ID.
 


### PR DESCRIPTION
## Summary

- Adds `Blocks:` header to `tickets/spec-erg-v1.md` as the documented inverse of `Blocked-by:` — parent/umbrella ticket lists child IDs it blocks
- Adds umbrella check to `skills/pick-ticket/SKILL.md` Step 3: before scope/risk assessment, auto-closes a parent ticket when all `Blocks:` children are already closed
- Prevents max-turns exhaustion on completed umbrella tickets

## Note on validator binary

The `erg` binary hardcodes accepted headers. A `Blocks:` header in a real ticket file may be rejected at commit time until the binary is updated to match the spec. This PR only covers the spec and skill prose.

## Test plan

- [ ] A ticket with `Blocks: 0042 0043` where both `tickets/closed/0042-*.erg` and `tickets/closed/0043-*.erg` exist causes `CLOSED: <id>` output from pick-ticket
- [ ] A ticket with `Blocks: 0042` where `0042` is still open is treated as a normal candidate (no auto-close)
- [ ] A ticket without `Blocks:` is unaffected (scope/risk assessment runs as before)

Closes #0122

🤖 Generated with [Claude Code](https://claude.com/claude-code)