### PR TITLE
ticket(0197): close and archive — PR #249

### DIFF
--- a/tickets/closed/0197-migrate-harness-ticket-store-to-current.erg
+++ b/tickets/closed/0197-migrate-harness-ticket-store-to-current.erg
@@ -2,11 +2,13 @@
 Title: Migrate harness ticket store to current erg (0216 dogfood)
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: harness store migrated; PR #249 merged via GH UI which skips erg-pr-merge's close step
 
 --- log ---
 2026-06-04T06:17Z MinhHaDuong created
 
 2026-06-04T06:18Z claude note migrate refreshed .ergrc+AGENTS.md (not init-preserved); diff inspected: pure template upgrades (mojibake fix, Tag->Label, artifacts-by-path rule, erg-github note), zero authored content lost
+2026-06-04T06:23Z MinhHaDuong closed — harness store migrated; PR #249 merged via GH UI which skips erg-pr-merge's close step
 --- body ---
 ## Context
 Seventh of eight stores in the git-erg 0216 dogfood migration (the most


### PR DESCRIPTION
PR #249 (harness store migration) was merged via the GitHub UI, skipping erg-pr-merge's atomic close. This PR carries only the close-and-archive of ticket 0197. No **Ticket:** auto-close line needed — the close commit is the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)