### PR TITLE
fix(merge): skip local fast-forward when main has unpushed commits (#0150)

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -114,7 +114,19 @@ if in_worktree; then
     echo "In git worktree — skipping checkout of ${BASE_BRANCH}; exit the worktree when done."
 else
     git checkout "$BASE_BRANCH"
-    git pull --rebase origin "$BASE_BRANCH"
+    # Safe fast-forward: skip when local branch has unpushed commits
+    # (e.g., housekeeping ticks) to avoid rebase conflicts on the
+    # already-squash-merged PR.  The GitHub merge succeeded; local
+    # state is the caller's responsibility.
+    LOCAL=$(git rev-parse HEAD)
+    git fetch origin "$BASE_BRANCH"
+    REMOTE=$(git rev-parse "origin/$BASE_BRANCH")
+    if git merge-base --is-ancestor "$LOCAL" "$REMOTE"; then
+        # Local is behind or at parity — safe to fast-forward
+        git merge --ff-only "origin/$BASE_BRANCH"
+    else
+        echo "erg-pr-merge: warning: local ${BASE_BRANCH} has unpushed commits — skipping pull to avoid rebase conflict"
+    fi
 fi
 
 echo "Done."

--- a/tickets/0150-erg-pr-merge-local-main-diverged.erg
+++ b/tickets/0150-erg-pr-merge-local-main-diverged.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: Fix erg-pr-merge when local main is ahead of origin/main
+Created: 2026-05-13
+Author: claude
+
+--- log ---
+2026-05-13T14:10Z claude created
+
+--- body ---
+## Context
+
+`erg-pr-merge` fails at the final squash-merge step when local `main`
+has unpushed commits (diverged from `origin/main`). The script tries to
+fast-forward local main after squash-merging, hits a rebase conflict,
+and exits non-zero — leaving a half-applied rebase that must be aborted
+manually.
+
+Observed in raid session 2026-05-13: PRs #183 and #186 both hit this.
+Workaround: `git rebase --abort` + manual `gh api .../merge` call.
+
+The root cause: the script assumes local main is either behind or at
+parity with origin/main. When a housekeeping session runs and leaves
+commits on local main (state machine tick), this assumption breaks.
+
+## Actions
+
+1. In `skills/merge/erg-pr-merge`, locate the post-merge `git pull`
+   or fast-forward step that updates local main.
+2. Replace with a safe variant: if local main diverges, skip the local
+   fast-forward (log a warning) and do NOT rebase. The squash-merge
+   on GitHub succeeded; local state is the caller's problem.
+3. Alternatively, do the squash-merge via `gh api` directly (matching
+   what we already do as the workaround) and skip the local git step
+   entirely — the local branch is a worktree throwaway anyway.
+
+## Test
+
+Set up a local main with 1 unpushed commit, then run `erg-pr-merge` on
+a PR. Verify: PR is squash-merged on GitHub, script exits 0, no rebase
+is left in progress.
+
+## Exit criteria
+
+- [ ] `erg-pr-merge` exits 0 when local main is ahead of origin/main
+- [ ] No `git rebase --abort` manual step required
+- [ ] PR is squash-merged on GitHub and ticket is closed


### PR DESCRIPTION
## Summary
- When local `main` has unpushed commits (e.g., from housekeeping ticks), `erg-pr-merge` would fail at the post-merge `git pull --rebase` step with a rebase conflict
- Replace the unconditional `git pull --rebase` with a safe fast-forward: fetch, check ancestry, and only `git merge --ff-only` when local is behind or at parity with remote
- When local diverges, log a warning and skip — the GitHub squash-merge already succeeded

**Ticket:** tickets/0150-erg-pr-merge-local-main-diverged

## Test plan
- [ ] Script syntax check passes (`bash -n`)
- [ ] With local main at parity: fast-forward works as before
- [ ] With local main ahead: warning logged, script exits 0
- [ ] Squash-merge on GitHub still succeeds regardless of local state

Generated with [Claude Code](https://claude.com/claude-code)