### PR TITLE
ticket(0187): release skill — audits, sign, tag, update download URL

### DIFF
--- a/tickets/0187-release-skill-automate-pre-release-audits-sign-tag.erg
+++ b/tickets/0187-release-skill-automate-pre-release-audits-sign-tag.erg
@@ -1,0 +1,58 @@
+%erg 0.1
+Title: release skill — automate pre-release audits, sign, tag, update download URL
+Created: 2026-05-30
+Author: Claude
+
+--- log ---
+2026-05-30T19:30Z Claude created — misfiled in git-erg, moved here
+2026-05-30T19:55Z Claude note scope: applies to any git-erg release; skill lives in IDH skills/release/
+
+--- body ---
+## Context
+
+Releasing git-erg currently requires a human to manually:
+- re-run security and UX audits
+- run the test suite
+- sign a GPG tag
+- update the `curl` URL in README to the new tag name
+- (future) update the blog
+
+The modus operandi agreed after git-erg 0181–0184: sign tags at release
+cadence, not CI cadence; the `curl` download URL pins to the latest signed
+tag so CI rebuilds never invalidate attested downloads. A `/release` skill
+encodes this as a repeatable checklist that runs audits autonomously and
+pauses at the human-only step (GPG signing).
+
+## Actions
+
+1. Write `skills/release/SKILL.md` with the frontmatter and prose spec.
+2. Write `skills/release/release` (executable script or inline skill body):
+   a. Pre-flight: `make check` must be green in the target repo; no open
+      `needs-human` blocking tickets.
+   b. Parallel agents: re-run security audit + UX dry-run (all four audiences,
+      both install paths per `tickets/0152`). Each agent files tickets for
+      findings (severity HIGH/MEDIUM/LOW).
+   c. Print findings summary. Pause: "Resolve HIGH findings before signing."
+   d. On continue: determine new tag name (date-based, e.g. `2026-05-30`).
+      Update the `curl` URL in README § Install to the new tag. Commit.
+   e. Print the exact `git tag -s <tag> HEAD && git push --tags` command.
+   f. After human pushes the tag: `git verify-tag <tag>` to confirm GPG good.
+   g. Stub blog-post ticket (deferred until blog infrastructure exists).
+3. Register in `make skills-catalog`.
+
+## Relevant files
+
+- `skills/` — existing skills for structure reference
+- Target repo `README.md` § Install — curl URL updated each release
+- Target repo `src/go/assets/integration.md` — updated if install steps change
+- `~/.claude/keys/` or `gpg --list-keys` — signing key reference
+
+## Exit criteria
+
+- [ ] `/release` skill exists and is listed in `make skills-catalog`
+- [ ] Pre-flight gate (`make check` + no blocking needs-human tickets) works
+- [ ] Security and UX audit agents fire in parallel; findings become filed tickets
+- [ ] Skill pauses at GPG-signing step and prints the exact `git tag -s` command
+- [ ] After tag push, skill verifies `git verify-tag` passes
+- [ ] Target repo curl URL is updated to new tag name as part of the release commit
+- [ ] Blog-post step is a documented stub (no implementation until blog exists)


### PR DESCRIPTION
Files IDH ticket 0187 for the release automation skill. Misfiled in git-erg originally — moved here where the skill implementation belongs.

Design agreed in git-erg 0181-0184: sign at release cadence not CI cadence; curl URL pins to latest signed tag; skill runs security + UX audits in parallel, pauses for human GPG signing step.

**Ticket:** tickets/0187-release-skill-automate-pre-release-audits-sign-tag.erg

Generated with Claude Code