### PR TITLE
fix(nightbeat): supervisor timer hourly at H+30

### DIFF
--- a/systemd/claude-nightbeat-supervisor.timer
+++ b/systemd/claude-nightbeat-supervisor.timer
@@ -1,14 +1,14 @@
 [Unit]
-Description=Nightbeat supervisor — every 15 min during nightbeat window
+Description=Nightbeat supervisor — hourly at H+30 during nightbeat window
 
 [Timer]
-# Weeknights: 22:00–06:59 every 15 min (matches nightbeat window)
-OnCalendar=Mon..Fri *-*-* 22,23,0,1,2,3,4,5,6:0,15,30,45:00
-# Weekends: all day every 15 min
-OnCalendar=Sat,Sun *-*-* *:0,15,30,45:00
+# Weeknights: hourly at :30 (beat fires at :00 ±5min; supervisor surveys after)
+OnCalendar=Mon..Fri *-*-* 22,23,0,1,2,3,4,5,6:30:00
+# Weekends: all day, hourly at :30
+OnCalendar=Sat,Sun *-*-* *:30:00
 # Fire once on boot if a scheduled run was missed while machine was off
 Persistent=true
-# Spread within 30 s to avoid exact collision with beat (which starts at :00)
+# Spread within 30 s to avoid exact collision with anything else at :30
 RandomizedDelaySec=30
 Unit=claude-nightbeat-supervisor.service
 

--- a/tickets/0156-supervisor-timer-hourly-at-h30.erg
+++ b/tickets/0156-supervisor-timer-hourly-at-h30.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-05-13T20:40Z claude created
+2026-05-13T20:46Z claude note updated timer: every-15-min → hourly at :30
 
 --- body ---
 ## Context

--- a/tickets/closed/0156-supervisor-timer-hourly-at-h30.erg
+++ b/tickets/closed/0156-supervisor-timer-hourly-at-h30.erg
@@ -2,11 +2,13 @@
 Title: Change nightbeat-supervisor timer to hourly at H+30
 Created: 2026-05-13
 Author: claude
+Closed: autoclosed — PR #193
 
 --- log ---
 2026-05-13T20:40Z claude created
 2026-05-13T20:46Z claude note updated timer: every-15-min → hourly at :30
 
+2026-05-13T20:52Z MinhHaDuong closed — autoclosed — PR #193
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
- Change `claude-nightbeat-supervisor.timer` from every 15 min to hourly at `:30`
- Beat fires at `:00` (±5min); supervisor at `:30` surveys a full hour of outcomes
- Eliminates three idle journal entries per hour

Ticket: tickets/0156-supervisor-timer-hourly-at-h30.erg

## Test plan
- [x] `systemctl --user list-timers` shows next trigger at H+30
- [x] Unit description updated
- [x] Install on padme