### PR TITLE
ticket(0188): raid Phase 3 — commit ticket files to a branch, or embed in prompt

### DIFF
--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -71,7 +71,10 @@ For each reimagined ticket, launch an agent (background):
   wrong implementation, or only a different one? Annotate any hits
   with the proposed fix.
 
-Wait for all. Commit planned tickets. Report scorecard.
+Wait for all. Commit planned tickets. Report scorecard. Ticket files go on a
+branch — stage and commit the `.erg` file immediately after writing it; if
+staging fails (gitignore or wrong cwd), embed the ticket content directly in
+the execute agent prompt and the agent creates the file as its first step.
 
 ## Phase 4: Verify feasibility
 

--- a/tickets/0188-raid-commit-ticket-file-before-execute.erg
+++ b/tickets/0188-raid-commit-ticket-file-before-execute.erg
@@ -6,6 +6,8 @@ Author: MinhHaDuong
 --- log ---
 2026-05-30T21:00Z MinhHaDuong created
 
+2026-06-03T20:05Z claude note added commit-or-embed note to raid Phase 3 checkpoint
+
 --- body ---
 ## Context
 

--- a/tickets/closed/0188-raid-commit-ticket-file-before-execute.erg
+++ b/tickets/closed/0188-raid-commit-ticket-file-before-execute.erg
@@ -2,12 +2,14 @@
 Title: raid phase 3 commit ticket file onto branch before execute
 Created: 2026-05-30
 Author: MinhHaDuong
+Closed: autoclosed — PR #239
 
 --- log ---
 2026-05-30T21:00Z MinhHaDuong created
 
 2026-06-03T20:05Z claude note added commit-or-embed note to raid Phase 3 checkpoint
 
+2026-06-03T21:17Z MinhHaDuong closed — autoclosed — PR #239
 --- body ---
 ## Context
 


### PR DESCRIPTION
Extends the Phase 3 checkpoint line in `skills/raid/SKILL.md` with the ticket's commit-or-embed note: ticket files go on a branch (stage + commit immediately after writing); if staging fails (gitignore or wrong cwd), embed the ticket content in the execute-agent prompt and let the agent create the file first.

Closes the gap that stranded an untracked ticket file during the 0200 raid. Kept to a note on the checkpoint sentence, not a procedure, per the exit criteria.

Note: PR #238 (ticket 0185) touches a different section of the same file — disjoint hunks; whichever merges second gets a trivial rebase.

**Ticket:** tickets/0188-raid-commit-ticket-file-before-execute.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)