### PR TITLE
fix(0173): pretooluse-worktree-path-guard resolves cwd from PreToolUse JSON

### DIFF
--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -8,8 +8,9 @@ input=$(cat)
 
 command -v jq &>/dev/null || exit 0
 
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
 [ -z "$file_path" ] && exit 0
+hook_cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 
 _in_worktree() {
     [ -f .git ] && grep -q "gitdir:" .git 2>/dev/null
@@ -29,9 +30,15 @@ fi
 
 [ "$worktree_root" = "$primary_root" ] && exit 0
 
-# Normalize to absolute path
+# Resolve relative file_path against the PreToolUse JSON's .cwd (the cwd the
+# tool will run from), not the hook's own cwd. Fall back to $(pwd) when .cwd
+# is absent so older runners and tests that don't supply it still work.
 if [ "${file_path#/}" = "$file_path" ]; then
-    file_path="$(pwd)/$file_path"
+    if [ -n "$hook_cwd" ]; then
+        file_path="$hook_cwd/$file_path"
+    else
+        file_path="$(pwd)/$file_path"
+    fi
 fi
 
 case "$file_path" in

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -14,9 +14,20 @@ _payload() {
     printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$fp"
 }
 
+_payload_with_cwd() {
+    local fp="$1" cwd="$2"
+    printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"},"cwd":"%s"}' "$fp" "$cwd"
+}
+
 _run_hook() {
     local wt="$1" pr="$2" fp="$3"
     _payload "$fp" | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" 2>&1 || true
+}
+
+_run_hook_with_cwd() {
+    local wt="$1" pr="$2" fp="$3" cwd="$4"
+    _payload_with_cwd "$fp" "$cwd" \
+        | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" 2>&1 || true
 }
 
 # 1. Main-repo path while in worktree → warn
@@ -62,6 +73,25 @@ if [ -z "$out" ]; then
     echo "PASS: silent when no file_path in payload"
 else
     echo "FAIL: unexpected output when no file_path: $out"
+    fail=1
+fi
+
+# 6. Relative file_path + .cwd inside primary repo → warn (resolves against .cwd,
+# not the hook's $(pwd)). Regression test for ticket 0173.
+out=$(_run_hook_with_cwd "$WORKTREE" "$PRIMARY" "src/main.py" "$PRIMARY")
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: warns on relative path resolved via .cwd into primary repo"
+else
+    echo "FAIL: expected warning for relative path with .cwd=primary; got: $out"
+    fail=1
+fi
+
+# 7. Relative file_path + .cwd inside worktree → silent (already inside worktree).
+out=$(_run_hook_with_cwd "$WORKTREE" "$PRIMARY" "src/main.py" "$WORKTREE")
+if [ -z "$out" ]; then
+    echo "PASS: silent for relative path resolved via .cwd into worktree"
+else
+    echo "FAIL: unexpected output for relative path with .cwd=worktree: $out"
     fail=1
 fi
 

--- a/tickets/0173-pretooluse-path-guard-resolve-cwd.erg
+++ b/tickets/0173-pretooluse-path-guard-resolve-cwd.erg
@@ -1,0 +1,90 @@
+%erg 0.1
+Title: pretooluse-worktree-path-guard.sh resolves relative paths against hook cwd instead of PreToolUse .cwd
+Created: 2026-05-28
+Author: claude
+
+--- log ---
+2026-05-28T08:45Z claude created — class-bug follow-up from celebrate sweep after PR #215
+
+--- body ---
+## Context
+
+PR #215 (commit 25f8152, ticket 0168-0169) fixed
+`scripts/guard-worktree-remove-wip.sh` to resolve relative paths against the
+PreToolUse JSON's `.cwd` field instead of the hook's own `$(pwd)`. That fix
+closed a false-negative where `git worktree remove ../wt-dirty` slipped past
+the WIP check because the hook resolved `../wt-dirty` from wherever the hook
+itself was invoked, not from where the tool would run.
+
+The celebrate sweep after that merge found the same class bug in
+`scripts/pretooluse-worktree-path-guard.sh:33-34`:
+
+```
+if [ "${file_path#/}" = "$file_path" ]; then
+    file_path="$(pwd)/$file_path"
+fi
+```
+
+This guard receives `file_path` from `tool_input.file_path` (Write / Edit /
+NotebookEdit). When the tool runs from a different cwd than the hook (which is
+the common case during a worktree session, since hooks fire from the harness
+working directory, not from where Bash will `cd`), a relative `file_path`
+resolves to the wrong directory and the main-repo-write warning is suppressed
+incorrectly.
+
+The previous celebrate session said it filed a ticket for this, but it was
+never committed — recreating here so the work survives.
+
+## Relevant files
+
+- `scripts/pretooluse-worktree-path-guard.sh` — the hook with the bug
+- `tests/test_pretooluse_worktree_path_guard.sh` — payloads currently omit
+  `.cwd`; add a case that sets it
+- `scripts/guard-worktree-remove-wip.sh` — reference implementation of the
+  fix pattern (read `.cwd` from JSON, fall back gracefully)
+
+## Actions
+
+1. In `pretooluse-worktree-path-guard.sh`, read the PreToolUse JSON's `.cwd`
+   field once near the top (alongside the `file_path` read), with the same
+   `2>/dev/null || true` defensive parse used in `guard-worktree-remove-wip.sh`.
+2. Replace `file_path="$(pwd)/$file_path"` with a resolution against the
+   hook-supplied `.cwd` when present, falling back to `$(pwd)` only if `.cwd`
+   is empty (preserves behavior when invoked by tests or older runners).
+3. Add a regression test in `tests/test_pretooluse_worktree_path_guard.sh`
+   that sends `tool_input.file_path` = a relative path plus `.cwd` = a path
+   inside the primary repo (but outside the worktree), asserting the warning
+   fires. Add a second case where `.cwd` is omitted to confirm the fallback
+   keeps current behavior.
+
+## Test
+
+Red step: extend `tests/test_pretooluse_worktree_path_guard.sh` with a case
+that submits `{"tool_input":{"file_path":"foo.md"},"cwd":"<primary_root>"}`
+under a fake worktree session (`_GUARD_WORKTREE_ROOT` / `_GUARD_PRIMARY_ROOT`
+env-var overrides already exist) and expects the "resolves to the main repo"
+warning on stderr. With current code the test fails because `$(pwd)` from the
+test harness doesn't resolve into `$primary_root`.
+
+## Verification
+
+- [ ] New test fails on current `pretooluse-worktree-path-guard.sh`
+- [ ] New test passes after the `.cwd` resolution change
+- [ ] Existing 5 cases in `test_pretooluse_worktree_path_guard.sh` still pass
+- [ ] `make check` passes
+
+## Invariants
+
+- Guard stays advisory (exit 0 on all paths)
+- Absolute `file_path` continues to bypass the resolution branch unchanged
+- Empty / missing `.cwd` falls back to `$(pwd)` so existing test payloads keep
+  working without modification
+
+## Exit criteria
+
+- `pretooluse-worktree-path-guard.sh` resolves relative `file_path` against
+  the PreToolUse JSON `.cwd` field, matching the pattern in
+  `guard-worktree-remove-wip.sh`
+- Regression test in `tests/test_pretooluse_worktree_path_guard.sh` asserts
+  the cwd-resolution behavior
+- `make check` passes


### PR DESCRIPTION
## Summary

Mirrors the fix landed in `guard-worktree-remove-wip.sh` (25f8152) to a sibling PreToolUse hook with the same shape: `scripts/pretooluse-worktree-path-guard.sh` was resolving relative `tool_input.file_path` against the hook's own `$(pwd)` instead of the PreToolUse JSON's `.cwd` field — so the main-repo-write warning depended on where the hook happened to be invoked, not where the tool would actually run.

Class-bug follow-up from the `/celebrate` sweep after #215. The previous celebrate session said it filed a ticket but never committed it — this PR recreates the ticket (0173) and ships the fix together.

## Changes

- `scripts/pretooluse-worktree-path-guard.sh`: read `.cwd` from the PreToolUse JSON, use it to resolve relative `file_path`, fall back to `$(pwd)` when absent so older runners and pre-existing payloads keep working.
- `tests/test_pretooluse_worktree_path_guard.sh`: add 2 cases (relative path + `.cwd`=primary → warn; relative path + `.cwd`=worktree → silent). All 7 cases pass.
- `tickets/0173-pretooluse-path-guard-resolve-cwd.erg`: the ticket itself.

## Test plan

- [x] `bash tests/test_pretooluse_worktree_path_guard.sh` — 7/7 pass
- [x] `python3 -m pytest tests/` — 252/252 pass (no regressions in worktree-tools suite)
- [x] `make check` — passes (skills drift + agnostic-guard)
- [x] `erg validate` + `erg check` — pass on the new ticket


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn2p1kZEftjc1D5wk6kB9g)_