### PR TITLE
feat(0180): auto-regenerate skills catalog on SKILL.md commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ tickets/tools/go/*.test
 # Makefile for harness targets (skills catalog, checks, etc.)
 !Makefile
 
+# Git hooks — tracked so all machines pick them up via on-start.sh
+!hooks/
+!hooks/**
+
 # settings.json: universal config (hooks, effortLevel, universal permissions) — tracked
 # settings.local.json: machine-specific permissions — gitignored
 !settings.json

--- a/STATE.md
+++ b/STATE.md
@@ -1,21 +1,21 @@
 # Imperial Dragon Harness — State
 
-Last updated: 2026-05-29T13:25Z
+Last updated: 2026-05-29T15:20Z
 
 ## North star
 
 A reusable, science-backed personal harness for AI-assisted research: code and prose, day and night, across projects and machines.
 
 ## Status
-<!-- generated 2026-05-29T13:25Z -->
+<!-- generated 2026-05-29T15:20Z -->
 
-**Tickets:** 6 ready · 6 blocked — `erg ready tickets/` for full list
+**Tickets:** 5 ready · 5 blocked — `erg ready tickets/` for full list
 **Recent commits:**
-  0a40ddf docs: regenerate skills catalog after squash-merge rename
-  baf2914 tickets: file 0178 — housekeeping detect and fix ticket corpus errors
-  0460305 config: auto mode, drop explicit model/effortLevel, skipAutoPermissionPrompt
-  081cce4 chore: squash-merge is disabled — purge stale wording across harness
-  7fecc71 Merge remote-tracking branch 'origin/main'
+  c121599 Merge pull request #228 from MinhHaDuong/t176-grep-e-guard
+  0ccc4eb ticket(0176): close and archive — PR #228
+  c67d99c feat(0176): add grep-e-guard CI job — no grep -E/-G with PCRE escapes
+  2289e7a Merge pull request #227 from MinhHaDuong/t179-refresh-state-path-arg-v2
+  4c3e311 Merge origin/main into t179 to resolve post-close-commit conflicts
 
 ## Blockers
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,46 @@
+#!/bin/sh
+# --- erg-source-guard ---
+# Reject any staged changes under tickets/tools/go/ — erg source is read-only
+# in IDH. All edits must go to the git-erg project.
+erg_source=$(git diff --cached --diff-filter=d --name-only | grep '^tickets/tools/go/' || true)
+if [ -n "$erg_source" ]; then
+    echo "ERROR: erg source is read-only in IDH — commit changes to git-erg project instead" >&2
+    echo "Rejected files:" >&2
+    echo "$erg_source" >&2
+    exit 1
+fi
+# --- erg-source-guard ---
+
+# --- skills-catalog-guard ---
+# When any skills/*/SKILL.md is staged, regenerate README.md skills catalog.
+skills_changed=$(git diff --cached --name-only | grep '^skills/.*/SKILL\.md$' || true)
+if [ -n "$skills_changed" ]; then
+    if ! make skills-catalog; then
+        echo "ERROR: make skills-catalog failed — commit aborted" >&2
+        exit 1
+    fi
+    git add README.md
+fi
+# --- skills-catalog-guard ---
+
+# --- git-erg: begin managed block ---
+# Pre-commit hook fragment for git-erg ticket validation.
+# The install script appends this between "# --- git-erg ---" markers,
+# composing safely with any existing pre-commit hook.
+# To install manually, append everything below the shebang to your hook.
+
+# Validate .erg files (if any are staged)
+erg_files=$(git diff --cached --name-only | grep '\.erg$' || true)
+if [ -n "$erg_files" ]; then
+    erg_bin="${ERG:-tickets/erg}"
+    if [ -x "$erg_bin" ]; then
+        if ! "$erg_bin" check tickets/; then
+            echo "ERROR: Ticket validation failed. Fix errors above." >&2
+            exit 1
+        fi
+    else
+        echo "ERROR: erg binary not found. Run 'make build' first." >&2
+        exit 1
+    fi
+fi
+# --- git-erg: end managed block ---

--- a/tests/test_guard_skills_catalog.sh
+++ b/tests/test_guard_skills_catalog.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+fail=0
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git -C "$TMPDIR" init -q
+git -C "$TMPDIR" config user.email "test@example.com"
+git -C "$TMPDIR" config user.name "Test"
+
+mkdir -p "$TMPDIR/skills/foo"
+cat > "$TMPDIR/README.md" <<'RDME'
+<!-- skills:begin -->
+
+| Command | Description |
+|---------|-------------|
+
+<!-- skills:end -->
+RDME
+cat > "$TMPDIR/skills/foo/SKILL.md" <<'SKL'
+---
+name: foo
+description: A test skill
+---
+SKL
+
+mkdir -p "$TMPDIR/scripts"
+cat > "$TMPDIR/Makefile" <<'MK'
+skills-catalog:
+	date >> README.md
+MK
+
+mkdir -p "$TMPDIR/.git/hooks"
+cat > "$TMPDIR/.git/hooks/pre-commit" <<'HOOK'
+skills_changed=$(git diff --cached --name-only | grep '^skills/.*/SKILL\.md$' || true)
+if [ -n "$skills_changed" ]; then
+    if ! make skills-catalog; then
+        echo "ERROR: make skills-catalog failed — commit aborted" >&2
+        exit 1
+    fi
+    git add README.md
+fi
+HOOK
+chmod +x "$TMPDIR/.git/hooks/pre-commit"
+
+git -C "$TMPDIR" add .
+git -C "$TMPDIR" commit -q -m "init"
+
+# Test 1: staging a SKILL.md triggers the guard
+echo "test edit" >> "$TMPDIR/skills/foo/SKILL.md"
+git -C "$TMPDIR" add skills/foo/SKILL.md
+git -C "$TMPDIR" commit -q -m "test: stage SKILL.md"
+if git -C "$TMPDIR" show --name-only HEAD | grep -q 'README.md'; then
+    echo "PASS: README.md was auto-staged when SKILL.md changed"
+else
+    echo "FAIL: README.md was not auto-staged"
+    fail=1
+fi
+
+# Test 2: staging an unrelated file does NOT trigger guard
+echo "something" > "$TMPDIR/unrelated.txt"
+git -C "$TMPDIR" add unrelated.txt
+git -C "$TMPDIR" commit -q -m "test: non-SKILL.md change"
+if git -C "$TMPDIR" show --name-only HEAD | grep -q 'README.md'; then
+    echo "FAIL: README.md was spuriously staged for a non-SKILL.md change"
+    fail=1
+else
+    echo "PASS: README.md not staged for unrelated change"
+fi
+
+if (( fail )); then exit 1; fi
+echo "PASS: skills-catalog-guard fires on SKILL.md changes and ignores others"

--- a/tests/test_guard_skills_catalog.sh
+++ b/tests/test_guard_skills_catalog.sh
@@ -33,16 +33,7 @@ skills-catalog:
 MK
 
 mkdir -p "$TMPDIR/.git/hooks"
-cat > "$TMPDIR/.git/hooks/pre-commit" <<'HOOK'
-skills_changed=$(git diff --cached --name-only | grep '^skills/.*/SKILL\.md$' || true)
-if [ -n "$skills_changed" ]; then
-    if ! make skills-catalog; then
-        echo "ERROR: make skills-catalog failed — commit aborted" >&2
-        exit 1
-    fi
-    git add README.md
-fi
-HOOK
+cp "$(git rev-parse --show-toplevel)/hooks/pre-commit" "$TMPDIR/.git/hooks/pre-commit"
 chmod +x "$TMPDIR/.git/hooks/pre-commit"
 
 git -C "$TMPDIR" add .

--- a/tickets/0174-celebrate-sweep-ticket-loss-guard.erg
+++ b/tickets/0174-celebrate-sweep-ticket-loss-guard.erg
@@ -2,11 +2,13 @@
 Title: /celebrate sweep can claim to file follow-up tickets without committing them
 Created: 2026-05-28
 Author: claude
+Closed: all exit criteria met — preflight script deployed, celebrate prose updated, regression tests in place, observation cycle confirmed by commit 3efdc7a (celebrate filed 0175-0177 from PR #221)
 
 --- log ---
 2026-05-28T09:30Z claude created — surfaced when raid 713 recovered the lost 0173 ticket
 
 2026-05-28T17:17Z audit: ExitWorktree is a harness tool, not Bash; Bash(git worktree remove*) matcher does not fire on it, so neither guard-worktree-remove-wip.sh nor worktree-gc.sh covered the loss path (gc runs after the exit in celebrate step 9.5). Fix: scripts/worktree-exit-preflight.sh + celebrate/end-session prose; preflight refuses on tracked-mod/staged/untracked (uses --untracked-files=all so individual draft files surface in the message). Regression suite: 6 cases in tests/test_worktree_tools.py. Awaiting observation cycle.
+2026-05-29T15:26Z MinhHaDuong closed — all exit criteria met — preflight script deployed, celebrate prose updated, regression tests in place, observation cycle confirmed by commit 3efdc7a (celebrate filed 0175-0177 from PR #221)
 --- body ---
 ## Context
 

--- a/tickets/closed/0180-skills-catalog-not-updated-on-skill-change.erg
+++ b/tickets/closed/0180-skills-catalog-not-updated-on-skill-change.erg
@@ -2,10 +2,12 @@
 Title: ensure skills-catalog is regenerated when any SKILL.md changes
 Created: 2026-05-29
 Author: haduong
+Closed: autoclosed — PR #229
 
 --- log ---
 2026-05-29T13:30Z haduong created
 
+2026-05-29T15:57Z MinhHaDuong closed — autoclosed — PR #229
 --- body ---
 ## Context
 


### PR DESCRIPTION
Add a `skills-catalog-guard` block to the pre-commit hook. When any
`skills/*/SKILL.md` is staged, the hook runs `make skills-catalog` and
stages the updated `README.md` automatically before the commit lands.

Also adds `tests/test_guard_skills_catalog.sh` which is auto-discovered
by `test_bash_suites.py`.

**Ticket:** tickets/0180-skills-catalog-not-updated-on-skill-change.erg