### PR TITLE
feat(skills): add nightbeat-risk-review skill

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -10,6 +10,7 @@ A reusable, science-backed personal harness for AI-assisted research: code and p
 <!-- generated 2026-05-13T05:48Z -->
 
 **Tickets:** 20 ready · 4 blocked — `erg ready tickets/` for full list
+**Morning review:** `/nightbeat-report` (narrative) · `/nightbeat-risk-review` (interactive triage before next run)
 **Recent commits:**
   4872f22 chore: housekeeping timestamp 2026-05-13T05:48Z
   e2127ee chore: ticket 0142 — verify agents must not use main repo as workspace

--- a/skills/nightbeat-risk-review/SKILL.md
+++ b/skills/nightbeat-risk-review/SKILL.md
@@ -11,6 +11,12 @@ Run this skill before starting a new nightbeat window to flag and de-risk struct
 
 ## Steps
 
+0. **Resolve the `erg` binary.**
+
+   ```bash
+   ERG=$(command -v erg 2>/dev/null || echo "tickets/erg")
+   ```
+
 1. **Collect the raw report.**
 
    Run:
@@ -22,7 +28,8 @@ Run this skill before starting a new nightbeat window to flag and de-risk struct
 
 2. **Extract risk signals.**
 
-   For each run in the report, extract the picked ticket ID (look for `PICK: NNNN` in the result text).
+   For each run in the report, read the ticket ID from the **Ticket** column of the run table
+   (the four-digit number shown for runs where a ticket was picked; rows showing `—` had no pick).
    Flag a ticket if **any** of:
    - `total_cost_usd > 2.0` — parallel fanout risk
    - `stop_reason` is `None` or absent — budget kill or crash
@@ -47,13 +54,14 @@ Run this skill before starting a new nightbeat window to flag and de-risk struct
 
    a. **sweep-skip** — tag the ticket deferred:
       ```bash
-      erg tag NNNN deferred tickets/
-      erg log NNNN "claude note sweep-skip: scope-too-large, deferred after risk review" tickets/
+      $ERG tag NNNN deferred tickets/
+      $ERG log NNNN "claude note sweep-skip: <signal>, deferred after risk review" tickets/
       ```
+      Replace `<signal>` with the actual risk signal (e.g. `cost>$2`, `budget-kill`, `repeated-pick`, `access-denied`, `expensive-fast`).
 
    b. **note** — append an explanation without tagging:
       ```bash
-      erg log NNNN "claude note <reason>" tickets/
+      $ERG log NNNN "claude note <reason>" tickets/
       ```
 
    c. **open sub-ticket** — split into a smaller ticket: invoke `/ticket-new` to create the sub-ticket with a focused scope.

--- a/skills/nightbeat-risk-review/SKILL.md
+++ b/skills/nightbeat-risk-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: nightbeat-risk-review
+description: Interactively de-risk nightbeat by reviewing logs for risky-ticket patterns.
+user-invocable: true
+argument-hint: "[--hours N]"
+---
+
+# Nightbeat Risk Review — interactive triage
+
+Run this skill before starting a new nightbeat window to flag and de-risk structurally problematic tickets.
+
+## Steps
+
+1. **Collect the raw report.**
+
+   Run:
+   ```bash
+   python3 ~/.claude/scripts/nightbeat-report.py --full --hours 72
+   ```
+   Accept `--hours N` from the skill argument and substitute it (default: 72 = 3 nights).
+   Capture and read the full output.
+
+2. **Extract risk signals.**
+
+   For each run in the report, extract the picked ticket ID (look for `PICK: NNNN` in the result text).
+   Flag a ticket if **any** of:
+   - `total_cost_usd > 2.0` — parallel fanout risk
+   - `stop_reason` is `None` or absent — budget kill or crash
+   - Same ticket ID picked ≥ 2 times in the window with no new commits between picks — repeated pick, no progress
+   - Result text contains "Access Denied" or "permission denial"
+   - `num_turns < 5` and `total_cost_usd > 1.0` — expensive but fast, parallel agents died early
+
+3. **Present risk table.**
+
+   Display a ranked table (worst signals first):
+
+   ```
+   | Ticket | Project | Attempts | Max Cost ($) | Signals |
+   |--------|---------|----------|--------------|---------|
+   ```
+
+   If no tickets are flagged, print "No risk signals detected in the window." and stop.
+
+4. **Interactive triage.**
+
+   For each flagged ticket (in risk-rank order), present signals and offer:
+
+   a. **sweep-skip** — tag the ticket deferred:
+      ```bash
+      erg tag NNNN deferred tickets/
+      erg log NNNN "claude note sweep-skip: scope-too-large, deferred after risk review" tickets/
+      ```
+
+   b. **note** — append an explanation without tagging:
+      ```bash
+      erg log NNNN "claude note <reason>" tickets/
+      ```
+
+   c. **open sub-ticket** — split into a smaller ticket: invoke `/ticket-new` to create the sub-ticket with a focused scope.
+
+   d. **skip** — leave unchanged, move to next.
+
+   Record every action taken.
+
+5. **Housekeeping commit.**
+
+   After triage, commit all modified ticket files:
+   ```bash
+   git add tickets/
+   git commit -m "chore(tickets): nightbeat risk-review triage $(date +%Y-%m-%d)"
+   ```
+   If no files were changed (all `skip`), print "No changes to commit."

--- a/tickets/closed/0065-nightbeat-risk-review-skill.erg
+++ b/tickets/closed/0065-nightbeat-risk-review-skill.erg
@@ -2,10 +2,12 @@
 Title: Skill to interactively de-risk nightbeat by reviewing logs for risky-ticket patterns
 Created: 2026-04-30
 Author: claude
+Closed: autoclosed — PR #183
 
 --- log ---
 2026-04-30T07:30Z claude created
 
+2026-05-13T11:47Z MinhHaDuong closed — autoclosed — PR #183
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0065-nightbeat-risk-review-skill.erg

## Summary
- New skill \`/nightbeat-risk-review\` parses nightbeat logs and flags structurally risky tickets
- Five risk signals: cost >$2, stop_reason None, repeated pick, access denied, high-cost-low-turns
- Interactive triage: sweep-skip, note, sub-ticket (via \`/ticket-new\`), or skip
- STATE.md updated with morning review reference

## Test plan
- [x] \`skills/nightbeat-risk-review/SKILL.md\` created
- [x] \`nightbeat-report.py --full --hours 72\` runs without error
- [x] STATE.md references the new skill
- [x] Verify: ticket extraction, erg binary resolution, sweep-skip label corrected

Closes #0065
🤖 Generated with [Claude Code](https://claude.com/claude-code)