### PR TITLE
fix(0174): worktree-exit preflight closes the ExitWorktree gap

### DIFF
--- a/scripts/worktree-exit-preflight.sh
+++ b/scripts/worktree-exit-preflight.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Refuse to exit a worktree that still has uncommitted state.
+#
+# Why: ExitWorktree is a harness tool, not a Bash command, so the
+# `Bash(git worktree remove*)` PreToolUse matcher cannot guard it. A sweep that
+# Write's a new ticket draft (untracked, never `git add`'d) and then calls
+# ExitWorktree will silently destroy the draft — the failure mode that lost
+# the 0173 ticket. See ticket 0174.
+#
+# This is a skill-level gate, called from /celebrate step 9 and /end-session
+# step 7 before invoking ExitWorktree. Checks tracked-modified, staged, AND
+# untracked entries — `git status --porcelain` covers all three by default.
+#
+# Arg: worktree path (default: current directory).
+# Exit 0 silently when clean. Exit 1 with a listing on stderr when dirty.
+
+path="${1:-.}"
+[ -d "$path" ] || { echo "worktree-exit-preflight: not a directory: $path" >&2; exit 2; }
+
+# -uall expands untracked directories so each lost file is named in the message
+# (the failure mode was a single .erg file inside an otherwise-untracked dir).
+status=$(git -C "$path" status --porcelain --untracked-files=all 2>/dev/null || true)
+[ -z "$status" ] && exit 0
+
+cat >&2 <<EOF
+Blocked: worktree '$path' has uncommitted state — ExitWorktree would destroy it.
+
+$status
+
+Commit (and push) anything you mean to keep before calling ExitWorktree. For
+ticket drafts filed during /celebrate sweeps, finish the /ticket-new commit
+step. For genuine WIP, salvage:
+
+  ~/.claude/scripts/worktree-salvage.sh "$path"
+
+See ticket 0174.
+EOF
+exit 1

--- a/skills/celebrate/SKILL.md
+++ b/skills/celebrate/SKILL.md
@@ -30,7 +30,7 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
    ```bash
    git rev-parse HEAD > "$(git rev-parse --git-common-dir)/celebrate-last-sha"
    ```
-3. **Sweep for similar patterns**: review the fix just completed. Grep/audit the codebase for the same anti-pattern in other files. File tickets for all instances found.
+3. **Sweep for similar patterns**: review the fix just completed. Grep/audit the codebase for the same anti-pattern in other files. File tickets for all instances found via `/ticket-new` (which commits at its step 6 — don't skip it; an uncommitted draft is destroyed by step 9's worktree exit, see ticket 0174).
 4. **Guard against regression**: if the sweep above was juicy — multiple instances of the same anti-pattern — the bug has a class shape. File a follow-up ticket for a standing regression test covering the class. Do not auto-write the test, do not bundle it into the fix PR. If the sweep found nothing, move on silently. /verify is a per-PR gate; a standing test is what catches the class coming back in an unrelated future PR.
 5. **Update project docs** if pipeline, data contract, or methodology changed.
 6. **Save persistent memory**: durable lessons from this task. No sweep here — sweeps happen at `/end-session`.
@@ -41,7 +41,14 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
 8. **Check for tracking ticket**: if the closed ticket has a parent, check whether all sibling sub-tickets are now closed.
     - All closed → integration review: re-read all child diffs, run full test suite, verify exit criteria.
     - Any open → do nothing, tracker stays open.
-9. **Exit worktree** (if in one): call `ExitWorktree` with action `remove`. Skip if not in a worktree.
+9. **Exit worktree** (if in one):
+    a. Preflight from inside the worktree:
+       ```bash
+       scripts/worktree-exit-preflight.sh
+       ```
+       Refuses (exit 1) when there are uncommitted/untracked files — including a fresh ticket draft `/ticket-new` wrote but never committed. The `Bash(git worktree remove*)` PreToolUse matcher does NOT fire on `ExitWorktree`, so this is the only gate. If it blocks, commit (or `~/.claude/scripts/worktree-salvage.sh`) and re-run. See ticket 0174.
+    b. Call `ExitWorktree` with action `remove`.
+    Skip if not in a worktree.
 9.5. **GC stale agent worktrees** (from the main repo): prune leftover `agent-*` worktrees whose branch is merged-and-gone — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
     ```bash
     git fetch --prune origin

--- a/skills/end-session/SKILL.md
+++ b/skills/end-session/SKILL.md
@@ -19,7 +19,9 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
 4. **Push all branches** — no local-only work overnight. `git branch` → ensure each non-main branch is pushed to origin.
 5. **Commit WIP if needed** — uncommitted work gets `wip:` prefix, committed to the current branch, and pushed.
 6. **Handoff notes** — for in-progress tickets with unpushed context, add a comment to the ticket: what's done, what's next, blockers.
-7. **Exit worktree** — if in a worktree, call `ExitWorktree` to return to the main working tree. All remaining steps run on main.
+7. **Exit worktree** — if in a worktree:
+    a. Preflight from inside the worktree: `scripts/worktree-exit-preflight.sh` (refuses on any uncommitted/untracked state; closes the ExitWorktree gap, ticket 0174). If it blocks, finish step 5/6 (commit WIP, handoff notes) and re-run.
+    b. Call `ExitWorktree` to return to the main working tree. All remaining steps run on main.
 8. **Hygiene sweep**:
    - `git worktree list` → remove any stale worktrees (`git worktree prune`)
    - `git branch -a` → delete stale remote branches

--- a/tests/test_worktree_tools.py
+++ b/tests/test_worktree_tools.py
@@ -1,9 +1,13 @@
-"""Tests for the worktree tooling scripts (tickets 0168, 0169).
+"""Tests for the worktree tooling scripts (tickets 0168, 0169, 0174).
 
 Exercises:
-  - scripts/worktree-salvage.sh        — commit + push WIP before removal
+  - scripts/worktree-salvage.sh         — commit + push WIP before removal
   - scripts/guard-worktree-remove-wip.sh — PreToolUse guard blocking removal on WIP
-  - scripts/worktree-gc.sh             — GC stale agent-* worktrees
+  - scripts/worktree-gc.sh              — GC stale agent-* worktrees
+  - scripts/worktree-exit-preflight.sh  — refuse worktree-exit while there are
+                                          uncommitted files (incl. untracked).
+                                          Closes the ExitWorktree gap that lost
+                                          the 0173 draft (ticket 0174).
 """
 
 import json
@@ -231,6 +235,93 @@ def test_gc_silent_when_nothing_to_do(origin):
     res = _gc(primary)
     assert res.returncode == 0
     assert res.stdout.strip() == ""
+
+
+# --------------------------------------------------------------------------- #
+# worktree-exit-preflight.sh — ticket 0174
+# --------------------------------------------------------------------------- #
+#
+# The PreToolUse Bash(git worktree remove*) matcher does not fire on the
+# ExitWorktree harness tool, so a /celebrate sweep that Write's a ticket draft
+# and then calls ExitWorktree silently drops the draft. The preflight script
+# is the skill-level gate that closes that window: invoked by the celebrate
+# and end-session skills before they call ExitWorktree, it refuses when the
+# worktree has any uncommitted state (tracked or untracked).
+
+def _preflight(path):
+    return subprocess.run(
+        [str(SCRIPTS / "worktree-exit-preflight.sh"), str(path)],
+        capture_output=True, text=True,
+    )
+
+
+def test_preflight_blocks_on_untracked_ticket_draft(origin):
+    """The exact failure mode that lost the 0173 draft: a /celebrate sweep
+    Write's a new ticket file (untracked, never `git add`'d) and step 9 then
+    calls ExitWorktree. The preflight must refuse before ExitWorktree runs."""
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-sweep", dirty=False)
+    (wt / "tickets").mkdir()
+    (wt / "tickets" / "0999-swept-class-bug.erg").write_text("%erg 0.1\n")
+
+    res = _preflight(wt)
+    assert res.returncode != 0
+    assert "0999-swept-class-bug.erg" in res.stderr
+    assert "ExitWorktree" in res.stderr  # message names the gate it's guarding
+
+
+def test_preflight_blocks_on_tracked_modification(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-mod", dirty=True)  # tracked-modified
+
+    res = _preflight(wt)
+    assert res.returncode != 0
+    assert "work.txt" in res.stderr
+
+
+def test_preflight_blocks_on_staged_uncommitted(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-staged", dirty=False)
+    (wt / "new.txt").write_text("staged\n")
+    git(wt, "add", "new.txt")
+
+    res = _preflight(wt)
+    assert res.returncode != 0
+    assert "new.txt" in res.stderr
+
+
+def test_preflight_passes_on_clean_worktree(origin):
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-clean-exit", dirty=False)
+
+    res = _preflight(wt)
+    assert res.returncode == 0
+    assert res.stdout == ""
+    assert res.stderr == ""
+
+
+def test_preflight_defaults_to_cwd(origin):
+    """No arg → check the current directory. Mirrors how skill prose invokes
+    it from inside the worktree it is about to exit."""
+    _, primary = origin
+    wt = make_agent_worktree(primary, "agent-cwd", dirty=False)
+    (wt / "tickets").mkdir()
+    (wt / "tickets" / "0998-draft.erg").write_text("%erg 0.1\n")
+
+    res = subprocess.run(
+        [str(SCRIPTS / "worktree-exit-preflight.sh")],
+        cwd=str(wt), capture_output=True, text=True,
+    )
+    assert res.returncode != 0
+    assert "0998-draft.erg" in res.stderr
+
+
+def test_preflight_errors_on_missing_path():
+    res = subprocess.run(
+        [str(SCRIPTS / "worktree-exit-preflight.sh"), "/no/such/dir"],
+        capture_output=True, text=True,
+    )
+    assert res.returncode != 0
 
 
 def test_gc_unlocks_and_removes_locked_gone_worktree(origin):

--- a/tickets/0174-celebrate-sweep-ticket-loss-guard.erg
+++ b/tickets/0174-celebrate-sweep-ticket-loss-guard.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-05-28T09:30Z claude created — surfaced when raid 713 recovered the lost 0173 ticket
 
+2026-05-28T17:17Z audit: ExitWorktree is a harness tool, not Bash; Bash(git worktree remove*) matcher does not fire on it, so neither guard-worktree-remove-wip.sh nor worktree-gc.sh covered the loss path (gc runs after the exit in celebrate step 9.5). Fix: scripts/worktree-exit-preflight.sh + celebrate/end-session prose; preflight refuses on tracked-mod/staged/untracked (uses --untracked-files=all so individual draft files surface in the message). Regression suite: 6 cases in tests/test_worktree_tools.py. Awaiting observation cycle.
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Closes the failure mode that lost the 0173 ticket draft: during `/celebrate` step 9, the `ExitWorktree` harness tool silently destroyed an untracked ticket file that the sweep had just `Write`'n.

**Audit** (ticket 0174 Action 1): the `Bash(git worktree remove*)` PreToolUse matcher does not fire on `ExitWorktree` because it's a harness tool, not a Bash command. `scripts/worktree-gc.sh` runs in step 9.5 — *after* the exit — so it can't help either. Neither existing guard covered this path.

**Fix:**
- `scripts/worktree-exit-preflight.sh` — refuses on any uncommitted state (tracked-modified, staged, OR untracked). Uses `--untracked-files=all` so individual draft files appear in the error message (not just the containing dir).
- `skills/celebrate/SKILL.md` step 9 — invoke preflight, then `ExitWorktree`.
- `skills/celebrate/SKILL.md` step 3 — make the per-ticket commit explicit by routing through `/ticket-new` (whose step 6 already commits).
- `skills/end-session/SKILL.md` step 7 — same preflight before `ExitWorktree`.

**Tests:** 6 new cases in `tests/test_worktree_tools.py` (`-k preflight`): untracked .erg draft, tracked-modified, staged, clean, default-cwd, missing-path.

Ticket 0174 stays open per its own exit criterion — it requires a real `/celebrate` observation cycle (next sweep that files a ticket should land on `main` instead of vanishing) before closing.

## Test plan
- [x] `pytest tests/test_worktree_tools.py` → 21 passed (15 pre-existing + 6 new)
- [x] `pytest tests/` → 258 passed, no regressions
- [x] `make check` (skills-drift + agnostic-tickets) passes
- [x] `./tickets/erg validate` + `./tickets/erg check` pass
- [ ] **Observation cycle**: next `/celebrate` whose sweep files a follow-up ticket — confirm the ticket reaches `main` and the preflight refused to exit while the draft was uncommitted

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAmE4J1NmJ7hpg1Q7Xi3AN)_