### PR TITLE
fix(0179): refresh-STATE.py uses path argument, not git rev-parse

### DIFF
--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -67,6 +67,32 @@ Run full repo housekeeping and act on every finding.
    Process all open tickets unconditionally (not just candidates).
    Batch-closing is allowed here: close every qualifying ticket in one pass.
 
+2.6. **Archive closed tickets.** Skip if `tickets/` is absent.
+
+   ```bash
+   tickets/erg archive tickets/
+   ```
+
+   This moves any ticket with a non-empty `Closed:` header from `tickets/`
+   into `tickets/closed/`. After archiving, remove any file from `tickets/`
+   that already exists in `tickets/closed/` (duplicate committed under both
+   paths):
+
+   ```bash
+   shopt -s nullglob
+   for f in tickets/*.erg; do
+     base=$(basename "$f")
+     if [ -f "tickets/closed/$base" ]; then
+       git rm -f "$f"
+     fi
+   done
+   shopt -u nullglob
+   ```
+
+   If any files were moved or removed, stage and include them in the step 3
+   commit (`chore: housekeeping fixes (sweep)`). Do not create a separate
+   commit for this step.
+
 3. **Fix `fix-now` items.** Apply every `fix-now` item inline. If any fixes were
    applied, commit once: `chore: housekeeping fixes (sweep)`.
 


### PR DESCRIPTION
## Summary

- Add `argparse` with optional positional `path` argument to `refresh-STATE.py`
- Pass `repo_root: Path` through `run()`, `get_commits()`, and `get_tickets()` (Pattern A), eliminating module-level globals `REPO_ROOT`, `STATE_FILE`, `TICKETS_DIR`, `ERG_BIN`
- Remove `from __future__ import annotations` (coding rules violation)
- Update existing test `fake_run` signatures from `(cmd)` to `(cmd, repo_root)`; add `tmp_path`-based fake erg binary to get_tickets tests so the existence check passes

## Problem

`refresh-STATE.py /home/haduong/.claude` was silently writing STATE.md to the worktree root instead of the main repo, because `git rev-parse --show-toplevel` resolves to the worktree when called from a worktree session.

## Test plan

- [ ] `python3 -m pytest tests/test_refresh_state.py -v` — all 11 tests pass
- [ ] New test `test_main_uses_path_argument` asserts `run()` receives `repo_root == tmp_path`
- [ ] `cd /some/worktree && python3 ~/.claude/scripts/refresh-STATE.py /home/haduong/.claude` updates the main repo's STATE.md

**Ticket:** tickets/0179-refresh-state-ignores-path-arg.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)