### PR TITLE
ticket(0189): PreToolUse guard — block cd-to-primary mutations in worktree sessions

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -41,6 +41,8 @@ During an `EnterWorktree` session, `Edit`/`Write`/`Read` tools accept any absolu
 
 For everything else (source code, manuscript prose, data files): if `git branch --show-current` is `main`, stop and switch to a branch first.
 
+The same trap exists on the Bash surface: prefixing a command with `cd <primary-repo-root> &&` silently lands `git`/`erg` mutations on the primary checkout (on main) instead of the worktree branch. A PreToolUse guard blocks `cd <primary-repo-root> && <mutating git/erg>` during worktree sessions; read-only inspection (`git status`, `git log`) is not penalised, and an intentional primary-repo mutation should use `git -C <path>` rather than a `cd`.
+
 # Escalation Protocol
 
 When stuck, escalate progressively:

--- a/scripts/guard-cd-primary-repo.sh
+++ b/scripts/guard-cd-primary-repo.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+# PreToolUse hook: block `cd <primary-repo-root> && <mutating git/erg>` during a
+# worktree session. In an EnterWorktree session the shell already sits in the
+# worktree and resets there after every command; prefixing `cd ~/<repo> &&`
+# silently cd's into the PRIMARY checkout (on main), so the mutation lands on
+# the wrong tree. Read-only inspection (status/log/diff) is not penalised.
+# See ticket 0189. Sibling of guard-destructive-bash.sh / the worktree-path guard.
+#
+# Exit 0 = allow, exit 2 = block with a stderr message.
+#
+# Fail-OPEN (not fail-closed) when jq is missing: this is a narrow advisory
+# guard against one reflex, not a security boundary — a missed warning is far
+# cheaper than blocking every Bash call on a box without jq. (Contrast
+# guard-destructive-bash.sh, which fails closed because it gates real data loss.)
+#
+# Deliberate YAGNI: only `cd && <git/erg>` is handled. We do NOT inspect
+# `sed -i`, `rm`, or `>>` redirects targeting the primary repo — those are not
+# the observed reflex and would broaden the hot path for little gain.
+
+input=$(cat)
+
+command -v jq &>/dev/null || exit 0
+
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+# Fast path: no `cd` word → nothing to guard. One grep, before the second jq.
+echo "$cmd" | grep -qwP 'cd' || exit 0
+
+cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+[ -z "$cwd" ] && exit 0  # fail-safe: cannot tell if this is a worktree session
+
+# Worktree detection (pure string, no git calls): cwd under .claude/worktrees/.
+case "$cwd" in
+    */.claude/worktrees/*) ;;
+    *) exit 0 ;;
+esac
+# primary_root = the prefix before the worktree marker.
+primary_root="${cwd%%/.claude/worktrees/*}"
+
+# Extract the first `cd <target>` token (before &&, ;, |, or whitespace end).
+# Take the text after the first `cd ` and lop off at the first delimiter.
+rest="${cmd#*cd }"
+target="${rest%%[ ;&|]*}"
+[ -z "$target" ] && exit 0
+
+# Strip surrounding quotes and a trailing slash.
+target="${target#\"}"; target="${target%\"}"
+target="${target#\'}"; target="${target%\'}"
+target="${target%/}"
+
+# Expand leading `~` and a literal `$HOME` using $HOME.
+target="${target/#\~/$HOME}"
+target="${target//\$HOME/$HOME}"
+
+# Only the primary repo root itself is the offence; subtrees (incl. the
+# worktree path, which lives under primary_root) are fine.
+[ "$target" = "$primary_root" ] || exit 0
+
+# Mutating git verbs or erg verbs after the cd → block.
+if echo "$cmd" | grep -qP '\bgit\s+(commit|add|switch|checkout|reset|merge|rebase|push|mv|rm|stash)\b' \
+   || echo "$cmd" | grep -qP '\berg\s+(close|archive)\b'; then
+    echo "BLOCKED: 'cd $target && ...' targets the PRIMARY repo (on main), but this is a worktree session (cwd=$cwd)." >&2
+    echo "The mutation would land on the wrong tree. Either:" >&2
+    echo "  - drop the 'cd' — plain git/erg already operate on the worktree branch, or" >&2
+    echo "  - for an intentional primary-repo op, use: git -C $primary_root ..." >&2
+    exit 2
+fi
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -104,6 +104,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/scripts/guard-cd-primary-repo.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash(git commit*)",
         "hooks": [
           {

--- a/tests/test_guard_cd_primary_repo.sh
+++ b/tests/test_guard_cd_primary_repo.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for scripts/guard-cd-primary-repo.sh — the PreToolUse Bash hook that
+# blocks `cd <primary-repo-root> && <mutating git/erg>` during a worktree
+# session (exit 2 = deny, exit 0 = allow). See ticket 0189.
+#
+# The guard is driven purely via the JSON payload's .cwd field (worktree
+# detection) and .tool_input.command — no test-only backdoor in the script.
+# HOME is pinned so leading-`~` expansion in the guard is deterministic.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HOOK="$PWD/scripts/guard-cd-primary-repo.sh"
+fail=0
+
+PRIMARY="/home/testuser/repo"
+WORKTREE="/home/testuser/repo/.claude/worktrees/t001"
+
+# Feed a Bash tool-input payload (with cwd) to the hook; print "<rc>\t<stderr>".
+# HOME pinned so `cd ~/repo` expands to /home/testuser/repo inside the guard.
+_run() {
+    local cmd="$1" cwd="$2"
+    local err rc
+    err=$(printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
+            "$(printf '%s' "$cmd" | jq -Rs .)" \
+            "$(printf '%s' "$cwd" | jq -Rs .)" \
+            | env HOME=/home/testuser bash "$HOOK" 2>&1 1>/dev/null) && rc=0 || rc=$?
+    printf '%s\t%s' "$rc" "$err"
+}
+
+# Exit code only (stderr discarded).
+_rc() {
+    local out; out=$(_run "$1" "$2")
+    printf '%s' "${out%%$'\t'*}"
+}
+
+_assert_blocked() {
+    local label="$1" cmd="$2" cwd="$3"
+    local rc; rc=$(_rc "$cmd" "$cwd")
+    if [[ "$rc" == "2" ]]; then
+        echo "PASS: blocks $label"
+    else
+        echo "FAIL: expected block (exit 2) for $label; got exit $rc — cmd: $cmd"
+        fail=1
+    fi
+}
+
+_assert_allowed() {
+    local label="$1" cmd="$2" cwd="$3"
+    local rc; rc=$(_rc "$cmd" "$cwd")
+    if [[ "$rc" == "0" ]]; then
+        echo "PASS: allows $label"
+    else
+        echo "FAIL: expected allow (exit 0) for $label; got exit $rc — cmd: $cmd"
+        fail=1
+    fi
+}
+
+# Allowed AND must emit nothing on stderr (the "must be SILENT" cases).
+_assert_allowed_silent() {
+    local label="$1" cmd="$2" cwd="$3"
+    local out rc err
+    out=$(_run "$cmd" "$cwd")
+    rc="${out%%$'\t'*}"
+    err="${out#*$'\t'}"
+    if [[ "$rc" == "0" && -z "$err" ]]; then
+        echo "PASS: allows + silent $label"
+    else
+        echo "FAIL: expected allow (exit 0) + empty stderr for $label; got exit $rc, stderr: '$err' — cmd: $cmd"
+        fail=1
+    fi
+}
+
+# --- BLOCK: cd into PRIMARY then a mutating verb, during a worktree session ---
+_assert_blocked "cd PRIMARY && git commit"     "cd $PRIMARY && git commit -m x"          "$WORKTREE"
+_assert_blocked "cd PRIMARY && git add -A"      "cd $PRIMARY && git add -A"               "$WORKTREE"
+_assert_blocked "cd PRIMARY && git switch -c x" "cd $PRIMARY && git switch -c x"          "$WORKTREE"
+_assert_blocked "cd PRIMARY && git reset HEAD~1" "cd $PRIMARY && git reset HEAD~1"        "$WORKTREE"
+_assert_blocked "cd PRIMARY && git push origin main" "cd $PRIMARY && git push origin main" "$WORKTREE"
+_assert_blocked "cd PRIMARY && erg close 123"   "cd $PRIMARY && erg close 123"            "$WORKTREE"
+_assert_blocked "cd ~/repo && git commit (tilde)" "cd ~/repo && git commit -m x"          "$WORKTREE"
+
+# --- ALLOW ----------------------------------------------------------------
+# Same cd+commit but cwd is the primary repo itself (not a worktree session).
+_assert_allowed "cd PRIMARY && git commit, cwd=PRIMARY (no worktree)" \
+                "cd $PRIMARY && git commit -m x" "$PRIMARY"
+# Bare mutating command inside the worktree — already targets the worktree.
+_assert_allowed "bare git commit in worktree" "git commit -m x" "$WORKTREE"
+# cd that stays inside the worktree tree.
+_assert_allowed "cd into worktree subtree && git commit" \
+                "cd $WORKTREE && git commit -m x" "$WORKTREE"
+# cd into an unrelated dir.
+_assert_allowed "cd /tmp && git commit" "cd /tmp && git commit -m x" "$WORKTREE"
+# Empty command.
+_assert_allowed "empty command" "" "$WORKTREE"
+
+# Read-only cd into PRIMARY must be allowed AND silent (no stderr noise).
+_assert_allowed_silent "cd PRIMARY && git status" "cd $PRIMARY && git status" "$WORKTREE"
+_assert_allowed_silent "cd PRIMARY && git log"    "cd $PRIMARY && git log -1"  "$WORKTREE"
+
+# --- Payload without .cwd → fail-safe allow -------------------------------
+rc=$(printf '{"tool_name":"Bash","tool_input":{"command":"cd /home/testuser/repo && git commit -m x"}}' \
+        | env HOME=/home/testuser bash "$HOOK" >/dev/null 2>&1; echo $?)
+if [[ "$rc" == "0" ]]; then
+    echo "PASS: allows payload with no .cwd (fail-safe)"
+else
+    echo "FAIL: expected allow for payload with no .cwd; got exit $rc"
+    fail=1
+fi
+
+# --- jq missing → fail-open (narrow-scope guard) --------------------------
+_tmpbin=$(mktemp -d)
+ln -s "$(type -P cat)" "$_tmpbin/cat"
+ln -s "$(type -P grep)" "$_tmpbin/grep"
+_real_bash="$(type -P bash)"
+rc=$(printf '{"tool_name":"Bash","tool_input":{"command":"cd /home/testuser/repo && git commit -m x"},"cwd":"/home/testuser/repo/.claude/worktrees/t001"}' \
+        | env PATH="$_tmpbin" HOME=/home/testuser "$_real_bash" "$HOOK" >/dev/null 2>&1; echo $?)
+rm -rf "$_tmpbin"
+if [[ "$rc" == "0" ]]; then
+    echo "PASS: fails open (exit 0) when jq is missing"
+else
+    echo "FAIL: expected fail-open (exit 0) without jq; got exit $rc"
+    fail=1
+fi
+
+if (( fail )); then
+    exit 1
+fi
+echo "PASS: guard-cd-primary-repo blocks cd-to-primary mutations in worktree sessions"

--- a/tickets/0189-worktree-cd-primary-repo-guard.erg
+++ b/tickets/0189-worktree-cd-primary-repo-guard.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-03T13:00Z claude created
+2026-06-03T20:08Z claude note implemented guard + tests + registration per plan
 
 --- body ---
 ## Context

--- a/tickets/0192-worktree-path-guard-test-brittle-in-worktree.erg
+++ b/tickets/0192-worktree-path-guard-test-brittle-in-worktree.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: Make test_pretooluse_worktree_path_guard.sh hermetic when run from a linked worktree
+Created: 2026-06-03
+Author: claude
+
+--- log ---
+2026-06-03T20:21Z claude created — surfaced independently by both 0187 and 0189 raid execute agents
+
+--- body ---
+## Context
+
+`tests/test_pretooluse_worktree_path_guard.sh` (case 4) fails when the
+suite is invoked from inside a linked git worktree, where `.git` is a
+*file* (`gitdir:` pointer) rather than a directory — this trips the
+test's worktree detection heuristic. In CI's fresh checkout `.git` is a
+directory and the suite is green, so the red only appears for agents
+and humans running `pytest tests/test_bash_suites.py` from a worktree
+session — which is the harness's default working mode.
+
+Confirmed pre-existing on `origin/main` (2026-06-03, raid 0186/0187/0189):
+both execute agents hit it independently; neither PR's diff touches the
+failing suite.
+
+## Relevant files
+
+- `tests/test_pretooluse_worktree_path_guard.sh` — case 4 and its
+  worktree-detection helper
+- `tests/test_bash_suites.py` — pytest wrapper that surfaces the red
+- `scripts/pretooluse-worktree-path-guard.sh` — guard under test (only
+  touch if the brittleness is in its own detection)
+
+## Actions
+
+1. Reproduce: run the suite once from a linked worktree (red, case 4)
+   and once from a fresh checkout (green).
+2. Make the test hermetic: derive the fixture's worktree-ness from the
+   fixture paths the test constructs (or pin fixture HOME/cwd), instead
+   of inheriting the invoking checkout's `.git` shape.
+3. If the brittleness turns out to live in the guard script's own
+   detection, fix it there and add a test case covering both `.git`
+   shapes.
+
+## Test
+
+The red step already exists: `bash tests/test_pretooluse_worktree_path_guard.sh`
+from inside any `.claude/worktrees/*` checkout fails case 4 today.
+
+## Verification
+
+- [ ] Suite green when invoked from a linked worktree
+- [ ] Suite green from a fresh checkout (CI environment)
+
+## Invariants
+
+- No behaviour change to `scripts/pretooluse-worktree-path-guard.sh`
+  unless step 3 applies (then a test proves both environments).
+- All other suites in `tests/test_bash_suites.py` stay green.
+
+## Exit criteria
+
+- [ ] `pytest tests/test_bash_suites.py` passes from a linked worktree
+      and from a fresh checkout


### PR DESCRIPTION
## Summary

PreToolUse Bash guard that blocks `cd ~/<repo> && <mutating git/erg verb>`
inside an EnterWorktree session, where the shell already sits in the
worktree. Prefixing `cd ~/<repo> &&` silently cd's into the PRIMARY
checkout (on main), so the mutation lands on the wrong tree. This bit one
autonomous session three times on 2026-06-03 (a 493-file commit on primary
main, a branch created in the wrong repo, pytest run against stale primary
files). A same-session memory did not prevent recurrence — the failure is a
reflex, so a mechanical guard is the right altitude, mirroring the existing
worktree-path Edit/Write guard.

The guard does pure-string worktree detection via the payload `.cwd` (no git
calls in the hot path), extracts the first `cd` target, expands `~`/`$HOME`,
and blocks (exit 2) only when the target equals the primary repo root AND the
command carries a mutating git/erg verb. Read-only inspection (status/log)
passes silently. Fails OPEN when jq is missing — a narrow advisory guard, not
a security boundary.

Also bundles the follow-up ticket 0192 (file only, no fix) per the
bundle-follow-up convention: the worktree-path-guard test brittleness was
surfaced independently by this raid wave's execute agents.

## Tests

- `tests/test_guard_cd_primary_repo.sh`: 17 cases, all green (drives the guard
  purely via JSON payload `.cwd` + pinned HOME — environment-independent, no
  test-only backdoor).

## Note for reviewers

Running `pytest tests/test_bash_suites.py` from inside a linked worktree shows
one pre-existing red: `test_pretooluse_worktree_path_guard.sh` case 4. It is
**not** introduced by this branch (the test file is byte-identical to
origin/main) and is CI-green on a fresh checkout where `.git` is a directory.
Tracked by ticket 0192 — does not block this PR.

**Ticket:** tickets/0189-worktree-cd-primary-repo-guard.erg
