### PR TITLE
fix(0179): refresh-STATE.py uses path argument, not git rev-parse

### DIFF
--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Replace the ## Status section of STATE.md with fresh git + erg output."""
 
-from __future__ import annotations
-
+import argparse
 import json
 import re
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+STATUS_HEADING = "## Status"
 
 
 def _repo_root() -> Path:
@@ -30,40 +31,39 @@ def _repo_root() -> Path:
     return Path(__file__).parent.parent  # fallback: script is in scripts/ of project
 
 
-REPO_ROOT = _repo_root()
-STATE_FILE = REPO_ROOT / "STATE.md"
-TICKETS_DIR = REPO_ROOT / "tickets"
-ERG_BIN = TICKETS_DIR / "erg"
-STATUS_HEADING = "## Status"
-
-
-def run(cmd):
+def run(cmd, repo_root: Path):
     try:
         return subprocess.run(
-            cmd, capture_output=True, text=True, check=True, cwd=REPO_ROOT, timeout=30
+            cmd, capture_output=True, text=True, check=True, cwd=repo_root, timeout=30
         ).stdout.strip()
     except subprocess.TimeoutExpired:
         print(f"WARNING: command timed out: {cmd}", file=sys.stderr)
         sys.exit(1)
 
 
-def get_commits(n=5):
-    return run(["git", "log", "--oneline", f"-{n}"]).splitlines()
+def get_commits(repo_root: Path, n=5):
+    return run(["git", "log", "--oneline", f"-{n}"], repo_root).splitlines()
 
 
-def get_tickets():
+def get_tickets(repo_root: Path):
     """Return (ready_count, blocked_count) from erg.
 
     `erg ready` lists only ready (unblocked, open) tickets; `erg list` lists
     all open tickets. Neither item carries a `ready` flag, so blocked is
     derived as open minus ready.
     """
-    if not ERG_BIN.exists():
-        print(f"ERROR: erg binary not found at {ERG_BIN}", file=sys.stderr)
+    tickets_dir = repo_root / "tickets"
+    erg_bin = tickets_dir / "erg"
+    if not erg_bin.exists():
+        print(f"ERROR: erg binary not found at {erg_bin}", file=sys.stderr)
         sys.exit(1)
     try:
-        ready = json.loads(run([str(ERG_BIN), "ready", str(TICKETS_DIR), "--json"]))
-        open_tickets = json.loads(run([str(ERG_BIN), "list", str(TICKETS_DIR), "--json"]))
+        ready = json.loads(
+            run([str(erg_bin), "ready", str(tickets_dir), "--json"], repo_root)
+        )
+        open_tickets = json.loads(
+            run([str(erg_bin), "list", str(tickets_dir), "--json"], repo_root)
+        )
     except subprocess.CalledProcessError as e:
         print(f"ERROR: erg query failed: {e.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
@@ -125,12 +125,28 @@ def refresh_last_updated(preamble, date_str):
     return preamble
 
 
-def main():
-    if not STATE_FILE.exists():
-        print(f"ERROR: {STATE_FILE} not found", file=sys.stderr)
+def main(repo_root: Path | None = None):
+    parser = argparse.ArgumentParser(
+        description="Replace the ## Status section of STATE.md with fresh git + erg output."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=None,
+        help="Path to the repository root (default: auto-detect via git rev-parse)",
+    )
+    args = parser.parse_args()
+
+    if repo_root is None:
+        repo_root = args.path if args.path is not None else _repo_root()
+
+    state_file = repo_root / "STATE.md"
+    if not state_file.exists():
+        print(f"ERROR: {state_file} not found", file=sys.stderr)
         sys.exit(1)
 
-    text = STATE_FILE.read_text()
+    text = state_file.read_text()
     preamble, tail = split_at_status(text)
 
     # tail starts with "## Status\n..."; find where Status body ends
@@ -141,8 +157,8 @@ def main():
     today = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     preamble = refresh_last_updated(preamble, today)
 
-    commits = get_commits()
-    ready_count, blocked_count = get_tickets()
+    commits = get_commits(repo_root)
+    ready_count, blocked_count = get_tickets(repo_root)
     status_lines = format_status(ready_count, blocked_count, commits)
 
     new_text = (
@@ -151,7 +167,7 @@ def main():
         + "\n".join(status_lines)
         + ("\n\n" + tail_after_status.lstrip() if tail_after_status.strip() else "\n")
     )
-    STATE_FILE.write_text(new_text)
+    state_file.write_text(new_text)
 
     total = len(new_text.splitlines())
     print(f"STATE.md refreshed — {len(status_lines)} status lines, {total} total.")

--- a/tests/test_refresh_state.py
+++ b/tests/test_refresh_state.py
@@ -11,7 +11,9 @@ import sys
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
-spec = importlib.util.spec_from_file_location("refresh_state", SCRIPTS / "refresh-STATE.py")
+spec = importlib.util.spec_from_file_location(
+    "refresh_state", SCRIPTS / "refresh-STATE.py"
+)
 rs = importlib.util.module_from_spec(spec)
 sys.modules["refresh_state"] = rs
 spec.loader.exec_module(rs)
@@ -79,32 +81,74 @@ def test_format_status_omits_commits_when_none():
 
 
 def _erg_item(tid: str) -> dict:
-    return {"id": tid, "title": f"t{tid}", "file": f"{tid}.erg",
-            "closed": False, "refs": [], "tags": [], "blocked_by": []}
+    return {
+        "id": tid,
+        "title": f"t{tid}",
+        "file": f"{tid}.erg",
+        "closed": False,
+        "refs": [],
+        "tags": [],
+        "blocked_by": [],
+    }
 
 
-def test_get_tickets_derives_blocked_from_open_minus_ready(monkeypatch):
+def test_get_tickets_derives_blocked_from_open_minus_ready(tmp_path, monkeypatch):
     import json as _json
+
+    (tmp_path / "tickets").mkdir()
+    (tmp_path / "tickets" / "erg").touch()
 
     ready = [_erg_item("0001"), _erg_item("0002"), _erg_item("0003")]
     open_all = [_erg_item(f"00{i:02d}") for i in range(1, 9)]  # 8 open
 
-    def fake_run(cmd):
-        # cmd is the list passed to subprocess; pick which query by subcommand
+    def fake_run(cmd, repo_root):
         return _json.dumps(ready if "ready" in cmd else open_all)
 
     monkeypatch.setattr(rs, "run", fake_run)
-    ready_count, blocked_count = rs.get_tickets()
+    ready_count, blocked_count = rs.get_tickets(tmp_path)
     assert (ready_count, blocked_count) == (3, 5)
 
 
-def test_get_tickets_never_returns_negative_blocked(monkeypatch):
+def test_get_tickets_never_returns_negative_blocked(tmp_path, monkeypatch):
     import json as _json
 
+    (tmp_path / "tickets").mkdir()
+    (tmp_path / "tickets" / "erg").touch()
+
     # Defensive: if ready somehow exceeds open, blocked floors at 0, not negative.
-    def fake_run(cmd):
-        return _json.dumps([_erg_item("0001"), _erg_item("0002")]) if "ready" in cmd \
+    def fake_run(cmd, repo_root):
+        return (
+            _json.dumps([_erg_item("0001"), _erg_item("0002")])
+            if "ready" in cmd
             else _json.dumps([_erg_item("0001")])
+        )
 
     monkeypatch.setattr(rs, "run", fake_run)
-    assert rs.get_tickets() == (2, 0)
+    assert rs.get_tickets(tmp_path) == (2, 0)
+
+
+def test_main_uses_path_argument(tmp_path, monkeypatch):
+    """main() must use the supplied path argument, not git rev-parse."""
+    state = tmp_path / "STATE.md"
+    state.write_text(
+        "# Project\n\nLast updated: 2020-01-01T00:00Z\n\n## Status\nold\n\n## Blockers\nnone\n"
+    )
+    tickets = tmp_path / "tickets"
+    tickets.mkdir()
+    (tickets / "erg").touch()  # satisfy erg_bin.exists() guard
+
+    def fake_run(cmd, repo_root):
+        assert repo_root == tmp_path, (
+            f"run() called with repo_root={repo_root!r}, expected {tmp_path!r}"
+        )
+        if "log" in cmd:
+            return "abc1234 test commit"
+        return "[]"
+
+    monkeypatch.setattr(rs, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["refresh-STATE.py", str(tmp_path)])
+    rs.main()
+
+    refreshed = state.read_text()
+    assert "old" not in refreshed
+    assert "Last updated:" in refreshed

--- a/tickets/0179-refresh-state-ignores-path-arg.erg
+++ b/tickets/0179-refresh-state-ignores-path-arg.erg
@@ -15,7 +15,7 @@ resolves to the worktree root when called from a worktree session. This causes
 STATE.md to be written in the worktree instead of the main repo — silently,
 with no error.
 
-Discovered 2026-05-29 during healthcheck: `refresh-STATE.py /home/haduong/.claude`
+Discovered 2026-05-29 during healthcheck: `refresh-STATE.py ~/.claude`
 appeared to succeed but left the main repo's STATE.md unchanged.
 
 ## Exit criteria
@@ -24,6 +24,6 @@ appeared to succeed but left the main repo's STATE.md unchanged.
   instead of calling `git rev-parse --show-toplevel`.
 - [ ] `REPO_ROOT` is set from `sys.argv[1]` when present, falling back to the
   current `_repo_root()` logic when no argument is given.
-- [ ] Running `cd /some/worktree && python3 ~/.claude/scripts/refresh-STATE.py /home/haduong/.claude`
-  updates `/home/haduong/.claude/STATE.md`, not the worktree's copy.
+- [ ] Running `cd /some/worktree && python3 ~/.claude/scripts/refresh-STATE.py ~/.claude`
+  updates `~/.claude/STATE.md`, not the worktree's copy.
 - [ ] `make check` passes.

--- a/tickets/closed/0179-refresh-state-ignores-path-arg.erg
+++ b/tickets/closed/0179-refresh-state-ignores-path-arg.erg
@@ -2,10 +2,12 @@
 Title: fix refresh-STATE.py to use its path argument instead of git rev-parse
 Created: 2026-05-29
 Author: haduong
+Closed: autoclosed — PR #227
 
 --- log ---
 2026-05-29T13:30Z haduong created
 
+2026-05-29T14:14Z MinhHaDuong closed — autoclosed — PR #227
 --- body ---
 ## Context
 


### PR DESCRIPTION
From a worktree, \`git rev-parse --show-toplevel\` resolves to the worktree root — causing STATE.md to be silently written to the wrong location (discovered 2026-05-29 during healthcheck).

Fix: add argparse with optional positional \`path\` argument; pass \`repo_root\` through \`run()\`, \`get_commits()\`, \`get_tickets()\` (Pattern A). Removes pre-existing \`from __future__ import annotations\` violation.

Existing \`get_tickets\` tests updated: \`fake_run\` signature gains \`repo_root\`; tests use \`tmp_path\` with stub erg binary to satisfy the \`erg_bin.exists()\` guard.

**Ticket:** tickets/0179-refresh-state-ignores-path-arg.erg