### PR TITLE
tickets: 0199 note — claim vs reference distinction

### DIFF
--- a/tickets/0199-erg-pr-merge-title-fallback-closes-ticke.erg
+++ b/tickets/0199-erg-pr-merge-title-fallback-closes-ticke.erg
@@ -6,6 +6,7 @@ Author: MinhHaDuong
 --- log ---
 2026-06-04T06:47Z MinhHaDuong created
 
+2026-06-04T06:52Z claude note audit precedent PR #190 (2026-05-13): annotation-only PRs use a Ticket: line as a REFERENCE on a deferred ticket that must stay open -- the fix must distinguish close-claim from reference (e.g. keep **Ticket:** as the claim, add Ticket-ref: or Ticket: none for non-closing references), not merely allow none
 --- body ---
 ## Source
 Live failure, git-erg PR #256 (2026-06-04). The PR body deliberately


### PR DESCRIPTION
One log line on 0199 from the near-close blast-radius audit: annotation PRs (precedent: #190 on deferred 0068) use Ticket: lines as references that must not close. No **Ticket:** line here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)