### PR TITLE
tickets: close 0173 — fix landed in #216

### DIFF
--- a/tickets/closed/0173-pretooluse-path-guard-resolve-cwd.erg
+++ b/tickets/closed/0173-pretooluse-path-guard-resolve-cwd.erg
@@ -2,10 +2,12 @@
 Title: pretooluse-worktree-path-guard.sh resolves relative paths against hook cwd instead of PreToolUse .cwd
 Created: 2026-05-28
 Author: claude
+Closed: fix landed in PR #216 (commit a5954c2)
 
 --- log ---
 2026-05-28T08:45Z claude created — class-bug follow-up from celebrate sweep after PR #215
 
+2026-05-28T07:02Z Claude closed — fix landed in PR #216 (commit a5954c2)
 --- body ---
 ## Context
 


### PR DESCRIPTION
Close ticket 0173 — fix shipped in #216 (commit a5954c2).

Pure metadata move (`tickets/` → `tickets/closed/`) with a `Closed:` header and a log line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn2p1kZEftjc1D5wk6kB9g)_