### PR TITLE
feat(0176): add grep-e-guard CI job — catch grep -E/-G with PCRE escapes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -134,6 +134,40 @@ jobs:
           fi
           echo "OK: guard passes compliant script"
 
+  grep-e-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No grep -E/-G with PCRE character escapes in hook scripts
+        run: |
+          violations=$(grep -Pn '(?=.*\bgrep\b)(?=.*-[a-zA-Z]*[EG])(?=.*\\[bsw])' scripts/*.sh 2>/dev/null || true)
+          if [ -n "$violations" ]; then
+            echo "FAIL: grep -E/-G used with PCRE escapes (\\b/\\s/\\w) — use grep -P instead:"
+            echo "$violations"
+            exit 1
+          fi
+          echo "OK: no grep -E/-G with PCRE character escapes found"
+      - name: Self-test — guard must catch a deliberate violation
+        run: |
+          tmp=$(mktemp --suffix=.sh)
+          printf '%s\n' '#!/bin/bash' 'set -euo pipefail' "grep -qE '\\bfoo\\b' file" > "$tmp"
+          violations=$(grep -Pn '(?=.*\bgrep\b)(?=.*-[a-zA-Z]*[EG])(?=.*\\[bsw])' "$tmp" 2>/dev/null || true)
+          if [ -z "$violations" ]; then
+            echo "FAIL: guard did not catch grep -E with PCRE escape"
+            exit 1
+          fi
+          echo "OK: deliberate violation caught"
+      - name: Self-test — guard must pass on clean script
+        run: |
+          tmp=$(mktemp --suffix=.sh)
+          printf '%s\n' '#!/bin/bash' 'set -euo pipefail' "grep -qP '\\bfoo\\b' file" > "$tmp"
+          violations=$(grep -Pn '(?=.*\bgrep\b)(?=.*-[a-zA-Z]*[EG])(?=.*\\[bsw])' "$tmp" 2>/dev/null || true)
+          if [ -n "$violations" ]; then
+            echo "FAIL: guard false-positived on grep -P (which is correct)"
+            exit 1
+          fi
+          echo "OK: guard passes clean script"
+
   pytest-guard:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/guard-worktree-remove-wip.sh
+++ b/scripts/guard-worktree-remove-wip.sh
@@ -14,7 +14,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 hook_cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 
 # Only act on git worktree remove (also catches it inside a compound command).
-echo "$cmd" | grep -qE '\bgit[[:space:]]+worktree[[:space:]]+remove\b' || exit 0
+echo "$cmd" | grep -qP '\bgit\s+worktree\s+remove\b' || exit 0
 
 # Extract the worktree path: first non-flag token after "remove".
 after=${cmd#*worktree*remove}

--- a/tickets/closed/0176-add-ci-guard-no-grep-e-with-s-b-w-in-hoo.erg
+++ b/tickets/closed/0176-add-ci-guard-no-grep-e-with-s-b-w-in-hoo.erg
@@ -2,11 +2,13 @@
 Title: Add CI guard: no grep -E with \s/\b/\w in hook scripts
 Created: 2026-05-29
 Author: claude
+Closed: autoclosed — PR #228
 
 --- log ---
 2026-05-29T06:35Z claude created
 
 2026-05-29T14:14Z MinhHaDuong note blocker 0175 closed — Blocked-by removed.
+2026-05-29T14:25Z MinhHaDuong closed — autoclosed — PR #228
 --- body ---
 ## Context
 The `grep -E` + `\s`/`\b`/`\w` portability bug (see 0175) has a class shape:


### PR DESCRIPTION
## Summary

- Adds `grep-e-guard` CI job: fails when `scripts/*.sh` uses `grep -E` or `grep -G` with `\b`, `\s`, or `\w` — PCRE escapes that silently fail on non-GNU grep
- Fixes `guard-worktree-remove-wip.sh` line 17: converts `grep -qE '\bgit...\b'` to `grep -qP` (last remaining violator missed by ticket 0175)
- Guard uses PCRE lookaheads to check three conditions on one line; includes self-tests for violation and false-positive-free clean paths

**Ticket:** tickets/0176-add-ci-guard-no-grep-e-with-s-b-w-in-hoo.erg

## Test plan
- [ ] CI `grep-e-guard` job passes on this PR
- [ ] Self-test "catch violation" step passes
- [ ] Self-test "pass clean script" step passes
- [ ] Existing scripts all pass the guard (no remaining violations)