### PR TITLE
fix(0168-0169): harden worktree tooling from opus-panel findings

### DIFF
--- a/scripts/guard-worktree-remove-wip.sh
+++ b/scripts/guard-worktree-remove-wip.sh
@@ -9,8 +9,9 @@ set -euo pipefail
 input=$(cat)
 
 command -v jq &>/dev/null || exit 0
-cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 [ -z "$cmd" ] && exit 0
+hook_cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 
 # Only act on git worktree remove (also catches it inside a compound command).
 echo "$cmd" | grep -qE '\bgit[[:space:]]+worktree[[:space:]]+remove\b' || exit 0
@@ -28,6 +29,14 @@ for t in "${toks[@]}"; do
 done
 
 [ -z "$path" ] && exit 0
+
+# Resolve relative paths against the PreToolUse JSON's .cwd (the cwd Bash will
+# run from), not the hook's own cwd. Doesn't help compound `cd && remove` —
+# that's a known matcher-dispatch gap, not a guard-script gap.
+if [ "${path#/}" = "$path" ] && [ -n "$hook_cwd" ]; then
+    path="$hook_cwd/$path"
+fi
+
 [ -d "$path" ] || exit 0
 
 if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then

--- a/scripts/worktree-gc.sh
+++ b/scripts/worktree-gc.sh
@@ -9,9 +9,13 @@ set -euo pipefail
 repo="${1:-.}"
 removed=0
 skipped_wip=0
+skipped_locked=0
 
 path=""
 branch=""
+locked_flag=0
+
+reset() { path=""; branch=""; locked_flag=0; }
 
 flush() {
     [ -z "$path" ] && return
@@ -19,41 +23,49 @@ flush() {
     base=$(basename "$path")
     case "$base" in
         agent-*) ;;
-        *) path=""; branch=""; return ;;
+        *) reset; return ;;
     esac
     # Never touch a worktree with uncommitted changes (could be user WIP).
     if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
         echo "worktree-gc: skip $base (uncommitted WIP)"
         skipped_wip=$((skipped_wip + 1))
-        path=""; branch=""; return
+        reset; return
     fi
-    if [ -z "$branch" ]; then path=""; branch=""; return; fi
+    if [ -z "$branch" ]; then reset; return; fi
     # 'gone' = the branch had an upstream that no longer exists (merged + pruned).
     local track
     track=$(git -C "$repo" for-each-ref --format='%(upstream:track)' "refs/heads/$branch" 2>/dev/null || true)
-    if [ "$track" = "[gone]" ]; then
-        git -C "$repo" worktree unlock "$path" 2>/dev/null || true
-        if git -C "$repo" worktree remove "$path" 2>/dev/null; then
-            echo "worktree-gc: removed $base (branch '$branch' gone)"
-            removed=$((removed + 1))
-        else
-            echo "worktree-gc: could not remove $base — left in place" >&2
+    if [ "$track" != "[gone]" ]; then reset; return; fi
+    # Locked worktrees: unlock first, then remove. If unlock fails (lock held
+    # by another process or by an admin-dir we can't write), skip + report.
+    if [ "$locked_flag" -eq 1 ]; then
+        if ! git -C "$repo" worktree unlock "$path" 2>/dev/null; then
+            echo "worktree-gc: skip $base (lock held — could not unlock)" >&2
+            skipped_locked=$((skipped_locked + 1))
+            reset; return
         fi
     fi
-    path=""; branch=""
+    if git -C "$repo" worktree remove "$path" 2>/dev/null; then
+        echo "worktree-gc: removed $base (branch '$branch' gone)"
+        removed=$((removed + 1))
+    else
+        echo "worktree-gc: could not remove $base — left in place" >&2
+    fi
+    reset
 }
 
 while IFS= read -r line; do
     case "$line" in
         "worktree "*) flush; path="${line#worktree }" ;;
         "branch refs/heads/"*) branch="${line#branch refs/heads/}" ;;
+        "locked"|"locked "*) locked_flag=1 ;;
         "") flush ;;
     esac
 done < <(git -C "$repo" worktree list --porcelain)
 flush
 
-if [ "$removed" -eq 0 ] && [ "$skipped_wip" -eq 0 ]; then
+if [ "$removed" -eq 0 ] && [ "$skipped_wip" -eq 0 ] && [ "$skipped_locked" -eq 0 ]; then
     exit 0   # nothing to GC — stay silent
 fi
-echo "worktree-gc: removed $removed, skipped $skipped_wip with WIP."
+echo "worktree-gc: removed $removed, skipped $skipped_wip with WIP, $skipped_locked locked."
 exit 0

--- a/skills/celebrate/SKILL.md
+++ b/skills/celebrate/SKILL.md
@@ -42,8 +42,9 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
     - All closed → integration review: re-read all child diffs, run full test suite, verify exit criteria.
     - Any open → do nothing, tracker stays open.
 9. **Exit worktree** (if in one): call `ExitWorktree` with action `remove`. Skip if not in a worktree.
-9.5. **GC stale agent worktrees** (from the main repo): prune leftover `agent-*` worktrees whose branch is merged-and-gone — intact dirs that `git worktree prune` misses:
+9.5. **GC stale agent worktrees** (from the main repo): prune leftover `agent-*` worktrees whose branch is merged-and-gone — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
     ```bash
+    git fetch --prune origin
     ~/.claude/scripts/worktree-gc.sh
     ```
     Removes only worktrees with no uncommitted changes; never `rm -rf`s, silent when there is nothing to clean. See ticket 0169.

--- a/tests/test_worktree_tools.py
+++ b/tests/test_worktree_tools.py
@@ -111,8 +111,11 @@ def test_salvage_missing_arg_errors(origin):
 # guard-worktree-remove-wip.sh
 # --------------------------------------------------------------------------- #
 
-def _guard(cmd):
-    payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
+def _guard(cmd, cwd=None):
+    body = {"tool_name": "Bash", "tool_input": {"command": cmd}}
+    if cwd is not None:
+        body["cwd"] = str(cwd)
+    payload = json.dumps(body)
     return subprocess.run(
         ["bash", str(SCRIPTS / "guard-worktree-remove-wip.sh")],
         input=payload, capture_output=True, text=True,
@@ -145,6 +148,26 @@ def test_guard_ignores_unrelated_command(origin):
 
 def test_guard_allows_nonexistent_path():
     res = _guard("git worktree remove /no/such/worktree/path")
+    assert res.returncode == 0
+
+
+def test_guard_resolves_relative_path_against_json_cwd(origin):
+    """A relative path should resolve against the PreToolUse JSON .cwd, not
+    the hook's own cwd. Otherwise dirty removes via relative paths slip past."""
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-rel", dirty=True)
+    # Command uses a relative path; cwd is primary's parent (the tmp dir).
+    res = _guard(f"git worktree remove --force {wt.name}", cwd=wt.parent)
+    assert res.returncode == 2
+    assert "uncommitted WIP" in res.stderr
+
+
+def test_guard_handles_malformed_json():
+    """Bad JSON on stdin should exit cleanly, not abort the script with set -e."""
+    res = subprocess.run(
+        ["bash", str(SCRIPTS / "guard-worktree-remove-wip.sh")],
+        input="not json{", capture_output=True, text=True,
+    )
     assert res.returncode == 0
 
 
@@ -207,3 +230,17 @@ def test_gc_silent_when_nothing_to_do(origin):
     res = _gc(primary)
     assert res.returncode == 0
     assert res.stdout.strip() == ""
+
+
+def test_gc_unlocks_and_removes_locked_gone_worktree(origin):
+    """A locked but unlockable agent-* worktree on a gone branch should be
+    unlocked and removed — exercises the locked-branch code path."""
+    remote, primary = origin
+    wt = make_agent_worktree(primary, "agent-locked", dirty=False)
+    git(primary, "worktree", "lock", str(wt))
+    make_branch_gone(remote, primary, "agent-locked")
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert "removed agent-locked" in res.stdout
+    assert str(wt) not in _worktree_paths(primary)

--- a/tests/test_worktree_tools.py
+++ b/tests/test_worktree_tools.py
@@ -169,6 +169,7 @@ def test_guard_handles_malformed_json():
         input="not json{", capture_output=True, text=True,
     )
     assert res.returncode == 0
+    assert res.stderr == ""
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Follow-up to #214. An Opus verification panel reviewed that PR after it merged; this PR lands the four cheap fixes the panel surfaced.

## Findings addressed

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| 1 | MEDIUM | `guard-worktree-remove-wip.sh` resolved relative paths against the hook's own cwd, ignoring the PreToolUse JSON `.cwd` field — `git worktree remove ../wt-dirty` could slip past as a false negative. | Resolve relative `path` against `.cwd` from the input JSON. |
| 2 | LOW | Malformed JSON on stdin → `jq` fails under `set -euo pipefail` → script exits 5 (noisy, though non-blocking). | `jq ... 2>/dev/null \|\| true` on the `cmd`/`cwd` extractions. |
| 3 | LOW | `celebrate` step 9.5 omitted the `git fetch --prune origin` precondition that `[gone]` detection relies on (`housekeeping` 1.5 already stated it). | Added the fetch line into celebrate's GC code block. |
| 4 | PARTIAL | `worktree-gc.sh` swallowed unlock failures and didn't distinctly report the "lock held by another process" case the ticket called out. | Parse the porcelain `locked` line into a flag; on locked worktrees, attempt `worktree unlock` — on failure, emit `skip <base> (lock held — could not unlock)` and increment a separate `skipped_locked` counter shown in the summary. |

## Out of scope

The remaining MEDIUM from the panel — the compound-command dispatch gap (`Bash(git worktree remove*)` is a prefix-glob and won't fire on `cd sub && git worktree remove ...`) — would require folding a check into the always-on `guard-destructive-bash.sh`. That touches a shared safety hook; deferred pending an explicit decision.

## Test plan

- [x] `python3 -m pytest tests/test_worktree_tools.py -v` — 15/15 pass (12 existing + 3 new):
    - `test_guard_resolves_relative_path_against_json_cwd` — covers fix 1
    - `test_guard_handles_malformed_json` — covers fix 2
    - `test_gc_unlocks_and_removes_locked_gone_worktree` — exercises the locked-branch code path (fix 4)
- [x] `make check` passes (skills-drift, agnostic-guard on tickets)
- [x] `bash scripts/check-agnostic.sh` clean
- [x] `grep -L 'set -euo pipefail' scripts/*.sh` clean
- [x] `./tickets/erg check tickets/` — 167 tickets pass
- [x] `jq -e . settings.json` valid

## Caveat

Fix 4's *unlock-failure* sub-branch is reachable in code with a distinct error message, but not directly unit-tested — chmod-based simulation of unlink failure requires a non-root user (CI runner is non-root, but the local sandbox here is root, so I kept the test on the "locked + unlockable" common-case path).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTxFWVtLV6BH8mKgtCv2UY)_