### PR TITLE
fix(beat): cap max_turns_pick_ticket in __post_init__

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -111,7 +111,7 @@ class ProjectConfig:
         pick_ticket_model — model used when repo has no recent commits.
         interval_minutes — minimum minutes between beats (0 = always run).
         raid_timeout_s — seconds before the raid subprocess is killed.
-        max_turns_pick_ticket — max agent turns for pick-ticket (default 30).
+        max_turns_pick_ticket — max agent turns for pick-ticket (default 30, cap 60).
         max_turns_housekeeping — max agent turns for housekeeping (default 40, cap 80).
     """
 
@@ -129,6 +129,9 @@ class ProjectConfig:
         cap = 2 * MAX_TURNS_HOUSEKEEPING
         if self.max_turns_housekeeping > cap:
             self.max_turns_housekeeping = cap
+        cap = 2 * MAX_TURNS_PICK_TICKET
+        if self.max_turns_pick_ticket > cap:
+            self.max_turns_pick_ticket = cap
 
 
 _BUILTIN_PROJECTS: list[ProjectConfig] = [

--- a/tickets/0143-beat-max-turns-pick-ticket-missing-cap-i.erg
+++ b/tickets/0143-beat-max-turns-pick-ticket-missing-cap-i.erg
@@ -5,6 +5,7 @@ Author: MinhHaDuong
 
 --- log ---
 2026-05-13T06:18Z MinhHaDuong created
+2026-05-13T07:15Z claude executed
 
 --- body ---
 ## Context

--- a/tickets/closed/0143-beat-max-turns-pick-ticket-missing-cap-i.erg
+++ b/tickets/closed/0143-beat-max-turns-pick-ticket-missing-cap-i.erg
@@ -2,11 +2,13 @@
 Title: beat: max_turns_pick_ticket missing cap in __post_init__
 Created: 2026-05-13
 Author: MinhHaDuong
+Closed: autoclosed — PR #169
 
 --- log ---
 2026-05-13T06:18Z MinhHaDuong created
 2026-05-13T07:15Z claude executed
 
+2026-05-13T08:38Z MinhHaDuong closed — autoclosed — PR #169
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
- `ProjectConfig.__post_init__` already caps `max_turns_housekeeping` at `2 × MAX_TURNS_HOUSEKEEPING`
- `max_turns_pick_ticket` had no analogous cap — a bad `beat.json` overlay could cause runaway agent costs
- This PR adds the same enforcement for parity

Ticket: tickets/0143-beat-max-turns-pick-ticket-missing-cap-i.erg

Scope overflow: tickets/0148

## Test plan
- [ ] Existing `ProjectConfig` tests in `tests/test_beat.py` pass
- [ ] `python3 -m pytest tests/test_beat.py -x -q`