### PR TITLE
fix(scripts): add timeout=30 to subprocess.run in git_utils, project-state, refresh-STATE

### DIFF
--- a/scripts/git_utils.py
+++ b/scripts/git_utils.py
@@ -1,18 +1,27 @@
 """Shared git helpers for harness scripts."""
 
 import subprocess
+import sys
 from pathlib import Path
 
 
 def _default_branch(project: Path) -> str:
     """Return the remote default branch name, falling back to 'main'."""
-    result = subprocess.run(  # noqa: S603
-        ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=project,
-    )
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=project,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"WARNING: git symbolic-ref timed out for {project}, falling back to 'main'",
+            file=sys.stderr,
+        )
+        return "main"
     return (
         result.stdout.strip().removeprefix("origin/")
         if result.returncode == 0

--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -14,7 +14,17 @@ THRESHOLD_HOURS = 12.0
 
 
 def run(args, cwd):
-    return subprocess.run(args, capture_output=True, text=True, check=False, cwd=cwd)
+    try:
+        return subprocess.run(
+            args, capture_output=True, text=True, check=False, cwd=cwd, timeout=30
+        )
+    except subprocess.TimeoutExpired:
+        import sys
+
+        print(f"WARNING: subprocess timed out: {args}", file=sys.stderr)
+        return subprocess.CompletedProcess(
+            args=args, returncode=1, stdout="", stderr="timeout"
+        )
 
 
 def git_state(project):

--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -12,9 +12,19 @@ from pathlib import Path
 
 
 def _repo_root() -> Path:
-    r = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
-    )
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            "WARNING: git rev-parse timed out, falling back to script parent",
+            file=sys.stderr,
+        )
+        return Path(__file__).parent.parent
     if r.returncode == 0:
         return Path(r.stdout.strip())
     return Path(__file__).parent.parent  # fallback: script is in scripts/ of project
@@ -28,9 +38,13 @@ STATUS_HEADING = "## Status"
 
 
 def run(cmd):
-    return subprocess.run(
-        cmd, capture_output=True, text=True, check=True, cwd=REPO_ROOT
-    ).stdout.strip()
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True, cwd=REPO_ROOT, timeout=30
+        ).stdout.strip()
+    except subprocess.TimeoutExpired:
+        print(f"WARNING: command timed out: {cmd}", file=sys.stderr)
+        sys.exit(1)
 
 
 def get_commits(n=5):

--- a/tickets/0141-subprocess-timeout-git-utils-project-state-refresh-state.erg
+++ b/tickets/0141-subprocess-timeout-git-utils-project-state-refresh-state.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-13T00:00Z claude created — celebrate sweep after raid 122/114/125/130/138
+2026-05-13T00:00Z claude note PR #173 opened — timeout=30 + TimeoutExpired handling added to all 4 call sites; 171 tests pass
 
 --- body ---
 ## Context

--- a/tickets/closed/0141-subprocess-timeout-git-utils-project-state-refresh-state.erg
+++ b/tickets/closed/0141-subprocess-timeout-git-utils-project-state-refresh-state.erg
@@ -2,11 +2,13 @@
 Title: Add timeout= to subprocess.run in git_utils, project-state, refresh-STATE
 Created: 2026-05-13
 Author: claude
+Closed: autoclosed — PR #173
 
 --- log ---
 2026-05-13T00:00Z claude created — celebrate sweep after raid 122/114/125/130/138
 2026-05-13T00:00Z claude note PR #173 opened — timeout=30 + TimeoutExpired handling added to all 4 call sites; 171 tests pass
 
+2026-05-13T09:36Z MinhHaDuong closed — autoclosed — PR #173
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0141-subprocess-timeout-git-utils-project-state-refresh-state.erg

Closes ticket 0141. Adds timeout=30 and TimeoutExpired handling to prevent hung git/system calls from silently blocking the supervisor.

## Changes

- `scripts/git_utils.py`: wrap `subprocess.run` in `_default_branch()` with try/except; on timeout log warning to stderr and return `"main"` (existing fallback)
- `scripts/project-state.py`: add `timeout=30` to the `run()` helper; on timeout log warning and return `subprocess.CompletedProcess(returncode=1, stdout="", stderr="timeout")` so all callers' `returncode == 0` checks degrade gracefully
- `scripts/refresh-STATE.py`: add `timeout=30` to `_repo_root()` (fallback to script-parent path) and to `run()` helper (print warning + `sys.exit(1)`, matching existing `CalledProcessError` behavior)

## Verification

- `python3 -m py_compile` passes on all 3 files
- 171 existing tests pass