### PR TITLE
state: branch-protection backlog item done — ruleset active

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -30,5 +30,4 @@ A reusable, science-backed personal harness for AI-assisted research: code and p
 ## Backlog
 
 - Streamline settings.json hook configuration
-- Enable branch protection requiring `validate-tickets` on main
 - Merge REALF guidelines and business rules


### PR DESCRIPTION
Removes the completed backlog line: repository ruleset `main-required-checks` (id 17254040) now requires all 7 CI checks on main — broader than the backlog's `validate-tickets`-only ask. Non-strict, empty bypass list (`current_user_can_bypass: never`).

This PR is also the ruleset's first live test: merging is now impossible until all 7 checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)