### PR TITLE
ticket(0185): document bundle-follow-up-tickets raid convention

### DIFF
--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -137,6 +137,15 @@ individual `/verify` verdicts.
 `/ticket-new` calls `erg next-id` and `erg validate <file>` (file arg, not
 directory), keeping mechanical work inside the tool where it belongs.
 
+**Bundle follow-up tickets into the spawning PR.** When a raid or review
+surfaces a follow-up, open it via `/ticket-new` and commit the `.erg` onto the
+current PR branch — the ticket only, never the fix. Reference it from the PR
+body (`Related follow-up: tickets/NNNN`, or `Scope overflow: tickets/NNNN` when
+it comes from a verify-gate verdict). The PR's `**Ticket:**` line still closes
+only its own ticket on merge; the bundled follow-up stays open. Never file the
+follow-up on a main checkout — main is read-only and may be dirty with parallel
+work.
+
 For each wave, merge APPROVED PRs one at a time. A PR is merge-eligible if:
 - `/verify-gate` verdict is APPROVED (one REROLL allowed — Phase 6 handles this), AND
 - `scope_overflow` in the verdict is empty or all entries have suggested disposition

--- a/tickets/0185-raid-bundle-followup-tickets-convention.erg
+++ b/tickets/0185-raid-bundle-followup-tickets-convention.erg
@@ -6,6 +6,8 @@ Author: claude
 --- log ---
 2026-05-30T11:00Z claude created
 
+2026-06-03T20:05Z claude note documented bundle-follow-up convention in raid SKILL.md Phase 7
+
 --- body ---
 ## Context
 

--- a/tickets/closed/0185-raid-bundle-followup-tickets-convention.erg
+++ b/tickets/closed/0185-raid-bundle-followup-tickets-convention.erg
@@ -2,12 +2,14 @@
 Title: Document "bundle follow-up tickets into the spawning PR" raid convention
 Created: 2026-05-30
 Author: claude
+Closed: autoclosed — PR #238
 
 --- log ---
 2026-05-30T11:00Z claude created
 
 2026-06-03T20:05Z claude note documented bundle-follow-up convention in raid SKILL.md Phase 7
 
+2026-06-03T21:16Z MinhHaDuong closed — autoclosed — PR #238
 --- body ---
 ## Context
 


### PR DESCRIPTION
Adds the author-confirmed convention to `skills/raid/SKILL.md` Phase 7, directly under the token-economy rule: follow-up tickets surfaced mid-raid are opened via `/ticket-new` and committed onto the spawning PR's branch (ticket only, never the fix), referenced from the PR body. Explicitly notes the parent `**Ticket:**` line closes only its own ticket, and why main checkouts are off-limits for filing (read-only + parallel-work dirt).

Cross-checked against the existing Phase 7 scope-overflow wording — the new note extends it (where the .erg lands) without contradicting it (how it's created and referenced), satisfying both exit criteria.

**Ticket:** tickets/0185-raid-bundle-followup-tickets-convention.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)