### PR TITLE
fix(beat): guard git checkout in housekeeping post-cleanup path

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -429,6 +429,7 @@ _HK_OUTCOME_MAP: dict[str, str] = {
     "deferred": "success",
     "timeout": "timeout",
     "failed": "fail",
+    "aborted-dirty-tree": "fail",
 }
 
 
@@ -840,11 +841,12 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
     """Run housekeeping on a dedicated branch cut from origin/main.
 
     Returns one of:
-      "skipped"    — housekeeping_needed was False
-      "no-changes" — skill ran clean, produced no commits
-      "deferred"   — commits on branch, left for human review
-      "timeout"    — skill timed out
-      "failed"     — git or skill error
+      "skipped"            — housekeeping_needed was False
+      "no-changes"         — skill ran clean, produced no commits
+      "deferred"           — commits on branch, left for human review
+      "timeout"            — skill timed out
+      "failed"             — git or skill error
+      "aborted-dirty-tree" — working tree dirty after skill run; checkout skipped
     """
     path = project.path
     if not housekeeping_needed(path):
@@ -903,6 +905,14 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
         return "failed"
 
     n = _git("rev-list", "--count", f"{base}..HEAD", cwd=path).stdout.strip() or "0"
+
+    status = _git("status", "--porcelain", cwd=path)
+    if status.stdout.strip():
+        dirty_files = status.stdout.strip().splitlines()
+        detail = f"{len(dirty_files)} file(s): {', '.join(f.strip() for f in dirty_files[:3])}"
+        _log(f"=== housekeeping: aborted-dirty-tree: {detail} {_now_iso()} ===")
+        return "aborted-dirty-tree"
+
     _git("checkout", default_branch, cwd=path)
     if int(n) == 0:
         _log(f"=== housekeeping: no commits, deleting branch {_now_iso()} ===")

--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -908,9 +908,10 @@ def _housekeeping_phase(project: ProjectConfig) -> str:
 
     status = _git("status", "--porcelain", cwd=path)
     if status.stdout.strip():
-        dirty_files = status.stdout.strip().splitlines()
-        detail = f"{len(dirty_files)} file(s): {', '.join(f.strip() for f in dirty_files[:3])}"
+        dirty_files = status.stdout.strip().splitlines()[:5]
+        detail = f"{len(dirty_files)} file(s): {', '.join(dirty_files[:3])}"
         _log(f"=== housekeeping: aborted-dirty-tree: {detail} {_now_iso()} ===")
+        _record_phase_outcome(path, "housekeeping", "aborted-dirty-tree", detail=detail)
         return "aborted-dirty-tree"
 
     _git("checkout", default_branch, cwd=path)

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -826,6 +826,37 @@ class TestHousekeepingPhase:
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
         assert outcome == "timeout"
 
+    def test_aborted_dirty_tree_when_post_skill_tree_dirty(self, tmp_project):
+        """Ticket 0137: dirty tree after skill run aborts checkout, returns
+        'aborted-dirty-tree' and never calls git checkout."""
+
+        checkout_calls = []
+
+        def git_dirty_after_skill(*args, cwd):
+            sub = args[0] if args else ""
+            if sub == "rev-parse":
+                return MagicMock(returncode=0, stdout="basesha\n", stderr="")
+            if sub == "checkout" and args[1:2] != ("-B",):
+                # Record unguarded checkout attempts (should not happen)
+                checkout_calls.append(args)
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if sub == "rev-list":
+                return MagicMock(returncode=0, stdout="2\n", stderr="")
+            if sub == "status":
+                return MagicMock(returncode=0, stdout=" M dirty_file.py\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("beat.housekeeping_needed", return_value=True),
+            patch("beat._git", side_effect=git_dirty_after_skill),
+            patch("beat.run_skill", return_value=(0, beat._SkillResult())),
+        ):
+            outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
+
+        assert outcome == "aborted-dirty-tree"
+        # The post-skill checkout must NOT have been reached
+        assert checkout_calls == [], f"unexpected checkout calls: {checkout_calls}"
+
     def test_raid_aborts_on_ci_failed(self, tmp_project, git_ok):
         with patch("beat._housekeeping_phase", return_value="failed"):
             outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -850,12 +850,20 @@ class TestHousekeepingPhase:
             patch("beat.housekeeping_needed", return_value=True),
             patch("beat._git", side_effect=git_dirty_after_skill),
             patch("beat.run_skill", return_value=(0, beat._SkillResult())),
+            patch("beat._record_phase_outcome") as mock_record,
         ):
             outcome = beat._housekeeping_phase(beat.ProjectConfig(path=tmp_project))
 
         assert outcome == "aborted-dirty-tree"
         # The post-skill checkout must NOT have been reached
         assert checkout_calls == [], f"unexpected checkout calls: {checkout_calls}"
+        # _record_phase_outcome must be called with the housekeeping phase and aborted-dirty-tree
+        mock_record.assert_called_once_with(
+            tmp_project,
+            "housekeeping",
+            "aborted-dirty-tree",
+            detail="1 file(s): M dirty_file.py",
+        )
 
     def test_raid_aborts_on_ci_failed(self, tmp_project, git_ok):
         with patch("beat._housekeeping_phase", return_value="failed"):

--- a/tickets/0137-beat-unguarded-checkout-housekeeping.erg
+++ b/tickets/0137-beat-unguarded-checkout-housekeeping.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-05-12T20:00Z claude created — celebrate sweep after 0120 fix; same class as 0120
 2026-05-13T00:00Z claude note PR #172 opened — guard added at line 909, _HK_OUTCOME_MAP updated, test added, 153 tests pass
+2026-05-13T00:01Z claude note PR #172 closed (branch contamination); PR #175 opened from clean t0137v3 branch, 152 tests pass
 
 --- body ---
 ## Context

--- a/tickets/0137-beat-unguarded-checkout-housekeeping.erg
+++ b/tickets/0137-beat-unguarded-checkout-housekeeping.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-12T20:00Z claude created — celebrate sweep after 0120 fix; same class as 0120
+2026-05-13T00:00Z claude note PR #172 opened — guard added at line 909, _HK_OUTCOME_MAP updated, test added, 153 tests pass
 
 --- body ---
 ## Context

--- a/tickets/closed/0137-beat-unguarded-checkout-housekeeping.erg
+++ b/tickets/closed/0137-beat-unguarded-checkout-housekeeping.erg
@@ -2,12 +2,14 @@
 Title: Guard git checkout in housekeeping post-cleanup path (beat.py line 807)
 Created: 2026-05-12
 Author: claude
+Closed: autoclosed — PR #175
 
 --- log ---
 2026-05-12T20:00Z claude created — celebrate sweep after 0120 fix; same class as 0120
 2026-05-13T00:00Z claude note PR #172 opened — guard added at line 909, _HK_OUTCOME_MAP updated, test added, 153 tests pass
 2026-05-13T00:01Z claude note PR #172 closed (branch contamination); PR #175 opened from clean t0137v3 branch, 152 tests pass
 
+2026-05-13T09:36Z MinhHaDuong closed — autoclosed — PR #175
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0137-beat-unguarded-checkout-housekeeping.erg

Closes ticket 0137. Mirrors the dirty-tree guard from _raid() (added in 0120) to the housekeeping cleanup path.

## Summary
- Adds a `git status --porcelain` check before `_git("checkout", default_branch)` in `_housekeeping_phase()` after the skill run completes
- Returns `"aborted-dirty-tree"` if the working tree is dirty, preventing a silent checkout failure that could leave the repo in an inconsistent state
- Adds `"aborted-dirty-tree": "fail"` to `_HK_OUTCOME_MAP` so the caller maps it to the `"fail"` outcome
- Updates the docstring to document the new return value
- Adds a test that patches `_git` to return non-empty stdout for `status --porcelain` and asserts the function returns `"aborted-dirty-tree"` without reaching checkout

## Test plan
- [x] `python3 -m pytest tests/test_beat.py -x -q` passes (152 tests)
- [x] New test `test_aborted_dirty_tree_when_post_skill_tree_dirty` explicitly asserts no post-skill checkout is called when tree is dirty

Generated with [Claude Code](https://claude.com/claude-code)