### PR TITLE
fix(0122): remove Blocks: header, use inverse Blocked-by lookup

### DIFF
--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -60,8 +60,10 @@ When you reach a root cause, repair if within authority:
   2× `RAID_TIMEOUT_S` (3600 s). Implementation slowness is a "ticket too
   large" signal — do not raise the timeout for that.
 - **Ticket too large to finish in one beat** → split into one ticket per
-  independent unit of work; convert the parent to an umbrella by adding
-  `Blocks: <id>...` and leaving it open (it may be blocking other tickets).
+  independent unit of work; leave the parent open as an umbrella. Each child
+  ticket must carry `Blocked-by: <umbrella-id>` so pick-ticket can auto-close
+  the umbrella when all children are done (it uses inverse lookup, not a
+  `Blocks:` header — that header is not valid in %erg v1).
 - **Dead timer** → restart it.
 - **Dirty working tree** (`outcome=aborted-dirty-tree`) → if the dirty files
   are machine-local state (beat-outcomes.jsonl, STATE.md, build artifacts),

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -30,20 +30,15 @@ Select one ticket for the current sweep run.
 
 3. **Assess remaining candidates.** For each remaining ticket:
 
-   **Umbrella check**: Before assessing scope, grep the ticket file header for
-   `^Blocks:` (anchored to line start). If found, extract the referenced ticket
-   IDs (one per `Blocks:` line — the header is repeatable). For each ID, check
-   whether `tickets/closed/<NNNN>-*.erg` exists.
-   If ALL referenced tickets are closed, run `/ticket-close <id> already-done`
-   and output `CLOSED: <id>`. Skip scope assessment for this ticket.
-
-   Shell reference:
+   **Umbrella check**: Before assessing scope, check if this ticket is
+   referenced as a blocker by other tickets. Run:
    ```bash
-   # Each Blocks: line yields one ID (repeatable header — one ref per line):
-   grep -oP '^Blocks:\s*\K\S+' ticket.erg
-   # Close check:
-   ls tickets/closed/${ID}-*.erg 2>/dev/null
+   grep -rl "Blocked-by:.*${TICKET_ID}" tickets/
    ```
+   to find tickets that list this one as a blocker. If any results are found
+   AND all matching tickets exist in `tickets/closed/`, auto-close this ticket
+   via `/ticket-close <id> already-done` and output `CLOSED: <id>`. Skip scope
+   assessment for this ticket.
 
    Read the ticket body and assess scope and risk:
    - **Scope:** estimated time and files touched (e.g. `30m/3f`)

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -31,14 +31,19 @@ Select one ticket for the current sweep run.
 3. **Assess remaining candidates.** For each remaining ticket:
 
    **Umbrella check**: Before assessing scope, check if this ticket is
-   referenced as a blocker by other tickets. Run:
+   referenced as a blocker by other tickets. Extract the ticket ID from the
+   filename (e.g., `TICKET_ID=0042` from `0042-some-slug.erg`), then run:
    ```bash
-   grep -rl "Blocked-by:.*${TICKET_ID}" tickets/
+   grep -rl "^Blocked-by:.*\b${TICKET_ID}\b" tickets/
    ```
-   to find tickets that list this one as a blocker. If any results are found
-   AND all matching tickets exist in `tickets/closed/`, auto-close this ticket
-   via `/ticket-close <id> already-done` and output `CLOSED: <id>`. Skip scope
+   to find tickets that list this one as a blocker. For each matching file,
+   check whether the ticket is closed using `$ERG status <id>`. If any results
+   are found AND all matching tickets are closed, auto-close this ticket via
+   `/ticket-close <id> already-done` and output `CLOSED: <id>`. Skip scope
    assessment for this ticket.
+
+   Convention: when splitting a ticket into children, each child ticket must
+   carry `Blocked-by: <umbrella-id>` so this inverse lookup can find them.
 
    Read the ticket body and assess scope and risk:
    - **Scope:** estimated time and files touched (e.g. `30m/3f`)

--- a/tickets/spec-erg-v1.md
+++ b/tickets/spec-erg-v1.md
@@ -64,7 +64,6 @@ format literals.
 | `Author` | yes | no | line | Agent or human identifier (non-empty) |
 | `Closed` | no | no | line | Closure reason (PR ref, supersession note, etc.); non-empty |
 | `Blocked-by` | no | yes | ref | Local `NNNN`, path-ref `module/NNNN`, or forge ref `host/owner/repo#N` (see grammar) |
-| `Blocks` | no | yes | ref | Inverse of `Blocked-by`: parent/umbrella ticket lists child IDs it blocks; used by pick-ticket to auto-close when all children are closed |
 | `Tag` | no | yes | enum | Configurable via `.ergrc [tags]`; defaults: `needs-human`, `deferred` |
 
 **All header values are line-strings — single line, no embedded newlines.**
@@ -123,10 +122,6 @@ default. One `Blocked-by:` line per dependency; remove the line once the depende
 
 **Resolution and cycle detection** for path-refs are deferred to a follow-up implementation ticket.
 Tools that cannot resolve a path-ref treat it as blocking (same behaviour as offline forge refs).
-
-**`Blocks:` references** use the same ref grammar as `Blocked-by:`. The auto-close logic in
-`pick-ticket` resolves local refs only (`[0-9]{4}`); path-refs and forge-refs in `Blocks:` lines
-are ignored by the auto-close check (treated as unresolvable — the umbrella stays open).
 
 There is no pending or doing header. If two agents need to avoid stepping on each other, they should
 coordinate via out-of-band signals — typically a git branch whose name contains the ticket ID.


### PR DESCRIPTION
Follow-up to #159. `Blocks:` header is not a permitted %erg v1 header.

## Changes

- **`tickets/spec-erg-v1.md`**: Remove the `Blocks:` row from the headers table and the `Blocks: references` prose section that was added in #159.
- **`skills/pick-ticket/SKILL.md`**: Rewrite the umbrella check (step 3) to use inverse `Blocked-by:` lookup instead of grepping for `^Blocks:`. The new check runs `grep -rl "Blocked-by:.*${TICKET_ID}" tickets/` to find tickets that list this one as a blocker, then verifies all matching tickets are in `tickets/closed/` before auto-closing.

## Why inverse lookup

The `Blocks:` header approach required umbrella tickets to explicitly list their children — a new header outside the permitted closed set. Inverse lookup reads the same information from existing `Blocked-by:` headers on child tickets, requiring no new header.

🤖 Generated with Claude Code