### PR TITLE
feat(0167-0169): mechanical raid worktree hygiene — salvage, GC, coordination PR

### DIFF
--- a/scripts/guard-worktree-remove-wip.sh
+++ b/scripts/guard-worktree-remove-wip.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+# PreToolUse hook: block "git worktree remove" when the target worktree has
+# uncommitted WIP — git worktree remove --force would silently destroy it.
+# Forces salvage first. Exit 0 = allow, Exit 2 = deny.
+# Matcher in settings.json scopes this to "git worktree remove" commands.
+# See ticket 0168.
+
+input=$(cat)
+
+command -v jq &>/dev/null || exit 0
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
+[ -z "$cmd" ] && exit 0
+
+# Only act on git worktree remove (also catches it inside a compound command).
+echo "$cmd" | grep -qE '\bgit[[:space:]]+worktree[[:space:]]+remove\b' || exit 0
+
+# Extract the worktree path: first non-flag token after "remove".
+after=${cmd#*worktree*remove}
+read -ra toks <<< "$after"
+path=""
+for t in "${toks[@]}"; do
+    case "$t" in
+        --|--force|-f) continue ;;
+        -*) continue ;;
+        *) path="$t"; break ;;
+    esac
+done
+
+[ -z "$path" ] && exit 0
+[ -d "$path" ] || exit 0
+
+if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
+    cat >&2 <<EOF
+Blocked: '$path' has uncommitted WIP — git worktree remove would destroy it.
+Salvage first (commits + pushes the branch so the work survives):
+
+  ~/.claude/scripts/worktree-salvage.sh "$path"
+
+Then re-run the remove. See ticket 0168.
+EOF
+    exit 2
+fi
+
+exit 0

--- a/scripts/worktree-gc.sh
+++ b/scripts/worktree-gc.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# GC stale agent worktrees: remove worktrees named agent-* whose branch is
+# gone from origin (squash-merged + remote-deleted) AND have no uncommitted
+# changes. Never touches dirty worktrees, never uses rm -rf, idempotent.
+# Relies on the caller having run `git fetch --prune` first (housekeeping /
+# celebrate do). Optional arg: repo dir (default: current dir). See ticket 0169.
+
+repo="${1:-.}"
+removed=0
+skipped_wip=0
+
+path=""
+branch=""
+
+flush() {
+    [ -z "$path" ] && return
+    local base
+    base=$(basename "$path")
+    case "$base" in
+        agent-*) ;;
+        *) path=""; branch=""; return ;;
+    esac
+    # Never touch a worktree with uncommitted changes (could be user WIP).
+    if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
+        echo "worktree-gc: skip $base (uncommitted WIP)"
+        skipped_wip=$((skipped_wip + 1))
+        path=""; branch=""; return
+    fi
+    if [ -z "$branch" ]; then path=""; branch=""; return; fi
+    # 'gone' = the branch had an upstream that no longer exists (merged + pruned).
+    local track
+    track=$(git -C "$repo" for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null || true)
+    if [ "$track" = "[gone]" ]; then
+        git -C "$repo" worktree unlock "$path" 2>/dev/null || true
+        if git -C "$repo" worktree remove "$path" 2>/dev/null; then
+            echo "worktree-gc: removed $base (branch '$branch' gone)"
+            removed=$((removed + 1))
+        else
+            echo "worktree-gc: could not remove $base — left in place" >&2
+        fi
+    fi
+    path=""; branch=""
+}
+
+while IFS= read -r line; do
+    case "$line" in
+        "worktree "*) flush; path="${line#worktree }" ;;
+        "branch refs/heads/"*) branch="${line#branch refs/heads/}" ;;
+        "") flush ;;
+    esac
+done < <(git -C "$repo" worktree list --porcelain)
+flush
+
+if [ "$removed" -eq 0 ] && [ "$skipped_wip" -eq 0 ]; then
+    exit 0   # nothing to GC — stay silent
+fi
+echo "worktree-gc: removed $removed, skipped $skipped_wip with WIP."
+exit 0

--- a/scripts/worktree-salvage.sh
+++ b/scripts/worktree-salvage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Salvage uncommitted WIP from a worktree before it is removed.
+# Commits everything, then pushes the branch so the work survives the
+# worktree's deletion. Safe to run on a clean worktree (no-op).
+# See ticket 0168.
+
+usage() { echo "usage: worktree-salvage.sh <worktree-path>" >&2; exit 2; }
+
+path="${1:-}"
+[ -z "$path" ] && usage
+[ -d "$path" ] || { echo "worktree-salvage: not a directory: $path" >&2; exit 2; }
+
+if [ -z "$(git -C "$path" status --porcelain)" ]; then
+    echo "worktree-salvage: nothing to salvage (clean tree) at $path"
+    exit 0
+fi
+
+git -C "$path" add -A
+git -C "$path" commit --quiet -m "WIP: salvaged from interrupted raid"
+
+branch=$(git -C "$path" symbolic-ref --quiet --short HEAD || true)
+if [ -z "$branch" ]; then
+    echo "worktree-salvage: committed WIP on detached HEAD at $path." >&2
+    echo "  HEAD is now $(git -C "$path" rev-parse --short HEAD); create a branch before removing the worktree." >&2
+    exit 0
+fi
+
+echo "worktree-salvage: committed WIP on branch '$branch'."
+if git -C "$path" push --quiet -u origin "$branch"; then
+    echo "worktree-salvage: pushed '$branch' to origin — WIP is safe."
+else
+    echo "worktree-salvage: WARNING — push failed. The WIP commit exists locally on '$branch'" >&2
+    echo "  but is NOT on origin yet. Push it manually before deleting the branch." >&2
+fi
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -124,6 +124,16 @@
         ]
       },
       {
+        "matcher": "Bash(git worktree remove*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/scripts/guard-worktree-remove-wip.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/skills/celebrate/SKILL.md
+++ b/skills/celebrate/SKILL.md
@@ -42,6 +42,11 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
     - All closed → integration review: re-read all child diffs, run full test suite, verify exit criteria.
     - Any open → do nothing, tracker stays open.
 9. **Exit worktree** (if in one): call `ExitWorktree` with action `remove`. Skip if not in a worktree.
+9.5. **GC stale agent worktrees** (from the main repo): prune leftover `agent-*` worktrees whose branch is merged-and-gone — intact dirs that `git worktree prune` misses:
+    ```bash
+    ~/.claude/scripts/worktree-gc.sh
+    ```
+    Removes only worktrees with no uncommitted changes; never `rm -rf`s, silent when there is nothing to clean. See ticket 0169.
 10. **Verify hygiene**:
     - `git branch -a` → no stale remote branches
     - Check for stale merge requests

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -39,6 +39,12 @@ Run full repo housekeeping and act on every finding.
    - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(scripts/housekeeping-git.sh)` from the project root.
    - If `BEAT_HOUSEKEEPING_BRANCH` **is** set (beat.py run): skip — beat.py already ran the git phase before invoking this skill.
 
+1.5. **GC stale agent worktrees.** Remove leftover `agent-*` worktrees whose branch is merged-and-gone (intact dirs that `git worktree prune` misses):
+   ```bash
+   ~/.claude/scripts/worktree-gc.sh
+   ```
+   Skips any worktree with uncommitted changes, never `rm -rf`s, silent when there is nothing to clean. Safe here because step 0 already confirmed no other live session, and the git phase above ran `git fetch --prune` so gone branches are detectable. See ticket 0169.
+
 2. **Healthcheck.** Invoke /healthcheck. The probe (`project-state.py`)
    runs once inside healthcheck and covers all checks — do not re-run git
    commands already collected there. Parse the **Action plan** section from

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -79,8 +79,29 @@ Launch agents by cluster to cross-check plans:
 - File paths, line numbers, function signatures
 - Data assumptions, API key requirements
 - Cross-ticket conflicts
+- Cross-cutting registries: a file holding a shared hash-set / dict / dispatch
+  table (test allowlist, dispatch keys, config conventions) that 3+ PRs will
+  edit. Flag any you find — they trigger the Phase 5.0 coordination PR.
 
 Annotate tickets with PASS/WARN/BLOCK. Commit annotations.
+
+## Phase 5.0: Land coordination PR (cross-cutting registries)
+
+**When**: 3+ PRs in a wave will edit the same file holding a shared
+hash-set / dict / dispatch registry (test allowlists like `VALID_ROUTES`,
+dispatch keys, config-file conventions). If ≤2 PRs touch it, skip — a manual
+rebase is cheaper than the coordination overhead.
+
+**Why**: when N parallel PRs each append to the same cross-cutting set, the
+rebase onto sibling-merged main silently drops each PR's own addition. Wave 2
+(SOTA-adapter raid, 2026-05-20) needed a resurrection agent for 3 of 4 merges
+because of this. (memory: feedback_rebase_drop_cascade)
+
+**How**: before opening any Wave-N PR, open one tiny PR that adds ALL of the
+wave's entries to the shared registries at once, and merge it first. Each
+Wave-N PR then makes a purely additive change (new file, new entry referencing
+a pre-registered key) without mutating the shared set. The coordination PR
+itself follows the normal verify/merge gates.
 
 ## Phase 5: Execute (waves, worktree-isolated)
 
@@ -168,9 +189,25 @@ All three triggers below require a bump log line written to the **main-repo**
 `tickets/` directory (not the killed agent's worktree copy), committed before
 relaunching: `{ISO8601} claude bump circuit-breaker — {reason}`.
 
-**Agent timeout**: If an agent has not pushed within 10 minutes,
-kill it. Split the ticket or relaunch with narrower scope.
-Bump reason: `agent timeout`.
+**Killing a mid-execution agent — salvage WIP first.** Before any
+`git worktree remove` on a killed agent's worktree, salvage its work so it
+survives the deletion:
+
+```bash
+~/.claude/scripts/worktree-salvage.sh <worktree-path>
+```
+
+This commits everything on the agent's branch and pushes it. A PreToolUse guard
+enforces the order: `git worktree remove` is blocked while the worktree has
+uncommitted changes. Relaunch the finisher on the **existing** branch with
+`git switch <branch>` (NOT `-c`); it inspects the salvaged WIP via
+`git show --stat HEAD` before continuing rather than starting from scratch.
+Salvage is the FIRST step of any restart, not an afterthought.
+(memory: feedback_killed_agent_salvage)
+
+**Agent timeout**: If an agent has not pushed within 10 minutes, salvage its
+worktree (above), then kill it. Split the ticket or relaunch with narrower
+scope. Bump reason: `agent timeout`.
 
 **Ping-pong detector**: If two agents edit the same file on the
 same branch, STOP. Reset to last known-good commit, relaunch ONE agent.

--- a/tests/test_worktree_tools.py
+++ b/tests/test_worktree_tools.py
@@ -1,0 +1,209 @@
+"""Tests for the worktree tooling scripts (tickets 0168, 0169).
+
+Exercises:
+  - scripts/worktree-salvage.sh        — commit + push WIP before removal
+  - scripts/guard-worktree-remove-wip.sh — PreToolUse guard blocking removal on WIP
+  - scripts/worktree-gc.sh             — GC stale agent-* worktrees
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("jq") is None,
+    reason="git and jq required",
+)
+
+
+def run(args, cwd=None, check=True):
+    return subprocess.run(
+        args, cwd=cwd, check=check, capture_output=True, text=True
+    )
+
+
+def git(repo, *args, check=True):
+    return run(["git", "-C", str(repo), *args], check=check)
+
+
+@pytest.fixture
+def origin(tmp_path):
+    """A bare remote plus a primary clone with an initial commit on main."""
+    remote = tmp_path / "remote.git"
+    run(["git", "init", "--bare", "-b", "main", str(remote)])
+
+    primary = tmp_path / "primary"
+    run(["git", "init", "-b", "main", str(primary)])
+    git(primary, "config", "user.email", "test@example.com")
+    git(primary, "config", "user.name", "Test")
+    git(primary, "config", "commit.gpgsign", "false")
+    (primary / "README").write_text("hi\n")
+    git(primary, "add", "-A")
+    git(primary, "commit", "-m", "init")
+    git(primary, "remote", "add", "origin", str(remote))
+    git(primary, "push", "-u", "origin", "main")
+    return remote, primary
+
+
+def make_agent_worktree(primary, name, *, dirty=False, push=True):
+    """Create an agent-* worktree on its own branch; optionally push + leave WIP."""
+    wt = primary.parent / name
+    git(primary, "worktree", "add", "-b", name, str(wt))
+    (wt / "work.txt").write_text("first\n")
+    git(wt, "add", "-A")
+    git(wt, "commit", "-m", "work")
+    if push:
+        git(wt, "push", "-u", "origin", name)
+    if dirty:
+        (wt / "work.txt").write_text("uncommitted change\n")
+    return wt
+
+
+def make_branch_gone(remote, primary, name):
+    """Delete the branch on the remote and prune so the local branch reads [gone]."""
+    git(remote, "update-ref", "-d", f"refs/heads/{name}")
+    git(primary, "fetch", "--prune", "origin")
+
+
+# --------------------------------------------------------------------------- #
+# worktree-salvage.sh
+# --------------------------------------------------------------------------- #
+
+def test_salvage_commits_and_pushes_wip(origin):
+    remote, primary = origin
+    wt = make_agent_worktree(primary, "agent-salv", dirty=True)
+
+    res = run([str(SCRIPTS / "worktree-salvage.sh"), str(wt)])
+    assert res.returncode == 0
+
+    head_msg = git(wt, "log", "-1", "--format=%s").stdout.strip()
+    assert head_msg == "WIP: salvaged from interrupted raid"
+    assert git(wt, "status", "--porcelain").stdout.strip() == ""
+    # Pushed: remote tip matches local HEAD.
+    local = git(wt, "rev-parse", "HEAD").stdout.strip()
+    remote_tip = git(remote, "rev-parse", "refs/heads/agent-salv").stdout.strip()
+    assert local == remote_tip
+
+
+def test_salvage_clean_tree_is_noop(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-clean", dirty=False)
+    before = git(wt, "rev-parse", "HEAD").stdout.strip()
+
+    res = run([str(SCRIPTS / "worktree-salvage.sh"), str(wt)])
+    assert res.returncode == 0
+    assert "nothing to salvage" in res.stdout
+    assert git(wt, "rev-parse", "HEAD").stdout.strip() == before
+
+
+def test_salvage_missing_arg_errors(origin):
+    res = run([str(SCRIPTS / "worktree-salvage.sh")], check=False)
+    assert res.returncode == 2
+
+
+# --------------------------------------------------------------------------- #
+# guard-worktree-remove-wip.sh
+# --------------------------------------------------------------------------- #
+
+def _guard(cmd):
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
+    return subprocess.run(
+        ["bash", str(SCRIPTS / "guard-worktree-remove-wip.sh")],
+        input=payload, capture_output=True, text=True,
+    )
+
+
+def test_guard_blocks_remove_with_wip(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-dirty", dirty=True)
+    res = _guard(f"git worktree remove --force {wt}")
+    assert res.returncode == 2
+    assert "uncommitted WIP" in res.stderr
+
+
+def test_guard_allows_remove_when_clean(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-ok", dirty=False)
+    res = _guard(f"git worktree remove {wt}")
+    assert res.returncode == 0
+    assert res.stderr == ""
+
+
+def test_guard_ignores_unrelated_command(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-x", dirty=True)
+    # Not a worktree-remove command — must not block even with a dirty path.
+    res = _guard(f"git worktree list {wt}")
+    assert res.returncode == 0
+
+
+def test_guard_allows_nonexistent_path():
+    res = _guard("git worktree remove /no/such/worktree/path")
+    assert res.returncode == 0
+
+
+# --------------------------------------------------------------------------- #
+# worktree-gc.sh
+# --------------------------------------------------------------------------- #
+
+def _gc(primary):
+    return run([str(SCRIPTS / "worktree-gc.sh"), str(primary)])
+
+
+def _worktree_paths(primary):
+    out = git(primary, "worktree", "list", "--porcelain").stdout
+    return [l[len("worktree "):] for l in out.splitlines() if l.startswith("worktree ")]
+
+
+def test_gc_removes_gone_clean_agent_worktree(origin):
+    remote, primary = origin
+    wt = make_agent_worktree(primary, "agent-gone", dirty=False)
+    make_branch_gone(remote, primary, "agent-gone")
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert "removed agent-gone" in res.stdout
+    assert str(wt) not in _worktree_paths(primary)
+
+
+def test_gc_keeps_dirty_worktree(origin):
+    remote, primary = origin
+    wt = make_agent_worktree(primary, "agent-wip", dirty=True)
+    make_branch_gone(remote, primary, "agent-wip")
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert "skip agent-wip (uncommitted WIP)" in res.stdout
+    assert str(wt) in _worktree_paths(primary)
+
+
+def test_gc_keeps_live_branch_worktree(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-live", dirty=False)  # branch still on origin
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert str(wt) in _worktree_paths(primary)
+
+
+def test_gc_ignores_non_agent_worktree(origin):
+    remote, primary = origin
+    wt = make_agent_worktree(primary, "feature-x", dirty=False)
+    make_branch_gone(remote, primary, "feature-x")
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert str(wt) in _worktree_paths(primary)
+
+
+def test_gc_silent_when_nothing_to_do(origin):
+    _, primary = origin
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert res.stdout.strip() == ""

--- a/tickets/0167-raid-coordination-pr-step.erg
+++ b/tickets/0167-raid-coordination-pr-step.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-05-21T00:15Z HDMX-coding-agent created
 2026-05-21T07:32Z claude note re-filed from aedist-technical-report/tickets/0188 — this is user-level skill work, not project work
 
+2026-05-27T20:53Z claude note Phase 5.0 coordination-PR step + Phase 4 cross-cutting-registry detection added to raid skill; pending merge + next-raid observation
 --- body ---
 ## Context
 

--- a/tickets/0168-raid-agent-salvage-step.erg
+++ b/tickets/0168-raid-agent-salvage-step.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-05-21T00:16Z HDMX-coding-agent created
 2026-05-21T07:32Z claude note re-filed from aedist-technical-report/tickets/0189 — this is user-level skill work, not project work; ref to former 0188 updated to 0167
 
+2026-05-27T20:53Z claude note salvage script + PreToolUse remove-WIP guard + raid circuit-breaker prose added; pending merge + next-raid observation
 --- body ---
 ## Context
 

--- a/tickets/0169-worktree-gc-after-raid.erg
+++ b/tickets/0169-worktree-gc-after-raid.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-05-21T00:17Z HDMX-coding-agent created
 2026-05-21T07:32Z claude note re-filed from aedist-technical-report/tickets/0190 — this is user-level skill work, not project work
 
+2026-05-27T20:53Z claude note worktree-gc.sh + celebrate/housekeeping GC steps + pytest coverage added; pending merge + next-raid observation
 --- body ---
 ## Context
 


### PR DESCRIPTION
Turn the three Wave-2 raid lessons into tooling instead of prose-only steps.

- 0169: scripts/worktree-gc.sh prunes merged-and-gone agent-* worktrees
  (skips uncommitted WIP, never rm -rf, idempotent); wired into celebrate
  step 9.5 and housekeeping step 1.5.
- 0168: scripts/worktree-salvage.sh commits + pushes WIP before removal, and
  guard-worktree-remove-wip.sh (PreToolUse) blocks `git worktree remove` while
  the worktree is dirty; raid circuit-breakers document salvage as step one.
- 0167: raid Phase 5.0 coordination-PR step + Phase 4 cross-cutting-registry
  detection.
- tests/test_worktree_tools.py: 12 cases over the three scripts (real temp
  git repos + worktrees).

https://claude.ai/code/session_01TTxFWVtLV6BH8mKgtCv2UY