### PR TITLE
ticket(0192): hermetic worktree-path-guard test — case 4 controls its own fixture

### DIFF
--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -57,9 +57,15 @@ else
     fail=1
 fi
 
-# 4. No worktree active (no env overrides, run from primary repo root where .git is a dir) → silent
-out=$(echo '{"tool_name":"Write","tool_input":{"file_path":"/home/haduong/.claude/src/main.py","content":"x"}}' \
+# 4. No worktree active → silent. Hermetic fixture: a temp dir whose cwd has
+# .git as a real DIRECTORY (not a gitdir: pointer file), so the guard's
+# _in_worktree() returns false regardless of where the suite itself runs from
+# (a linked worktree's .git is a file, which would otherwise trip detection).
+_case4_dir=$(mktemp -d)
+mkdir "$_case4_dir/.git"
+out=$( cd "$_case4_dir" && echo '{"tool_name":"Write","tool_input":{"file_path":"/tmp/unrelated/file.py","content":"x"}}' \
       | bash "$HOOK" 2>&1 || true)
+rm -rf "$_case4_dir"
 if [ -z "$out" ]; then
     echo "PASS: silent when not in a worktree"
 else

--- a/tickets/0192-worktree-path-guard-test-brittle-in-worktree.erg
+++ b/tickets/0192-worktree-path-guard-test-brittle-in-worktree.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-03T20:21Z claude created — surfaced independently by both 0187 and 0189 raid execute agents
+2026-06-04T06:49Z claude note made case 4 hermetic via mktemp fixture with .git directory
 
 --- body ---
 ## Context

--- a/tickets/closed/0192-worktree-path-guard-test-brittle-in-worktree.erg
+++ b/tickets/closed/0192-worktree-path-guard-test-brittle-in-worktree.erg
@@ -2,11 +2,13 @@
 Title: Make test_pretooluse_worktree_path_guard.sh hermetic when run from a linked worktree
 Created: 2026-06-03
 Author: claude
+Closed: autoclosed — PR #255
 
 --- log ---
 2026-06-03T20:21Z claude created — surfaced independently by both 0187 and 0189 raid execute agents
 2026-06-04T06:49Z claude note made case 4 hermetic via mktemp fixture with .git directory
 
+2026-06-04T07:56Z MinhHaDuong closed — autoclosed — PR #255
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`tests/test_pretooluse_worktree_path_guard.sh` case 4 ("silent when not in a worktree") inferred worktree-ness from the invoking checkout's `.git` shape. The suite `cd`'s to the repo root (line 5); in a linked git worktree that root's `.git` is a `gitdir:` pointer **file**, so the guard's `_in_worktree()` returned true, the guard activated, and the main-repo `file_path` tripped a warning where the case expects silence.

This made the suite red for agents and humans running it from a worktree session (the harness's default mode) while staying green in CI's fresh checkout where `.git` is a directory. Independently surfaced by both the 0187 and 0189 raid execute agents.

Fix is in the **test only** — `scripts/pretooluse-worktree-path-guard.sh` is unchanged (ticket invariant). Case 4 now builds a hermetic fixture: a `mktemp` dir with `.git` as a real **directory**, and runs the hook from inside it via a `cd`-subshell (`$HOOK` is absolute, so the `cd` is safe). `_in_worktree()` then returns false regardless of where the suite runs, the guard early-exits before any path logic, and the case is silent as expected.

## Why both exit criteria hold

- **Linked worktree** (the RED environment): proven by RED→GREEN below.
- **Fresh checkout** (CI): true by construction — the fixture's own `.git` directory forces `_in_worktree()` false the same way CI's checkout already does, so the guard never reaches the path branch. The `file_path` value is immaterial once the guard early-exits.

## RED (from a linked worktree, before fix)

```
FAIL: unexpected output when no worktree: Worktree path guard: 'src/main.py'
resolves to the main repo, not the worktree.
Did you mean: /home/haduong/.claude/.claude/worktrees/.../src/main.py
```

## GREEN (after fix)

```
PASS: warns on main-repo path
PASS: silent for worktree-rooted path
PASS: silent for unrelated path
PASS: silent when not in a worktree
PASS: silent when no file_path in payload
PASS: warns on relative path resolved via .cwd into primary repo
PASS: silent for relative path resolved via .cwd into worktree
```

`python3 -m pytest tests/test_bash_suites.py` → 11 passed. `make check` → exit 0.

**Ticket:** tickets/0192-worktree-path-guard-test-brittle-in-worktree.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)