### PR TITLE
feat(0178): housekeeping step 2.6 — archive closed tickets and remove stale live duplicates

### DIFF
--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -71,6 +71,7 @@ Run full repo housekeeping and act on every finding.
 
    ```bash
    tickets/erg archive tickets/
+   git add tickets/closed/
    ```
 
    This moves any ticket with a non-empty `Closed:` header from `tickets/`
@@ -83,7 +84,7 @@ Run full repo housekeeping and act on every finding.
    for f in tickets/*.erg; do
      base=$(basename "$f")
      if [ -f "tickets/closed/$base" ]; then
-       git rm -f "$f"
+       git rm "$f"
      fi
    done
    shopt -u nullglob

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -67,6 +67,32 @@ Run full repo housekeeping and act on every finding.
    Process all open tickets unconditionally (not just candidates).
    Batch-closing is allowed here: close every qualifying ticket in one pass.
 
+2.6. **Archive closed tickets.** Skip if `tickets/` is absent.
+
+   ```bash
+   tickets/erg archive tickets/
+   ```
+
+   This moves any ticket with a non-empty `Closed:` header from `tickets/`
+   into `tickets/closed/`. After archiving, remove any file from `tickets/`
+   that already exists in `tickets/closed/` (duplicate committed under both
+   paths):
+
+   ```bash
+   shopt -s nullglob
+   for f in tickets/*.erg; do
+     base=$(basename "$f")
+     if [ -f "tickets/closed/$base" ]; then
+       git rm -f "$f"
+     fi
+   done
+   shopt -u nullglob
+   ```
+
+   If any files were moved or removed, stage and include them in the step 3
+   commit (`chore: housekeeping fixes (sweep)`). Do not create a separate
+   commit for this step.
+
 3. **Fix `fix-now` items.** Apply every `fix-now` item inline. If any fixes were
    applied, commit once: `chore: housekeeping fixes (sweep)`.
 

--- a/tickets/closed/0178-housekeeping-ticket-corpus-hygiene.erg
+++ b/tickets/closed/0178-housekeeping-ticket-corpus-hygiene.erg
@@ -2,10 +2,12 @@
 Title: housekeeping: detect and fix ticket corpus errors + archive closed tickets
 Created: 2026-05-24
 Author: haduong
+Closed: autoclosed — PR #223
 
 --- log ---
 2026-05-24T08:35Z haduong created
 
+2026-05-29T14:13Z MinhHaDuong closed — autoclosed — PR #223
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Adds step 2.6 to `/housekeeping` between the exit-criteria audit (2.5) and fix-now (3)
- Runs `erg archive tickets/` to move tickets with a `Closed:` header from `tickets/` to `tickets/closed/`
- Removes stale live duplicates: any `tickets/*.erg` whose basename already exists in `tickets/closed/`
- Uses `shopt nullglob` so `git rm` does not fail when no `.erg` files remain
- Fixes are staged and folded into the existing `chore: housekeeping fixes (sweep)` commit — no separate commit

## Test plan

- [ ] `make check` passes (pre-existing failure in ticket 0179 is unrelated)
- [ ] Step 2.6 appears in correct position in `skills/housekeeping/SKILL.md` between steps 2.5 and 3
- [ ] Manual: run `/housekeeping` on a repo with an un-archived closed ticket; confirm it is moved to `tickets/closed/`
- [ ] Manual: run `/housekeeping` on a repo with a duplicate live ticket; confirm `git rm` removes the live copy

**Ticket:** tickets/0178-housekeeping-ticket-corpus-hygiene.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)