### PR TITLE
tickets: track 0182-0185, 0188 — previously untracked on main checkout

### DIFF
--- a/tickets/0182-fang-handcuff-test-audit-skill.erg
+++ b/tickets/0182-fang-handcuff-test-audit-skill.erg
@@ -1,0 +1,137 @@
+%erg 0.1
+Title: Extract test-quality audit workflow (fang/handcuff/scope) into a skill
+Created: 2026-05-30
+Author: claude
+Tag: deferred
+
+--- log ---
+2026-05-30T10:00Z claude created — after the fang-audit fan-out run on git-erg validated the design
+
+--- body ---
+## Context
+
+A fan-out mutation-testing workflow ("fang audit") was prototyped and run end-to-end
+on the `git-erg` Go test harness (19 test files, 31 agents, ~29 min, 1.3M tokens).
+It works: 90 confirmed fangs, 8 toothless tests surfaced, both guard canaries caught.
+Durable artifacts from the validating run (copied OUT of the ephemeral session dir):
+- Reviewed+verified plan: `~/.claude/plans/quizzical-booping-puffin.md` (the M1–M4 fixes,
+  pairing table, verdict rules, lens design — survived two local review passes).
+- Proven workflow script: `~/.claude/plans/fang-audit-erg-prototype.js` (the exact script
+  that produced the 19-file run; start the extraction from this, do not rewrite from memory).
+- Sample output: `git-erg/FANG-AUDIT.md` (90 caught / 8 toothless / 4 equivalent, canary PASS).
+
+Per the approved plan's follow-up, the pattern generalizes to any repo with a runnable
+test suite and should become a reusable harness skill — but only now that the concrete
+run has shaken out the design. This ticket extracts it AND adds the complementary
+"handcuff audit" (the other half of test scoping).
+
+Two axes of test scoping, both mechanically checkable by mutation:
+- **Fang (sensitivity):** behavior-CHANGING mutation → the test must go RED. A test
+  that stays green is toothless. (This is what the prototype already does.)
+- **Handcuff (robustness):** behavior-PRESERVING refactor (rename locals, reorder
+  independent statements, swap an equivalent construct, change an unexported
+  representation) → the test must stay GREEN. A test that goes red is over-scoped and
+  blocks legitimate evolution.
+- **Scope / altitude (class coverage):** for each behavior-changing mutation that IS
+  caught, apply the SAME mutation operator at every structurally-similar sibling site.
+  If only the site with a regression test goes red and the siblings survive, the test is
+  pinned to one INSTANCE when the defect is a CLASS — it guards the past, not the future.
+  Flag for promotion to a class/invariant guard (the project already does this for ASCII,
+  scaling, resource-hygiene). Oracle: sibling-survives = under-scoped contract.
+Right-scoped on all three = bites the defect, tolerates refactors, AND guards the whole
+class. The prototype only measures the first axis (fang).
+
+## Design rationale — the lens taxonomy
+
+A test is a CLASSIFIER over code-versions: it partitions every possible version into
+accept (green) / reject (red). A perfect test draws that boundary exactly along the
+contract. Every quality lens is a way the boundary is wrong, untrustworthy, or too
+costly to consult. Three families:
+
+1. Is the boundary in the RIGHT PLACE? (mutation-mechanizable — this skill)
+   - fang: rejects bad versions (recall). Toothless = too loose.
+   - handcuff: accepts good versions (precision; tolerates refactors). Brittle = too tight.
+   - altitude/scope: boundary resolution vs the defect-CLASS edge (instance vs class).
+   - oracle-strength: the continuous form of fang — a weak assertion (!= nil) kills few
+     mutants, a strong one (== expected) kills many. Free from the same mutation data.
+
+2. Can you BELIEVE the verdict? (empirically-mechanizable — re-run/shuffle/time, no LLM)
+   - determinism: same code -> same verdict. Flaky tests have NEGATIVE value (they train
+     the team to ignore red, disarming the whole suite).
+   - independence: verdict invariant under reorder/parallel/isolation.
+   - faithfulness: exercises prod-like code paths, not a mocked fiction (LLM-auditable).
+
+3. Can you AFFORD and ACT on the verdict?
+   - speed: a correct test nobody runs has ~zero realized value (the `scaling` build tag
+     exists for exactly this — quarantine the slow guard).
+   - diagnosticity: on red, does it bisect to the cause? Mutation-derivable: how FEW /
+     how targeted are the tests that fire per killed mutant. Free from v1's data.
+   - maintainability: a legitimate contract change touches one test, not fifty.
+
+META-LENS: test quality is NOT intrinsic — it is relative to RISK x CHURN. Spend test
+budget where blast-radius x change-frequency is highest. (The audit's scariest finding
+was identity_test's sanitize = a SECURITY invariant, header injection — weight it above
+cosmetic checks regardless of verdict count.) And: most toothlessness is a NEGATIVE-SPACE
+failure — the test never constructs the adversarial input where the defect lives; mutation
+testing finds these precisely because the mutation manufactures that input.
+
+## Lens roadmap (avoid cramming everything into one skill)
+
+- v1 (THIS skill): the three boundary lenses + oracle-strength + diagnosticity. The last
+  two are FREE RIDERS — derivable from the mutation data v1 already collects, no extra runs.
+- v1 PRECHECK (gate): a quick determinism check (re-run unchanged suite N times) BEFORE
+  trusting any mutation verdict — you cannot mutation-test a flaky suite. This is a
+  dependency, not a nice-to-have. Independence (shuffle/parallel) optional in the precheck.
+- DEFERRED, separate tickets (different MECHANISM — do not bloat this skill):
+  * empirical trio as a lightweight CI-side utility: flakiness / independence / speed
+    (a small test-runner wrapper, NOT an expensive fan-out).
+  * LLM-audit pass: faithfulness, readability/intent, negative-space coverage,
+    change-detector smell (read-and-judge, no execution) — a sibling skill.
+  * risk x churn = a PRESENTATION/prioritization layer over findings (pull churn from
+    git log, sort by blast-radius x change-frequency). Keep the human in the loop; do NOT
+    automate the risk judgment.
+
+## Design note — one workflow, two passes (recommended)
+
+Run both in the SAME workflow, NOT two disconnected runs:
+- They share ~80% of scaffolding: the explicit test↔source pairing table, worktree
+  setup, baseline-green check, untracked-input copy, per-file fan-out, the canary gate.
+- Keep the two ORACLES in separate agent roles — do not make one agent juggle
+  red=good and red=bad; that invites misclassification.
+- Pipeline them: fang pass first, then a handcuff pass (can prioritise tests that
+  showed fangs / are non-trivial). Emit ONE unified per-test report: `has-fang? |
+  is-handcuff?` on both axes — far more actionable than two separate tables.
+- The handcuff pass needs its OWN skeptic, symmetric to the equivalent-mutant skeptic:
+  when a test goes red on a supposed refactor, verify the refactor was TRULY
+  behavior-preserving. If it secretly changed behavior, the red is a legitimate catch,
+  NOT a handcuff — withdraw the accusation. (Mirror image of the false-accusation guard.)
+
+## Known defect to fix during extraction
+
+The prototype's canary validity-gate trusted an `isCanary` flag from ALL agents;
+behavioral audit agents mis-set it on their own findings and produced a false "FAIL".
+Scope the canary gate strictly to the designated guard files. (Fixed ad hoc in the
+prototype via `f.isCanary && /scaling_test|resource_test/.test(file)` — bake the
+principle into the skill: canary designation is a workflow input, not an agent claim.)
+
+## Exit criteria
+- [ ] `skills/fang-audit/SKILL.md` + workflow script committed; registered via
+      `make skills-catalog`; `make check-skills-drift` passes in CI.
+- [ ] Repo-specific knobs are explicit inputs (NOT name heuristics): `TEST_GLOB`,
+      `RUN_TEST` (+ tag variants), the test↔source pairing table, designated canary
+      files, language-specific mutation heuristics.
+- [ ] Fang mode reproduces the git-erg result (toothless list + canary PASS).
+- [ ] Handcuff mode implemented: behavior-preserving mutation operators + inverted
+      oracle (red = over-scoped) + behavior-preservation skeptic.
+- [ ] Scope/altitude mode implemented: replay each caught mutation's operator across
+      structurally-similar sibling sites; flag instance-pinned contracts (sibling
+      survives) for promotion to a class guard.
+- [ ] Oracle-strength + diagnosticity reported as free riders from the existing mutation
+      data (mutants-killed-per-assertion; tests-fired-per-killed-mutant) — no extra runs.
+- [ ] Determinism precheck gates the run: re-run the unchanged suite N times; abort with a
+      clear "suite is flaky, verdicts untrustworthy" message if verdicts vary.
+- [ ] Unified per-test report covers all three axes (fang? / handcuff? / right-scope?)
+      and is sortable by a risk x churn weighting (churn from git log).
+- [ ] Canary gate scoped to designated guard files only (isCanary-pollution bug gone).
+- [ ] Forge-agnostic, language-pluggable (validated on at least one non-Go repo or a
+      documented plug-in path).

--- a/tickets/0183-llm-test-audit-sibling-skill.erg
+++ b/tickets/0183-llm-test-audit-sibling-skill.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: LLM read-and-judge test-audit (faithfulness, intent, negative-space, change-detector)
+Created: 2026-05-30
+Author: claude
+Tag: deferred
+
+--- log ---
+2026-05-30T10:30Z claude created — sibling to 0182; different mechanism (judge, no execution)
+
+--- body ---
+## Context
+
+Sibling to [[0182]] (the mutation-oracle test-quality audit: fang / handcuff / scope).
+Those three lenses are MUTATION-mechanizable — mutate, run, read the oracle. A second
+family of test-quality lenses cannot be measured that way; they require READING the test
+and judging intent, with no execution. Different mechanism => separate skill, so neither
+bloats the other. Build AFTER 0182 v1 proves the harness shape.
+
+## Lenses in scope (read-and-judge, no test runs)
+- **Faithfulness / test-reality gap:** does the test exercise prod-like paths, or a mocked
+  fiction that can stay green while production breaks? Flag heavy mocking that stubs the
+  very thing under test.
+- **Readability / intent legibility:** can a reader tell WHICH contract is asserted and WHY,
+  without running it? Flag tests whose name lies about what they check, or that pass for the
+  wrong reason.
+- **Negative-space coverage:** does it test error paths, boundaries, malformed/empty/huge
+  inputs — or only the happy path? (The 0182 run showed most toothlessness is a
+  negative-space failure; this lens finds it statically, before mutation confirms it.)
+- **Change-detector smell:** does it assert HOW the code works (call sequences, mock
+  interaction order) instead of WHAT it produces? The structural cause of handcuffs.
+
+## Design notes
+- Pure LLM fan-out (one judge per test file); NO worktrees, NO go test — cheap relative to
+  0182 (no compile/run loop), but still token-heavy. Use a cheaper model for the bulk pass;
+  reserve a stronger model for flagged/ambiguous cases.
+- Output joins 0182's per-test report so a test gets ONE row across all lenses, or a
+  standalone report keyed on the same test-file identity.
+- These verdicts are SOFT (judgment, not a passing/failing oracle) — present as advisory
+  findings with rationale, never as a hard gate.
+
+## Exit criteria
+- [ ] `skills/test-audit-llm/` (or a mode of the 0182 skill) with the four lenses above.
+- [ ] One judge agent per test file; structured findings with rationale + severity.
+- [ ] Cheap-model bulk pass + stronger-model escalation for flagged cases.
+- [ ] Report composes with 0182 output (shared test-file keys) OR a clean standalone report.
+- [ ] Explicitly advisory: no CI hard-gate; findings feed ticket creation, not PR blocks.

--- a/tickets/0184-empirical-test-quality-ci-utility.erg
+++ b/tickets/0184-empirical-test-quality-ci-utility.erg
@@ -1,0 +1,44 @@
+%erg 0.1
+Title: Empirical test-quality CI utility (flakiness / independence / speed)
+Created: 2026-05-30
+Author: claude
+Tag: deferred
+
+--- log ---
+2026-05-30T10:45Z claude created — cheap-tier sibling to 0182/0183; the per-PR-gateable lenses
+
+--- body ---
+## Context
+
+Third in the test-quality tooling family ([[0182]] mutation oracles, [[0183]] LLM judge).
+This one carves out the lenses that are CHEAP and DETERMINISTIC — measurable by re-running
+the existing suite, no mutation, no LLM, no tokens. Because they cost seconds not dollars,
+these are the ONLY test-quality checks suitable as a per-PR CI gate (0182/0183 are
+scheduled/on-demand only — a full mutation run was ~1.3M tokens / ~29 min for 19 files).
+
+Reusable harness utility (hence IDH store); per-repo CI wiring is a thin adapter each repo
+adds (erg's wiring would be a small erg-project task, NOT this ticket).
+
+## Lenses in scope (re-run / shuffle / time — no LLM)
+- **Flakiness / determinism:** run the unchanged suite N times; flag any test whose verdict
+  varies. NEGATIVE-value tests — they train teams to ignore red. Also a hard PRECONDITION
+  for 0182: you cannot mutation-test a flaky suite (0182 imports this as its precheck gate).
+- **Independence / isolation:** run shuffled and in parallel; flag tests whose verdict
+  depends on order or shared state.
+- **Speed:** time each test; flag the slow tail and suggest tagging (cf. erg's `scaling`
+  build tag) so the fast feedback loop stays fast.
+
+## Design notes
+- Language-pluggable runner adapter (Go: `go test -count=N -shuffle=on -json`; others: their
+  equivalents). Parse machine-readable test output; pure data, no agents.
+- Output: per-test {stable?, order-independent?, duration}. Composes with 0182/0183 reports
+  via shared test identity, or stands alone.
+- CADENCE: this is the per-PR tier. Fast enough to gate. Pair with a ratchet so it blocks
+  only on NEW flakiness/slowness introduced by the diff, not pre-existing debt.
+
+## Exit criteria
+- [ ] Utility runs the three checks from a single entry point; machine-readable output.
+- [ ] Flakiness check is exposed as a reusable gate that 0182 calls as its precheck.
+- [ ] Go adapter implemented; the runner interface is documented for other languages.
+- [ ] Ratchet mode: fail only on diff-introduced regressions, baseline the rest.
+- [ ] Cost note honored: zero LLM tokens; runtime bounded for per-PR use.

--- a/tickets/0185-raid-bundle-followup-tickets-convention.erg
+++ b/tickets/0185-raid-bundle-followup-tickets-convention.erg
@@ -1,0 +1,41 @@
+%erg 0.1
+Title: Document "bundle follow-up tickets into the spawning PR" raid convention
+Created: 2026-05-30
+Author: claude
+
+--- log ---
+2026-05-30T11:00Z claude created
+
+--- body ---
+## Context
+
+During raid 0175 (git-erg Tag→Label rename), a review surfaced a pre-existing,
+out-of-scope finding. Filing the follow-up ticket "cleanly on main" stalled —
+main was checked out and dirty in the main repo (parallel work), so it could not
+be committed there from the worktree.
+
+The author confirmed the resolution and wants it documented as a standing
+convention: **bundle the follow-up ticket file onto the spawning PR's branch**
+(the ticket only, never the fix), and reference it from the PR body/comment. The
+parent PR's `**Ticket:**` line still closes only its own ticket on merge; the
+bundled follow-up stays open.
+
+## Actions
+1. Decide the canonical home for the convention. Candidates:
+   - `skills/raid/SKILL.md` — Phase 6/7 (already covers /ticket-new + scope
+     overflow during a raid); most thematically coherent.
+   - `rules/workflow.md` — "Ticket discipline for multi-PR work" section.
+2. Add a concise note: when a raid/review surfaces a follow-up, open it via
+   `/ticket-new` and commit the `.erg` onto the current PR branch; reference it
+   in the PR (e.g. "Related follow-up:" / "Scope overflow: tickets/NNNN").
+   Commit the ticket only, not the implementation.
+3. Cross-check against the existing Phase 7 scope-overflow / "Scope overflow:
+   tickets/NNNN" wording so the two are consistent, not contradictory.
+
+## Exit criteria
+- [ ] The bundle-follow-ups convention is documented in one canonical place
+- [ ] No contradiction with the existing Phase 7 scope-overflow guidance
+
+## Notes
+Memory captured this session: feedback_bundle_followup_tickets (git-erg project
+memory). Author asked for an IDH ticket rather than an in-session edit.

--- a/tickets/0188-raid-commit-ticket-file-before-execute.erg
+++ b/tickets/0188-raid-commit-ticket-file-before-execute.erg
@@ -1,0 +1,36 @@
+%erg 0.1
+Title: raid phase 3 commit ticket file onto branch before execute
+Created: 2026-05-30
+Author: MinhHaDuong
+
+--- log ---
+2026-05-30T21:00Z MinhHaDuong created
+
+--- body ---
+## Context
+
+During the 0200 raid, the ticket file was written to the main repo's
+working tree as an untracked file. When the branch switched it stranded,
+and the gitignore for .claude/worktrees blocked staging it from the
+hook-reset cwd. The ticket had to be embedded in the execute agent
+prompt as a fallback.
+
+## Problem
+
+The raid skill's Phase 2/3 checkpoint says "commit planned tickets"
+but does not specify WHERE or HOW. A ticket created with Write to the
+main repo's working tree will strand on the next branch switch.
+
+## Fix
+
+Add one sentence to the raid skill's Phase 3 checkpoint:
+
+  "Ticket files go on a branch — stage and commit the .erg file
+  immediately after writing it. If staging fails (gitignore or
+  wrong cwd), embed the ticket content directly in the execute
+  agent prompt; the agent creates the file as its first step."
+
+## Exit criteria
+
+- [ ] SKILL.md Phase 3 checkpoint includes the commit-or-embed note
+- [ ] The note is one sentence, not a procedure


### PR DESCRIPTION
Five ticket files were created on the main checkout but never committed, leaving them invisible to pick-ticket/raid sweeps and dirtying the tree (blocks beat's pre-flight gate).

This PR adds the files verbatim — no code changes, no ticket closures.

Note: deliberately **no** `**Ticket:**` line — these tickets are being *opened*, not closed; erg-pr-merge must not auto-close them.

After merge: delete the now-redundant untracked copies on the main checkout before pulling (identical content, but git refuses to overwrite untracked files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)