### PR TITLE
test(beat): add test_max_turns_pick_ticket_cap

### DIFF
--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1757,6 +1757,10 @@ class TestProjectConfigFields:
         cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_housekeeping=9999)
         assert cfg.max_turns_housekeeping == 2 * beat.MAX_TURNS_HOUSEKEEPING
 
+    def test_max_turns_pick_ticket_cap(self):
+        cfg = beat.ProjectConfig(path=Path("/tmp/p"), max_turns_pick_ticket=9999)
+        assert cfg.max_turns_pick_ticket == 2 * beat.MAX_TURNS_PICK_TICKET
+
 
 class TestApplyBeatJsonOverlay:
     def test_overlay_merges_known_keys(self, tmp_path):

--- a/tickets/0148-test-max-turns-pick-ticket-cap.erg
+++ b/tickets/0148-test-max-turns-pick-ticket-cap.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-13T08:30Z claude created
+2026-05-13T10:15Z claude executed — PR reopened after contamination fix
 
 --- body ---
 ## Context

--- a/tickets/closed/0148-test-max-turns-pick-ticket-cap.erg
+++ b/tickets/closed/0148-test-max-turns-pick-ticket-cap.erg
@@ -2,11 +2,13 @@
 Title: add test_max_turns_pick_ticket_cap to test_beat.py
 Created: 2026-05-13
 Author: claude
+Closed: autoclosed — PR #177
 
 --- log ---
 2026-05-13T08:30Z claude created
 2026-05-13T10:15Z claude executed — PR reopened after contamination fix
 
+2026-05-13T09:34Z MinhHaDuong closed — autoclosed — PR #177
 --- body ---
 ## Context
 PR #169 (ticket 0143) added a `__post_init__` cap for `max_turns_pick_ticket`


### PR DESCRIPTION
Ticket: tickets/0148-test-max-turns-pick-ticket-cap.erg

Closes ticket 0148. Missing regression test for max_turns_pick_ticket cap added in PR #169.