### PR TITLE
fix(supervisor): commit tracked writes after every mutation

### DIFF
--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -131,7 +131,7 @@ cd $HARNESS_DIR
 dirty=$(git status --porcelain)
 if [ -n "$dirty" ]; then
   echo "WARNING: supervisor leaving dirty tree: $dirty"
-  git add -A && git commit -m 'chore(supervisor): commit residual tracked writes'
+  git add -u && git commit -m 'chore(supervisor): commit residual tracked writes'
 fi
 ```
 This is a safety net — every write should already be committed by the steps

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -13,6 +13,12 @@ failures to their root cause, repair within authority, escalate when stuck.
 **Non-negotiables**: never merge without `verdict: APPROVED`; stop the main
 timer before editing `beat.py`, restart after; never edit skill SKILL.md files.
 
+**Commit tracked writes immediately.** Every write to a tracked file in
+`$HARNESS_DIR` (`settings.json`, `scripts/beat.py`, `tickets/*.erg`) must be
+followed by `git add <file> && git commit -m 'chore(supervisor): <description>'`
+before proceeding to the next action. Uncommitted tracked files cause the next
+beat cycle's dirty-tree pre-flight to abort.
+
 ## 1. Survey
 
 Pre-flight: verify no dual-journal state exists (`canonical` vs `logs/` path). If both
@@ -43,7 +49,12 @@ and `project_path` derived by the survey script from the project's git remote):
    git fetch origin
    gh pr checkout <pr_number> --repo <github_repo>   # harness-extension-point
    ```
-   Then: `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body) and move on. ESCALATE → go to step 4.
+   Then: `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body), then commit the ticket file:
+   ```bash
+   cd $HARNESS_DIR
+   git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): append REROLL note to <ticket>'
+   ```
+   and move on. ESCALATE → go to step 4.
    After verify-gate and merge complete, `cd $HARNESS_DIR` to return to the harness directory for the next PR.
 
 ## 3. Diagnose and repair
@@ -55,41 +66,47 @@ actionable root cause:
 
 When you reach a root cause, repair if within authority:
 
-- **Missing permission** → add to `settings.json` allowlist.
+- **Missing permission** → add to `settings.json` allowlist, then
+  `git add settings.json && git commit -m 'chore(supervisor): add <permission> to allowlist'`.
 - **Budget too small for the actual scope of work** → before raising, apply
   the convergence guard:
   1. Count `action=repair` journal entries for the same project+phase in the
      last 7 days. If ≥ 3: **do not raise**. Instead, open a ticket:
      "budget not converging for {project} {phase} — {N} raises in 7 days,
      current={current}, started={first}."
+     Then `git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): convergence ticket for <project>'`.
   2. If the proposed raise would exceed 1.5× the module-level constant for
      that phase, log a warning and include it in the ticket body (note: the
      hard ceiling remains 2× the module-level constant — the 1.5× threshold
      is a warning only, not a new cap).
   If neither guard triggers: raise the per-project `ProjectConfig` field in
   `beat.py` by 20%, capped at 2× the module-level constant; never touch the
-  module-level constant.
+  module-level constant. Then
+  `git add scripts/beat.py && git commit -m 'chore(supervisor): raise <field> budget for <project>'`.
 - **Raid timeout during verify/review** (`outcome=timeout` AND why-chain
   shows verify/review slowness, not implementation slowness) → raise
   `raid_timeout_s` in the per-project config by 20%, capped at
-  2× `RAID_TIMEOUT_S` (3600 s). Implementation slowness is a "ticket too
+  2× `RAID_TIMEOUT_S` (3600 s). Then
+  `git add scripts/beat.py && git commit -m 'chore(supervisor): raise raid_timeout_s for <project>'`.
+  Implementation slowness is a "ticket too
   large" signal — do not raise the timeout for that.
 - **Ticket too large to finish in one beat** → split into one ticket per
   independent unit of work; leave the parent open as an umbrella. Each child
   ticket must carry `Blocked-by: <umbrella-id>` so pick-ticket can auto-close
   the umbrella when all children are done (it uses inverse lookup, not a
-  `Blocks:` header — that header is not valid in %erg v1).
+  `Blocks:` header — that header is not valid in %erg v1). Commit all new/modified
+  ticket files: `git add tickets/*.erg && git commit -m 'chore(supervisor): split <ticket> into children'`.
 - **Dead timer** → restart it.
 - **Dirty working tree** (`outcome=aborted-dirty-tree`) → if the dirty files
   are machine-local state (beat-outcomes.jsonl, STATE.md, build artifacts),
   commit or stash them; otherwise open a ticket naming the dirty files and
-  their likely source.
+  their likely source, and `git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): dirty-tree ticket'`.
 
 If the why-chain bottoms out without reaching anything repairable: escalate
 (step 4).
 
 **Anything else**: open a ticket stating the root cause chain; do not
-auto-repair.
+auto-repair. Then `git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): ticket for <root-cause>'`.
 
 ## 4. Escalate
 
@@ -98,14 +115,30 @@ or the same root cause recurring ≥ 3 consecutive runs for a project.
 
 Call `advisor` if available. Otherwise `Agent(model="opus")` with the log
 context (no extended thinking in Agent mode — honest degradation). Create a
-ticket with the verdict if the fix is outside authority.
+ticket with the verdict if the fix is outside authority. Commit the ticket:
+`git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): escalation ticket for <project>'`.
 
 ## 5. Done
 
 Append one journal entry per action taken this cycle to
 `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl`. If no actions were taken,
 append a single `action=idle` entry — this serves as the watermark so the
-next cycle knows where to resume. End with:
+next cycle knows where to resume.
+
+**Clean-tree guard.** Before printing the summary, run:
+```bash
+cd $HARNESS_DIR
+dirty=$(git status --porcelain)
+if [ -n "$dirty" ]; then
+  echo "WARNING: supervisor leaving dirty tree: $dirty"
+  git add -A && git commit -m 'chore(supervisor): commit residual tracked writes'
+fi
+```
+This is a safety net — every write should already be committed by the steps
+above. If the guard fires, it means a write point was missed; log the warning
+so the next nightbeat-report flags it for a skill fix.
+
+End with:
 
 ```
 supervisor: <ts> — merged: N, repaired: N, tickets: N, escalated: N

--- a/tests/test_nightbeat_supervisor_skill.py
+++ b/tests/test_nightbeat_supervisor_skill.py
@@ -1,0 +1,45 @@
+"""Adherence tests for nightbeat-supervisor SKILL.md — commit discipline."""
+
+import re
+from pathlib import Path
+
+SKILL = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "nightbeat-supervisor"
+    / "SKILL.md"
+)
+
+
+def _read_skill() -> str:
+    return SKILL.read_text()
+
+
+def test_clean_tree_guard_present():
+    text = _read_skill()
+    assert "git status --porcelain" in text
+
+
+def test_tracked_write_points_have_commit():
+    text = _read_skill()
+    write_markers = [
+        "settings.json` allowlist",
+        "raise the per-project `ProjectConfig`",
+        "raid_timeout_s` in the per-project",
+        "split into one ticket",
+        "open a ticket stating the root cause",
+        "REROLL → append the failing criteria",
+        "Create a\nticket with the verdict",
+    ]
+    for marker in write_markers:
+        idx = text.find(marker)
+        assert idx != -1, f"write-point marker not found: {marker}"
+        surrounding = text[idx : idx + 400]
+        assert re.search(r"git (add|commit)", surrounding), (
+            f"no commit instruction near write point: {marker}"
+        )
+
+
+def test_commit_principle_declared():
+    text = _read_skill()
+    assert "Commit tracked writes immediately" in text

--- a/tickets/closed/0164-supervisor-commit-own-writes.erg
+++ b/tickets/closed/0164-supervisor-commit-own-writes.erg
@@ -2,10 +2,12 @@
 Title: Fix nightbeat supervisor to commit its own writes before exiting
 Created: 2026-05-15
 Author: claude
+Closed: autoclosed — PR #208
 
 --- log ---
 2026-05-15T07:30Z claude created
 
+2026-05-15T09:04Z MinhHaDuong closed — autoclosed — PR #208
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add explicit `git add && git commit` after every write point in `nightbeat-supervisor/SKILL.md`: REROLL notes, permission adds, budget raises, timeout raises, ticket splits, root-cause tickets, escalation tickets
- Add a clean-tree guard (`git status --porcelain`) in Step 5 as a safety net
- Add a "Commit tracked writes immediately" principle at the top
- Adherence test validates commit instructions are present near each write point

**Ticket:** tickets/0164-supervisor-commit-own-writes

## Test plan

- [x] `python3 -m pytest tests/test_nightbeat_supervisor_skill.py -v` — 3 adherence tests pass
- [x] `python3 -m pytest tests/ -v` — 227 tests pass (no regressions)
- [x] `make check-skills-drift` — catalog in sync
- [ ] One full overnight beat run with no `aborted-dirty-tree` outcomes attributable to supervisor writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)