### PR TITLE
ticket(0186): erg-pr-merge closes ALL **Ticket:** lines, not just the first

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automaticall
 | `/healthcheck` | Repo healthcheck — git hygiene, test status, and deep freshness verification of status/directive docs. Gracefully degrades when project-specific conventions (git-erg tickets, STATE.md, etc.) are absent. |
 | `/housekeeping` | Repo housekeeping — git sync, healthcheck, eager fix-now repairs, and ticket creation for open-ticket findings. Safe to call interactively or from automated sweeps. |
 | `/memory` | Write, update, or sweep persistent memory. Enforces list caps, TTLs, and staleness criteria. |
-| `/merge` | Atomically close the linked ticket and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI). |
+| `/merge` | Atomically close the linked ticket(s) and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI). |
 | `/nightbeat-report` | Morning review of autonomous nightbeat runs. Parses logs, narrates work done, and surfaces harness improvement opportunities. |
 | `/nightbeat-supervisor` | Continuous autonomous supervisor for nightbeat. Watches beat outcomes, merges ready PRs, diagnoses and repairs failures, escalates when stuck. |
 | `/perch` | Mid-session orientation — summarize what's done, surface unresolved points. Assesses clear-readiness and offers to do the work if conditions are right. |

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge
-description: Atomically close the linked ticket and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI).
+description: Atomically close the linked ticket(s) and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI).
 user-invocable: true
 argument-hint: [pr-number]
 ---

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -12,7 +12,7 @@
 #
 # Happy path:
 #   0. Verify: on PR head branch, CI green, no conflicts
-#   1. Find ticket ID from "Ticket: tickets/NNNN-..." in PR body (or title fallback)
+#   1. Find ticket ID(s) from "Ticket: tickets/NNNN-..." lines in PR body (or title fallback)
 #   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push
 #   2a. Wait for CI to pass on ticket-close commit (timeout 600s)
 #   3. Merge + delete remote branch (forge CLI — harness-extension-point)
@@ -72,27 +72,35 @@ BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
 TITLE=$(gh pr view "$PR" --json title --jq '.title') # harness-extension-point
 
 # Accept: **Ticket:** tickets/NNNN, **Ticket**: tickets/NNNN, Ticket: tickets/NNNN
-TICKET_ID=$(echo "$BODY" | grep -oiP '^\*{0,2}ticket:?\*{0,2}:?\s*tickets/\K\d+' | head -1 || true)
+# A PR may bundle several tickets — collect ALL matching lines. `sort -u` is
+# load-bearing: a duplicated ID would re-close an already-archived ticket in
+# the loop below and abort under `set -e`.
+TICKET_IDS=$(echo "$BODY" | grep -oiP '^\*{0,2}ticket:?\*{0,2}:?\s*tickets/\K\d+' | sort -u || true)
 
 # Fallback: parse feat(NNNN) or ticket(NNNN) from PR title
-if [[ -z "$TICKET_ID" ]]; then
-    TICKET_ID=$(echo "$TITLE" | grep -oP '(?:feat|fix|ticket|chore)\(\K\d+' | head -1 || true)
+if [[ -z "$TICKET_IDS" ]]; then
+    TICKET_IDS=$(echo "$TITLE" | grep -oP '(?:feat|fix|ticket|chore)\(\K\d+' | sort -u || true)
 fi
 
-if [[ -z "$TICKET_ID" ]] && [[ -d tickets ]]; then
-    die "no ticket reference found in PR body or title — add 'Ticket: tickets/NNNN-...' to the PR body"
+if [[ -z "$TICKET_IDS" ]] && [[ -d tickets ]]; then
+    die "no ticket reference found in PR body or title — add one or more 'Ticket: tickets/NNNN-...' lines to the PR body"
 fi
 
 # ── Step 2: close ticket (only if erg project and ticket found) ───────────────
 
 ERG=${ERG:-erg}
-if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; then
-    echo "Closing ticket ${TICKET_ID}..."
-    "$ERG" close "$TICKET_ID" "autoclosed — PR #${PR}"
-    "$ERG" archive "$TICKET_ID" 2>/dev/null || true
+if [[ -n "$TICKET_IDS" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; then
+    CLOSED_LIST=""
+    while IFS= read -r tid; do
+        [[ -z "$tid" ]] && continue
+        echo "Closing ticket ${tid}..."
+        "$ERG" close "$tid" "autoclosed — PR #${PR}"
+        "$ERG" archive "$tid" 2>/dev/null || true
+        CLOSED_LIST="${CLOSED_LIST:+${CLOSED_LIST}, }${tid}"
+    done <<< "$TICKET_IDS"
     git add tickets/ 2>/dev/null || true
     if ! git diff --cached --quiet; then
-        git commit -m "ticket(${TICKET_ID}): close and archive — PR #${PR}"
+        git commit -m "ticket(${CLOSED_LIST}): close and archive — PR #${PR}"
     fi
 
     # Check if this is an erg-only branch (no changes outside tickets/)
@@ -107,8 +115,8 @@ if [[ -n "$TICKET_ID" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; t
         timeout 600 gh pr checks "$PR" --watch --fail-fast \
             || die "CI did not pass within 600s (failed or timed out) — aborting merge"
     fi
-elif [[ -n "$TICKET_ID" ]]; then
-    echo "Note: ticket ${TICKET_ID} found but no erg available — skipping close"
+elif [[ -n "$TICKET_IDS" ]]; then
+    echo "Note: ticket(s) ${TICKET_IDS//$'\n'/, } found but no erg available — skipping close"
 fi
 
 # ── Step 3: merge via forge CLI (works in worktrees and on VMs) ──────────────

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Regression suite for skills/merge/erg-pr-merge multi-ticket close.
+#
+# Builds a self-contained temp repo + git worktree, stubs `gh` on PATH with
+# canned JSON, and runs the real erg-pr-merge script. Asserts that a PR body
+# carrying multiple `**Ticket:**` lines closes and archives ALL of them in one
+# close commit, that a single-ticket PR still works, and that a duplicated
+# Ticket line does not crash (exercises the load-bearing `sort -u` dedup).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT="$REPO_ROOT/skills/merge/erg-pr-merge"
+ERG_BIN="$REPO_ROOT/tickets/erg"
+fail=0
+
+[[ -x "$SCRIPT" ]]  || { echo "FAIL: $SCRIPT not executable"; exit 1; }
+[[ -x "$ERG_BIN" ]] || { echo "FAIL: $ERG_BIN not found";    exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ── gh stub: dispatch by subcommand, emit canned JSON ─────────────────────────
+STUBDIR="$WORK/bin"
+mkdir -p "$STUBDIR"
+cat > "$STUBDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Canned gh: BODY and BRANCH come from the environment set by the harness.
+set -euo pipefail
+case "$1 $2" in
+  "pr view")
+    # find what --json/--jq asked for
+    args="$*"
+    if [[ "$args" == *"--jq"* ]]; then
+      # number-only or title-only single-field --jq queries
+      if [[ "$args" == *"number"* ]]; then echo "$STUB_PR"; exit 0; fi
+      if [[ "$args" == *"title"*  ]]; then echo "$STUB_TITLE"; exit 0; fi
+    fi
+    if [[ "$args" == *"title"* ]]; then
+      jq -n --arg t "$STUB_TITLE" '{title:$t}'; exit 0
+    fi
+    # the big composite query
+    jq -n \
+      --arg n "$STUB_PR" --arg h "$STUB_BRANCH" --arg b "$STUB_BASE" \
+      --arg body "$STUB_BODY" \
+      '{number:($n|tonumber),headRefName:$h,baseRefName:$b,mergeable:"MERGEABLE",statusCheckRollup:[],body:$body}'
+    exit 0 ;;
+  "pr merge")
+    echo "stub: merged $3"; exit 0 ;;
+  "pr checks")
+    echo "stub: checks ok"; exit 0 ;;
+  *)
+    echo "stub gh: unexpected: $*" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$STUBDIR/gh"
+
+# ── seed a standalone repo with open tickets, then a PR branch ────────────────
+# The real erg resolves its tickets/ dir relative to its own binary location
+# (./tickets/erg → ./tickets/), so each fixture repo gets its own erg copy and
+# ERG points at it. Step 4 of the script runs `git checkout <base>` here (the
+# repo is not a linked worktree), so we assert on the committed branch ref —
+# never the working tree.
+# Sets globals: $REPO repo dir, $BRANCH the PR branch, $BASE the base branch,
+# $ERG_LOCAL the per-repo erg path.
+seed_repo() {
+    local name="$1"; shift          # remaining args: ticket numbers to create
+    REPO="$WORK/$name"
+    git init -q "$REPO"
+    git -C "$REPO" config user.email "test@example.com"
+    git -C "$REPO" config user.name  "Test"
+    mkdir -p "$REPO/tickets"
+    cp "$ERG_BIN" "$REPO/tickets/erg"
+    ERG_LOCAL="$REPO/tickets/erg"
+    local n
+    for n in "$@"; do
+        cat > "$REPO/tickets/${n}-fixture.erg" <<ERG
+%erg 0.1
+Title: Fixture ticket ${n}
+Created: 2026-06-03
+Author: test
+
+--- log ---
+2026-06-03T00:00Z test created
+
+--- body ---
+## Context
+Fixture for erg-pr-merge multi-close test.
+ERG
+    done
+    git -C "$REPO" add tickets
+    git -C "$REPO" commit -q -m "init: open tickets"
+    # self as origin so origin/<base> resolves (script line ~99)
+    git -C "$REPO" remote add origin "$REPO"
+    git -C "$REPO" fetch -q origin
+    BASE=$(git -C "$REPO" branch --show-current)
+    BRANCH="pr-$name"
+    git -C "$REPO" switch -q -c "$BRANCH"
+}
+
+run_merge() {  # $1 body, $2 title  — runs the script with cwd in the repo
+    ( cd "$REPO"
+      PATH="$STUBDIR:$PATH" \
+      ERG="$ERG_LOCAL" \
+      STUB_PR="42" STUB_BRANCH="$BRANCH" STUB_BASE="$BASE" \
+      STUB_BODY="$1" STUB_TITLE="$2" \
+      bash "$SCRIPT" 42 )
+}
+
+closed_has() {  # $1 ticket-number -> 0 if archived under tickets/closed/
+    git -C "$REPO" ls-tree -r --name-only "$BRANCH" -- tickets/closed/ \
+        | grep -q "${1}-"
+}
+open_has() {    # $1 ticket-number -> 0 if still a top-level open ticket
+    git -C "$REPO" ls-tree -r --name-only "$BRANCH" -- tickets/ \
+        | grep -v 'tickets/closed/' | grep -q "tickets/${1}-"
+}
+commit_subject() { git -C "$REPO" log -1 --format=%s "$BRANCH"; }
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 1: three Ticket lines -> all three closed + commit names all three
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo three 0181 0182 0183
+BODY1=$'Summary line.\n\n**Ticket:** tickets/0181-fixture.erg\n**Ticket:** tickets/0182-fixture.erg\n**Ticket:** tickets/0183-fixture.erg\n'
+if run_merge "$BODY1" "ticket(0181): multi" >/dev/null 2>&1; then
+    miss=0
+    for n in 0181 0182 0183; do closed_has "$n" || { echo "  not closed: $n"; miss=1; }; done
+    SUBJ=$(commit_subject)
+    for n in 0181 0182 0183; do [[ "$SUBJ" == *"$n"* ]] || { echo "  subject missing $n: $SUBJ"; miss=1; }; done
+    if (( miss )); then echo "FAIL: multi-ticket close incomplete"; fail=1
+    else echo "PASS: three Ticket lines all closed and archived; commit names all three"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on three-ticket PR"; fail=1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 2: single Ticket line -> unchanged behavior
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo single 0190
+BODY2=$'Summary.\n\n**Ticket:** tickets/0190-fixture.erg\n'
+if run_merge "$BODY2" "ticket(0190): solo" >/dev/null 2>&1; then
+    if closed_has 0190 && [[ "$(commit_subject)" == *0190* ]]; then
+        echo "PASS: single Ticket line still closes and archives (no regression)"
+    else
+        echo "FAIL: single-ticket close did not archive 0190"; fail=1
+    fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on single-ticket PR"; fail=1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 3: duplicated Ticket line -> dedup, no crash (exercises sort -u)
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo dup 0195
+BODY3=$'Summary.\n\n**Ticket:** tickets/0195-fixture.erg\n**Ticket:** tickets/0195-fixture.erg\n'
+if run_merge "$BODY3" "ticket(0195): dup" >/dev/null 2>&1; then
+    if closed_has 0195; then
+        echo "PASS: duplicated Ticket line deduped, closed once, no crash"
+    else
+        echo "FAIL: duplicated Ticket line did not close 0195"; fail=1
+    fi
+else
+    echo "FAIL: erg-pr-merge crashed on duplicated Ticket line"; fail=1
+fi
+
+if (( fail )); then exit 1; fi
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe"

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -110,10 +110,6 @@ closed_has() {  # $1 ticket-number -> 0 if archived under tickets/closed/
     git -C "$REPO" ls-tree -r --name-only "$BRANCH" -- tickets/closed/ \
         | grep -q "${1}-"
 }
-open_has() {    # $1 ticket-number -> 0 if still a top-level open ticket
-    git -C "$REPO" ls-tree -r --name-only "$BRANCH" -- tickets/ \
-        | grep -v 'tickets/closed/' | grep -q "tickets/${1}-"
-}
 commit_subject() { git -C "$REPO" log -1 --format=%s "$BRANCH"; }
 
 # ════════════════════════════════════════════════════════════════════════════

--- a/tickets/0186-erg-pr-merge-only-closes-first-ticket-lin.erg
+++ b/tickets/0186-erg-pr-merge-only-closes-first-ticket-lin.erg
@@ -5,7 +5,7 @@ Author: Claude
 
 --- log ---
 2026-05-30T19:45Z Claude created — surfaced in raid 0181-0184 (PR #207 had four tickets; only 0181 auto-closed)
-
+2026-06-03T20:11Z claude note implemented multi-ticket close loop (sort -u dedup, single close commit)
 --- body ---
 ## Context
 

--- a/tickets/0191-doc-propagate-multi-ticket-close-into-rule.erg
+++ b/tickets/0191-doc-propagate-multi-ticket-close-into-rule.erg
@@ -1,0 +1,64 @@
+%erg 0.1
+Title: Propagate multi-ticket close into single-ticket rule prose
+Created: 2026-06-03
+Author: claude
+
+--- log ---
+2026-06-03T20:11Z claude created — follow-up to 0186 multi-ticket close
+
+--- body ---
+## Context
+
+Ticket 0186 changed `skills/merge/erg-pr-merge` to close ALL `**Ticket:**`
+lines in a PR body, not just the first. Two rule files still assert the old
+single-ticket invariant and will read as stale once that change lands:
+
+- `rules/workflow.md` § Ticket discipline: "One PR closes exactly one ticket"
+  and "erg-pr-merge closes whatever ticket appears in the PR body's
+  `**Ticket:**` line — unconditionally". The mechanism described is now plural.
+- `rules/git.md` bullet: "Include a `**Ticket:** tickets/NNNN-...` line in the
+  PR body so erg-pr-merge can auto-close the ticket on merge." Singular line;
+  multiple are now supported.
+
+This is a documentation-only propagation pass. The behavioral change and its
+test already landed under 0186; this ticket only reconciles the prose so the
+rules describe what the script actually does.
+
+## Relevant files
+
+- `rules/workflow.md` — § Ticket discipline for multi-PR work
+- `rules/git.md` — the "Create a merge request" bullet
+
+## Actions
+
+1. In `rules/workflow.md`, reconcile the "one PR closes exactly one ticket"
+   guidance with the new plural behavior. The child-ticket-per-PR convention
+   (split into child tickets before work starts) is still the recommended
+   workflow for review hygiene — keep that intent, but stop asserting that the
+   script can only close one. Note that listing multiple `**Ticket:**` lines
+   now closes all of them on merge.
+2. In `rules/git.md`, update the singular "a `**Ticket:** tickets/NNNN-...`
+   line" wording to allow one or more lines.
+3. Keep wording forge-agnostic (no hardcoded `gh`/GitHub references).
+
+## Test
+
+- `bash scripts/check-agnostic.sh` passes (no forge-specific terms introduced).
+- A grep for "closes exactly one ticket" / "the ticket appears in the PR body's"
+  no longer contradicts the multi-close mechanism.
+
+## Verification
+
+- [ ] `rules/workflow.md` no longer asserts a one-ticket-per-merge mechanism.
+- [ ] `rules/git.md` allows one or more `**Ticket:**` lines.
+- [ ] `bash scripts/check-agnostic.sh` passes.
+
+## Invariants
+
+- Child-ticket-per-PR remains the recommended review-hygiene workflow.
+- No behavioral code change — docs only.
+
+## Exit criteria
+
+- Both rule files describe the actual multi-ticket-close behavior; agnostic
+  guard passes.

--- a/tickets/closed/0186-erg-pr-merge-only-closes-first-ticket-lin.erg
+++ b/tickets/closed/0186-erg-pr-merge-only-closes-first-ticket-lin.erg
@@ -2,10 +2,12 @@
 Title: erg-pr-merge: only closes first **Ticket:** line — loop over all
 Created: 2026-05-30
 Author: Claude
+Closed: autoclosed — PR #242
 
 --- log ---
 2026-05-30T19:45Z Claude created — surfaced in raid 0181-0184 (PR #207 had four tickets; only 0181 auto-closed)
 2026-06-03T20:11Z claude note implemented multi-ticket close loop (sort -u dedup, single close commit)
+2026-06-03T21:10Z MinhHaDuong closed — autoclosed — PR #242
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`skills/merge/erg-pr-merge` extracted the ticket ID with `head -1`, so a PR
that bundled several `**Ticket:**` lines (common in raid waves) closed only
the first ticket — the rest stayed open and needed manual `erg close` +
`erg archive` after merge (this bit PR #207, tickets 0181-0184).

This change collects every matching `**Ticket:**` line via `sort -u`
(`TICKET_ID` → `TICKET_IDS`), applies the same to the title fallback, and
loops close+archive over each ID, accumulating a comma-separated
`CLOSED_LIST` into a single close commit. The `sort -u` dedup is
load-bearing: a duplicated ID would re-close an already-archived ticket and
abort under `set -e`.

## Test

`tests/test_erg_pr_merge.sh` (TDD red-first): stubs `gh`, copies the real
`erg` binary into a temp repo (erg resolves `tickets/` relative to its own
binary location), and asserts all three tickets are archived and named in
the close commit. Single-ticket and duplicated-line regression cases
included; the dup case goes red when `sort -u` is removed (dedup guard
verified). Case 1 was red against the pre-edit script. `make check`,
`check-agnostic.sh`, and the pytest bash-suite wrapper all pass.

**Ticket:** tickets/0186-erg-pr-merge-only-closes-first-ticket-lin.erg

Related follow-up: tickets/0191-doc-propagate-multi-ticket-close-into-rule.erg (doc-propagation: rules/workflow.md and rules/git.md still assert single-ticket-per-PR prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
