### PR TITLE
Remove stale _BUILTIN_PROJECTS fallback (ticket 0155)

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -133,26 +133,6 @@ class ProjectConfig:
             self.max_turns_pick_ticket = cap
 
 
-_BUILTIN_PROJECTS: list[ProjectConfig] = [
-    ProjectConfig(
-        path=Path.home() / "aedist-technical-report",
-        budget_housekeeping=0.40,
-        budget_pick_ticket=0.50,
-    ),
-    ProjectConfig(
-        path=Path.home() / "cadens",
-        budget_housekeeping=0.40,
-        budget_pick_ticket=0.50,
-    ),
-    ProjectConfig(path=Path.home() / "Climate_finance"),
-    ProjectConfig(path=Path.home() / "fuzzy-corpus"),
-    ProjectConfig(
-        path=HARNESS_DIR,
-        budget_housekeeping=0.40,
-        budget_pick_ticket=0.50,
-    ),
-]
-
 _PROJ_KEYS = {
     "budget_housekeeping",
     "budget_pick_ticket",
@@ -185,12 +165,13 @@ def _apply_beat_json_overlay(config: ProjectConfig) -> None:
 
 
 def load_projects(config_path: Path) -> list[ProjectConfig]:
-    """Load project list from JSON; fall back to built-in defaults on any error."""
+    """Load project list from JSON; exit(1) if missing or malformed."""
     if not config_path.exists():
         print(
-            f"[beat] {config_path} not found, using built-in defaults", file=sys.stderr
+            f"[beat] {config_path} not found — beat requires valid projects.json",
+            file=sys.stderr,
         )
-        return list(_BUILTIN_PROJECTS)
+        sys.exit(1)
     try:
         entries = json.loads(config_path.read_text())
         configs = [
@@ -202,10 +183,10 @@ def load_projects(config_path: Path) -> list[ProjectConfig]:
         ]
     except Exception as exc:  # noqa: BLE001
         print(
-            f"[beat] error loading {config_path}: {exc}, using built-in defaults",
+            f"[beat] error loading {config_path}: {exc}",
             file=sys.stderr,
         )
-        return list(_BUILTIN_PROJECTS)
+        sys.exit(1)
     for cfg in configs:
         _apply_beat_json_overlay(cfg)
     return configs

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1447,23 +1447,18 @@ class TestLoadProjects:
         projects = beat.load_projects(cfg)
         assert projects[0].pick_ticket_model == "claude-opus-4-7"
 
-    def test_falls_back_when_missing(self, tmp_path, capsys):
-        projects = beat.load_projects(tmp_path / "nonexistent.json")
-        assert projects == beat._BUILTIN_PROJECTS
+    def test_exits_on_missing_config(self, tmp_path, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            beat.load_projects(tmp_path / "nonexistent.json")
+        assert exc_info.value.code == 1
         assert "not found" in capsys.readouterr().err
 
-    def test_falls_back_on_bad_json(self, tmp_path, capsys):
+    def test_exits_on_malformed_json(self, tmp_path, capsys):
         bad = tmp_path / "projects.json"
         bad.write_text("not { valid json")
-        projects = beat.load_projects(bad)
-        assert projects == beat._BUILTIN_PROJECTS
-        assert "error" in capsys.readouterr().err.lower()
-
-    def test_falls_back_on_missing_path_key(self, tmp_path, capsys):
-        cfg = tmp_path / "projects.json"
-        cfg.write_text(json.dumps([{"budget_housekeeping": 0.4}]))
-        projects = beat.load_projects(cfg)
-        assert projects == beat._BUILTIN_PROJECTS
+        with pytest.raises(SystemExit) as exc_info:
+            beat.load_projects(bad)
+        assert exc_info.value.code == 1
         assert "error" in capsys.readouterr().err.lower()
 
 


### PR DESCRIPTION
## Summary

Remove the hardcoded `_BUILTIN_PROJECTS` fallback list from beat.py and enforce that projects.json is required. This completes the migration from hardcoded defaults (ticket 0046) by removing the safety net that masked missing or malformed configuration files.

- Delete 19-line _BUILTIN_PROJECTS list
- Refactor load_projects() to exit(1) on missing/malformed config
- Remove 3 fallback-behavior tests; add 2 new exit-behavior tests
- All tests pass; no dangling references

## Exit criteria

- [x] _BUILTIN_PROJECTS no longer exists in beat.py
- [x] beat exits(1) when projects.json is missing
- [x] beat exits(1) when projects.json is malformed
- [x] Tests updated; all pass

Fixes #155