### PR TITLE
test(beat): add missing coverage for max_turns_housekeeping and no-timestamp markers

### DIFF
--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1745,6 +1745,18 @@ class TestProjectConfigFields:
         cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_pick_ticket=50)
         assert cfg.max_turns_pick_ticket == 50
 
+    def test_max_turns_housekeeping_default(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"))
+        assert cfg.max_turns_housekeeping == beat.MAX_TURNS_HOUSEKEEPING
+
+    def test_max_turns_housekeeping_custom(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_housekeeping=10)
+        assert cfg.max_turns_housekeeping == 10
+
+    def test_max_turns_housekeeping_cap(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_housekeeping=9999)
+        assert cfg.max_turns_housekeeping == 2 * beat.MAX_TURNS_HOUSEKEEPING
+
 
 class TestApplyBeatJsonOverlay:
     def test_overlay_merges_known_keys(self, tmp_path):
@@ -1824,6 +1836,17 @@ class TestLoadProjectsOverlay:
         cfg = beat.ProjectConfig(path=proj_dir)
         beat._apply_beat_json_overlay(cfg)
         assert cfg.max_turns_pick_ticket == 45
+
+    def test_beat_json_overlay_max_turns_housekeeping(self, tmp_path):
+        proj_dir = tmp_path / "myproject"
+        proj_dir.mkdir()
+        (proj_dir / ".claude").mkdir()
+        (proj_dir / ".claude" / "beat.json").write_text(
+            json.dumps({"max_turns_housekeeping": 55})
+        )
+        cfg = beat.ProjectConfig(path=proj_dir)
+        beat._apply_beat_json_overlay(cfg)
+        assert cfg.max_turns_housekeeping == 55
 
 
 class TestRaidBudgetPassthrough:

--- a/tests/test_nightbeat_report.py
+++ b/tests/test_nightbeat_report.py
@@ -115,3 +115,30 @@ def test_no_timestamp_less_log_markers():
         if re.search(r"=== .+ ===", line) and "_now_iso" not in line
     ]
     assert bad == [], "Timestamp-less _log markers:\n" + "\n".join(bad)
+
+
+# ── No-timestamp marker parsing (ticket 0146) ─────────────────────────────────
+
+
+def test_hk_status_no_changes(tmp_path):
+    """parse_log sets hk_status='no-changes' for a no-timestamp no-commits marker."""
+    body = (
+        "=== beat start 2026-01-01T00:00:00Z ===\n"
+        "=== housekeeping: running on claude/hk-abc 2026-01-01T00:00:01Z ===\n"
+        "=== housekeeping: no commits ===\n"
+        "=== beat done elapsed=5s 2026-01-01T00:00:06Z ===\n"
+    )
+    run = nbr.parse_log(_write_log(tmp_path, body))
+    assert run.hk_status == "no-changes"
+
+
+def test_hk_status_deferred(tmp_path):
+    """parse_log sets hk_status='deferred' for a no-timestamp deferred marker."""
+    body = (
+        "=== beat start 2026-01-01T00:00:00Z ===\n"
+        "=== housekeeping: running on claude/hk-abc 2026-01-01T00:00:01Z ===\n"
+        "=== housekeeping: deferred — 3 commit(s) on claude/hk-abc ready for review ===\n"
+        "=== beat done elapsed=5s 2026-01-01T00:00:06Z ===\n"
+    )
+    run = nbr.parse_log(_write_log(tmp_path, body))
+    assert run.hk_status == "deferred"

--- a/tickets/0146-add-tests-for-max-turns-housekeeping-and-handle-marker-branches.erg
+++ b/tickets/0146-add-tests-for-max-turns-housekeeping-and-handle-marker-branches.erg
@@ -5,6 +5,7 @@ Author: MinhHaDuong
 
 --- log ---
 2026-05-13T08:30Z MinhHaDuong created
+2026-05-13T00:00Z claude executed
 
 --- body ---
 ## Context

--- a/tickets/0148-test-max-turns-pick-ticket-cap.erg
+++ b/tickets/0148-test-max-turns-pick-ticket-cap.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: add test_max_turns_pick_ticket_cap to test_beat.py
+Created: 2026-05-13
+Author: claude
+
+--- log ---
+2026-05-13T08:30Z claude created
+
+--- body ---
+## Context
+PR #169 (ticket 0143) added a `__post_init__` cap for `max_turns_pick_ticket`
+at `2 × MAX_TURNS_PICK_TICKET = 60`. No test was added in that PR, and ticket
+0146 covered only `max_turns_housekeeping`. A regression in the cap logic would
+go undetected. Identified during verify of PR #169.
+
+Scope overflow from PR #169.
+
+## Actions
+1. In `tests/test_beat.py`, in `TestProjectConfigFields`, add:
+   ```python
+   def test_max_turns_pick_ticket_cap(self):
+       cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_pick_ticket=9999)
+       assert cfg.max_turns_pick_ticket == 2 * beat.MAX_TURNS_PICK_TICKET
+   ```
+2. Run `python3 -m pytest tests/test_beat.py -x -q` to confirm it passes.
+
+## Test
+Write the test first — it should pass immediately since the cap already exists.
+A failing test here would indicate the cap logic regressed.
+
+## Exit criteria
+- [ ] `test_max_turns_pick_ticket_cap` exists in `TestProjectConfigFields`
+- [ ] `python3 -m pytest tests/test_beat.py -x -q` passes

--- a/tickets/closed/0146-add-tests-for-max-turns-housekeeping-and-handle-marker-branches.erg
+++ b/tickets/closed/0146-add-tests-for-max-turns-housekeeping-and-handle-marker-branches.erg
@@ -2,11 +2,13 @@
 Title: add tests for max_turns_housekeeping and new _handle_marker branches
 Created: 2026-05-13
 Author: MinhHaDuong
+Closed: autoclosed — PR #171
 
 --- log ---
 2026-05-13T08:30Z MinhHaDuong created
 2026-05-13T00:00Z claude executed
 
+2026-05-13T08:42Z MinhHaDuong closed — autoclosed — PR #171
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
- 3 `ProjectConfig` tests for `max_turns_housekeeping` (default, custom, cap) — mirrors existing `max_turns_pick_ticket` tests
- 1 overlay test verifying `beat.json` sets `max_turns_housekeeping`
- 2 `parse_log` tests for no-timestamp `housekeeping: no commits` and `housekeeping: deferred` markers via the `_MARKER_NO_TS` fallback

Ticket: tickets/0146-add-tests-for-max-turns-housekeeping-and-handle-marker-branches.erg

## Test plan
- [ ] `python3 -m pytest tests/test_beat.py tests/test_nightbeat_report.py -x -q`