### PR TITLE
fix(0166): add Worktree paths exception rule to workflow.md

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -1,7 +1,7 @@
 <!-- last-reviewed: 2026-04-29 -->
 # Git Discipline
 
-- **Always work on a branch.** Main is read-only except for STATE housekeeping.
+- **Always work on a branch.** Main is read-only except for STATE housekeeping. For the full exception list (tickets, memory, config), see `rules/workflow.md` § Worktree paths.
 - **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.
 - **Merge commits**: strategic-level detail — architecture decisions, cross-file impacts, residual debt. Feature merges go through merge requests; chores merge locally via short-lived branch + fast-forward.
 - **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`.

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -21,6 +21,17 @@ After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→
 
 After entering the worktree, run `git switch <branch>` (or `git switch -c <branch>`) to land on the correct branch. The worktree is throwaway — all durable state lives in branches.
 
+# Worktree paths
+
+During an `EnterWorktree` session, `Edit`/`Write`/`Read` tools accept any absolute path. An edit at `/home/haduong/<repo>/<file>` lands in the **main repo**, not the worktree. Use worktree-rooted paths for code, prose, and data.
+
+Exception — the following may land directly on main without a branch:
+- `STATE.md` updates (always main — see `git.md` "Main is read-only except for STATE housekeeping")
+- Ticket lifecycle: closing finished tickets (`erg close`), opening new `.erg` files, batch ticket housekeeping
+- Harness memory and config files (`memory/*.md`, `settings.json`, `MEMORY.md`)
+
+For everything else (source code, manuscript prose, data files): if `git branch --show-current` is `main`, stop and switch to a branch first.
+
 # Escalation Protocol
 
 When stuck, escalate progressively:

--- a/tickets/closed/0166-clarify-worktree-paths-rule-main-exception.erg
+++ b/tickets/closed/0166-clarify-worktree-paths-rule-main-exception.erg
@@ -2,10 +2,12 @@
 Title: Clarify worktree-paths rule — main-branch exception for housekeeping
 Created: 2026-05-20
 Author: claude
+Closed: autoclosed — PR #210
 
 --- log ---
 2026-05-20T22:30Z claude created
 
+2026-05-23T14:57Z MinhHaDuong closed — autoclosed — PR #210
 --- body ---
 ## Context
 


### PR DESCRIPTION
Add a `# Worktree paths` section to `rules/workflow.md` that enumerates
what may land directly on main (STATE, tickets, memory/config) versus
what requires a branch (code, prose, data). Cross-reference added to
`rules/git.md`.

Resolves the contradiction between `workflow.md`'s implicit "stop on main"
guidance and `git.md`'s sanctioned main commits for housekeeping.

**Ticket:** tickets/0166-clarify-worktree-paths-rule-main-exception