### PR TITLE
fix(0114): cleanup orphaned git-locked worktrees at beat start

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -331,15 +331,17 @@ def _cleanup_locked_worktrees(project: Path) -> None:
             f"=== startup: removing orphaned locked worktree {name} (dead pid {pid}) ==="
         )
         try:
-            subprocess.run(
+            subprocess.run(  # noqa: S603
                 ["git", "worktree", "unlock", str(worktree_path)],
                 cwd=project,
                 capture_output=True,
+                check=False,
             )
-            subprocess.run(
+            subprocess.run(  # noqa: S603
                 ["git", "worktree", "remove", "--force", str(worktree_path)],
                 cwd=project,
                 capture_output=True,
+                check=False,
             )
         except OSError as exc:
             _log(f"=== startup: failed to remove worktree {name}: {exc} ===")

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -267,6 +267,84 @@ def _cleanup_stale_in_progress(project: Path) -> None:
         _log(f"=== startup: cleaned stale in_progress records in {project.name} ===")
 
 
+# Harness worktree name patterns created by EnterWorktree
+_HARNESS_WORKTREE_RE = re.compile(r"^(agent-|explore-|t\d|review-)")
+
+
+def _cleanup_locked_worktrees(project: Path) -> None:
+    """Unlock and remove git-locked worktrees whose agent PID is no longer alive.
+
+    EnterWorktree writes a lock file at .git/worktrees/<name>/locked with content
+    like "claude agent <name> (pid NNNN)". When an agent is killed the lock is never
+    removed. This function scans all locked worktrees belonging to this project,
+    checks PID liveness, and removes orphans so housekeeping does not fail with
+    "fatal: impossible de supprimer un arbre de travail verrouillé".
+    """
+    git_dir = project / ".git"
+    if not git_dir.is_dir():
+        return
+    worktrees_admin = git_dir / "worktrees"
+    if not worktrees_admin.is_dir():
+        return
+
+    for admin_dir in sorted(worktrees_admin.iterdir()):
+        if not admin_dir.is_dir():
+            continue
+        name = admin_dir.name
+        if not _HARNESS_WORKTREE_RE.match(name):
+            continue
+
+        lock_file = admin_dir / "locked"
+        if not lock_file.exists():
+            continue
+
+        # Extract PID from lock content, e.g. "claude agent <name> (pid 1234)"
+        content = lock_file.read_text().strip()
+        pid_match = re.search(r"\(pid (\d+)\)", content)
+        if not pid_match:
+            # Unknown format — skip to avoid accidentally removing a live worktree
+            _log(
+                f"=== startup: skipping locked worktree {name}: unknown lock format ==="
+            )
+            continue
+
+        pid = int(pid_match.group(1))
+        try:
+            os.kill(pid, 0)
+            alive = True
+        except ProcessLookupError:
+            alive = False
+        except PermissionError:
+            alive = True  # process exists but owned by another user
+
+        if alive:
+            continue
+
+        # Resolve the worktree checkout path from .git/worktrees/<name>/gitdir
+        gitdir_file = admin_dir / "gitdir"
+        if not gitdir_file.exists():
+            continue
+        # gitdir contains "<worktree_path>/.git", so parent is the checkout dir
+        worktree_path = Path(gitdir_file.read_text().strip()).parent
+
+        _log(
+            f"=== startup: removing orphaned locked worktree {name} (dead pid {pid}) ==="
+        )
+        try:
+            subprocess.run(
+                ["git", "worktree", "unlock", str(worktree_path)],
+                cwd=project,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(worktree_path)],
+                cwd=project,
+                capture_output=True,
+            )
+        except OSError as exc:
+            _log(f"=== startup: failed to remove worktree {name}: {exc} ===")
+
+
 def append_beat_log(project: Path, record: dict) -> None:
     """Append one compact-JSON record; no-op in dry-run mode."""
     if DRY_RUN:
@@ -1211,6 +1289,9 @@ def main() -> None:
     # Layer-1 cleanup: rewrite buried stale in_progress records that crash
     # recovery missed (it only checks the most-recent record within 55 min).
     _cleanup_stale_in_progress(path)
+
+    # Layer-2 cleanup: remove orphaned git-locked worktrees left by killed agents.
+    _cleanup_locked_worktrees(path)
 
     # Crash / SIGKILL recovery
     last = read_last_beat_record(path)

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -983,6 +984,163 @@ class TestPerProjectLock:
         ):
             beat.main()
         assert exc_info.value.code == 0
+
+
+# ── orphaned locked worktree cleanup ──────────────────────────────────────────
+
+
+class TestCleanupLockedWorktrees:
+    """Tests for _cleanup_locked_worktrees — orphan detection and removal."""
+
+    def _make_locked_worktree(self, git_dir: Path, name: str, pid: int) -> Path:
+        """Create a fake worktree admin dir with a lock file and gitdir pointer."""
+        admin = git_dir / "worktrees" / name
+        admin.mkdir(parents=True)
+        (admin / "locked").write_text(f"claude agent {name} (pid {pid})\n")
+        # gitdir points to <worktree_checkout>/.git
+        fake_checkout = git_dir.parent / ".claude" / "worktrees" / name
+        fake_checkout.mkdir(parents=True, exist_ok=True)
+        (admin / "gitdir").write_text(str(fake_checkout / ".git") + "\n")
+        return fake_checkout
+
+    def test_removes_worktree_with_dead_pid(self, tmp_path):
+        """Orphaned locked worktree (dead PID) is unlocked and removed."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        git_dir = project / ".git"
+        git_dir.mkdir()
+
+        dead_pid = 999999  # almost certainly not alive
+        worktree_path = self._make_locked_worktree(git_dir, "agent-deadbeef", dead_pid)
+
+        run_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            patch("beat.subprocess.run", side_effect=fake_run),
+            patch("beat.os.kill", side_effect=ProcessLookupError),
+        ):
+            beat._cleanup_locked_worktrees(project)
+
+        assert any("worktree" in " ".join(c) and "unlock" in c for c in run_calls), (
+            f"Expected a 'git worktree unlock' call; got: {run_calls}"
+        )
+        assert any("worktree" in " ".join(c) and "remove" in c for c in run_calls), (
+            f"Expected a 'git worktree remove' call; got: {run_calls}"
+        )
+
+    def test_skips_worktree_with_live_pid(self, tmp_path):
+        """Locked worktree whose PID is alive must not be removed."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        git_dir = project / ".git"
+        git_dir.mkdir()
+
+        live_pid = os.getpid()  # our own PID — definitely alive
+        self._make_locked_worktree(git_dir, "agent-liveone", live_pid)
+
+        run_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch("beat.subprocess.run", side_effect=fake_run):
+            beat._cleanup_locked_worktrees(project)
+
+        assert run_calls == [], (
+            f"Should not have called subprocess.run; got: {run_calls}"
+        )
+
+    def test_skips_non_harness_name(self, tmp_path):
+        """Worktree names not matching harness patterns are left alone."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        git_dir = project / ".git"
+        git_dir.mkdir()
+
+        self._make_locked_worktree(git_dir, "custom-worktree", 999999)
+
+        run_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            patch("beat.subprocess.run", side_effect=fake_run),
+            patch("beat.os.kill", side_effect=ProcessLookupError),
+        ):
+            beat._cleanup_locked_worktrees(project)
+
+        assert run_calls == [], (
+            f"Non-harness worktree should be skipped; got: {run_calls}"
+        )
+
+    def test_skips_lock_file_without_pid(self, tmp_path):
+        """Lock file with unknown format (no PID) is skipped safely."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        git_dir = project / ".git"
+        git_dir.mkdir()
+
+        admin = git_dir / "worktrees" / "agent-nopid"
+        admin.mkdir(parents=True)
+        (admin / "locked").write_text("some other format\n")
+        fake_checkout = tmp_path / "worktrees" / "agent-nopid"
+        fake_checkout.mkdir(parents=True)
+        (admin / "gitdir").write_text(str(fake_checkout / ".git") + "\n")
+
+        run_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            patch("beat.subprocess.run", side_effect=fake_run),
+            patch("beat.os.kill", side_effect=ProcessLookupError),
+        ):
+            beat._cleanup_locked_worktrees(project)
+
+        assert run_calls == [], (
+            f"Unknown lock format should be skipped; got: {run_calls}"
+        )
+
+    def test_noop_when_no_git_dir(self, tmp_path):
+        """Function returns silently when project has no .git directory."""
+        project = tmp_path / "notgit"
+        project.mkdir()
+        # Should not raise
+        beat._cleanup_locked_worktrees(project)
+
+    def test_skips_permission_error_pid(self, tmp_path):
+        """PermissionError from os.kill means PID is alive — worktree kept."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        git_dir = project / ".git"
+        git_dir.mkdir()
+
+        self._make_locked_worktree(git_dir, "agent-foreign", 12345)
+
+        run_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            patch("beat.subprocess.run", side_effect=fake_run),
+            patch("beat.os.kill", side_effect=PermissionError),
+        ):
+            beat._cleanup_locked_worktrees(project)
+
+        assert run_calls == [], (
+            f"PermissionError PID should be treated as alive; got: {run_calls}"
+        )
 
 
 # ── crash recovery ─────────────────────────────────────────────────────────────

--- a/tickets/0125-housekeeping-delete-stale-branches.erg
+++ b/tickets/0125-housekeeping-delete-stale-branches.erg
@@ -7,6 +7,7 @@ Author: MinhHaDuong
 2026-05-11T21:30Z MinhHaDuong created
 2026-05-12T21:00Z claude note — reimagine: case 2 (empty orphan branches) deferred as stretch goal. Core fix: reclassify closed-ticket branches with 0 commits_beyond_default from cleanup-candidate to fix-now in healthcheck SKILL.md. Use git branch -d (not -D) — fails safely on unmerged. Open-PR guard via gh pr list --head.
 
+2026-05-12T21:25Z bump verify-reroll — round 1: EC1 not satisfied for squash-merged branches (primary use case)
 --- body ---
 ## Context
 

--- a/tickets/closed/0114-cleanup-orphaned-locked-worktrees.erg
+++ b/tickets/closed/0114-cleanup-orphaned-locked-worktrees.erg
@@ -2,11 +2,13 @@
 Title: Clean up orphaned git-locked worktrees before each beat run
 Created: 2026-05-10
 Author: claude
+Closed: autoclosed — PR #163
 
 --- log ---
 2026-05-10T11:30Z claude created — identified in 0109 denial catalog (Run 20260507T230223Z)
 2026-05-12T21:00Z claude note — reimagine: check .git/worktrees/*/locked marker (not HEAD.lock). Scope cleanup to harness-pattern names (agent-*, explore-*, t[0-9]*, review-*). Insert after _cleanup_stale_in_progress at beat.py:1213.
 
+2026-05-12T21:27Z MinhHaDuong closed — autoclosed — PR #163
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes #0114

## Summary

- Adds `_cleanup_locked_worktrees(path)` to `scripts/beat.py`, called immediately after `_cleanup_stale_in_progress` at beat startup
- Scans `.git/worktrees/*/locked` marker files for harness-pattern worktree names (`agent-*`, `explore-*`, `t[0-9]*`, `review-*`)
- Parses PID from lock content (`claude agent <name> (pid NNNN)`), checks liveness via `os.kill(pid, 0)`, and runs `git worktree unlock` + `git worktree remove --force` for dead-agent trees
- Skips: live PIDs, `PermissionError` (foreign-user process), unknown lock format, non-harness names

## Test plan

- [x] `TestCleanupLockedWorktrees` — 6 new tests covering dead PID removal, live PID skip, non-harness name skip, unknown format skip, no `.git` dir noop, `PermissionError` treated as alive
- [x] `python -m pytest tests/test_beat.py -x -q` → 147 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)