### PR TITLE
rules: merge-bounce recovery, verify-sync, and diagnosis discipline

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-05-29 -->
+<!-- last-reviewed: 2026-06-03 -->
 # Git Discipline
 
 - **Always work on a branch.** Main is read-only — no exceptions. Everything (code, docs, tickets, STATE, memory, config) lands via branch + PR. See `rules/workflow.md` § Worktree paths.
@@ -9,6 +9,12 @@
 - **Squash merge is disabled.** This repo uses regular merge commits only (`--merge`). `git merge-base --is-ancestor` works correctly. For branches that may have been squash-merged historically (before 2026-05-25), verify via `gh pr view --json headRefName,mergeCommit` instead of `git cherry`.
 - **Create a merge request** for each ticket to review changes before merging. Include a `**Ticket:** tickets/NNNN-...` line in the PR body so `erg-pr-merge` can auto-close the ticket on merge.
 - **Rebase before merge.** Before merging any PR, rebase onto current `origin/main`, push `--force-with-lease`, and wait for CI to pass. This prevents "Base branch was modified" failures mid-merge and keeps history linear.
+- **After an APPROVED `/verify`, sync before merging.** `/verify` may commit and push fixes from its own review worktree, leaving your local branch behind `origin`. Run `git fetch origin && git merge --ff-only origin/<branch>` before you rebase/merge — otherwise a rebase + `--force-with-lease` silently drops the verify fix.
+- **Merge-bounce recovery.** `erg-pr-merge` legitimately bounces in sequence; each bounce has a specific retry — do not blanket-fall back to `gh pr merge`:
+  - *Mergeability `UNKNOWN` / "not mergeable" right after a `--force-with-lease` push or the ticket-close commit* — GitHub is recomputing mergeability/checks. Wait for the live check (`gh run watch <run-id>`), then re-invoke `erg-pr-merge`.
+  - *"CI has N check(s) still running"* — `gh run watch` the pending run to completion, then re-invoke.
+  - *"close: no ticket found" on a retry* — the FIRST run already `erg close`d + archived + pushed the close commit (the script is **not** idempotent past that step). Do NOT re-run it and do NOT hand-close the ticket; the close commit is already on the branch, so finish with `gh pr merge <N> --merge` directly once CI is green.
+  - *"must run from PR branch" after a fast-forward* — HEAD detached after `merge --ff-only`; `git checkout <branch>`, then retry.
 - **Delete branches after merge.** All repos use `deleteBranchOnMerge: true` on GitHub, so the remote branch disappears automatically when a PR merges. Clean up stale local branches with:
   ```bash
   git fetch --prune

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-05-26 -->
+<!-- last-reviewed: 2026-06-03 -->
 # Session Start
 
 At the beginning of every conversation:
@@ -51,6 +51,20 @@ When stuck, escalate progressively:
 5. Stop — ask the author.
 
 Save a feedback memory at each escalation (what failed, why). Stop if repeating yourself.
+
+# Diagnosis discipline
+
+Report the **observation**; hold the **cause** until you have isolated it. Don't
+reach for loaded causal labels — *corrupt*, *broken*, *tampered*, *hacked*,
+*hazard* — before evidence rules the cause in: they misdirect the fix (reinstall
+vs reword) and manufacture false alarm. Before blaming a tool, check the cheap
+discriminators: is it intact (package-verify / hash)? deterministic? does an
+independent code path reproduce it? does upstream document the behaviour? Any
+"yes" points away from corruption toward *intended behaviour*. State "X emits Y
+for input Z; cause not yet established," not a verdict dressed as a finding.
+(Cost of skipping this, 2026-06-03: a stock gofmt doc-comment smart-quote
+feature — intact binary, deterministic, reproduced by the stdlib — was
+misdiagnosed as a "broken toolchain" and nearly got a spurious reinstall ticket.)
 
 # When to Ask the Author
 


### PR DESCRIPTION
## Summary

Codifies three lessons from the git-erg `erg-imagine-charter` raid (2026-06-02..03), where ~15 PRs were merged through `erg-pr-merge` + `/verify`. All three recurred and were rediscovered each time.

**`rules/git.md`**
- **Merge-bounce recovery** — the specific retry for each `erg-pr-merge` bounce, so agents stop blanket-falling-back to `gh pr merge`:
  - `UNKNOWN` / "not mergeable" right after a `--force-with-lease` push or the close-commit → wait (`gh run watch`), re-invoke.
  - "CI has N check(s) still running" → watch the run, re-invoke.
  - "close: no ticket found" on a retry → the first run already closed+archived+pushed; finish with `gh pr merge` directly, do **not** re-run or hand-close.
  - "must run from PR branch" after a fast-forward → detached HEAD; `git checkout <branch>`, retry.
- **After an APPROVED `/verify`, sync before merging** — `/verify` pushes fixes from its review worktree; `git fetch && git merge --ff-only origin/<branch>` before rebase or the fix is silently dropped.

**`rules/workflow.md`**
- **Diagnosis discipline** — report the observation, hold the cause; don't reach for "corrupt/broken/tampered" before isolating it (check: intact? deterministic? reproduced by an independent path? upstream-documented?). Triggered by misdiagnosing stock gofmt doc-comment smart-quoting as a "broken toolchain."

Both files' `last-reviewed` stamps bumped to 2026-06-03. Rules-only; no skills touched (no catalog regen).

> Left for your review/merge — these are the harness's own governance rules, and the repo has other in-flight work on `idh-0187-release-skill`. Done in an isolated worktree off `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)