### PR TITLE
ticket(0198): note — erg-only fast path also needs --auto

### DIFF
--- a/tickets/0198-erg-pr-merge-use-auto-merge.erg
+++ b/tickets/0198-erg-pr-merge-use-auto-merge.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-06-04T08:40Z claude created — enabled by allow_auto_merge + main-required-checks ruleset (both 2026-06-04)
 
+2026-06-04T06:33Z claude note edge from 0216 runs: the erg-only fast path (DIFF_SIZE=0, skips CI wait, plain gh pr merge) is also broken by the main-required-checks ruleset -- ticket-only PRs now bounce at merge until checks pass; apply --auto there too, not only in the CI-wait block
 --- body ---
 ## Context
 


### PR DESCRIPTION
One-line log note on 0198 from today's 0216 migration PRs: the erg-only fast path (skip-CI-wait → plain merge) also bounces under the main-required-checks ruleset; the --auto replacement must cover it too. This PR doubles as the first live test of auto-merge queuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)