### PR TITLE
feat(verify-adherence): use haiku model

### DIFF
--- a/skills/verify-adherence/SKILL.md
+++ b/skills/verify-adherence/SKILL.md
@@ -2,6 +2,7 @@
 name: verify-adherence
 description: Check a branch's diff against project rules. Mechanical-first — runs hygiene tests + grep ratchet before falling back to LLM. Emits suggested tests for any semantic finding so the LLM surface shrinks over time.
 disable-model-invocation: false
+model: haiku
 user-invocable: true
 argument-hint: <branch>
 context: fork


### PR DESCRIPTION
## Summary
- Add `model: haiku` to `verify-adherence/SKILL.md` frontmatter
- Adherence checking is mechanical-first (bash/grep/pytest); LLM only handles semantic residue — Haiku is sufficient and cheaper

## Test plan
- [ ] Run `/verify` on a PR and confirm adherence phase uses haiku