### PR TITLE
rules: no direct-to-main exceptions + rebase before merge

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -1,7 +1,7 @@
 <!-- last-reviewed: 2026-05-29 -->
 # Git Discipline
 
-- **Always work on a branch.** Main is read-only except for STATE housekeeping. For the full exception list (tickets, memory, config), see `rules/workflow.md` § Worktree paths.
+- **Always work on a branch.** Main is read-only — no exceptions. Everything (code, docs, tickets, STATE, memory, config) lands via branch + PR. See `rules/workflow.md` § Worktree paths.
 - **One change per commit.** Message explains *why this change and not another*: alternatives considered, local design choices made.
 - **Merge commits**: strategic-level detail — architecture decisions, cross-file impacts, residual debt. Feature merges go through merge requests; chores merge locally via short-lived branch + fast-forward.
 - **Git is the project's long-term memory.** Top-level files reflect *now* — history lives in `git log`.

--- a/rules/git.md
+++ b/rules/git.md
@@ -8,6 +8,7 @@
 - **Worktree isolation is automatic** — the SessionStart hook enforces it. All worktrees are throwaway; branches hold durable state. Skills must not manually delete worktrees created via `Agent(isolation:"worktree")` — use `git worktree prune` after branch deletion, never `rm -rf`.
 - **Squash merge is disabled.** This repo uses regular merge commits only (`--merge`). `git merge-base --is-ancestor` works correctly. For branches that may have been squash-merged historically (before 2026-05-25), verify via `gh pr view --json headRefName,mergeCommit` instead of `git cherry`.
 - **Create a merge request** for each ticket to review changes before merging. Include a `**Ticket:** tickets/NNNN-...` line in the PR body so `erg-pr-merge` can auto-close the ticket on merge.
+- **Rebase before merge.** Before merging any PR, rebase onto current `origin/main`, push `--force-with-lease`, and wait for CI to pass. This prevents "Base branch was modified" failures mid-merge and keeps history linear.
 - **Delete branches after merge.** All repos use `deleteBranchOnMerge: true` on GitHub, so the remote branch disappears automatically when a PR merges. Clean up stale local branches with:
   ```bash
   git fetch --prune

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -37,10 +37,7 @@ If `origin/main` is ahead and overlaps your area, reconcile first (rebase onto i
 
 During an `EnterWorktree` session, `Edit`/`Write`/`Read` tools accept any absolute path. An edit at `/home/haduong/<repo>/<file>` lands in the **main repo**, not the worktree. Use worktree-rooted paths for code, prose, and data.
 
-Exception — the following may land directly on main without a branch:
-- `STATE.md` updates (always main — see `git.md` "Main is read-only except for STATE housekeeping")
-- Ticket lifecycle: closing finished tickets (`erg close`), opening new `.erg` files, batch ticket housekeeping
-- Harness memory and config files (`memory/*.md`, `settings.json`, `MEMORY.md`)
+**No exceptions. Everything goes through a PR.** `STATE.md`, ticket lifecycle, memory files, config — all changes land via branch + PR. The GitHub gate is closed; there is no direct-push-to-main path.
 
 For everything else (source code, manuscript prose, data files): if `git branch --show-current` is `main`, stop and switch to a branch first.
 


### PR DESCRIPTION
Two rule fixes:

1. **Drop all direct-to-main exceptions.** workflow.md listed STATE, ticket lifecycle, and memory files as exempt from the PR gate. The GitHub permission model has no reliable carve-out for these — every push to main requires a PR. Rule now says: no exceptions.

2. **Rebase before merge.** git.md gains an explicit rule: rebase onto current origin/main, push --force-with-lease, wait for CI, then merge. Matches the existing memory entry and prevents mid-merge base-modification failures.

Generated with Claude Code