### PR TITLE
tickets: file 0175-0177 from PR #221 celebrate-sweep

### DIFF
--- a/tickets/0175-convert-remaining-hook-guards-from-grep.erg
+++ b/tickets/0175-convert-remaining-hook-guards-from-grep.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Convert remaining hook guards from grep -E with \s to grep -P
+Created: 2026-05-29
+Author: claude
+
+--- log ---
+2026-05-29T06:35Z claude created
+
+--- body ---
+## Context
+PR #221 fixed `guard-destructive-bash.sh` to use `grep -P` after a Copilot
+review noted that `\s` and `\b` are GNU-only extensions in POSIX ERE (`grep -E`)
+— on a non-GNU grep they degrade to the literal `s` / word-boundary-less match,
+silently defeating the guard.
+
+A celebrate-sweep found the same anti-pattern in two more PreToolUse guards:
+- `scripts/guard-no-push.sh:12`   `grep -qE '\bgit\s+push\b'`
+- `scripts/guard-no-push.sh:16`   `grep -qE "\b${BEAT_HOUSEKEEPING_BRANCH}\b"`
+- `scripts/guard-commit-on-main.sh:17`  `grep -qE '\bgit\s+commit\b'`
+
+(`guard-worktree-remove-wip.sh` already uses the correct `[[:space:]]` form.)
+
+## Exit criteria
+- [ ] `guard-no-push.sh` and `guard-commit-on-main.sh` no longer rely on
+      `\s`/`\b` under `grep -E` (switch to `grep -P`, matching guard-destructive-bash.sh)
+- [ ] A test exercises each guard's block/allow behaviour (extend the
+      `tests/*.sh` suites picked up by `tests/test_bash_suites.py`)
+- [ ] `make check` and the pytest suite pass
+
+## Notes
+Do not bundle with 0176 (the standing CI guard for the class).
+

--- a/tickets/0176-add-ci-guard-no-grep-e-with-s-b-w-in-hoo.erg
+++ b/tickets/0176-add-ci-guard-no-grep-e-with-s-b-w-in-hoo.erg
@@ -1,0 +1,28 @@
+%erg 0.1
+Title: Add CI guard: no grep -E with \s/\b/\w in hook scripts
+Created: 2026-05-29
+Author: claude
+Blocked-by: 0175
+
+--- log ---
+2026-05-29T06:35Z claude created
+
+--- body ---
+## Context
+The `grep -E` + `\s`/`\b`/`\w` portability bug (see 0175) has a class shape:
+it recurred across multiple hook guards because nothing flags it. PCRE escapes
+in an ERE pattern fail silently on non-GNU grep — exactly the kind of latent
+gap a standing guard should catch, analogous to the existing `pipefail-guard`
+in `.github/workflows/CI.yml`.
+
+## Exit criteria
+- [ ] CI job (or extension of an existing guard job) fails when a `scripts/*.sh`
+      hook uses `grep -E`/`-G` with `\s`, `\b`, or `\w`
+- [ ] Self-tests in the CI job: catches a deliberate violation AND passes a
+      clean script (mirror the pipefail-guard / status-verb-guard pattern)
+- [ ] Existing scripts pass once 0175 lands (sequence 0175 before enabling)
+
+## Notes
+Standing regression test for the class — not a per-PR fix. Keep separate from
+0175 so the guard can be enabled after the existing offenders are converted.
+

--- a/tickets/0177-fix-project-state-py-ready-ids-always-em.erg
+++ b/tickets/0177-fix-project-state-py-ready-ids-always-em.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: Fix project-state.py ready_ids always empty (erg has no ready key)
+Created: 2026-05-29
+Author: claude
+
+--- log ---
+2026-05-29T06:35Z claude created
+
+--- body ---
+## Context
+Same erg-JSON-schema misunderstanding that PR #221 fixed in `refresh-STATE.py`.
+`erg ready --json` items carry keys [id, title, file, closed, refs, tags,
+blocked_by] — there is NO `ready` field. `scripts/project-state.py:147`:
+
+    ready_ids = [t["id"] for t in ready_list if t.get("ready", False)]
+
+The `.get(..., False)` default means this never raises (unlike refresh-STATE,
+which crashed) — but it silently always evaluates to False, so `ready_ids` is
+ALWAYS `[]` and the reported "ready" count is permanently 0. Confirmed live:
+no item in `erg ready --json` has a `ready` key.
+
+## Exit criteria
+- [ ] `ready_ids` reflects the actual ready tickets — `erg ready` already
+      returns only ready ones, so `ready_ids = [t["id"] for t in ready_list]`
+- [ ] Test pins the real erg schema (no `ready` key) so the regression can't
+      silently return
+- [ ] `make check` / pytest pass
+
+## Notes
+Related class to 0175/0176 only loosely (schema assumption, not grep). The
+refresh-STATE fix (PR #221) is the sibling instance; consider whether a shared
+erg-result helper is worth extracting.
+


### PR DESCRIPTION
## Summary

Follow-up tickets from the **celebrate-sweep** after PR #221. The sweep found that two bugs PR #221 fixed each have a class shape with more live instances. Per celebrate discipline, this PR files **tickets only** — fixes are deliberately not bundled.

## Tickets

- **0175** — `guard-no-push.sh` (lines 12, 16) and `guard-commit-on-main.sh` (line 17) still use `grep -E` with `\s`/`\b`, the GNU-only ERE extensions Copilot flagged in `guard-destructive-bash.sh`. On a non-GNU grep these degrade to literals and silently defeat the guard. (`guard-worktree-remove-wip.sh` already uses the correct `[[:space:]]` form.)
- **0176** — standing CI guard for that class (blocked-by 0175), modeled on the existing `pipefail-guard` self-test pattern, so the bug can't silently recur in a future hook.
- **0177** — `project-state.py:147` has the same erg-JSON-schema bug PR #221 fixed in `refresh-STATE.py`: `erg ready --json` items have no `ready` key, so `ready_ids` is **always `[]`**. Here a `.get(..., False)` default hides it (silently wrong) instead of crashing. Confirmed live.

## Validation
- `./tickets/erg check tickets/` → `PASS (172 tickets)`
- `erg ready` correctly shows 0175 + 0177 ready, 0176 hidden (blocked-by 0175).

No code changes — ticket files only.

https://claude.ai/code/session_01FeV7BeReT2RPFLUXW9HCwr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeV7BeReT2RPFLUXW9HCwr)_