### PR TITLE
ticket(0196): rtk-proof stale-branch cleanup — exit-code probe loop

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -16,7 +16,9 @@
 - **Delete branches after merge.** All repos use `deleteBranchOnMerge: true` on GitHub, so the remote branch disappears automatically when a PR merges. Clean up stale local branches with:
   ```bash
   git fetch --prune
-  git branch -vv | awk '/: gone]/{print $1}' | xargs -r git branch -D
+  for b in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
+    git merge-base --is-ancestor "$b" origin/main && git branch -d "$b"
+  done
   ```
-  The healthcheck's branch hygiene check flags stale locals; this is how to resolve them. Do not use `git branch -D` on a branch whose PR you have not verified is merged.
+  The old `git branch -vv | awk '/: gone]/'` pipeline silently no-ops under rtk output rewriting; the merge-probe loop keys on exit code, not parsed stdout, so it stays robust under any hook. The healthcheck's branch hygiene check flags stale locals; this is how to resolve them. Do not use `git branch -D` on a branch whose PR you have not verified is merged.
 - **Don't gitignore handoff artifacts.** Generated files that a downstream workpackage consumes (figures, tables, macros `\input`ed by the manuscript) are durable state — commit them. Caches, LaTeX aux files, and the final rendered PDF are regenerable — gitignore.

--- a/tickets/0196-stale-branch-snippet-fails-under-rtk.erg
+++ b/tickets/0196-stale-branch-snippet-fails-under-rtk.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-04T06:10Z claude created — failed twice during raid 0185-0189 cleanup
+2026-06-04T06:49Z claude note replaced snippet with exit-code merge-probe loop; manual +/- cases verified
 
 --- body ---
 ## Context

--- a/tickets/closed/0196-stale-branch-snippet-fails-under-rtk.erg
+++ b/tickets/closed/0196-stale-branch-snippet-fails-under-rtk.erg
@@ -2,11 +2,13 @@
 Title: Stale-branch cleanup snippet in rules/git.md silently no-ops under rtk
 Created: 2026-06-04
 Author: claude
+Closed: autoclosed — PR #256
 
 --- log ---
 2026-06-04T06:10Z claude created — failed twice during raid 0185-0189 cleanup
 2026-06-04T06:49Z claude note replaced snippet with exit-code merge-probe loop; manual +/- cases verified
 
+2026-06-04T07:57Z MinhHaDuong closed — autoclosed — PR #256
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

The stale-local-branch cleanup snippet in `rules/git.md` ("Delete branches after merge") used `git branch -vv | awk '/: gone]/' | xargs git branch -D`. Under the rtk hook, `git branch -vv` stdout is rewritten/summarised, so the `: gone]` pattern never matches and the pipeline silently deletes nothing — the worst failure mode for a hygiene command (operator believes cleanup ran). It bit twice during raid cleanup on 2026-06-03.

Replaced the parsed-stdout pipeline with a per-branch merge-probe loop keyed on `git merge-base --is-ancestor` exit code, robust under any output rewriting. Chose this over an rtk passthrough because rules must not depend on host-specific hook config. The `git fetch --prune` line, the healthcheck cross-reference, and the unverified-`-D` caveat are preserved.

## Verification

Manual, in an isolated worktree (not CI-testable — rtk is host config):

- **Negative / safety case:** created `test-unmerged` with an empty commit (not an ancestor of `origin/main`), ran the loop → branch NOT deleted (`git for-each-ref` grep count stayed 1). Confirms the merge-base guard protects unmerged work.
- **Positive case:** created `test-merged` at `origin/main` exactly, ran the loop → branch deleted (grep count 1 → 0). Confirms cleanup works.

The loop keys on exit code, not parsed loop stdout, so rtk's "ok"-summary rewriting does not affect it. `make check` passes (EXIT=0); the `rules/git.md` diff touches only the intended bullet (merge-bounce section lines 13-17 untouched).

Observation (not changed, out of scope): the loop calls `git branch -d` on every ancestor of `origin/main`, including branches checked out in other worktrees; those fail safely with git's worktree-protection / merged-check, so cleanup is harmless.

**Ticket:** tickets/0196-stale-branch-snippet-fails-under-rtk.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)