### PR TITLE
tickets: erg-pr-merge matcher bug (0199) + push-skip note on 0198

### DIFF
--- a/tickets/0198-erg-pr-merge-use-auto-merge.erg
+++ b/tickets/0198-erg-pr-merge-use-auto-merge.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-06-04T08:40Z claude created — enabled by allow_auto_merge + main-required-checks ruleset (both 2026-06-04)
 
 2026-06-04T06:33Z claude note edge from 0216 runs: the erg-only fast path (DIFF_SIZE=0, skips CI wait, plain gh pr merge) is also broken by the main-required-checks ruleset -- ticket-only PRs now bounce at merge until checks pass; apply --auto there too, not only in the CI-wait block
+2026-06-04T06:47Z claude note live failure PR git-erg#256: the erg-only fast path committed the ticket-close locally and never pushed it before gh pr merge -- the close commit was stranded and the remote branch auto-deleted; the rewrite must push before --auto. Past close commits survived only because non-erg-only PRs hit the push branch.
 --- body ---
 ## Context
 

--- a/tickets/0199-erg-pr-merge-title-fallback-closes-ticke.erg
+++ b/tickets/0199-erg-pr-merge-title-fallback-closes-ticke.erg
@@ -1,0 +1,44 @@
+%erg 0.1
+Title: erg-pr-merge: title fallback closes tickets the PR did not claim
+Created: 2026-06-04
+Author: MinhHaDuong
+
+--- log ---
+2026-06-04T06:47Z MinhHaDuong created
+
+--- body ---
+## Source
+Live failure, git-erg PR #256 (2026-06-04). The PR body deliberately
+carried no `**Ticket:**` line ("0216 stays open until the last two
+stores are done") -- yet erg-pr-merge closed and archived 0216 anyway.
+
+## Context
+Step 1 of skills/merge/erg-pr-merge falls back, when the body has no
+Ticket line, to parsing the PR TITLE: `(?:feat|fix|ticket|chore)\(\K\d+`.
+A conventional title prefix like `chore(0216): log dogfood run` is a
+*subject* reference, not a close claim, but the fallback cannot tell
+the difference. The body's explicit close intent (or its absence) is
+silently overridden.
+
+The rule in workflow.md is the opposite: erg-pr-merge closes whatever
+the `**Ticket:**` line names -- the line IS the claim. A fallback that
+manufactures a claim from the title breaks "one PR closes exactly one
+ticket" in both directions (closes unclaimed tickets; encourages
+omitting the explicit line).
+
+(The companion failure on the same run -- close commit never pushed on
+the erg-only path -- is logged on 0198, whose rewrite owns that block.)
+
+## Fix
+Remove the title fallback. If the body has no `**Ticket:**` line:
+- tickets/ exists: keep the current die() asking for an explicit line,
+  and extend the message: PRs that intentionally close nothing may say
+  `Ticket: none`, which skips Step 2 instead of dying.
+- Update SKILL.md and the workflow.md merge prose accordingly.
+
+## Exit criteria
+- [ ] Title prefixes (feat/fix/ticket/chore(NNNN)) never trigger a close
+- [ ] `Ticket: none` in the body skips the close step without dying
+- [ ] tests/test_erg_pr_merge.sh covers: title-only PR dies with the
+      explicit-line message; `Ticket: none` merges without closing
+- [ ] SKILL.md + rules prose updated


### PR DESCRIPTION
Two live findings from merging git-erg PR #256, see ticket bodies. Ticket-filing only; closes nothing — and per 0199 itself, no **Ticket:** line here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)