### PR TITLE
feat(0171): PreToolUse hook — warn on main-repo writes during worktree

### DIFF
--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+# PreToolUse hook: warn when Write/Edit/NotebookEdit targets the main repo
+# path during a worktree session. Non-blocking (exit 0) — advisory only.
+# See ticket 0171.
+
+input=$(cat)
+
+command -v jq &>/dev/null || exit 0
+
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+[ -z "$file_path" ] && exit 0
+
+_in_worktree() {
+    [ -f .git ] && grep -q "gitdir:" .git 2>/dev/null
+}
+
+# Allow env-var overrides for testing without a real git repo
+if [ -n "${_GUARD_WORKTREE_ROOT:-}" ] && [ -n "${_GUARD_PRIMARY_ROOT:-}" ]; then
+    worktree_root="$_GUARD_WORKTREE_ROOT"
+    primary_root="$_GUARD_PRIMARY_ROOT"
+elif _in_worktree; then
+    worktree_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+    git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+    primary_root=$(dirname "$git_common_dir")
+else
+    exit 0
+fi
+
+[ "$worktree_root" = "$primary_root" ] && exit 0
+
+# Normalize to absolute path
+if [ "${file_path#/}" = "$file_path" ]; then
+    file_path="$(pwd)/$file_path"
+fi
+
+case "$file_path" in
+    "$primary_root"/*)
+        case "$file_path" in
+            "$worktree_root"/*)
+                exit 0  # already inside the worktree
+                ;;
+        esac
+        rel="${file_path#$primary_root/}"
+        echo "Worktree path guard: '$rel' resolves to the main repo, not the worktree." >&2
+        echo "Did you mean: $worktree_root/$rel" >&2
+        ;;
+esac
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -131,6 +131,16 @@
             "command": "rtk hook claude"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/scripts/pretooluse-worktree-path-guard.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tests for scripts/pretooluse-worktree-path-guard.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HOOK="$PWD/scripts/pretooluse-worktree-path-guard.sh"
+fail=0
+
+PRIMARY="/home/testuser/repo"
+WORKTREE="/home/testuser/repo/.worktrees/t001"
+
+_payload() {
+    local fp="$1"
+    printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$fp"
+}
+
+_run_hook() {
+    local wt="$1" pr="$2" fp="$3"
+    _payload "$fp" | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" 2>&1 || true
+}
+
+# 1. Main-repo path while in worktree → warn
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "$PRIMARY/src/main.py")
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: warns on main-repo path"
+else
+    echo "FAIL: expected warning for main-repo path; got: $out"
+    fail=1
+fi
+
+# 2. Worktree-rooted path → silent
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "$WORKTREE/src/main.py")
+if [ -z "$out" ]; then
+    echo "PASS: silent for worktree-rooted path"
+else
+    echo "FAIL: unexpected output for worktree path: $out"
+    fail=1
+fi
+
+# 3. Path outside both roots → silent
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "/tmp/unrelated/file.py")
+if [ -z "$out" ]; then
+    echo "PASS: silent for unrelated path"
+else
+    echo "FAIL: unexpected output for unrelated path: $out"
+    fail=1
+fi
+
+# 4. No worktree active (no env overrides, run from primary repo root where .git is a dir) → silent
+out=$(echo '{"tool_name":"Write","tool_input":{"file_path":"/home/haduong/.claude/src/main.py","content":"x"}}' \
+      | bash "$HOOK" 2>&1 || true)
+if [ -z "$out" ]; then
+    echo "PASS: silent when not in a worktree"
+else
+    echo "FAIL: unexpected output when no worktree: $out"
+    fail=1
+fi
+
+# 5. Missing file_path field → silent
+out=$(_payload "" | env _GUARD_WORKTREE_ROOT="$WORKTREE" _GUARD_PRIMARY_ROOT="$PRIMARY" bash "$HOOK" 2>&1 || true)
+if [ -z "$out" ]; then
+    echo "PASS: silent when no file_path in payload"
+else
+    echo "FAIL: unexpected output when no file_path: $out"
+    fail=1
+fi
+
+exit $fail

--- a/tickets/closed/0171-pretooluse-guard-worktree-path-writes.erg
+++ b/tickets/closed/0171-pretooluse-guard-worktree-path-writes.erg
@@ -2,10 +2,12 @@
 Title: PreToolUse hook — warn when Write/Edit targets the main repo path during a worktree session
 Created: 2026-05-23
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #212
 
 --- log ---
 2026-05-23T14:25Z HDMX-coding-agent created — wasted edit + main-repo revert during worktree session in aedist-technical-report
 
+2026-05-23T14:58Z MinhHaDuong closed — autoclosed — PR #212
 --- body ---
 ## Context
 


### PR DESCRIPTION
Add `scripts/pretooluse-worktree-path-guard.sh` and wire it as a
`Write|Edit|NotebookEdit` PreToolUse hook in `settings.json`.

When a worktree session is active and a write tool targets a path under the
primary repo root (instead of the worktree), the hook emits a declarative
warning with the corrected worktree-rooted path. Non-blocking (exit 0) to
avoid false positives on legitimate cross-repo edits.

Uses `_GUARD_WORKTREE_ROOT` / `_GUARD_PRIMARY_ROOT` env overrides for
testability. 5 unit tests, all passing.

**Ticket:** tickets/0171-pretooluse-guard-worktree-path-writes