### PR TITLE
docs(nightbeat-supervisor): budget-raise convergence guard

### DIFF
--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -56,9 +56,19 @@ actionable root cause:
 When you reach a root cause, repair if within authority:
 
 - **Missing permission** → add to `settings.json` allowlist.
-- **Budget too small for the actual scope of work** → raise the per-project
-  `ProjectConfig` field in `beat.py` by 20%, capped at 2× the module-level
-  constant; never touch the module-level constant.
+- **Budget too small for the actual scope of work** → before raising, apply
+  the convergence guard:
+  1. Count `action=repair` journal entries for the same project+phase in the
+     last 7 days. If ≥ 3: **do not raise**. Instead, open a ticket:
+     "budget not converging for {project} {phase} — {N} raises in 7 days,
+     current={current}, started={first}."
+  2. If the proposed raise would exceed 1.5× the module-level constant for
+     that phase, log a warning and include it in the ticket body (note: the
+     hard ceiling remains 2× the module-level constant — the 1.5× threshold
+     is a warning only, not a new cap).
+  If neither guard triggers: raise the per-project `ProjectConfig` field in
+  `beat.py` by 20%, capped at 2× the module-level constant; never touch the
+  module-level constant.
 - **Raid timeout during verify/review** (`outcome=timeout` AND why-chain
   shows verify/review slowness, not implementation slowness) → raise
   `raid_timeout_s` in the per-project config by 20%, capped at

--- a/tickets/0119-budget-raise-convergence-guard.erg
+++ b/tickets/0119-budget-raise-convergence-guard.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=9, sev=medium, score=18
 2026-05-11T16:52Z claude note — reverted erroneous auto-close (PR #139 opens this ticket, does not implement it)
+2026-05-13T00:00Z claude note — implemented convergence guard in SKILL.md; PR #178 opened; 216 tests pass
 --- body ---
 ## Context
 

--- a/tickets/closed/0119-budget-raise-convergence-guard.erg
+++ b/tickets/closed/0119-budget-raise-convergence-guard.erg
@@ -2,11 +2,13 @@
 Title: skill-doctor: budget-raise convergence guard — escalate after 3 consecutive raises
 Created: 2026-05-11
 Author: claude
+Closed: autoclosed — PR #178
 
 --- log ---
 2026-05-11T16:00Z claude created — skill-doctor survey: freq=9, sev=medium, score=18
 2026-05-11T16:52Z claude note — reverted erroneous auto-close (PR #139 opens this ticket, does not implement it)
 2026-05-13T00:00Z claude note — implemented convergence guard in SKILL.md; PR #178 opened; 216 tests pass
+2026-05-13T09:53Z MinhHaDuong closed — autoclosed — PR #178
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes ticket 0119. Adds a 3-raises/7-days convergence guard to prevent infinite budget escalation. Raises that would exceed 1.5x the constant trigger a warning ticket instead.

## Summary
- Before raising a budget, count `action=repair` journal entries for the same project+phase in the last 7 days
- If ≥ 3 entries: open a ticket instead of raising (hard stop)
- If the proposed raise would exceed 1.5× the module-level constant: log a warning and include it in the ticket (soft threshold — the 2× hard ceiling is unchanged)

## Test plan
- [x] `python3 -m pytest tests/ -x -q` — 216 passed (doc-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ticket: tickets/0119-budget-raise-convergence-guard.erg