### PR TITLE
beat(0158): replace beat-log state encoding with event encoding

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -229,47 +229,6 @@ def _beat_log_path(project: Path) -> Path:
     return project / "beat-log.jsonl"
 
 
-def _cleanup_stale_in_progress(project: Path) -> None:
-    """Rewrite any in_progress record older than CRASH_RECOVERY_WINDOW_S to aborted.
-
-    Crash recovery only catches the most-recent record; this catches orphans
-    buried under subsequent done/failed records when the 55-min window elapsed
-    before the project was next visited.
-    """
-    path = _beat_log_path(project)
-    if not path.exists():
-        return
-    cutoff = time.time() - CRASH_RECOVERY_WINDOW_S
-    lines = path.read_text().splitlines()
-    changed = False
-    new_lines: list[str] = []
-    for line in lines:
-        if line.strip():
-            try:
-                rec = json.loads(line)
-                if rec.get("outcome") == "in_progress":
-                    epoch = datetime.fromisoformat(
-                        rec.get("last_run_at", "1970-01-01T00:00:00Z").replace(
-                            "Z", "+00:00"
-                        )
-                    ).timestamp()
-                    if epoch < cutoff:
-                        rec["outcome"] = "aborted"
-                        rec["diagnostics"] = (
-                            "stale in_progress — cleaned on next beat start"
-                        )
-                        line = json.dumps(rec, separators=(",", ":"))
-                        changed = True
-            except (json.JSONDecodeError, ValueError, TypeError):
-                pass
-        new_lines.append(line)
-    if changed:
-        path.write_text("\n".join(new_lines) + "\n")
-        _log(
-            f"=== startup: cleaned stale in_progress records in {project.name} {_now_iso()} ==="
-        )
-
-
 # Harness worktree name patterns created by EnterWorktree
 _HARNESS_WORKTREE_RE = re.compile(r"^(agent-|explore-|t\d|review-)")
 
@@ -352,7 +311,7 @@ def _cleanup_locked_worktrees(project: Path) -> None:
             )
 
 
-def append_beat_log(project: Path, record: dict) -> None:
+def _append(project: Path, record: dict) -> None:
     """Append one compact-JSON record; no-op in dry-run mode."""
     if DRY_RUN:
         return
@@ -361,51 +320,112 @@ def append_beat_log(project: Path, record: dict) -> None:
         fh.write(json.dumps(record, separators=(",", ":")) + "\n")
 
 
-def finalize_beat_log(project: Path, record: dict) -> None:
-    """Write terminal spin-down record, replacing any trailing in_progress.
+def _reversed_lines(project: Path):
+    """Yield non-empty lines from beat-log.jsonl in reverse order."""
+    path = _beat_log_path(project)
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    for line in reversed(path.read_text().splitlines()):
+        if line.strip():
+            yield line
+
+
+def _parse_epoch(ts_str: str | None) -> float:
+    """Parse an ISO-8601 timestamp string (with optional Z suffix) to epoch seconds."""
+    if not ts_str:
+        return 0.0
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def write_beat_start(project: Path) -> None:
+    """Append a start event. Idempotent — never mutates existing records."""
+    _append(project, {"type": "start", "ts": _now_iso()})
+
+
+def write_beat_end(project: Path, outcome: str, **fields) -> None:
+    """Append an end event. Never scans or rewrites anything.
 
     Idempotent via _state.final_written; no-op in dry-run mode.
     """
     if _state.final_written or DRY_RUN:
         return
+    record = {"type": "end", "ts": _now_iso(), "outcome": outcome, **fields}
+    _append(project, record)
     _state.final_written = True
 
-    path = _beat_log_path(project)
-    if not path.exists():
-        append_beat_log(project, record)
-        return
 
-    lines = path.read_text().splitlines()
-    while lines:
+def _is_end_record(rec: dict) -> bool:
+    """Identify an end-event record across new and legacy formats.
+
+    New format: type == "end".
+    Legacy format: no `type` key, an `outcome` key is present, and outcome
+    is not "in_progress". The `outcome` key check is required to reject
+    pretty-printed `}` lines that parse to {} but lack any beat semantics.
+    """
+    if rec.get("type") == "end":
+        return True
+    if (
+        rec.get("type") is None
+        and "outcome" in rec
+        and rec.get("outcome") != "in_progress"
+    ):
+        return True
+    return False
+
+
+def _is_start_record(rec: dict) -> bool:
+    """Identify a start-event record across new and legacy formats."""
+    if rec.get("type") == "start":
+        return True
+    if rec.get("type") is None and rec.get("outcome") == "in_progress":
+        return True
+    return False
+
+
+def last_completed_beat(project: Path) -> dict | None:
+    """Return the most recent end-event record, or None.
+
+    Handles both new (`type:"end"`) and legacy records (no `type`, with
+    `outcome` key not equal to `in_progress`). Start events and stray
+    `}` lines from pretty-printed JSON are skipped.
+    """
+    for line in _reversed_lines(project):
         try:
-            if json.loads(lines[-1]).get("outcome") == "in_progress":
-                lines.pop()
-                continue
-        except (json.JSONDecodeError, AttributeError):
-            pass
-        break
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        if _is_end_record(rec):
+            return rec
+    return None
 
-    lines.append(json.dumps(record, separators=(",", ":")))
-    path.write_text("\n".join(lines) + "\n")
 
+def last_beat_crashed(project: Path, window_s: int = CRASH_RECOVERY_WINDOW_S) -> bool:
+    """True if the most recent start event has no following end event within window.
 
-def read_last_beat_record(project: Path) -> dict | None:
-    """Return the last record in beat-log.jsonl, handling pretty-printed JSON."""
-    path = _beat_log_path(project)
-    if not path.exists() or path.stat().st_size == 0:
-        return None
-    result = subprocess.run(  # noqa: S603
-        ["jq", "-s", "last"],
-        input=path.read_text(),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    try:
-        obj = json.loads(result.stdout)
-        return obj if isinstance(obj, dict) else None
-    except json.JSONDecodeError:
-        return None
+    Reverse-scans the log. If we see a completed-beat (end event) before any
+    orphaned start, the previous beat finished cleanly. If we see a start
+    event first, check its age: if within the crash-recovery window it counts
+    as a crash; otherwise it's old enough to ignore.
+    """
+    for line in _reversed_lines(project):
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        if _is_end_record(rec):
+            return False
+        if _is_start_record(rec):
+            ts_str = rec.get("ts") or rec.get("last_run_at")
+            age = time.time() - _parse_epoch(ts_str)
+            return age < window_s
+    return False
 
 
 # ── Phase outcome log ─────────────────────────────────────────────────────────
@@ -466,17 +486,12 @@ def _on_sigterm(_signum: int, _frame: object) -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
     if _state.project is not None:
-        finalize_beat_log(
+        write_beat_end(
             _state.project,
-            {
-                "last_run_at": _now_iso(),
-                "ticket_id": None,
-                "branch": None,
-                "PR": None,
-                "outcome": "aborted",
-                "diagnostics": "systemd SIGTERM — beat exceeded time budget",
-                "duration_s": elapsed,
-            },
+            "aborted",
+            ticket_id=None,
+            diagnostics="systemd SIGTERM — beat exceeded time budget",
+            duration_s=elapsed,
         )
     _log(f"=== beat SIGTERM elapsed={elapsed}s {_now_iso()} ===")
     sys.exit(143)
@@ -1093,15 +1108,15 @@ def _raid(project: ProjectConfig) -> tuple[str, str | None]:
     # Layer 2 pre-flight skip (ticket 0051): if nothing has changed in the repo
     # or ticket files since the last beat, skip the Claude pick-ticket invocation
     # and return idle directly — saves tokens on dormant projects.
-    _last_record = read_last_beat_record(path)
+    _last_record = last_completed_beat(path)
     _last_beat_at: datetime | None = None
-    if _last_record and _last_record.get("last_run_at"):
-        try:
-            _last_beat_at = datetime.fromisoformat(
-                _last_record["last_run_at"].replace("Z", "+00:00")
-            )
-        except (ValueError, TypeError):
-            pass
+    if _last_record:
+        _last_ts = _last_record.get("ts") or _last_record.get("last_run_at")
+        if _last_ts:
+            try:
+                _last_beat_at = datetime.fromisoformat(_last_ts.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                pass
     if not _pick_needed(path, _last_beat_at):
         _log(
             f"=== pick-ticket: skipped (nothing changed since"
@@ -1281,65 +1296,47 @@ def main() -> None:
 
     # Interval skip: project can declare a minimum interval between beats.
     if project.interval_minutes > 0:
-        last = read_last_beat_record(path)
-        if last and last.get("last_run_at"):
+        last = last_completed_beat(path)
+        if last:
+            last_ts = last.get("ts") or last.get("last_run_at")
             try:
-                last_epoch = datetime.fromisoformat(
-                    last["last_run_at"].replace("Z", "+00:00")
-                ).timestamp()
-                elapsed_s = time.time() - last_epoch
-                if elapsed_s < project.interval_minutes * 60:
-                    remaining = int(project.interval_minutes * 60 - elapsed_s)
-                    _log(
-                        f"=== interval-skip: {path.name} (next run in {remaining}s) {_now_iso()} ==="
-                    )
-                    _record_phase_outcome(
-                        path,
-                        "interval",
-                        "skip",
-                        detail=f"interval={project.interval_minutes}m, remaining={remaining}s",
-                    )
-                    lock_fh.close()
-                    sys.exit(0)
+                last_epoch = _parse_epoch(last_ts)
+                if last_epoch > 0:
+                    elapsed_s = time.time() - last_epoch
+                    if elapsed_s < project.interval_minutes * 60:
+                        remaining = int(project.interval_minutes * 60 - elapsed_s)
+                        _log(
+                            f"=== interval-skip: {path.name} (next run in {remaining}s) {_now_iso()} ==="
+                        )
+                        _record_phase_outcome(
+                            path,
+                            "interval",
+                            "skip",
+                            detail=f"interval={project.interval_minutes}m, remaining={remaining}s",
+                        )
+                        lock_fh.close()
+                        sys.exit(0)
             except (ValueError, TypeError):
                 pass
 
     (path / ".claude" / "sweep-state").mkdir(parents=True, exist_ok=True)
 
-    # Layer-1 cleanup: rewrite buried stale in_progress records that crash
-    # recovery missed (it only checks the most-recent record within 55 min).
-    _cleanup_stale_in_progress(path)
-
-    # Layer-2 cleanup: remove orphaned git-locked worktrees left by killed agents.
+    # Cleanup: remove orphaned git-locked worktrees left by killed agents.
     _cleanup_locked_worktrees(path)
 
-    # Crash / SIGKILL recovery
-    last = read_last_beat_record(path)
-    if last and last.get("outcome") == "in_progress":
-        try:
-            last_at = last.get("last_run_at", "1970-01-01T00:00:00Z")
-            last_epoch = datetime.fromisoformat(
-                last_at.replace("Z", "+00:00")
-            ).timestamp()
-            if (time.time() - last_epoch) < CRASH_RECOVERY_WINDOW_S:
-                append_beat_log(
-                    path,
-                    {
-                        "last_run_at": _now_iso(),
-                        "ticket_id": None,
-                        "branch": None,
-                        "PR": None,
-                        "outcome": "aborted",
-                        "diagnostics": "crash/SIGKILL recovery — previous run never completed spin-down",
-                    },
-                )
-                _log(f"=== beat aborted: crash recovery {_now_iso()} ===")
-                sys.exit(0)
-        except (ValueError, TypeError):
-            pass
+    # Crash / SIGKILL recovery: detect a start event with no following end event.
+    if last_beat_crashed(path):
+        write_beat_end(
+            path,
+            "aborted",
+            ticket_id=None,
+            diagnostics="crash/SIGKILL recovery — previous run never completed spin-down",
+        )
+        _log(f"=== beat aborted: crash recovery {_now_iso()} ===")
+        sys.exit(0)
 
     # Spin-in
-    append_beat_log(path, {"outcome": "in_progress", "last_run_at": _now_iso()})
+    write_beat_start(path)
 
     # Orchestration
     outcome = "idle"
@@ -1393,16 +1390,11 @@ def main() -> None:
 
     # Spin-down
     elapsed = int(time.monotonic() - _state.beat_start)
-    finalize_beat_log(
+    write_beat_end(
         path,
-        {
-            "last_run_at": _now_iso(),
-            "ticket_id": ticket_id,
-            "branch": None,
-            "PR": None,
-            "outcome": outcome,
-            "duration_s": elapsed,
-        },
+        outcome,
+        ticket_id=ticket_id,
+        duration_s=elapsed,
     )
 
     ticket_label = ticket_id if ticket_id else "—"

--- a/scripts/nightbeat-report.py
+++ b/scripts/nightbeat-report.py
@@ -341,10 +341,14 @@ def _beat_log_night_summary(proj: Path, since: datetime) -> dict:
             rec = json.loads(raw)
         except json.JSONDecodeError:
             continue
+        # Skip start events (event-model): they have type:"start" but no outcome.
+        if rec.get("type") == "start":
+            continue
         last = rec
-        if rec.get("last_run_at", "") >= since_str:
+        ts = rec.get("ts") or rec.get("last_run_at", "")
+        if ts >= since_str:
             outcome = rec.get("outcome", "?")
-            if outcome != "in_progress":  # orphans cleaned by beat.py; skip noise
+            if outcome != "in_progress":  # legacy orphans; skip noise
                 counts[outcome] = counts.get(outcome, 0) + 1
     return {"counts": counts, "last": last}
 
@@ -628,7 +632,9 @@ def main() -> None:
                 parts_p.append(f"{outcome}:{counts[outcome]}")
         last_ticket = last.get("ticket_id") or "—"
         last_outcome = last.get("outcome", "?")
-        last_at = (last.get("last_run_at") or "")[:16].replace("T", " ")
+        last_at = (last.get("ts") or last.get("last_run_at") or "")[:16].replace(
+            "T", " "
+        )
         counts_str = "  ".join(parts_p) if parts_p else "no runs"
         print(
             f"  {proj_path.name:<30}  {counts_str:<28}  last: {last_ticket} ({last_outcome}) @ {last_at}"

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -5,7 +5,6 @@ import json
 import os
 import subprocess
 import sys
-import textwrap
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -189,124 +188,175 @@ class TestHousekeepingNeeded:
             assert beat.housekeeping_needed(tmp_project) is False
 
 
-# ── append_beat_log ────────────────────────────────────────────────────────────
+# ── write_beat_start ───────────────────────────────────────────────────────────
 
 
-class TestAppendBeatLog:
-    def test_appends_record(self, tmp_project, beat_log):
-        beat.append_beat_log(
-            tmp_project, {"outcome": "in_progress", "last_run_at": "t"}
-        )
+class TestWriteBeatStart:
+    def test_appends_start_event(self, tmp_project, beat_log):
+        beat.write_beat_start(tmp_project)
         records = [json.loads(line) for line in beat_log.read_text().splitlines()]
-        assert records == [{"outcome": "in_progress", "last_run_at": "t"}]
+        assert len(records) == 1
+        assert records[0]["type"] == "start"
+        assert "ts" in records[0]
 
-    def test_appends_multiple_records(self, tmp_project, beat_log):
-        beat.append_beat_log(tmp_project, {"outcome": "in_progress"})
-        beat.append_beat_log(tmp_project, {"outcome": "done"})
-        outcomes = [
-            json.loads(line)["outcome"] for line in beat_log.read_text().splitlines()
-        ]
-        assert outcomes == ["in_progress", "done"]
+    def test_multiple_starts_are_appended(self, tmp_project, beat_log):
+        beat.write_beat_start(tmp_project)
+        beat.write_beat_start(tmp_project)
+        records = [json.loads(line) for line in beat_log.read_text().splitlines()]
+        assert len(records) == 2
+        assert all(r["type"] == "start" for r in records)
 
     def test_dry_run_is_noop(self, tmp_project, beat_log):
         beat.DRY_RUN = True
-        beat.append_beat_log(tmp_project, {"outcome": "done"})
+        beat.write_beat_start(tmp_project)
         assert not beat_log.exists()
 
 
-# ── finalize_beat_log ──────────────────────────────────────────────────────────
+# ── write_beat_end ─────────────────────────────────────────────────────────────
 
 
-class TestFinalizeBeatLog:
-    def test_replaces_trailing_in_progress(self, tmp_project, beat_log):
+class TestWriteBeatEnd:
+    def test_appends_end_event(self, tmp_project, beat_log):
+        beat.write_beat_end(tmp_project, "idle", ticket_id=None, duration_s=12)
+        records = [json.loads(line) for line in beat_log.read_text().splitlines()]
+        assert len(records) == 1
+        assert records[0]["type"] == "end"
+        assert records[0]["outcome"] == "idle"
+        assert records[0]["ticket_id"] is None
+        assert records[0]["duration_s"] == 12
+        assert "ts" in records[0]
+
+    def test_append_only_does_not_mutate_prior_records(self, tmp_project, beat_log):
+        # Prior start event must remain in place — event log is append-only.
         beat_log.write_text(
-            json.dumps({"outcome": "in_progress", "last_run_at": "t"}) + "\n"
+            json.dumps({"type": "start", "ts": "2026-01-01T00:00:00Z"}) + "\n"
         )
-        beat.finalize_beat_log(tmp_project, {"outcome": "done", "ticket_id": "0001"})
-        lines = beat_log.read_text().splitlines()
-        assert len(lines) == 1
-        assert json.loads(lines[0])["outcome"] == "done"
-
-    def test_keeps_prior_records(self, tmp_project, beat_log):
-        beat_log.write_text(
-            json.dumps({"outcome": "done", "ticket_id": "0001"})
-            + "\n"
-            + json.dumps({"outcome": "in_progress"})
-            + "\n"
-        )
-        beat.finalize_beat_log(tmp_project, {"outcome": "idle"})
-        lines = [json.loads(line) for line in beat_log.read_text().splitlines()]
-        assert len(lines) == 2
-        assert lines[0]["outcome"] == "done"
-        assert lines[1]["outcome"] == "idle"
-
-    def test_creates_file_if_missing(self, tmp_project, beat_log):
-        beat.finalize_beat_log(tmp_project, {"outcome": "idle"})
-        # append_beat_log is called internally; dry-run=False so it writes
-        assert beat_log.exists()
+        beat.write_beat_end(tmp_project, "done", ticket_id="0042")
+        records = [json.loads(line) for line in beat_log.read_text().splitlines()]
+        assert len(records) == 2
+        assert records[0]["type"] == "start"
+        assert records[1]["type"] == "end"
+        assert records[1]["outcome"] == "done"
 
     def test_idempotent_second_call_ignored(self, tmp_project, beat_log):
-        beat_log.write_text(json.dumps({"outcome": "in_progress"}) + "\n")
-        beat.finalize_beat_log(tmp_project, {"outcome": "done"})
-        beat.finalize_beat_log(tmp_project, {"outcome": "failed"})  # should be ignored
-        lines = beat_log.read_text().splitlines()
-        assert json.loads(lines[-1])["outcome"] == "done"
-
-    def test_handles_pretty_printed_in_progress(self, tmp_project, beat_log):
-        # Legacy records may be multi-line JSON; finalize_beat_log works on
-        # compact lines it wrote itself — pretty-printed records are left as-is.
-        pretty = textwrap.dedent("""\
-            {
-              "outcome": "done",
-              "ticket_id": "0001"
-            }
-        """)
-        # The last line of a pretty record is '}', which json.loads succeeds on
-        # but .get("outcome") returns None → loop breaks → final record appended.
-        beat_log.write_text(pretty)
-        beat.finalize_beat_log(tmp_project, {"outcome": "idle"})
-        last_line = beat_log.read_text().splitlines()[-1]
-        assert json.loads(last_line)["outcome"] == "idle"
+        beat.write_beat_end(tmp_project, "done")
+        beat.write_beat_end(tmp_project, "failed")  # should be ignored
+        records = [json.loads(line) for line in beat_log.read_text().splitlines()]
+        assert len(records) == 1
+        assert records[0]["outcome"] == "done"
 
     def test_dry_run_is_noop(self, tmp_project, beat_log):
         beat.DRY_RUN = True
-        beat_log.write_text(json.dumps({"outcome": "in_progress"}) + "\n")
-        beat.finalize_beat_log(tmp_project, {"outcome": "done"})
-        assert json.loads(beat_log.read_text().strip())["outcome"] == "in_progress"
+        beat.write_beat_end(tmp_project, "done")
+        assert not beat_log.exists()
 
 
-# ── read_last_beat_record ──────────────────────────────────────────────────────
+# ── last_completed_beat ────────────────────────────────────────────────────────
 
 
-class TestReadLastBeatRecord:
-    def test_returns_last_compact_record(self, tmp_project, beat_log):
+class TestLastCompletedBeat:
+    def test_returns_last_end_event(self, tmp_project, beat_log):
         beat_log.write_text(
-            json.dumps({"outcome": "done"})
+            json.dumps({"type": "end", "ts": "2026-01-01T00:00:00Z", "outcome": "done"})
             + "\n"
-            + json.dumps({"outcome": "idle"})
+            + json.dumps(
+                {"type": "end", "ts": "2026-01-02T00:00:00Z", "outcome": "idle"}
+            )
             + "\n"
         )
-        result = beat.read_last_beat_record(tmp_project)
+        result = beat.last_completed_beat(tmp_project)
         assert result is not None
         assert result["outcome"] == "idle"
 
     def test_returns_none_for_missing_file(self, tmp_project):
-        result = beat.read_last_beat_record(tmp_project)
-        assert result is None
+        assert beat.last_completed_beat(tmp_project) is None
 
     def test_returns_none_for_empty_file(self, tmp_project, beat_log):
         beat_log.write_text("")
-        result = beat.read_last_beat_record(tmp_project)
-        assert result is None
+        assert beat.last_completed_beat(tmp_project) is None
 
-    def test_handles_pretty_printed_json(self, tmp_project, beat_log):
-        pretty = (
-            '{"outcome": "in_progress",\n  "last_run_at": "2026-01-01T00:00:00Z"\n}\n'
+    def test_skips_start_events(self, tmp_project, beat_log):
+        """Regression: Layer 2 was reading the current beat's start event,
+        causing _pick_needed to compare against NOW and always skip."""
+        beat_log.write_text(
+            '{"outcome":"idle","last_run_at":"2026-01-01T00:00:00Z"}\n'
+            '{"type":"start","ts":"2026-01-02T00:00:00Z"}\n'
         )
-        beat_log.write_text(pretty)
-        result = beat.read_last_beat_record(tmp_project)
+        result = beat.last_completed_beat(tmp_project)
         assert result is not None
-        assert result["outcome"] == "in_progress"
+        assert result["outcome"] == "idle"  # must not return the start event
+
+    def test_legacy_records_without_type_count_as_end(self, tmp_project, beat_log):
+        # Legacy spin-down records have no `type` field and outcome != in_progress.
+        beat_log.write_text(
+            json.dumps({"outcome": "done", "last_run_at": "2026-01-01T00:00:00Z"})
+            + "\n"
+        )
+        result = beat.last_completed_beat(tmp_project)
+        assert result is not None
+        assert result["outcome"] == "done"
+
+    def test_legacy_in_progress_is_skipped(self, tmp_project, beat_log):
+        # Legacy in_progress records are start events, not completed beats.
+        beat_log.write_text(
+            json.dumps({"outcome": "done", "last_run_at": "2026-01-01T00:00:00Z"})
+            + "\n"
+            + json.dumps(
+                {"outcome": "in_progress", "last_run_at": "2026-01-02T00:00:00Z"}
+            )
+            + "\n"
+        )
+        result = beat.last_completed_beat(tmp_project)
+        assert result is not None
+        assert result["outcome"] == "done"
+
+    def test_rejects_pretty_printed_closing_brace(self, tmp_project, beat_log):
+        # `}` lines parse to {} — must not be returned as a completed beat.
+        beat_log.write_text(
+            json.dumps({"type": "end", "ts": "2026-01-01T00:00:00Z", "outcome": "done"})
+            + "\n"
+            + "}\n"
+        )
+        result = beat.last_completed_beat(tmp_project)
+        assert result is not None
+        assert result["outcome"] == "done"
+
+
+# ── last_beat_crashed ──────────────────────────────────────────────────────────
+
+
+class TestLastBeatCrashed:
+    def test_false_when_no_log(self, tmp_project):
+        assert beat.last_beat_crashed(tmp_project) is False
+
+    def test_false_when_last_event_is_end(self, tmp_project, beat_log):
+        beat_log.write_text(
+            json.dumps({"type": "start", "ts": "2026-01-01T00:00:00Z"})
+            + "\n"
+            + json.dumps(
+                {"type": "end", "ts": "2026-01-01T00:01:00Z", "outcome": "done"}
+            )
+            + "\n"
+        )
+        assert beat.last_beat_crashed(tmp_project) is False
+
+    def test_true_when_recent_orphaned_start(self, tmp_project, beat_log):
+        recent_ts = beat._now_iso()
+        beat_log.write_text(json.dumps({"type": "start", "ts": recent_ts}) + "\n")
+        assert beat.last_beat_crashed(tmp_project) is True
+
+    def test_false_when_orphaned_start_outside_window(self, tmp_project, beat_log):
+        # Start event older than CRASH_RECOVERY_WINDOW_S is too stale to recover.
+        old_ts = "2020-01-01T00:00:00Z"
+        beat_log.write_text(json.dumps({"type": "start", "ts": old_ts}) + "\n")
+        assert beat.last_beat_crashed(tmp_project) is False
+
+    def test_legacy_in_progress_counts_as_start(self, tmp_project, beat_log):
+        recent_ts = beat._now_iso()
+        beat_log.write_text(
+            json.dumps({"outcome": "in_progress", "last_run_at": recent_ts}) + "\n"
+        )
+        assert beat.last_beat_crashed(tmp_project) is True
 
 
 # ── run_skill (dry-run mode) ───────────────────────────────────────────────────
@@ -1187,64 +1237,46 @@ class TestCleanupLockedWorktrees:
 
 
 class TestCrashRecovery:
-    def test_recent_in_progress_triggers_aborted(self, tmp_project, beat_log):
-        from datetime import datetime
+    def test_recent_orphan_triggers_aborted(self, tmp_project, beat_log):
+        """An orphaned start event within window triggers write_beat_end(aborted)."""
+        recent_ts = beat._now_iso()
+        beat_log.write_text(json.dumps({"type": "start", "ts": recent_ts}) + "\n")
 
-        recent_ts = "2026-04-25T15:00:00Z"
+        with patch("beat.write_beat_end") as mock_write_end:
+            if beat.last_beat_crashed(tmp_project):
+                beat.write_beat_end(
+                    tmp_project,
+                    "aborted",
+                    ticket_id=None,
+                    diagnostics="crash/SIGKILL recovery — previous run never completed spin-down",
+                )
+
+        mock_write_end.assert_called_once()
+        args, kwargs = mock_write_end.call_args
+        assert args[1] == "aborted"
+        assert "crash" in kwargs["diagnostics"]
+
+    def test_old_orphan_does_not_trigger_recovery(self, tmp_project, beat_log):
+        """An orphaned start event outside window is too stale to recover."""
+        old_ts = "2020-01-01T00:00:00Z"
+        beat_log.write_text(json.dumps({"type": "start", "ts": old_ts}) + "\n")
+        assert beat.last_beat_crashed(tmp_project) is False
+
+    def test_legacy_in_progress_record_triggers_recovery(self, tmp_project, beat_log):
+        """Legacy in_progress records (no `type` field) still trigger recovery."""
+        recent_ts = beat._now_iso()
         beat_log.write_text(
             json.dumps({"outcome": "in_progress", "last_run_at": recent_ts}) + "\n"
         )
-        recent_epoch = datetime.fromisoformat(
-            recent_ts.replace("Z", "+00:00")
-        ).timestamp()
-
-        with (
-            patch("beat.read_last_beat_record") as mock_last,
-            patch("beat.append_beat_log") as mock_append,
-            patch("beat.time.time", return_value=recent_epoch + 60),  # 1 min later
-        ):
-            mock_last.return_value = {
-                "outcome": "in_progress",
-                "last_run_at": recent_ts,
-            }
-            last = mock_last(tmp_project)
-            if last and last.get("outcome") == "in_progress":
-                last_at = last.get("last_run_at", "1970-01-01T00:00:00Z")
-                last_ep = datetime.fromisoformat(
-                    last_at.replace("Z", "+00:00")
-                ).timestamp()
-                if (recent_epoch + 60 - last_ep) < beat.CRASH_RECOVERY_WINDOW_S:
-                    mock_append(
-                        tmp_project,
-                        {
-                            "outcome": "aborted",
-                            "diagnostics": "crash/SIGKILL recovery — previous run never completed spin-down",
-                        },
-                    )
-
-        mock_append.assert_called_once()
-        call_record = mock_append.call_args[0][1]
-        assert call_record["outcome"] == "aborted"
-        assert "crash" in call_record["diagnostics"]
-
-    def test_old_in_progress_does_not_trigger_recovery(self, tmp_project):
-        from datetime import datetime
-
-        old_ts = "2026-04-25T00:00:00Z"
-        old_epoch = datetime.fromisoformat(old_ts.replace("Z", "+00:00")).timestamp()
-        now = old_epoch + 15 * 3600  # 15 hours after spin-in
-
-        last_epoch = datetime.fromisoformat(old_ts.replace("Z", "+00:00")).timestamp()
-        elapsed = now - last_epoch
-        assert elapsed >= beat.CRASH_RECOVERY_WINDOW_S
+        assert beat.last_beat_crashed(tmp_project) is True
 
 
 # ── spin-down completeness ─────────────────────────────────────────────────────
 
 
 class TestSpinDown:
-    def test_finalize_always_called_on_normal_exit(self, tmp_project, beat_log, git_ok):
-        beat_log.write_text(json.dumps({"outcome": "in_progress"}) + "\n")
+    def test_write_beat_end_called_on_normal_exit(self, tmp_project, beat_log, git_ok):
+        beat_log.write_text(json.dumps({"type": "start", "ts": "t"}) + "\n")
         with (
             patch("beat.housekeeping_needed", return_value=False),
             patch(
@@ -1259,17 +1291,16 @@ class TestSpinDown:
             beat._state.final_written = False
             beat.DRY_RUN = False
             outcome, ticket = beat._raid(beat.ProjectConfig(path=tmp_project))
-            beat.finalize_beat_log(
+            beat.write_beat_end(
                 tmp_project,
-                {
-                    "last_run_at": "t",
-                    "ticket_id": ticket,
-                    "outcome": outcome,
-                    "duration_s": 0,
-                },
+                outcome,
+                ticket_id=ticket,
+                duration_s=0,
             )
         last_line = beat_log.read_text().splitlines()[-1]
-        assert json.loads(last_line)["outcome"] == "idle"
+        last_rec = json.loads(last_line)
+        assert last_rec["type"] == "end"
+        assert last_rec["outcome"] == "idle"
 
 
 # ── _repo_active (ticket 0038) ─────────────────────────────────────────────────
@@ -1989,12 +2020,14 @@ class TestIntervalSkip:
             patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
             patch("beat.fcntl.flock"),
             patch("beat._log", side_effect=log_lines.append),
-            patch("beat.read_last_beat_record") as mock_read,
+            patch("beat.last_completed_beat") as mock_read,
+            patch("beat.last_beat_crashed", return_value=False),
             pytest.raises(SystemExit) as exc_info,
         ):
             mock_read.return_value = {
+                "type": "end",
                 "outcome": "done",
-                "last_run_at": recent_ts,
+                "ts": recent_ts,
             }
             beat.main()
 
@@ -2025,16 +2058,17 @@ class TestIntervalSkip:
             ),  # single project — no fallback
             patch("beat.fcntl.flock"),
             patch("beat._raid", return_value=("idle", None)) as mock_raid,
-            patch("beat.finalize_beat_log"),
-            patch("beat._cleanup_stale_in_progress"),
+            patch("beat.write_beat_end"),
+            patch("beat.write_beat_start"),
+            patch("beat.last_beat_crashed", return_value=False),
             patch(
-                "beat.read_last_beat_record",
+                "beat.last_completed_beat",
                 return_value={
+                    "type": "end",
                     "outcome": "done",
-                    "last_run_at": old_ts,
+                    "ts": old_ts,
                 },
             ),
-            patch("beat.append_beat_log"),
         ):
             beat.main()
 
@@ -2058,16 +2092,17 @@ class TestIntervalSkip:
             ),  # single project — no fallback
             patch("beat.fcntl.flock"),
             patch("beat._raid", return_value=("idle", None)) as mock_raid,
-            patch("beat.finalize_beat_log"),
-            patch("beat._cleanup_stale_in_progress"),
+            patch("beat.write_beat_end"),
+            patch("beat.write_beat_start"),
+            patch("beat.last_beat_crashed", return_value=False),
             patch(
-                "beat.read_last_beat_record",
+                "beat.last_completed_beat",
                 return_value={
+                    "type": "end",
                     "outcome": "done",
-                    "last_run_at": recent_ts,
+                    "ts": recent_ts,
                 },
             ),
-            patch("beat.append_beat_log"),
         ):
             beat.main()
 
@@ -2135,10 +2170,10 @@ class TestFallbackRotation:
             patch.object(beat, "PROJECTS", projects),
             patch("beat.fcntl.flock"),
             patch("beat._raid", side_effect=raid_fn),
-            patch("beat.finalize_beat_log"),
-            patch("beat._cleanup_stale_in_progress"),
-            patch("beat.read_last_beat_record", return_value=None),
-            patch("beat.append_beat_log"),
+            patch("beat.write_beat_end"),
+            patch("beat.write_beat_start"),
+            patch("beat.last_completed_beat", return_value=None),
+            patch("beat.last_beat_crashed", return_value=False),
         ]
 
     def test_fallback_attempted_when_primary_idle(self, tmp_project, tmp_path):

--- a/tickets/0158-beat-log-event-model-replace-state-encod.erg
+++ b/tickets/0158-beat-log-event-model-replace-state-encod.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-05-14T07:15Z claude created
 
+2026-05-14T14:57Z claude note implementing sections 1-5 and 7; section 6 asyncio split to followup
 --- body ---
 ## Context
 

--- a/tickets/0160-restore-asyncio-streaming-in-beat-py-run.erg
+++ b/tickets/0160-restore-asyncio-streaming-in-beat-py-run.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: restore asyncio streaming in beat.py run_skill
+Created: 2026-05-14
+Author: MinhHaDuong
+
+--- log ---
+2026-05-14T14:58Z MinhHaDuong created
+2026-05-14T15:00Z claude note split from 0158 section 6; PR #200 left run_skill synchronous
+
+--- body ---
+## Context
+
+PR #189 (ticket 0103) removed `threading.Thread` from `run_skill` but
+replaced it with `Popen.communicate()`, which buffers all subprocess
+output until exit. Real-time stdout streaming was silently lost — beat
+log output appears in a single burst at the end of each skill run.
+
+This was originally part of ticket 0158 (section 6) but was split out so
+that the beat-log event-model fix (sections 1-5, 7) could land first as
+a focused PR (#200).
+
+## Actions
+
+Replace `run_skill` with an async implementation:
+
+```python
+async def run_skill(...) -> tuple[int, _SkillResult]:
+    proc = await asyncio.create_subprocess_exec(
+        *argv, stdout=asyncio.subprocess.PIPE, stderr=None, cwd=cwd, env=env
+    )
+    stdout_lines: list[str] = []
+    async def _read():
+        async for raw in proc.stdout:
+            line = raw.decode().rstrip("\n")
+            _log(line)
+            stdout_lines.append(line)
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(_read(), proc.wait()), timeout=timeout_s
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return TIMEOUT_EXIT_CODE, _SkillResult()
+    ...
+```
+
+- `fcntl` lock acquisition stays synchronous in `main()` before
+  `asyncio.run()`.
+- `_on_sigterm` becomes `loop.add_signal_handler`.
+- Convert `main()`, `_raid()`, `_housekeeping_phase()` to `async def`.
+- Entry point: `asyncio.run(main())`.
+
+## Exit criteria
+
+- [ ] `run_skill` uses `asyncio.create_subprocess_exec` — stdout streamed
+      line-by-line during execution, not buffered until exit
+- [ ] `grep threading scripts/beat.py` returns nothing (already true; must stay true)
+- [ ] `grep asyncio scripts/beat.py` returns results
+- [ ] Tests still pass — including timeout, dry-run, and signal-handling paths
+- [ ] `make check` (or equivalent) passes


### PR DESCRIPTION
## Summary

- Fixes Layer 2 pre-flight skip blocker: `_pick_needed` was comparing against the current beat's own `in_progress` timestamp (NOW), so pick-ticket was always skipped on dormant projects — and active projects.
- Replaces the state-encoded `beat-log.jsonl` (mutable `in_progress` record) with append-only event encoding (`type:"start"` / `type:"end"`).
- Crash recovery becomes a passive reader: an orphaned start event within `CRASH_RECOVERY_WINDOW_S` is a crash. No log mutation, no `_cleanup_stale_in_progress` scan.

## Changes

- `scripts/beat.py`:
  - Add `write_beat_start`, `write_beat_end`, `last_completed_beat`, `last_beat_crashed`, helpers `_append`, `_reversed_lines`, `_parse_epoch`.
  - Delete `append_beat_log`, `finalize_beat_log`, `read_last_beat_record`, `_cleanup_stale_in_progress`.
  - Update Layer 2 / interval-skip / crash recovery / SIGTERM / spin-down call sites.
- `scripts/nightbeat-report.py`:
  - Read `ts` field with `last_run_at` fallback.
  - Skip `type:"start"` records when tallying outcomes.
- `tests/test_beat.py`:
  - Rewrite `TestAppendBeatLog`/`TestFinalizeBeatLog`/`TestReadLastBeatRecord` → `TestWriteBeatStart`/`TestWriteBeatEnd`/`TestLastCompletedBeat`/`TestLastBeatCrashed` with legacy-compat coverage.
  - Patch `TestCrashRecovery`, `TestSpinDown`, `TestIntervalSkip`, `TestFallbackRotation` for new API.

## Scope note

Section 6 of ticket 0158 (asyncio conversion of `run_skill`) is intentionally **excluded** and will be filed as a follow-up ticket. This PR keeps the synchronous subprocess interface.

## Test plan

- [x] `pytest tests/test_beat.py -v` — 159 passed
- [x] `pytest tests/ -v` — 223 passed
- [x] Legacy records (no `type` field, `outcome != "in_progress"`) read correctly
- [x] Legacy `in_progress` records counted as start (crash detection)
- [x] Pretty-printed `}` lines rejected by `last_completed_beat`
- [x] Append-only invariant: `write_beat_end` does not mutate prior records
- [x] `write_beat_end` idempotent via `_state.final_written`

🤖 Generated with [Claude Code](https://claude.com/claude-code)