### PR TITLE
feat(beat): add per-project max_turns_housekeeping override

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -112,6 +112,7 @@ class ProjectConfig:
         interval_minutes — minimum minutes between beats (0 = always run).
         raid_timeout_s — seconds before the raid subprocess is killed.
         max_turns_pick_ticket — max agent turns for pick-ticket (default 30).
+        max_turns_housekeeping — max agent turns for housekeeping (default 40, cap 80).
     """
 
     path: Path
@@ -122,6 +123,12 @@ class ProjectConfig:
     interval_minutes: int = 0  # 0 = always run
     raid_timeout_s: int = RAID_TIMEOUT_S
     max_turns_pick_ticket: int = MAX_TURNS_PICK_TICKET
+    max_turns_housekeeping: int = MAX_TURNS_HOUSEKEEPING
+
+    def __post_init__(self) -> None:
+        cap = 2 * MAX_TURNS_HOUSEKEEPING
+        if self.max_turns_housekeeping > cap:
+            self.max_turns_housekeeping = cap
 
 
 _BUILTIN_PROJECTS: list[ProjectConfig] = [
@@ -152,6 +159,7 @@ _PROJ_KEYS = {
     "interval_minutes",
     "raid_timeout_s",
     "max_turns_pick_ticket",
+    "max_turns_housekeeping",
 }
 
 
@@ -867,7 +875,7 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
             budget=project.budget_housekeeping,
             timeout_s=HOUSEKEEPING_TIMEOUT_S,
             cwd=path,
-            max_turns=MAX_TURNS_HOUSEKEEPING,
+            max_turns=project.max_turns_housekeeping,
         )
     finally:
         os.environ.pop("BEAT_HOUSEKEEPING_BRANCH", None)
@@ -877,7 +885,7 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
         return "timeout"
     if hk_res.subtype == "error_max_turns":
         _log(
-            f"=== housekeeping: max-turns ({MAX_TURNS_HOUSEKEEPING}) reached — context cap hit {_now_iso()} ==="
+            f"=== housekeeping: max-turns ({project.max_turns_housekeeping}) reached — context cap hit {_now_iso()} ==="
         )
     if hk_rc != 0:
         _log(f"=== housekeeping: rc={hk_rc} on {branch} {_now_iso()} ===")

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -173,6 +173,8 @@ def _apply_beat_json_overlay(config: ProjectConfig) -> None:
         for k, v in overrides.items():
             if k in _PROJ_KEYS:
                 setattr(config, k, v)
+        # __post_init__ doesn't re-run after setattr; re-apply caps manually.
+        config.__post_init__()
     except Exception as exc:  # noqa: BLE001
         print(
             f"[beat] error loading {beat_cfg}: {exc}, ignoring overlay",

--- a/tickets/closed/0139-housekeeping-max-turns-per-project.erg
+++ b/tickets/closed/0139-housekeeping-max-turns-per-project.erg
@@ -2,10 +2,12 @@
 Title: Add per-project max_turns_housekeeping override (chemin-de-voix hit cap)
 Created: 2026-05-12
 Author: nightbeat-supervisor
+Closed: autoclosed — PR #166
 
 --- log ---
 2026-05-12T20:30Z nightbeat-supervisor created
 
+2026-05-13T06:02Z MinhHaDuong closed — autoclosed — PR #166
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0139-housekeeping-max-turns-per-project.erg

## Summary

- Adds `max_turns_housekeeping: int` field to `ProjectConfig` (defaults to `MAX_TURNS_HOUSEKEEPING=40`, capped at 80 via `__post_init__`)
- Adds `"max_turns_housekeeping"` to `_PROJ_KEYS` so `beat.json` overlays can set it
- Wires `project.max_turns_housekeeping` through to the `/housekeeping` call site and log message (was hardcoded to module constant)
- Calls `config.__post_init__()` after the `beat.json` overlay loop so the 2x cap is enforced even when `setattr` bypasses `__post_init__`
- chemin-de-voix local `beat.json` updated with `max_turns_housekeeping: 48` (20% bump above 40)

Closes ticket 0139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)