### PR TITLE
fix(0170): guard --delete-branch behind in_worktree in erg-pr-merge

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -114,7 +114,13 @@ fi
 # ── Step 3: squash-merge via forge CLI (works in worktrees and on VMs) ───────
 
 echo "Merging PR #${PR}..."
-gh pr merge "$PR" --squash --delete-branch # harness-extension-point
+if in_worktree; then
+    # deleteBranchOnMerge cleans the remote; the local flag would fail
+    # on the primary worktree's main-lock (see ticket 0170).
+    gh pr merge "$PR" --squash # harness-extension-point
+else
+    gh pr merge "$PR" --squash --delete-branch # harness-extension-point
+fi
 
 # ── Step 4: return to base branch (skipped inside a worktree) ────────────────
 

--- a/tickets/0166-clarify-worktree-paths-rule-main-exception.erg
+++ b/tickets/0166-clarify-worktree-paths-rule-main-exception.erg
@@ -12,7 +12,7 @@ Author: claude
 The `rules/workflow.md` "Worktree paths" section currently says:
 
 > In an `EnterWorktree` session, `Edit`/`Write`/`Read` tools accept any absolute
-> path. Edits at `/home/haduong/<repo>/<file>` go to the **main repo**, not the
+> path. Edits at `~/<repo>/<file>` go to the **main repo**, not the
 > worktree. Always use worktree-rooted paths. Confirm with `pwd` and
 > `git branch --show-current` before committing — if branch is `main`, stop.
 
@@ -70,6 +70,6 @@ There is no automated test for prose rules. Validation is by reading:
 
 - This is rules-only, no code touched.
 - Triggered by AEDIST session 2026-05-20: agent wrote ticket files to
-  `/home/haduong/<repo>/tickets/...` from within a worktree, committed them
+  `~/<repo>/tickets/...` from within a worktree, committed them
   on main, and pushed without incident — which workflow.md's literal reading
   would have prevented but git.md's reading explicitly allows.

--- a/tickets/0171-pretooluse-guard-worktree-path-writes.erg
+++ b/tickets/0171-pretooluse-guard-worktree-path-writes.erg
@@ -10,7 +10,7 @@ Author: HDMX-coding-agent
 ## Context
 
 During an `EnterWorktree` session, `Write`/`Edit`/`Read` accept any absolute path.
-An edit to `/home/haduong/<repo>/<file>` lands in the **main repo**, not the
+An edit to `~/<repo>/<file>` lands in the **main repo**, not the
 worktree — the project rule `.claude/rules/workflow.md` ("Worktree paths") warns
 about exactly this, but nothing enforces it.
 

--- a/tickets/closed/0170-erg-pr-merge-drop-delete-branch-in-worktree.erg
+++ b/tickets/closed/0170-erg-pr-merge-drop-delete-branch-in-worktree.erg
@@ -2,10 +2,12 @@
 Title: erg-pr-merge — drop --delete-branch when run inside a git worktree
 Created: 2026-05-23
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #211
 
 --- log ---
 2026-05-23T14:25Z HDMX-coding-agent created — recurring main-lock error during a merge-heavy session in aedist-technical-report
 
+2026-05-23T14:55Z MinhHaDuong closed — autoclosed — PR #211
 --- body ---
 ## Context
 


### PR DESCRIPTION
When `erg-pr-merge` runs inside a git worktree, `gh pr merge --delete-branch`
fails with _"main is already used by worktree"_ — the local cleanup tries to
switch off the merged branch, but the primary worktree holds `main` locked.

The remote branch is deleted by `deleteBranchOnMerge: true` regardless; the
local `--delete-branch` flag is redundant inside worktrees. Wrap line 117 in
an `if in_worktree; then … else` guard using the existing `in_worktree()`
function (already used at step 4).

**Ticket:** tickets/0170-erg-pr-merge-drop-delete-branch-in-worktree