### PR TITLE
feat(housekeeping): add open-ticket exit-criteria audit

### DIFF
--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -21,6 +21,22 @@ Run full repo housekeeping and act on every finding.
    the output: the bold headings `**fix-now**`, `**open-ticket**`, `**skip**`
    are the contract interface consumed by steps 3–5 below.
 
+2.5. **Audit open-ticket exit criteria.** For each open ticket, apply the
+   same lightweight grep-able checks used by /pick-ticket step 4. Only
+   check exit criteria that reduce to one of three crisp shapes:
+
+   1. **String absence**: `! grep -qF "<literal>" <file>`
+   2. **File absence**: `test ! -f <path>`
+   3. **Symbol presence**: `grep -qE '^(def|class|func) <name>' <file>`
+
+   If *all* of a ticket's exit criteria reduce to these shapes AND all
+   pass: call `/ticket-close <id> already-done`. Log each closure as a
+   fix-now action and include it in the step 3 commit. If *any* criterion
+   is vague or cannot be reduced to these shapes → leave the ticket open.
+
+   Process all open tickets unconditionally (not just candidates).
+   Batch-closing is allowed here: close every qualifying ticket in one pass.
+
 3. **Fix `fix-now` items.** Apply every `fix-now` item inline. If any fixes were
    applied, commit once: `chore: housekeeping fixes (sweep)`.
 

--- a/tickets/0049-truth-in-ticket-open-status.erg
+++ b/tickets/0049-truth-in-ticket-open-status.erg
@@ -9,6 +9,7 @@ Author: claude
 2026-04-29T09:18Z claude note sweep-skip: scope-too-large hash:a817bfe3a1a2 expires:2026-04-30T09:18Z
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:1141174ff292 expires:2026-04-30T09:21Z
 2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
+2026-05-13T12:02Z verify-gate round=1 verdict=APPROVED — PR #186 cleared
 --- body ---
 ## Context
 

--- a/tickets/closed/0049-truth-in-ticket-open-status.erg
+++ b/tickets/closed/0049-truth-in-ticket-open-status.erg
@@ -2,6 +2,7 @@
 Title: Enforce Truth in Ticket Open Status across the beat pipeline
 Created: 2026-04-29
 Author: claude
+Closed: autoclosed — PR #186
 
 --- log ---
 2026-04-29T09:00Z claude created
@@ -10,6 +11,7 @@ Author: claude
 2026-04-29T09:25Z claude note sweep-skip: scope-too-large hash:1141174ff292 expires:2026-04-30T09:21Z
 2026-04-29T18:55Z claude note repaired body corruption from erg sweep-skip bug (ticket 0060)
 2026-05-13T12:02Z verify-gate round=1 verdict=APPROVED — PR #186 cleared
+2026-05-13T12:06Z MinhHaDuong closed — autoclosed — PR #186
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: tickets/0049-truth-in-ticket-open-status.erg

## Summary
- Add step 2.5 to housekeeping skill: audit open tickets for grep-able exit criteria
- Tickets whose exit criteria reduce to string-absence, file-absence, or symbol-presence checks — and all pass — are closed automatically
- Tier 1 of ticket #0049; Tiers 2 (pick-ticket step 4) and 3 (start-ticket step 2) already shipped

## Test plan
- [x] Step 2.5 inserted between step 2 and step 3 in housekeeping/SKILL.md
- [x] References /pick-ticket step 4 for the canonical grep-shape definitions
- [x] Does not renumber existing steps

Closes #0049
🤖 Generated with [Claude Code](https://claude.com/claude-code)