### PR TITLE
fix(0157): isolate beat-outcomes.jsonl for test suite

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -64,7 +64,15 @@ MODEL_SONNET: str = "sonnet"
 MODEL_HAIKU: str = "claude-haiku-4-5-20251001"
 
 PROJECTS_CONFIG: Path = HARNESS_DIR / "scripts" / "projects.json"
-OUTCOMES_LOG: Path = HARNESS_DIR / "logs" / "beat-outcomes.jsonl"
+
+
+def _get_outcomes_log() -> Path:
+    """Return the outcomes log path, respecting BEAT_OUTCOMES_LOG env override."""
+    return Path(
+        os.environ.get("BEAT_OUTCOMES_LOG")
+        or str(HARNESS_DIR / "logs" / "beat-outcomes.jsonl")
+    )
+
 
 # Weekly /fewer-permission-prompts cadence. Folded into nightbeat instead of
 # a dedicated systemd timer (ticket 0043). Lowercase weekday name; matched
@@ -458,8 +466,9 @@ def _record_phase_outcome(
             rec["cost_usd"] = round(skill_result.cost_usd, 4)
         if skill_result.permission_denials:
             rec["denied"] = skill_result.permission_denials
-    OUTCOMES_LOG.parent.mkdir(parents=True, exist_ok=True)
-    with OUTCOMES_LOG.open("a") as fh:
+    outcomes_log = _get_outcomes_log()
+    outcomes_log.parent.mkdir(parents=True, exist_ok=True)
+    with outcomes_log.open("a") as fh:
         fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
 
 

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -33,6 +33,12 @@ def reset_state():
     beat.DRY_RUN = original_dry_run
 
 
+@pytest.fixture(autouse=True)
+def isolate_outcomes_log(tmp_path, monkeypatch):
+    """Isolate beat-outcomes.jsonl to tmp_path for all tests."""
+    monkeypatch.setenv("BEAT_OUTCOMES_LOG", str(tmp_path / "outcomes.jsonl"))
+
+
 @pytest.fixture()
 def tmp_project(tmp_path):
     """Minimal git-like project directory with beat-log.jsonl."""


### PR DESCRIPTION
## Summary

Test suite writes to production beat-outcomes.jsonl, causing 100-200+ test entries per project to accumulate over 7 days and skew analyses (nightbeat-report, nightbeat-supervisor-survey, permission-prune telemetry).

Root cause: OUTCOMES_LOG was hardcoded at module import time, evaluated before pytest fixtures could override it.

## Solution

- Add `_get_outcomes_log()` function that respects `BEAT_OUTCOMES_LOG` env override
- Update `_record_phase_outcome()` to call the function dynamically
- Add autouse fixture in `test_beat.py` to isolate all tests to tmp_path

## Test Results

- All 217 tests pass
- Production log (beat-outcomes.jsonl) unchanged after test runs
- No new `test_*` entries written during pytest execution

## Exit Criteria

- [x] `BEAT_OUTCOMES_LOG` env var overrides the log path in beat.py
- [x] All test fixtures that invoke beat functions use a tmp_path-isolated log
- [x] Running `pytest tests/` does not append any new `test_*` entries to `~/.claude/logs/beat-outcomes.jsonl`
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)