### PR TITLE
tickets(0194-0196): housekeeping-sweep nits — skill/rule drift and GC blind spot

### DIFF
--- a/tickets/0194-housekeeping-skill-commits-directly-on-main.erg
+++ b/tickets/0194-housekeeping-skill-commits-directly-on-main.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: Align housekeeping skill with no-direct-push rule — fixes land via branch + PR
+Created: 2026-06-04
+Author: claude
+
+--- log ---
+2026-06-04T06:10Z claude created — surfaced by interactive /housekeeping after raid 0185-0189
+
+--- body ---
+## Context
+
+`skills/housekeeping/SKILL.md` steps 3 and 6 say to commit fix-now items
+and the STATE timestamp directly, and the interactive-mode note says
+"commit in place as before — no PR detour for hand-typed runs". That
+predates the no-direct-push-to-main policy (PR #231): main is read-only,
+everything lands via branch + PR. Same anti-pattern class as ticket
+0190's finding in skills/ticket-close (which goes further and
+fast-forward-pushes to origin/main).
+
+The 2026-06-04 interactive run already worked around it: fixes rode a
+`housekeeping-YYYYMMDD` branch and merged as PR #246. The skill prose
+should codify that flow so the next agent doesn't direct-commit.
+
+## Relevant files
+
+- `skills/housekeeping/SKILL.md` — steps 3, 6, and the "Beat mode" /
+  interactive-mode notes
+- `rules/workflow.md` § Worktree paths — the policy being violated
+- `tickets/closed/...` 0190 sibling finding for ticket-close
+
+## Actions
+
+1. Rewrite step 3 and step 6: interactive runs cut a
+   `housekeeping-<date>` branch from origin/main, commit fixes +
+   timestamp there, open a merge request, merge after CI.
+2. Keep beat mode unchanged (beat.py already supplies a dedicated
+   branch via BEAT_HOUSEKEEPING_BRANCH).
+3. Cross-check step 2.6 (archive) and 2.5 (auto-close) wording for the
+   same direct-commit assumption.
+
+## Test
+
+Grep-able red step: `grep -n "commit in place" skills/housekeeping/SKILL.md`
+returns a hit today; after the fix it returns none and the prose
+mentions opening a merge request for interactive runs.
+
+## Exit criteria
+
+- [ ] Interactive flow in SKILL.md routes fixes through branch + merge request
+- [ ] Beat mode behaviour unchanged
+- [ ] No "commit in place" wording remains

--- a/tickets/0195-worktree-gc-blind-to-out-of-tree-worktrees.erg
+++ b/tickets/0195-worktree-gc-blind-to-out-of-tree-worktrees.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: worktree-gc: enumerate via git worktree list, not the .claude/worktrees directory
+Created: 2026-06-04
+Author: claude
+
+--- log ---
+2026-06-04T06:10Z claude created — /tmp worktree with stranded ticket 0190 survived GC for hours
+
+--- body ---
+## Context
+
+`scripts/worktree-gc.sh` discovers candidates by scanning the
+`.claude/worktrees/` directory. A worktree created elsewhere — e.g.
+`/tmp/erg-migrate-216/claude-harness` from the 2026-06-03 erg-migrate
+session — is invisible to GC and lingers after its session dies. Cost
+realized on 2026-06-04: that worktree held the only copy of ticket 0190
+(stranded, unmerged commit) and was found by accident during a
+healthcheck, not by GC.
+
+## Relevant files
+
+- `scripts/worktree-gc.sh` — candidate enumeration
+- `tickets/closed/0169-worktree-gc-after-raid.erg` — original GC design
+- `skills/celebrate/SKILL.md` step 9.5, `skills/housekeeping/SKILL.md`
+  step 1.5 — callers
+
+## Actions
+
+1. Enumerate candidates from `git worktree list --porcelain` (every
+   registered worktree except the primary and the invoking one),
+   instead of globbing `.claude/worktrees/`.
+2. Keep existing safety rails: skip dirty worktrees, skip worktrees on
+   branches with unmerged commits (git cherry vs origin default),
+   never rm -rf.
+3. Keep the agent-* fast path if useful, but the registry walk is the
+   source of truth.
+
+## Test
+
+Red step: create a throwaway worktree under /tmp on a merged branch,
+run worktree-gc.sh, assert it is NOT removed today (bug), then assert
+it IS removed after the fix. Shell test mirroring tests/test_*.sh
+conventions, hermetic in a fixture repo.
+
+## Exit criteria
+
+- [ ] GC removes clean, merged worktrees regardless of their path
+- [ ] Dirty or unmerged worktrees still skipped (test covers both)
+- [ ] Callers (celebrate 9.5, housekeeping 1.5) need no wording change

--- a/tickets/0196-stale-branch-snippet-fails-under-rtk.erg
+++ b/tickets/0196-stale-branch-snippet-fails-under-rtk.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Stale-branch cleanup snippet in rules/git.md silently no-ops under rtk
+Created: 2026-06-04
+Author: claude
+
+--- log ---
+2026-06-04T06:10Z claude created — failed twice during raid 0185-0189 cleanup
+
+--- body ---
+## Context
+
+`rules/git.md` documents stale-local-branch cleanup as:
+
+    git branch -vv | awk '/: gone]/{print $1}' | xargs -r git branch -D
+
+Under the rtk hook, `git branch -vv` output is rewritten/summarised, so
+the `: gone]` pattern never matches and the pipeline silently deletes
+nothing. It failed twice on 2026-06-03 (post-#236 cleanup and Phase 7
+cleanup); the working fallback both times was a per-branch probe:
+
+    git merge-base --is-ancestor <branch> origin/main && git branch -d <branch>
+
+(or the PR-number grep probe from healthcheck check 4 for cherry-picked
+content). Silent no-op is the worst failure mode for a documented
+hygiene command — the operator believes cleanup happened.
+
+## Relevant files
+
+- `rules/git.md` — "Delete branches after merge" bullet
+- `skills/healthcheck/SKILL.md` check 4 — already documents the robust probe
+- rtk configuration (out-of-repo) — alternative fix surface
+
+## Actions
+
+1. Decide the fix surface: (a) replace the snippet in rules/git.md with
+   the merge-probe loop (robust under any output rewriting), or (b) add
+   an rtk passthrough for `git branch -vv` so the documented snippet
+   works as written. Prefer (a): rules should not depend on rtk config.
+2. Apply, keeping the "do not -D unverified branches" caveat.
+
+## Test
+
+Not CI-testable (rtk is host config). Verification: run the documented
+snippet on a repo with a known gone-upstream branch under rtk and
+confirm it deletes the branch.
+
+## Exit criteria
+
+- [ ] The documented cleanup command works under rtk (verified manually)
+- [ ] Caveat about unverified -D preserved


### PR DESCRIPTION
Three tickets from the 2026-06-04 housekeeping nit sweep, user-approved:

- **0194** — `/housekeeping` prose still instructs commit-on-main; codify branch+PR (policy from #231; 0190 found the same class in `ticket-close`)
- **0195** — `worktree-gc.sh` enumerates by directory glob, blind to out-of-tree worktrees (the /tmp one that stranded ticket 0190)
- **0196** — `rules/git.md` stale-branch snippet silently no-ops under rtk; replace with the merge-probe loop

Tickets only, no fixes. No `**Ticket:**` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)