### PR TITLE
fix(healthcheck,housekeeping): probe squash-merges by PR number

### DIFF
--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -32,10 +32,10 @@ Parse the JSON output. Use its fields to populate checks 1–9 below without re-
    - **Closed-ticket branches** (name matches `t<NNNN>-*` and ticket NNNN has a `Closed:` line) where the squash-merge probe succeeds: classify as **fix-now** — safe to delete. Run this probe per branch:
      ```bash
      merge_base=$(git merge-base main <branch>)
-     ticket_id=$(echo <branch> | grep -oP 't\K\d+')
-     git log $merge_base..main --format="%s" | grep -qP "(feat|fix|chore|ticket)\($ticket_id\)"
+     pr_num=$(grep -oP '#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
+     [ -n "$pr_num" ] && git log $merge_base..main --format="%s" | grep -qE "\(#${pr_num}\)"
      ```
-     If the grep exits 0, the branch was squash-merged into main. Emit one fix-now bullet per matching branch: `Delete local branch \`<branch>\` (closed ticket <NNNN>, squash-merged into main)`.
+     If the probe exits 0, the branch was squash-merged into main. Emit one fix-now bullet per matching branch: `Delete local branch \`<branch>\` (closed ticket <NNNN>, squash-merged into main)`.
    - **Closed-ticket branches** where the squash-merge probe fails (grep exits non-zero): flag as cleanup candidate (commits not yet on default branch — manual review needed before deleting).
 5. **Worktrees** — from `worktrees`. Flag entries with `locked: true` whose lock pid is no longer running.
 6. **Working tree** — from `git.clean` / `git.dirty_files`. List uncommitted files if dirty.

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -32,7 +32,7 @@ Parse the JSON output. Use its fields to populate checks 1–9 below without re-
    - **Closed-ticket branches** (name matches `t<NNNN>-*` and ticket NNNN has a `Closed:` line) where the squash-merge probe succeeds: classify as **fix-now** — safe to delete. Run this probe per branch:
      ```bash
      merge_base=$(git merge-base main <branch>)
-     pr_num=$(grep -oP '#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
+     pr_num=$(grep -oP '^Closed:.*#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
      [ -n "$pr_num" ] && git log $merge_base..main --format="%s" | grep -qE "\(#${pr_num}\)"
      ```
      If the probe exits 0, the branch was squash-merged into main. Emit one fix-now bullet per matching branch: `Delete local branch \`<branch>\` (closed ticket <NNNN>, squash-merged into main)`.

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -33,7 +33,7 @@ Parse the JSON output. Use its fields to populate checks 1–9 below without re-
      ```bash
      merge_base=$(git merge-base main <branch>)
      pr_num=$(grep -oP '^Closed:.*#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
-     [ -n "$pr_num" ] && git log $merge_base..main --format="%s" | grep -qE "\(#${pr_num}\)"
+     [ -n "$pr_num" ] && git log $merge_base..main --format="%s%n%b" | grep -qE "\(#${pr_num}\)"
      ```
      If the probe exits 0, the branch was squash-merged into main. Emit one fix-now bullet per matching branch: `Delete local branch \`<branch>\` (closed ticket <NNNN>, squash-merged into main)`.
    - **Closed-ticket branches** where the squash-merge probe fails (grep exits non-zero): flag as cleanup candidate (commits not yet on default branch — manual review needed before deleting).

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -33,7 +33,7 @@ Run full repo housekeeping and act on every finding.
      ```bash
      merge_base=$(git merge-base main <branch>)
      pr_num=$(grep -oP '^Closed:.*#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
-     [ -n "$pr_num" ] && git log $merge_base..main --format="%s" | grep -qE "\(#${pr_num}\)"
+     [ -n "$pr_num" ] && git log $merge_base..main --format="%s%n%b" | grep -qE "\(#${pr_num}\)"
      ```
    - **Worktree guard**: if the branch is prefixed with `+` in `git branch` output, a
      worktree is checked out on it. Skip if the worktree is dirty (uncommitted changes).

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -32,7 +32,7 @@ Run full repo housekeeping and act on every finding.
      diverged, the branch is not yet merged — skip deletion.
      ```bash
      merge_base=$(git merge-base main <branch>)
-     pr_num=$(grep -oP '#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
+     pr_num=$(grep -oP '^Closed:.*#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
      [ -n "$pr_num" ] && git log $merge_base..main --format="%s" | grep -qE "\(#${pr_num}\)"
      ```
    - **Worktree guard**: if the branch is prefixed with `+` in `git branch` output, a

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -32,8 +32,8 @@ Run full repo housekeeping and act on every finding.
      diverged, the branch is not yet merged — skip deletion.
      ```bash
      merge_base=$(git merge-base main <branch>)
-     ticket_id=$(echo <branch> | grep -oP 't\K\d+')
-     git log $merge_base..main --format="%s" | grep -qP "(feat|fix|chore|ticket)\($ticket_id\)"
+     pr_num=$(grep -oP '#\K[0-9]+' tickets/closed/$(ls tickets/closed/ | grep -P "^$(echo <branch> | grep -oP 't\K\d+')-" | head -1) 2>/dev/null | head -1 || true)
+     [ -n "$pr_num" ] && git log $merge_base..main --format="%s" | grep -qE "\(#${pr_num}\)"
      ```
    - **Worktree guard**: if the branch is prefixed with `+` in `git branch` output, a
      worktree is checked out on it. Skip if the worktree is dirty (uncommitted changes).


### PR DESCRIPTION
## Summary
- Replace broken regex probe `(feat|fix|chore|ticket)\(NNNN\)` with PR-number extraction from `Closed:` line
- Match `(#NNN)` in main's commit subjects — the actual squash-merge format
- Anchor extraction to `^Closed:` line to prevent false matches from body/Blocked-by references
- Conservative fallback: when no PR# recorded, skip deletion (not false-positive delete)

## Test plan
- [x] `grep -oP '^Closed:.*#\K[0-9]+'` correctly extracts PR number from Closed: line
- [x] Anchor ignores `#NNN` references in body and other headers
- [x] All 6 confirmed-merged PR numbers (174, 175, 177, 178, 179, 171) found in main commit log

Closes #0149
🤖 Generated with [Claude Code](https://claude.com/claude-code)