### PR TITLE
chore(raid 713 cleanup): close 0168, open 0174, refresh STATE.md

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,21 +1,21 @@
 # Imperial Dragon Harness — State
 
-Last updated: 2026-05-15T20:05Z
+Last updated: 2026-05-28T11:51Z
 
 ## North star
 
 A reusable, science-backed personal harness for AI-assisted research: code and prose, day and night, across projects and machines.
 
 ## Status
-<!-- generated 2026-05-15T20:05Z -->
+<!-- generated 2026-05-28T11:51Z -->
 
-**Tickets:** 0 ready · 5 deferred/blocked — `erg ready tickets/` for full list
+**Tickets:** 3 ready · 5 blocked — `erg ready tickets/` for full list
 **Recent commits:**
-  9e2d136 chore(nightbeat): remove IDH from beat roll
-  984303b chore: tag 0165 deferred, wire make check target
-  f94978c fix(probe): filter erg ready --json by ready:true field
-  c6cb68f dream: consolidate chemin-de-voix memory (26→26 entries)
-  dc46bcb chore(state): refresh 2026-05-15 end-of-session — dream merged, 233 tests
+  01720db tickets: close 0173 — fix landed in #216 (#217)
+  a5954c2 fix(0173): pretooluse-worktree-path-guard resolves cwd from PreToolUse JSON (#216)
+  0ef401a Merge pull request #215 from MinhHaDuong/claude/erg-ready-presentation-BJhbR
+  85d41f8 test(0168): assert malformed-JSON guard stays silent on stderr
+  25f8152 fix(0168-0169): harden worktree tooling from opus-panel findings
 
 ## Blockers
 

--- a/tickets/0174-celebrate-sweep-ticket-loss-guard.erg
+++ b/tickets/0174-celebrate-sweep-ticket-loss-guard.erg
@@ -1,0 +1,92 @@
+%erg 0.1
+Title: /celebrate sweep can claim to file follow-up tickets without committing them
+Created: 2026-05-28
+Author: claude
+
+--- log ---
+2026-05-28T09:30Z claude created — surfaced when raid 713 recovered the lost 0173 ticket
+
+--- body ---
+## Context
+
+`skills/celebrate/SKILL.md` step 3 ("Sweep for similar patterns") instructs the
+agent to "File tickets for all instances found" and step 4 escalates to a class
+test when the sweep is juicy. Both steps depend on the agent actually writing,
+validating, committing, and pushing the new ticket file before the worktree is
+removed in step 9.
+
+In the celebrate run after PR #215 the sweep correctly identified a class bug
+(`scripts/pretooluse-worktree-path-guard.sh` using `$(pwd)` instead of the
+PreToolUse JSON `.cwd`, mirroring the bug `25f8152` had just fixed in
+`guard-worktree-remove-wip.sh`). The session reported "filed a ticket" — but
+nothing ever made it to a commit, so when the worktree was removed in step 9
+the ticket draft went with it. Only a user-side memory of "celebrate said it
+filed a ticket" surfaced the loss; without that, the class bug would have
+shipped silently to the next raid.
+
+Raid 713 recovered the lost ticket as 0173 and shipped the fix (#216), but the
+underlying skill failure mode remains: there is no mechanical gate that
+prevents step 9 (Exit worktree) from running while step 3 has uncommitted
+files in the worktree.
+
+## Relevant files
+
+- `skills/celebrate/SKILL.md` — steps 3, 4, 9 are the relevant slice
+- `scripts/guard-worktree-remove-wip.sh` — already blocks `git worktree remove`
+  when the target has uncommitted files; the same guard would catch this case
+  if the agent reached step 9 with the new ticket still uncommitted
+- `skills/ticket-new/SKILL.md` — step 6 says "Commit the ticket file" but is
+  silent on push
+
+## Actions
+
+1. Audit whether the existing `guard-worktree-remove-wip.sh` already covers
+   step 9 of `/celebrate`. If yes, the loss must have come from a different
+   exit path (worktree-gc pruning a "clean" worktree that had ticket files
+   never `git add`'d). Document the actual failure mode before designing
+   the fix.
+2. In `skills/celebrate/SKILL.md` step 3, make the commit gate explicit:
+   each filed ticket must be `git add`'d, committed, and pushed in the same
+   step that created it. Reference `/ticket-new` (which already requires
+   commit at step 6) rather than describing the mechanics inline.
+3. Consider a step 3.5 / wrap-up assertion: before step 9 (Exit worktree),
+   run `git status --porcelain tickets/` in the worktree and refuse to
+   proceed if there are unstaged or uncommitted ticket files. Cheaper than
+   a hook; lives in the skill prose where the failure happened.
+4. If the failure mode is gc-pruning untracked ticket drafts: confirm
+   `worktree-gc.sh` skips worktrees with any untracked files, not just
+   tracked modifications. Currently it uses `git status --porcelain`, which
+   does include untracked files by default — so a freshly-`Write`'n ticket
+   would block GC. Verify in a test.
+
+## Test
+
+Add a `tests/test_celebrate_ticket_loss_regression.sh` (or extend
+`test_worktree_tools.py`) that simulates the failure path: create a worktree,
+write a ticket file inside it without staging, then attempt the celebrate
+step-9 sequence (`worktree remove` followed by `worktree-gc`). Assert that
+the ticket file is preserved or its loss is reported, not silently dropped.
+
+## Verification
+
+- [ ] Failure mode reproduced and documented (which exit path lost the ticket)
+- [ ] Celebrate skill prose makes the commit-before-exit gate explicit
+- [ ] Regression test asserts the gate fires
+- [ ] `make check` passes
+
+## Invariants
+
+- Existing celebrate flow unchanged for runs whose sweep finds nothing
+- Existing worktree-gc and remove guards stay advisory / blocking exactly as
+  they are today — no behavior change for unrelated cases
+- No new dependency added to `/celebrate` (any check must use tools already
+  available in the skill's environment)
+
+## Exit criteria
+
+- The failure mode that lost the 0173 draft is identified in the ticket log
+- Celebrate skill or supporting guard prevents a sweep-filed ticket from
+  being lost across worktree exit
+- Regression test in place
+- One observation cycle: next celebrate that files a sweep ticket lands it
+  on `main` rather than losing it

--- a/tickets/closed/0168-raid-agent-salvage-step.erg
+++ b/tickets/closed/0168-raid-agent-salvage-step.erg
@@ -2,12 +2,14 @@
 Title: Add killed-agent salvage step to raid skill — commit WIP before worktree remove
 Created: 2026-05-21
 Author: HDMX-coding-agent
+Closed: skill update merged in fc51c4c; feedback_killed_agent_salvage referenced from raid skill prose at line 206
 
 --- log ---
 2026-05-21T00:16Z HDMX-coding-agent created
 2026-05-21T07:32Z claude note re-filed from aedist-technical-report/tickets/0189 — this is user-level skill work, not project work; ref to former 0188 updated to 0167
 
 2026-05-27T20:53Z claude note salvage script + PreToolUse remove-WIP guard + raid circuit-breaker prose added; pending merge + next-raid observation
+2026-05-28T11:51Z Claude closed — skill update merged in fc51c4c; feedback_killed_agent_salvage referenced from raid skill prose at line 206
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Three small housekeeping items surfaced by raid 713:

- **Close 0168** — both exit criteria met (skill update merged in `fc51c4c`; `feedback_killed_agent_salvage` referenced from `skills/raid/SKILL.md:206`). 0167 and 0169 stay open — both have a "next raid observes the pattern firing" gate that hasn't tripped yet.
- **Open 0174** — `/celebrate` sweep ticket-loss guard. Raid 713 existed because the previous celebrate sweep correctly identified the path-guard class bug but the follow-up ticket draft was never committed before worktree exit. The skill needs a mechanical gate so the next sweep doesn't lose work the same way.
- **Refresh STATE.md** — last-updated stamp + recent-commits block were two weeks stale; ready-ticket count was wrong (said 0, now 3).

## Test plan

- [x] `erg validate` + `erg check` pass on 0174
- [x] `erg ready tickets/` now shows 2 ready (0167, 0169) — 0168 archived
- [x] STATE.md regenerated by `scripts/refresh-STATE.py`, no hand edits
- [x] `make check` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn2p1kZEftjc1D5wk6kB9g)_