### PR TITLE
ticket(0187): /release skill — pre-release audits, GPG pause, download-URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automaticall
 | `/raid` | Run an Imperial Dragon raid across multiple tickets. Picks targets, manages waves, enforces isolation. Merges APPROVED PRs after verify-gate clears. |
 | `/related-work-note` | Author's due-diligence note for one cited paragraph of a manuscript. Covers relevance, history, cited works (detailed), related-but-not-cited (justified), methods, verification checklist, bibliography with DOI/URL. |
 | `/related-work-note-validate` | Re-resolve every DOI/URL/eprint in a related-work-note's Bibliography. Append a provenance line to Methods. One-line verdict to stdout (PASS / WARN / FAIL). |
+| `/release` | Pre-release audit, GPG tag signing, and download-URL update for a target repo. Runs audits autonomously; pauses at the human-only signing step. |
 | `/review-pr` | Multi-perspective code review with parallel agents. Covers correctness, consistency, scope, red team, and doc propagation. |
 | `/review-pr-prose` | Simulated peer review panel for manuscript prose. Spins discipline-specific agents for multi-perspective review. |
 | `/skill-doctor` | Weekly failure-pattern analysis across journals, logs, and git history. Clusters recurring failures and opens tickets with proposed patches. Never auto-applies fixes. |

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: release
+description: Pre-release audit, GPG tag signing, and download-URL update for a target repo. Runs audits autonomously; pauses at the human-only signing step.
+user-invocable: true
+argument-hint: [new-tag-name]
+---
+
+# Release $ARGUMENTS
+
+Encode the release checklist as a repeatable flow: run audits autonomously,
+pause at the human-only step (GPG signing), then verify and summarise. The
+skill **never signs** a tag — that is the human's sole responsibility.
+
+## When to use
+
+- Invoke from the **target repo's working directory**, on its **main
+  branch**, with **all feature work already merged**.
+- **Cross-repo prerequisite**: the caller must ensure cwd is the target
+  project before invoking `/release`. The skill is cwd-based — it never
+  takes a repo or path argument. For cross-repo flows, change into the
+  target project directory and fetch from the forge before the call.
+
+## 1. Pre-flight gate
+
+- Run the target repo's `make check`. **HALT** on failure — print the failing
+  output and stop. A release never ships on a red suite.
+- Scan open tickets for the `needs-human` tag. If any are tagged, **HALT**,
+  list them, and stop — these are blocking human-judgment items that must be
+  resolved before a release. Degrade gracefully with a warning if there is no
+  `tickets/` directory or no `erg` binary available (the gate is informational
+  in that case, not blocking).
+
+## 2. Parallel audits
+
+Launch **two background agents in parallel** (single message, both as
+background agents). Wait for both to return, then consolidate.
+
+**Agent A — security audit.** Review the release surface for:
+- supply chain (dependencies, pinned versions, fetched scripts),
+- permissions (file modes, capabilities, token scopes),
+- injection (unsanitised input reaching a shell, eval, or template),
+- signing (tag-signing path, key handling, attestation of downloads).
+
+**Agent B — UX dry-run.** Read the target repo's `tickets/0152` for the
+audience definitions and install paths, and walk each one. If `0152` is
+absent, degrade to generic heuristics: a clean install from scratch, plus a
+first-use walkthrough of the primary command.
+
+Each agent files **one ticket per finding** via `/ticket-new`, with a severity
+of HIGH / MEDIUM / LOW in the title or body. If there is no `tickets/`
+directory, the agent prints its findings to output instead of filing.
+
+After both return, print a **consolidated summary**: count of findings by
+severity, grouped by agent.
+
+## 3. Resolve HIGH findings
+
+If any finding is **HIGH**, print the list, **STOP**, and await a human
+"continue". A release does not proceed past an open HIGH finding without
+explicit human go-ahead.
+
+## 4. Update the download URL
+
+- Determine the new tag: the **skill argument** if given, else the current
+  **UTC date** in `YYYY-MM-DD` form.
+- Verify the tag does not already exist: `git tag -l <tag>` must be empty. If
+  it exists, STOP — a release tag is never reused.
+- Run the helper on `README.md` (and on `src/go/assets/integration.md` if that
+  file is present):
+
+  ```bash
+  ~/.claude/skills/release/rewrite-download-url README.md <tag>
+  ```
+
+  The helper rewrites the tag-like segment inside raw-download / release URLs
+  to the new tag and prints a replacement count; it exits non-zero if no such
+  URL is found, so a missing or already-current URL surfaces immediately.
+- Commit the change: `release(<tag>): update download URL to <tag>`.
+
+## 5. GPG signing pause (human-only)
+
+Print **exactly** this command, then end the turn:
+
+```
+git tag -s <tag> HEAD && git push --tags
+```
+
+The human signs the tag with their GPG key and pushes it, then replies to
+resume. The skill never runs this step itself.
+
+## 6. Verify the tag
+
+On resume, confirm the signature:
+
+```bash
+git verify-tag <tag>
+```
+
+If verification fails, print the error and **STOP** — an unverifiable tag is
+not a release.
+
+## 7. Blog post (stub)
+
+File a **deferred** ticket via `/ticket-new` titled
+`Write release blog post for <tag>`. This is a documented placeholder — there
+is no blog implementation until blog infrastructure exists.
+
+## 8. Summary
+
+Print: the tag, the findings count (by severity), whether the download URL was
+updated, and whether the tag verified.
+
+## Language and identity
+
+- Forge-agnostic: "merge request" not the forge-specific term, "ticket" not
+  the tracker-specific term, "forge" for the hosting service.
+- No forge-CLI commands in this prose.
+- The Imperial Dragon is not a bird — no avian analogies. Scale, power,
+  taxonomy.

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -73,8 +73,10 @@ explicit human go-ahead.
   ```
 
   The helper rewrites the tag-like segment inside raw-download / release URLs
-  to the new tag and prints a replacement count; it exits non-zero if no such
-  URL is found, so a missing or already-current URL surfaces immediately.
+  to the new tag and prints a match count; it exits non-zero (with a
+  diagnostic) if **no** such URL is found, so a missing URL surfaces
+  immediately. An already-current URL is a normal match: the helper prints its
+  count and exits 0 (idempotent no-op).
 - Commit the change: `release(<tag>): update download URL to <tag>`.
 
 ## 5. GPG signing pause (human-only)

--- a/skills/release/rewrite-download-url
+++ b/skills/release/rewrite-download-url
@@ -32,7 +32,10 @@ fi
 # Tag-bearing download-URL path segment: /raw/<tag>/ or /download/<tag>/
 pattern='/(raw|download)/([0-9]{4}-[0-9]{2}-[0-9]{2}|v?[0-9]+\.[0-9]+\.[0-9]+)/'
 
-count=$(grep -oE "$pattern" "$file" | wc -l)
+# `|| true`: a no-match makes grep exit 1, which (with set -e + pipefail)
+# would abort the script here and skip the diagnostic below. Swallow it so
+# the explicit zero-count branch runs and prints the message.
+count=$(grep -oE "$pattern" "$file" | wc -l || true)
 
 if [[ "$count" -eq 0 ]]; then
     echo "rewrite-download-url: no tag-bearing download URL found in $file" >&2

--- a/skills/release/rewrite-download-url
+++ b/skills/release/rewrite-download-url
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# rewrite-download-url <file> <new-tag>
+#
+# Rewrites the tag-like segment inside raw-download / release URLs to a new
+# release tag, in place. Forge-generic: matches on path shape, not host.
+# Recognised positions:
+#   .../raw/<tag>/...        (raw file at a ref)
+#   .../download/<tag>/...   (release asset at a ref)
+# Recognised tag shapes:
+#   YYYY-MM-DD date tags, or v?MAJOR.MINOR.PATCH semver.
+#
+# Prints the number of matching URL segments. Exits non-zero if zero match.
+#
+# Exit code keys off "a tag-bearing download URL was FOUND", not "the file
+# changed" — so re-running with the same tag is a content no-op that still
+# exits 0 (idempotent), while a file with no such URL exits non-zero.
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: rewrite-download-url <file> <new-tag>" >&2
+    exit 2
+fi
+
+file="$1"
+new_tag="$2"
+
+if [[ ! -f "$file" ]]; then
+    echo "rewrite-download-url: not a file: $file" >&2
+    exit 2
+fi
+
+# Tag-bearing download-URL path segment: /raw/<tag>/ or /download/<tag>/
+pattern='/(raw|download)/([0-9]{4}-[0-9]{2}-[0-9]{2}|v?[0-9]+\.[0-9]+\.[0-9]+)/'
+
+count=$(grep -oE "$pattern" "$file" | wc -l)
+
+if [[ "$count" -eq 0 ]]; then
+    echo "rewrite-download-url: no tag-bearing download URL found in $file" >&2
+    exit 1
+fi
+
+# `#` delimiter — URLs contain `/`. Replace only the <tag> capture group,
+# keeping the /raw/ or /download/ verb and the trailing path intact.
+sed -E -i "s#/(raw|download)/([0-9]{4}-[0-9]{2}-[0-9]{2}|v?[0-9]+\.[0-9]+\.[0-9]+)/#/\1/${new_tag}/#g" "$file"
+
+echo "$count"

--- a/tests/test_release_rewrite_url.sh
+++ b/tests/test_release_rewrite_url.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Tests for skills/release/rewrite-download-url — rewrites the tag-like
+# segment inside raw-download / release URLs to a new release tag.
+#
+# Exit-code contract (the subtle part):
+#   - exit code keys off "a tag-bearing download URL was FOUND", not
+#     "the file bytes changed". So a second run with the same tag is a
+#     content no-op but still exits 0 (the URL still matches).
+#   - zero matching URLs → exit non-zero.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HELPER="$PWD/skills/release/rewrite-download-url"
+fail=0
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# (a) single download URL pinned to an old date tag → rewritten to new tag.
+f_a="$TMPDIR/single.md"
+cat > "$f_a" <<'MD'
+# Install
+
+    curl -fsSL https://example.com/repo/raw/2026-05-30/install.sh | sh
+MD
+if bash "$HELPER" "$f_a" 2026-06-03 >/dev/null 2>&1; then
+    if grep -q '/raw/2026-06-03/' "$f_a" && ! grep -q '2026-05-30' "$f_a"; then
+        echo "PASS: (a) single URL rewritten to new tag, old tag gone"
+    else
+        echo "FAIL: (a) URL not rewritten correctly"; cat "$f_a"; fail=1
+    fi
+else
+    echo "FAIL: (a) helper exited non-zero on a matching URL"; fail=1
+fi
+
+# (b) two URLs in one file → both rewritten.
+f_b="$TMPDIR/double.md"
+cat > "$f_b" <<'MD'
+Download script: https://example.com/repo/raw/2026-05-30/install.sh
+Download binary: https://example.com/repo/download/2026-05-30/erg
+MD
+if bash "$HELPER" "$f_b" 2026-06-03 >/dev/null 2>&1; then
+    n_new=$(grep -c '2026-06-03' "$f_b")
+    if [[ "$n_new" -eq 2 ]] && ! grep -q '2026-05-30' "$f_b"; then
+        echo "PASS: (b) both URLs rewritten"
+    else
+        echo "FAIL: (b) expected 2 rewrites, found $n_new new / old remaining"; cat "$f_b"; fail=1
+    fi
+else
+    echo "FAIL: (b) helper exited non-zero with two matching URLs"; fail=1
+fi
+
+# (c) no matching download URL → exit non-zero.
+f_c="$TMPDIR/nomatch.md"
+cat > "$f_c" <<'MD'
+# README
+
+No download URL here, just prose and a plain link https://example.com/repo.
+MD
+if bash "$HELPER" "$f_c" 2026-06-03 >/dev/null 2>&1; then
+    echo "FAIL: (c) helper exited zero on a file with no matching URL"; fail=1
+else
+    echo "PASS: (c) helper exits non-zero when no URL matches"
+fi
+
+# (d) idempotence — second run with the same tag exits 0, file unchanged.
+f_d="$TMPDIR/idem.md"
+cat > "$f_d" <<'MD'
+    curl -fsSL https://example.com/repo/raw/2026-06-03/install.sh | sh
+MD
+before=$(cat "$f_d")
+if bash "$HELPER" "$f_d" 2026-06-03 >/dev/null 2>&1; then
+    after=$(cat "$f_d")
+    if [[ "$before" == "$after" ]]; then
+        echo "PASS: (d) idempotent re-run exits 0 and leaves file unchanged"
+    else
+        echo "FAIL: (d) file changed on idempotent re-run"; diff <(echo "$before") <(echo "$after"); fail=1
+    fi
+else
+    echo "FAIL: (d) helper exited non-zero on a URL already at the target tag"; fail=1
+fi
+
+if (( fail )); then
+    exit 1
+fi
+echo "PASS: rewrite-download-url handles single, double, no-match, and idempotent cases"

--- a/tests/test_release_rewrite_url.sh
+++ b/tests/test_release_rewrite_url.sh
@@ -50,17 +50,23 @@ else
     echo "FAIL: (b) helper exited non-zero with two matching URLs"; fail=1
 fi
 
-# (c) no matching download URL → exit non-zero.
+# (c) no matching download URL → exit non-zero AND print a diagnostic.
+# The diagnostic assertion guards against an errexit-on-grep regression where
+# the script aborts before the explicit zero-count branch, silently dropping
+# the "no tag-bearing download URL found" message.
 f_c="$TMPDIR/nomatch.md"
 cat > "$f_c" <<'MD'
 # README
 
 No download URL here, just prose and a plain link https://example.com/repo.
 MD
-if bash "$HELPER" "$f_c" 2026-06-03 >/dev/null 2>&1; then
+c_err="$TMPDIR/nomatch.err"
+if bash "$HELPER" "$f_c" 2026-06-03 >/dev/null 2>"$c_err"; then
     echo "FAIL: (c) helper exited zero on a file with no matching URL"; fail=1
+elif grep -qi 'no tag-bearing download URL' "$c_err"; then
+    echo "PASS: (c) helper exits non-zero and prints a diagnostic when no URL matches"
 else
-    echo "PASS: (c) helper exits non-zero when no URL matches"
+    echo "FAIL: (c) helper exited non-zero but printed no diagnostic"; cat "$c_err"; fail=1
 fi
 
 # (d) idempotence — second run with the same tag exits 0, file unchanged.

--- a/tickets/0187-release-skill-automate-pre-release-audits-sign-tag.erg
+++ b/tickets/0187-release-skill-automate-pre-release-audits-sign-tag.erg
@@ -6,6 +6,7 @@ Author: Claude
 --- log ---
 2026-05-30T19:30Z Claude created — misfiled in git-erg, moved here
 2026-05-30T19:55Z Claude note scope: applies to any git-erg release; skill lives in IDH skills/release/
+2026-06-03T20:08Z claude note implemented skills/release per plan
 
 --- body ---
 ## Context

--- a/tickets/closed/0187-release-skill-automate-pre-release-audits-sign-tag.erg
+++ b/tickets/closed/0187-release-skill-automate-pre-release-audits-sign-tag.erg
@@ -2,12 +2,14 @@
 Title: release skill — automate pre-release audits, sign, tag, update download URL
 Created: 2026-05-30
 Author: Claude
+Closed: autoclosed — PR #240
 
 --- log ---
 2026-05-30T19:30Z Claude created — misfiled in git-erg, moved here
 2026-05-30T19:55Z Claude note scope: applies to any git-erg release; skill lives in IDH skills/release/
 2026-06-03T20:08Z claude note implemented skills/release per plan
 
+2026-06-03T21:14Z MinhHaDuong closed — autoclosed — PR #240
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Adds the `/release` skill encoding the release checklist agreed after git-erg 0181-0184: sign tags at release cadence (not CI cadence) and pin the download URL to the latest signed tag so CI rebuilds never invalidate attested downloads.

- `skills/release/SKILL.md` — pre-flight gate (`make check` + `needs-human` ticket scan, both HALT), two parallel background audit agents (security + UX dry-run, one ticket per finding), HIGH-finding stop, download-URL update, **human-only GPG signing pause** (the skill never signs), `git verify-tag` on resume, deferred blog-post stub, summary. Forge-agnostic prose, no avian analogies.
- `skills/release/rewrite-download-url` — executable bash helper. Rewrites the tag-like segment (date `YYYY-MM-DD` or semver) inside `/raw/<tag>/` and `/download/<tag>/` URL positions, forge-generic (matches path shape, not host). Exit code keys off "a tag-bearing URL was found", not "the file changed" — so re-running with the same tag is idempotent (exits 0, no-op) while a file with no such URL exits non-zero.
- `tests/test_release_rewrite_url.sh` — TDD-first, four cases: single URL, two URLs in one file, no-match (non-zero exit), idempotent re-run. Auto-discovered by `test_bash_suites.py`.
- README catalog regenerated (`make skills-catalog`); `make check-skills-drift` and `check-agnostic.sh` pass.

## Tests

- New suite green (4/4 cases).
- `make check` passes (skills-drift + agnostic-tickets).
- `python3 -m pytest tests/test_bash_suites.py -q`: 8 passed including the new suite. One pre-existing unrelated failure (`test_pretooluse_worktree_path_guard.sh`) confirmed failing on `origin/main` too — out of scope.

**Ticket:** tickets/0187-release-skill-automate-pre-release-audits-sign-tag.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)