### PR TITLE
fix(beat): stamp idle/no-commits markers; add parser fallback for old logs

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -896,11 +896,13 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
     n = _git("rev-list", "--count", f"{base}..HEAD", cwd=path).stdout.strip() or "0"
     _git("checkout", default_branch, cwd=path)
     if int(n) == 0:
-        _log("=== housekeeping: no commits, deleting branch ===")
+        _log(f"=== housekeeping: no commits, deleting branch {_now_iso()} ===")
         _git("branch", "-D", branch, cwd=path)
         return "no-changes"
 
-    _log(f"=== housekeeping: deferred — {n} commit(s) on {branch} ready for review ===")
+    _log(
+        f"=== housekeeping: deferred — {n} commit(s) on {branch} ready for review {_now_iso()} ==="
+    )
     return "deferred"
 
 
@@ -1158,7 +1160,7 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
         # raids a ticket that may be already done.
         _log(
             f"=== pick-ticket: idle — {MAX_CLOSED_REPICKS} consecutive CLOSED"
-            " picks; aborting beat to avoid loop ==="
+            f" picks; aborting beat to avoid loop {_now_iso()} ==="
         )
         _record_phase_outcome(
             path,
@@ -1176,7 +1178,7 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
             else ""
         )
         _log(
-            f"=== pick-ticket: idle — {last_result_line or 'IDLE: no eligible tickets'} ==="
+            f"=== pick-ticket: idle — {last_result_line or 'IDLE: no eligible tickets'} {_now_iso()} ==="
         )
         _record_phase_outcome(
             path, "pick_ticket", "idle", detail=last_result_line, skill_result=pt_res

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -91,6 +91,7 @@ def _git_log_oneline(project: Path, branch: str, max_commits: int = 5) -> list[s
 
 
 _MARKER = re.compile(r"^=== (.+?) (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z) ===$")
+_MARKER_NO_TS = re.compile(r"^=== (.+?) ===$")
 _RUN_RE = re.compile(r"^Run \d+\s+\S+\s+project slot \d+: (.+)$")
 _LOCK_RE = re.compile(r"beat already running for (\S+), skipping")
 
@@ -178,8 +179,8 @@ def parse_log(path: Path) -> BeatRun:
             run.project = Path(m.group(1).strip())
             continue
 
-        # Marker lines
-        m = _MARKER.search(line)
+        # Marker lines (timestamped preferred; fall back to timestamp-less)
+        m = _MARKER.search(line) or _MARKER_NO_TS.search(line)
         if m:
             label = m.group(1)
             _handle_marker(label, line, run, section_ref := [section])
@@ -223,6 +224,12 @@ def _handle_marker(label: str, line: str, run: BeatRun, section_ref: list) -> No
             section_ref[0] = None
         elif status == "done" or status.startswith("done "):
             run.hk_status = "done"
+            section_ref[0] = None
+        elif status.startswith("no commits"):
+            run.hk_status = "no-changes"
+            section_ref[0] = None
+        elif status.startswith("deferred"):
+            run.hk_status = "deferred"
             section_ref[0] = None
         else:
             run.hk_status = status.split()[0]  # e.g. "rc=1"

--- a/tickets/closed/0144-nightbeat-report-table-shows-running-for.erg
+++ b/tickets/closed/0144-nightbeat-report-table-shows-running-for.erg
@@ -2,10 +2,12 @@
 Title: nightbeat-report: table shows 'running' for completed-idle beats
 Created: 2026-05-13
 Author: MinhHaDuong
+Closed: autoclosed — PR #167
 
 --- log ---
 2026-05-13T06:22Z MinhHaDuong created
 
+2026-05-13T06:28Z MinhHaDuong closed — autoclosed — PR #167
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0144-nightbeat-report-table-shows-running-for.erg

## Summary

- **beat.py**: four terminal log markers were emitted without ISO timestamps, so \`_MARKER\` (which requires a trailing timestamp) never matched them. Affected: \`housekeeping: no commits\`, \`housekeeping: deferred\`, \`pick-ticket: idle\` (×2).
- **nightbeat-report.py**: adds \`_MARKER_NO_TS\` fallback regex for timestamp-less markers (degrades gracefully on old log files); adds explicit \`no-commits\` / \`deferred\` branches in \`_handle_marker\` so \`hk_status\` gets a meaningful value rather than the first word of the status string.

**Root cause:** for an idle beat, \`hk_status\` was set to \`"running"\` by the start marker and never cleared (the end marker had no timestamp and was silently dropped). \`_outcome()\` fell through to \`hk_status or "?"\` → table showed \`"running"\` while \`beat-outcomes.jsonl\` correctly recorded \`"idle"\`.

Closes #0144

## Test plan

- [ ] Regex smoke-test passes (verified inline: 6/6 cases OK)
- [ ] \`python3 -m py_compile scripts/beat.py scripts/nightbeat-report.py\` passes
- [ ] Existing idle beat logs reparse with \`_outcome()\` returning \`"idle"\` or \`"no-changes"\` instead of \`"running"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)