### PR TITLE
chore(tickets): three spinoffs from 0068 annotation (0151, 0152, 0153)

### DIFF
--- a/tickets/0151-extract-harness-rules-from-skills-it-is.erg
+++ b/tickets/0151-extract-harness-rules-from-skills-it-is.erg
@@ -1,0 +1,45 @@
+%erg 0.1
+Title: Extract harness-rules from skills/ — it is documentation, not a skill
+Created: 2026-05-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-05-13T14:14Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+`skills/harness-rules/` has no `SKILL.md`. It's a rule-pack
+(`README.md`, `workflow.md`, `git.md`, `state.md`, `coding-python.md`)
+auto-injected by the session-start hook. It appears in the
+user-facing skill list only because of its directory location.
+
+Surfaced as cleanup finding 1.a in the 2026-05-13 annotation on
+ticket 0068. Splitting out so 0068 can stay focused on naming;
+this is structural.
+
+## Actions
+
+1. Pick a destination — candidates: `rules/`, `docs/rules/`,
+   `skills/_rules/` (leading-underscore convention to mark
+   non-skill). Prefer `rules/` for short paths and clear semantics.
+2. `git mv skills/harness-rules/* rules/` (or chosen path).
+3. Update the session-start injection hook (likely a script under
+   `scripts/` or a `settings.json` startup hook entry) to read from
+   the new path.
+4. Update `skills/verify-adherence/SKILL.md` — it references this
+   rule-pack as "the single source of truth" on rule applicability.
+5. Update any cross-refs in other skill files (`skills/end-session/`
+   references `state.md`; ticket-flow skills reference the
+   `tickets/AGENTS.md` pointer).
+6. Update README.md.
+7. Update the `agnostic-guard` CI grep paths if it scans
+   `skills/harness-rules/`.
+
+## Exit criteria
+
+- [ ] `skills/harness-rules/` does not exist.
+- [ ] New rules directory is auto-injected on session start.
+- [ ] No skill listing shows `harness-rules` as an invocable skill.
+- [ ] All cross-refs updated.
+- [ ] `make check` (or equivalent CI) passes.

--- a/tickets/0152-rescope-nightbeat-risk-review-into-check.erg
+++ b/tickets/0152-rescope-nightbeat-risk-review-into-check.erg
@@ -1,0 +1,66 @@
+%erg 0.1
+Title: Rescope nightbeat-risk-review into check-readiness — multi-repo pre-flight
+Created: 2026-05-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-05-13T14:14Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+`nightbeat-risk-review` today pre-flights one autonomous nightbeat
+on one repo by scanning the prior journal for risky-ticket signals
+(parallel-fanout cost, repeated picks, permission denials). Narrow
+scope, narrow value: only useful before scheduling `nightbeat-supervisor`.
+
+What we actually want is a **multi-repo readiness and configuration
+review**: a pre-flight that runs across every consumer project the
+harness manages and surfaces:
+
+- Per-repo git hygiene (uncommitted, drift from origin, stale
+  branches, dirty worktrees)
+- Ticket flow health (open count, stale-claim count, unclaimed
+  ready, blocked-by chains)
+- CLAUDE.md presence and freshness
+- `.claude/settings.json` drift across projects (skill aliases,
+  permission allowlists, hooks)
+- Skill-version drift if multiple project copies of skills exist
+  (current state: skills are global in `~/.claude/`, so not yet
+  applicable — but the audit anticipates per-project skill libs)
+- The current `nightbeat-risk-review` content, as one mode
+  (`--mode=nightbeat-history`) of the larger skill
+
+Surfaced as cleanup finding 1.b in the 2026-05-13 annotation on
+ticket 0068.
+
+## Actions
+
+1. Decide canonical name. Annotation proposed `check-readiness`;
+   alternatives: `audit-fleet`, `pre-flight`, `survey-repos`. The
+   annotation's recommended schema (option B from 0068) prefers
+   verb-object, so `check-readiness` fits.
+2. Rename `skills/nightbeat-risk-review/` → `skills/check-readiness/`.
+   Update SKILL.md frontmatter and self-references.
+3. Generalize the survey logic: today it shells `nightbeat-report.py`
+   for one repo. Iterate over `~/.claude/projects/*/` (or wherever
+   the project root list lives) and aggregate.
+4. Add the new modes:
+   - default (full sweep across all projects)
+   - `--mode=nightbeat-history` (preserves today's behaviour as a
+     legacy sub-mode, until 0068 closes and aliases land)
+   - `--project <name>` (scope to one project)
+5. Update STATE.md "Morning review" if it references the old name.
+6. Coordinate with 0068 — this rescope changes one row of the v2
+   mapping table.
+
+## Exit criteria
+
+- [ ] `skills/check-readiness/SKILL.md` exists and covers
+      multi-project pre-flight.
+- [ ] Today's nightbeat-risk-review behaviour available as a
+      sub-mode.
+- [ ] At least one cross-project signal surfaced that the old
+      skill couldn't (e.g. settings.json drift).
+- [ ] `skills/nightbeat-risk-review/` removed or redirects to the
+      new skill (depends on 0068's alias mechanism).

--- a/tickets/0153-design-evergreen-documentation-system-fo.erg
+++ b/tickets/0153-design-evergreen-documentation-system-fo.erg
@@ -1,0 +1,84 @@
+%erg 0.1
+Title: Design evergreen documentation system for the harness
+Created: 2026-05-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-05-13T14:14Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+The harness has README.md, STATE.md, scattered `docs/*.md` raid
+notes, per-skill `SKILL.md` frontmatter, the `harness-rules/` pack,
+and ticket bodies — but no single authoritative manual, and no
+mechanism keeping any of it in sync as skills evolve.
+
+Symptoms:
+- Onboarding agents (and humans) can't quickly answer "what does
+  this harness do? What skills exist? How do I run a typical day?"
+  without grepping the repo.
+- Mid-session, agents can't query "remind me what `/perch`
+  actually does" without reading the file.
+- New skills don't auto-appear anywhere users discover them
+  (slash-command picker is interactive-only).
+- Ticket 0068's v2 mapping table will be stale within weeks of any
+  new skill landing.
+
+Raised by the author during the 2026-05-13 annotation on 0068:
+"we need an evergreen documentation system for the harness — the
+README can only go so far."
+
+## Design space — candidates to explore
+
+This ticket is a design-stub, not an implementation plan. Each
+candidate is worth a paragraph of research before any code:
+
+a. **Auto-generated `SKILLS.md` catalog** — one file regenerated
+   from every `SKILL.md` frontmatter (name, description, args,
+   user-invocable). Cheap; stale-by-construction unless tied to a
+   pre-commit or CI hook.
+
+b. **`/show-docs <topic>` skill** — queryable corpus: skill
+   catalog + rule-pack + lifecycle docs surfaced via a single
+   command. Fits the agent-introspection use case.
+
+c. **`/show-skill <name>` skill** — focused variant: print one
+   skill's description, args, and source for in-session reference
+   without leaving the chat. Probably trivial to ship as a starter.
+
+d. **Architecture page regenerated from ticket history** — the
+   "why" of the harness lives in closed tickets. Could generate a
+   curated digest weekly via `skill-doctor` style sweep.
+
+e. **Docs as source of truth, skills derived** — the most
+   ambitious: SKILL.md frontmatter + rule-pack + ticket
+   conventions all derive from a single `docs/` source. Inverts
+   the current dependency. Probably overkill for a personal-fleet
+   harness.
+
+f. **Embedded query interface** — index everything (skills,
+   rules, tickets, STATE) into a small SQLite or grep-cache;
+   expose via `/query`. Crosses into RAG territory.
+
+## Actions (design phase only — no implementation in this ticket)
+
+1. Survey what's out there. Anthropic's own Claude Code docs,
+   public harnesses (Aider's structure, Cursor's rules, OpenDevin's
+   manifest format, any agent-OS literature from 2026).
+2. Decide the *primary use case*: agent introspection
+   mid-session? Human onboarding? Both? The answer shapes the
+   format.
+3. Pick the lightest candidate that solves the primary use case.
+   Candidate (c) `/show-skill` alone might be 80% of the value.
+4. Open one or more implementation tickets with concrete scope.
+5. Close this ticket with the design decision as the closing log
+   entry.
+
+## Exit criteria
+
+- [ ] A design note names the chosen approach and rejected
+      alternatives (in this ticket's body, or a separate
+      `docs/0153-doc-system-design.md`).
+- [ ] At least one implementation ticket filed.
+- [ ] Author signs off on the design.


### PR DESCRIPTION
Splits three concerns out of the [0068 annotation PR](https://github.com/MinhHaDuong/ImperialDragonHarness/pull/190) so 0068 can stay focused on naming/aliases.

## Tickets filed

**0151 — extract `harness-rules` from `skills/`**
`skills/harness-rules/` has no `SKILL.md`. It's the rule-pack the session-start hook auto-injects (workflow.md, git.md, state.md, coding-python.md). It only appears in the skill list because of its directory location. Move to `rules/` (or `docs/rules/`) and update the injection hook + `verify-adherence` cross-ref.

**0152 — rescope `nightbeat-risk-review` → `check-readiness`**
Today's skill pre-flights one nightbeat run on one repo. The needed scope is multi-repo: git hygiene, ticket-flow health, CLAUDE.md / settings.json drift, and skill-version drift across all consumer projects. Today's nightbeat-history sweep survives as a sub-mode.

**0153 — design evergreen documentation system**
Design-stub ticket. README, STATE, scattered docs/, SKILL.md frontmatter, rule-pack and tickets are not kept in sync. Six candidates listed from cheap (auto-generated SKILLS.md catalog regenerated by a pre-commit / CI hook) to ambitious (docs are the source of truth, skills derive from them). Picks deferred to the implementer of this design ticket.

## Why split

0068 is large enough; mixing structural changes (0151) and scope changes (0152) and a design exercise (0153) would conflate three different decision velocities. Each can move independently.

## Test plan

- [ ] All three tickets validate (\`erg validate\`)
- [ ] Agnostic-guard passes (no absolute home paths)
- [ ] Author reads each and decides ordering / priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)