### PR TITLE
fix(beat): lazy-load PROJECTS to unblock pytest-guard

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -200,7 +200,15 @@ def load_projects(config_path: Path) -> list[ProjectConfig]:
     return configs
 
 
-PROJECTS: list[ProjectConfig] = load_projects(PROJECTS_CONFIG)
+_PROJECTS_CACHE: list[ProjectConfig] | None = None
+
+
+def _get_projects() -> list[ProjectConfig]:
+    """Lazy-load projects from PROJECTS_CONFIG; cache result for reuse."""
+    global _PROJECTS_CACHE  # noqa: PLW0603
+    if _PROJECTS_CACHE is None:
+        _PROJECTS_CACHE = load_projects(PROJECTS_CONFIG)
+    return _PROJECTS_CACHE
 
 
 # ── Logging ────────────────────────────────────────────────────────────────────
@@ -820,14 +828,15 @@ def _pick_project() -> tuple[int, ProjectConfig]:
     count = int(COUNTER_FILE.read_text().strip()) if COUNTER_FILE.exists() else 0
     COUNTER_FILE.write_text(str(count + 1))
     override = os.environ.get("BEAT_PROJECT")
+    projects = _get_projects()
     if override:
         override_path = Path(override).resolve()
-        for cfg in PROJECTS:
+        for cfg in projects:
             if cfg.path == override_path:
                 return count, cfg
         return count, ProjectConfig(path=override_path)
-    idx = count % len(PROJECTS)
-    return count, PROJECTS[idx]
+    idx = count % len(projects)
+    return count, projects[idx]
 
 
 def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
@@ -1288,7 +1297,8 @@ def main() -> None:
         sys.exit(0)
 
     _log(f"=== beat start {_now_iso()} ===")
-    _log(f"Run {count}  →  project slot {count % len(PROJECTS)}: {path}")
+    projects = _get_projects()
+    _log(f"Run {count}  →  project slot {count % len(projects)}: {path}")
 
     if not (path / ".git").is_dir():
         _log(f"ERROR: {path} is not a git repository. Aborting.")
@@ -1351,10 +1361,11 @@ def main() -> None:
         if outcome == "idle" and not os.environ.get("BEAT_PROJECT"):
             _log(f"=== fallback: primary idle, trying other projects {_now_iso()} ===")
             fallback_tried = 0
-            for fallback_cfg in PROJECTS:
+            projects = _get_projects()
+            for fallback_cfg in projects:
                 if fallback_cfg.path == path:
                     continue
-                if fallback_tried >= len(PROJECTS) - 1:
+                if fallback_tried >= len(projects) - 1:
                     break
                 fb_lock_fh = _lockfile(fallback_cfg.path).open("w")
                 try:

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -2054,7 +2054,7 @@ class TestIntervalSkip:
             ),
             patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
             patch.object(
-                beat, "PROJECTS", [primary_cfg]
+                beat, "_PROJECTS_CACHE", [primary_cfg]
             ),  # single project — no fallback
             patch("beat.fcntl.flock"),
             patch("beat._raid", return_value=("idle", None)) as mock_raid,
@@ -2088,7 +2088,7 @@ class TestIntervalSkip:
             ),
             patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
             patch.object(
-                beat, "PROJECTS", [primary_cfg]
+                beat, "_PROJECTS_CACHE", [primary_cfg]
             ),  # single project — no fallback
             patch("beat.fcntl.flock"),
             patch("beat._raid", return_value=("idle", None)) as mock_raid,
@@ -2167,7 +2167,7 @@ class TestFallbackRotation:
             patch.object(beat, "LOGDIR", tmp_path / "logs"),
             patch("beat._pick_project", return_value=(0, primary_cfg)),
             patch.object(beat, "_LOCK_DIR", tmp_path / "locks"),
-            patch.object(beat, "PROJECTS", projects),
+            patch.object(beat, "_PROJECTS_CACHE", projects),
             patch("beat.fcntl.flock"),
             patch("beat._raid", side_effect=raid_fn),
             patch("beat.write_beat_end"),


### PR DESCRIPTION
## Summary
Move module-level PROJECTS initialization into a lazy-loaded cached accessor to avoid hanging pytest-import on projects.json (which may not exist during test setup).

## Changes
- Delete module-level `PROJECTS = load_projects(PROJECTS_CONFIG)` assignment (line 203)
- Add `_PROJECTS_CACHE` module variable and `_get_projects()` lazy-load function
- Replace 4 direct PROJECTS references with _get_projects() calls:
  - 2 in _pick_project() (lines 828, 830)
  - 2 in main() fallback rotation (lines 1363, 1366)
  - 1 bonus: logging statement (line 1300)
- Update 3 test patches from `beat.PROJECTS` to `beat._PROJECTS_CACHE` (lines 2057, 2091, 2170)

## Test status
All 159 tests pass. No asyncio changes (clean branch from origin/main).

Fixes #161

🧗 Generated with [Claude Code](https://claude.com/claude-code)