### PR TITLE
feat(0159): skip PR loop for erg-only branches

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -94,11 +94,19 @@ if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; t
     if ! git diff --cached --quiet; then
         git commit -m "ticket(${TICKET_ID}): close and archive — PR #${PR}"
     fi
-    git push origin HEAD
-    echo "Waiting for CI after ticket-close commit..."
-    # harness-extension-point
-    timeout 600 gh pr checks "$PR" --watch --fail-fast \
-        || die "CI did not pass within 600s (failed or timed out) — aborting merge"
+
+    # Check if this is an erg-only branch (no changes outside tickets/)
+    DIFF_SIZE=$(git diff origin/main...HEAD -- . ':(exclude)tickets/' | wc -c)
+
+    if [[ "$DIFF_SIZE" -eq 0 ]]; then
+        echo "Erg-only branch detected — skipping CI wait (no code changes)"
+    else
+        git push origin HEAD
+        echo "Waiting for CI after ticket-close commit..."
+        # harness-extension-point
+        timeout 600 gh pr checks "$PR" --watch --fail-fast \
+            || die "CI did not pass within 600s (failed or timed out) — aborting merge"
+    fi
 elif [[ -n "$TICKET_ID" ]]; then
     echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"
 fi

--- a/skills/ticket-close/SKILL.md
+++ b/skills/ticket-close/SKILL.md
@@ -8,6 +8,14 @@ argument-hint: <ticket-id> [reason]
 
 # Close ticket $ARGUMENTS
 
-1. Parse `$ARGUMENTS`: first word is `<id>`, rest is `<reason>` (default: `done`).
-2. Run: `${ERG:-erg} close <id> <reason>`
-3. Commit: `git add tickets/ && git commit -m "ticket(<id>): close — <reason>"`
+Run:
+```bash
+~/.claude/skills/ticket-close/ticket-close-impl $ARGUMENTS
+```
+
+**Behavior**:
+- Closes the ticket and commits the change
+- Detects if the branch contains only erg file changes
+- For erg-only branches: attempts fast-forward push to origin/main (bypasses PR)
+- For non-erg branches or if push fails: returns non-zero (caller should create PR)
+- If script exits 0, ticket is already merged; if non-zero, PR path should be used

--- a/skills/ticket-close/ticket-close-impl
+++ b/skills/ticket-close/ticket-close-impl
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ticket-close-impl — close a ticket and optionally push directly to main for erg-only changes
+#
+# Usage: ticket-close-impl <ticket-id> [reason]
+#
+# Behavior:
+#   1. Close the ticket using `erg close <id> <reason>`
+#   2. Stage and commit the changes
+#   3. Check if the branch contains only erg file changes (no other files modified)
+#   4. If erg-only: attempt fast-forward push to origin/main
+#   5. If non-erg or push fails: return without creating PR (caller handles PR creation)
+
+set -euo pipefail
+
+die() { echo "ticket-close-impl: $*" >&2; exit 1; }
+
+# Parse arguments
+if [[ $# -lt 1 ]]; then
+    die "usage: ticket-close-impl <ticket-id> [reason]"
+fi
+
+TICKET_ID="$1"
+REASON="${2:-done}"
+
+# Ensure we're in a git repo with tickets directory
+if ! [[ -d tickets ]]; then
+    die "not in a project with tickets/ directory"
+fi
+
+ERG=${ERG:-erg}
+if ! command -v "$ERG" &>/dev/null; then
+    die "erg not found in PATH"
+fi
+
+# Step 1: Close the ticket
+echo "Closing ticket ${TICKET_ID}..."
+"$ERG" close "$TICKET_ID" "$REASON"
+
+# Step 2: Stage and commit
+git add tickets/
+if git diff --cached --quiet; then
+    echo "No changes to commit (ticket already closed)"
+    exit 0
+fi
+
+git commit -m "ticket(${TICKET_ID}): close — ${REASON}"
+
+# Step 3: Detect if branch is erg-only
+# A branch is erg-only if all changes are in tickets/ directory
+DIFF_SIZE=$(git diff origin/main...HEAD -- . ':(exclude)tickets/' | wc -c)
+
+if [[ "$DIFF_SIZE" -eq 0 ]]; then
+    echo "Branch contains only erg changes — attempting fast-forward push to origin/main"
+
+    # Step 4: Try to push directly to main
+    if git push origin HEAD:main 2>/dev/null; then
+        echo "Successfully pushed to origin/main"
+        exit 0
+    else
+        echo "Fast-forward push failed (non-fast-forward or other error) — falling back to PR path"
+        exit 1
+    fi
+else
+    echo "Branch contains non-erg changes — PR path will be used by caller"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Implements direct push to main for branches containing only .erg file changes (ticket creates/closes), bypassing the full PR + CI loop. This reduces overhead for pure metadata changes.

## Changes

1. **ticket-close-impl script**: New bash script that:
   - Closes the ticket using `erg close`
   - Detects if branch contains only tickets/ changes
   - For erg-only branches: attempts fast-forward push to origin/main
   - For non-erg or failed push: returns non-zero (caller handles PR)

2. **ticket-close skill**: Updated to use the new implementation script

3. **erg-pr-merge script**: Added early-exit check:
   - Detects erg-only branches before waiting for CI
   - Skips CI wait for erg-only changes (no code risk)

## Test plan

- Verified erg-only detection works correctly (diff size == 0)
- Verified mixed changes are properly detected (diff size > 0)
- Scripts are executable and well-documented

## Exit criteria

- [x] ticket-close detects erg-only branches and pushes directly to main
- [x] Non-erg changes still go through the normal PR path
- [x] Fast-forward failure falls back gracefully
- [x] erg-pr-merge skips CI wait for erg-only branches

Ticket: tickets/0159-skip-pr-loop-for-erg-only-branches.erg