### PR TITLE
ticket(0194): housekeeping interactive runs land via branch + merge request

### DIFF
--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -36,7 +36,7 @@ Run full repo housekeeping and act on every finding.
    Exception: `BEAT_HOUSEKEEPING_BRANCH` is set — beat.py manages concurrency itself; skip this guard.
 
 1. **Git phase.**
-   - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(scripts/housekeeping-git.sh)` from the project root.
+   - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(scripts/housekeeping-git.sh)` from the project root. Then cut a dated branch: `git switch -c housekeeping-$(date -u +%Y%m%d) origin/main`. All subsequent commits in this run land on that branch.
    - If `BEAT_HOUSEKEEPING_BRANCH` **is** set (beat.py run): skip — beat.py already ran the git phase before invoking this skill.
 
 1.5. **GC stale agent worktrees.** Remove leftover `agent-*` worktrees whose branch is merged-and-gone (intact dirs that `git worktree prune` misses):
@@ -125,6 +125,8 @@ Run full repo housekeeping and act on every finding.
 
 6. **Timestamp.** Update STATE.md to note the housekeeping run UTC date and time, commit it.
 
+6.5. **Open merge request (interactive run only).** If `BEAT_HOUSEKEEPING_BRANCH` is unset and any commits were created in this run: push the branch (`git push -u origin HEAD`), open a merge request titled `chore: housekeeping sweep <date>`, include a `**Ticket:**` line only if a ticket tracks the run, and enable auto-merge so it lands after CI. If no commits were created: `git switch main && git branch -d housekeeping-$(date -u +%Y%m%d)` and skip the merge request.
+
 7. **Report.** Summarize what you did.
 
 ## Beat mode
@@ -137,5 +139,7 @@ items and the timestamp as usual. Do NOT push or open a PR yourself.
 the branch; if there are commits it leaves the branch locally as a
 "deferred" candidate for human review.
 
-If `BEAT_HOUSEKEEPING_BRANCH` is unset (interactive `/housekeeping`), commit
-in place as before — no PR detour for hand-typed runs.
+If `BEAT_HOUSEKEEPING_BRANCH` is unset (interactive `/housekeeping`), step 1
+cuts a `housekeeping-<date>` branch from origin/main before any commits, and
+step 6.5 pushes it and opens a merge request. All fixes — including the STATE
+timestamp — land via that merge, never directly on main.

--- a/tickets/0194-housekeeping-skill-commits-directly-on-main.erg
+++ b/tickets/0194-housekeeping-skill-commits-directly-on-main.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-04T06:10Z claude created — surfaced by interactive /housekeeping after raid 0185-0189
+2026-06-04T06:49Z claude note implemented branch+MR flow per plan
 
 --- body ---
 ## Context

--- a/tickets/closed/0194-housekeeping-skill-commits-directly-on-main.erg
+++ b/tickets/closed/0194-housekeeping-skill-commits-directly-on-main.erg
@@ -2,11 +2,13 @@
 Title: Align housekeeping skill with no-direct-push rule — fixes land via branch + PR
 Created: 2026-06-04
 Author: claude
+Closed: autoclosed — PR #254
 
 --- log ---
 2026-06-04T06:10Z claude created — surfaced by interactive /housekeeping after raid 0185-0189
 2026-06-04T06:49Z claude note implemented branch+MR flow per plan
 
+2026-06-04T07:53Z MinhHaDuong closed — autoclosed — PR #254
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

The interactive `/housekeeping` flow previously committed fix-now items and the STATE timestamp directly on `main`, violating the no-direct-push policy (PR #231) where main is read-only.

- **Step 1**: after the git phase, interactive runs cut a `housekeeping-<date>` branch from `origin/main`; all subsequent commits land there.
- **New step 6.5**: if any commits were created, push the branch and open a merge request (`chore: housekeeping sweep <date>`) with auto-merge enabled so fixes land after CI. If no commits were created, switch back to main and delete the branch.
- **Trailing note** rewritten: describes the branch + merge-request flow instead of "commit in place".
- Beat mode (BEAT_HOUSEKEEPING_BRANCH) and step 0 are untouched — beat.py still manages its own branch lifecycle.

Verification: `grep -c "commit in place"` → 0, `grep -q "merge request"` → success, `make check` passes, `scripts/check-agnostic.sh` passes.

**Ticket:** tickets/0194-housekeeping-skill-commits-directly-on-main.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)