### PR TITLE
ticket(0195): worktree-gc removes any-path stale worktrees — drop agent-* filter, add self-skip rail

### DIFF
--- a/scripts/worktree-gc.sh
+++ b/scripts/worktree-gc.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# GC stale agent worktrees: remove worktrees named agent-* whose branch is
-# gone from origin (squash-merged + remote-deleted) AND have no uncommitted
-# changes. Never touches dirty worktrees, never uses rm -rf, idempotent.
-# Relies on the caller having run `git fetch --prune` first (housekeeping /
-# celebrate do). Optional arg: repo dir (default: current dir). See ticket 0169.
+# GC stale worktrees: remove any registered worktree (regardless of path or
+# name — including ones outside .claude/worktrees/, e.g. a stranded /tmp
+# worktree) when ALL safety rails pass: the tree is clean (no uncommitted
+# changes), its branch is upstream-gone (merged + remote-deleted), and it is
+# not the worktree this script is invoked from. `git worktree remove` only
+# detaches the worktree — branches and commits survive — and we never rm -rf,
+# so a mistaken removal loses no history. Idempotent. Relies on the caller
+# having run `git fetch --prune` first (housekeeping / celebrate do).
+# Optional arg: repo dir (default: current dir). See tickets 0169, 0195.
 
 repo="${1:-.}"
 removed=0
@@ -21,10 +25,10 @@ flush() {
     [ -z "$path" ] && return
     local base
     base=$(basename "$path")
-    case "$base" in
-        agent-*) ;;
-        *) reset; return ;;
-    esac
+    # Never remove the worktree we are running from (covers the race where a
+    # live session sits on a just-merged, now-gone branch). git worktree list
+    # reports absolute paths; $PWD is absolute, so this compares cleanly.
+    if [ "$path" = "$PWD" ]; then reset; return; fi
     # Never touch a worktree with uncommitted changes (could be user WIP).
     if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
         echo "worktree-gc: skip $base (uncommitted WIP)"

--- a/skills/celebrate/SKILL.md
+++ b/skills/celebrate/SKILL.md
@@ -49,12 +49,12 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
        Refuses (exit 1) when there are uncommitted/untracked files — including a fresh ticket draft `/ticket-new` wrote but never committed. The `Bash(git worktree remove*)` PreToolUse matcher does NOT fire on `ExitWorktree`, so this is the only gate. If it blocks, commit (or `~/.claude/scripts/worktree-salvage.sh`) and re-run. See ticket 0174.
     b. Call `ExitWorktree` with action `remove`.
     Skip if not in a worktree.
-9.5. **GC stale agent worktrees** (from the main repo): prune leftover `agent-*` worktrees whose branch is merged-and-gone — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
+9.5. **GC stale worktrees** (from the main repo): prune any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
     ```bash
     git fetch --prune origin
     ~/.claude/scripts/worktree-gc.sh
     ```
-    Removes only worktrees with no uncommitted changes; never `rm -rf`s, silent when there is nothing to clean. See ticket 0169.
+    Removes only worktrees with no uncommitted changes (and never the one it runs from); never `rm -rf`s, silent when there is nothing to clean. See tickets 0169, 0195.
 10. **Verify hygiene**:
     - `git branch -a` → no stale remote branches
     - Check for stale merge requests

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -39,11 +39,11 @@ Run full repo housekeeping and act on every finding.
    - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(scripts/housekeeping-git.sh)` from the project root. Then cut a dated branch: `git switch -c housekeeping-$(date -u +%Y%m%d) origin/main`. All subsequent commits in this run land on that branch.
    - If `BEAT_HOUSEKEEPING_BRANCH` **is** set (beat.py run): skip — beat.py already ran the git phase before invoking this skill.
 
-1.5. **GC stale agent worktrees.** Remove leftover `agent-*` worktrees whose branch is merged-and-gone (intact dirs that `git worktree prune` misses):
+1.5. **GC stale worktrees.** Remove any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` (intact dirs that `git worktree prune` misses):
    ```bash
    ~/.claude/scripts/worktree-gc.sh
    ```
-   Skips any worktree with uncommitted changes, never `rm -rf`s, silent when there is nothing to clean. Safe here because step 0 already confirmed no other live session, and the git phase above ran `git fetch --prune` so gone branches are detectable. See ticket 0169.
+   Skips any worktree with uncommitted changes (and the one it runs from), never `rm -rf`s, silent when there is nothing to clean. Safe here because step 0 already confirmed no other live session, and the git phase above ran `git fetch --prune` so gone branches are detectable. See tickets 0169, 0195.
 
 2. **Healthcheck.** Invoke /healthcheck. The probe (`project-state.py`)
    runs once inside healthcheck and covers all checks — do not re-run git

--- a/tests/test_worktree_tools.py
+++ b/tests/test_worktree_tools.py
@@ -3,7 +3,10 @@
 Exercises:
   - scripts/worktree-salvage.sh         — commit + push WIP before removal
   - scripts/guard-worktree-remove-wip.sh — PreToolUse guard blocking removal on WIP
-  - scripts/worktree-gc.sh              — GC stale agent-* worktrees
+  - scripts/worktree-gc.sh              — GC stale worktrees (any path/name)
+                                          on upstream-gone branches; rails:
+                                          clean tree, gone branch, not the
+                                          invoking worktree
   - scripts/worktree-exit-preflight.sh  — refuse worktree-exit while there are
                                           uncommitted files (incl. untracked).
                                           Closes the ExitWorktree gap that lost
@@ -27,9 +30,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def run(args, cwd=None, check=True):
-    return subprocess.run(
-        args, cwd=cwd, check=check, capture_output=True, text=True
-    )
+    return subprocess.run(args, cwd=cwd, check=check, capture_output=True, text=True)
 
 
 def git(repo, *args, check=True):
@@ -79,6 +80,7 @@ def make_branch_gone(remote, primary, name):
 # worktree-salvage.sh
 # --------------------------------------------------------------------------- #
 
+
 def test_salvage_commits_and_pushes_wip(origin):
     remote, primary = origin
     wt = make_agent_worktree(primary, "agent-salv", dirty=True)
@@ -115,6 +117,7 @@ def test_salvage_missing_arg_errors(origin):
 # guard-worktree-remove-wip.sh
 # --------------------------------------------------------------------------- #
 
+
 def _guard(cmd, cwd=None):
     body = {"tool_name": "Bash", "tool_input": {"command": cmd}}
     if cwd is not None:
@@ -122,7 +125,9 @@ def _guard(cmd, cwd=None):
     payload = json.dumps(body)
     return subprocess.run(
         ["bash", str(SCRIPTS / "guard-worktree-remove-wip.sh")],
-        input=payload, capture_output=True, text=True,
+        input=payload,
+        capture_output=True,
+        text=True,
     )
 
 
@@ -170,7 +175,9 @@ def test_guard_handles_malformed_json():
     """Bad JSON on stdin should exit cleanly, not abort the script with set -e."""
     res = subprocess.run(
         ["bash", str(SCRIPTS / "guard-worktree-remove-wip.sh")],
-        input="not json{", capture_output=True, text=True,
+        input="not json{",
+        capture_output=True,
+        text=True,
     )
     assert res.returncode == 0
     assert res.stderr == ""
@@ -180,13 +187,16 @@ def test_guard_handles_malformed_json():
 # worktree-gc.sh
 # --------------------------------------------------------------------------- #
 
+
 def _gc(primary):
     return run([str(SCRIPTS / "worktree-gc.sh"), str(primary)])
 
 
 def _worktree_paths(primary):
     out = git(primary, "worktree", "list", "--porcelain").stdout
-    return [l[len("worktree "):] for l in out.splitlines() if l.startswith("worktree ")]
+    return [
+        l[len("worktree ") :] for l in out.splitlines() if l.startswith("worktree ")
+    ]
 
 
 def test_gc_removes_gone_clean_agent_worktree(origin):
@@ -213,21 +223,24 @@ def test_gc_keeps_dirty_worktree(origin):
 
 def test_gc_keeps_live_branch_worktree(origin):
     _, primary = origin
-    wt = make_agent_worktree(primary, "agent-live", dirty=False)  # branch still on origin
+    wt = make_agent_worktree(
+        primary, "agent-live", dirty=False
+    )  # branch still on origin
 
     res = _gc(primary)
     assert res.returncode == 0
     assert str(wt) in _worktree_paths(primary)
 
 
-def test_gc_ignores_non_agent_worktree(origin):
+def test_gc_removes_non_agent_named_worktree_on_gone_branch(origin):
     remote, primary = origin
     wt = make_agent_worktree(primary, "feature-x", dirty=False)
     make_branch_gone(remote, primary, "feature-x")
 
     res = _gc(primary)
     assert res.returncode == 0
-    assert str(wt) in _worktree_paths(primary)
+    assert "removed feature-x" in res.stdout
+    assert str(wt) not in _worktree_paths(primary)
 
 
 def test_gc_silent_when_nothing_to_do(origin):
@@ -235,6 +248,47 @@ def test_gc_silent_when_nothing_to_do(origin):
     res = _gc(primary)
     assert res.returncode == 0
     assert res.stdout.strip() == ""
+
+
+def _out_of_tree_worktree(remote, primary, tmp_path, *, dirty=False):
+    """Register a worktree on branch raid-session-01 at an arbitrary path
+    OUTSIDE .claude/worktrees/ (mirrors /tmp/erg-migrate-216/claude-harness),
+    committed + pushed. Returns its path."""
+    wt = tmp_path / "erg-migrate-test" / "claude-harness"
+    wt.parent.mkdir(parents=True, exist_ok=True)
+    git(primary, "worktree", "add", "-b", "raid-session-01", str(wt))
+    (wt / "work.txt").write_text("first\n")
+    git(wt, "add", "-A")
+    git(wt, "commit", "-m", "work")
+    git(wt, "push", "-u", "origin", "raid-session-01")
+    if dirty:
+        (wt / "work.txt").write_text("uncommitted change\n")
+    return wt
+
+
+def test_gc_removes_out_of_tree_worktree(origin, tmp_path):
+    """The real 0195 bug: a clean, gone-branch worktree at an arbitrary path
+    (not named agent-*, not under .claude/worktrees/) must be removed."""
+    remote, primary = origin
+    wt = _out_of_tree_worktree(remote, primary, tmp_path)
+    make_branch_gone(remote, primary, "raid-session-01")
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert "removed claude-harness" in res.stdout
+    assert str(wt) not in _worktree_paths(primary)
+
+
+def test_gc_keeps_dirty_out_of_tree_worktree(origin, tmp_path):
+    """The dirty rail must still protect an out-of-tree worktree with WIP."""
+    remote, primary = origin
+    wt = _out_of_tree_worktree(remote, primary, tmp_path, dirty=True)
+    make_branch_gone(remote, primary, "raid-session-01")
+
+    res = _gc(primary)
+    assert res.returncode == 0
+    assert "skip claude-harness (uncommitted WIP)" in res.stdout
+    assert str(wt) in _worktree_paths(primary)
 
 
 # --------------------------------------------------------------------------- #
@@ -248,10 +302,12 @@ def test_gc_silent_when_nothing_to_do(origin):
 # and end-session skills before they call ExitWorktree, it refuses when the
 # worktree has any uncommitted state (tracked or untracked).
 
+
 def _preflight(path):
     return subprocess.run(
         [str(SCRIPTS / "worktree-exit-preflight.sh"), str(path)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
 
 
@@ -310,7 +366,9 @@ def test_preflight_defaults_to_cwd(origin):
 
     res = subprocess.run(
         [str(SCRIPTS / "worktree-exit-preflight.sh")],
-        cwd=str(wt), capture_output=True, text=True,
+        cwd=str(wt),
+        capture_output=True,
+        text=True,
     )
     assert res.returncode != 0
     assert "0998-draft.erg" in res.stderr
@@ -319,7 +377,8 @@ def test_preflight_defaults_to_cwd(origin):
 def test_preflight_errors_on_missing_path():
     res = subprocess.run(
         [str(SCRIPTS / "worktree-exit-preflight.sh"), "/no/such/dir"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert res.returncode != 0
 

--- a/tickets/0195-worktree-gc-blind-to-out-of-tree-worktrees.erg
+++ b/tickets/0195-worktree-gc-blind-to-out-of-tree-worktrees.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-06-04T06:10Z claude created — /tmp worktree with stranded ticket 0190 survived GC for hours
+2026-06-04T06:52Z claude note real bug was agent-* basename filter, not enumeration; removed filter + added self-skip rail
 
 --- body ---
 ## Context

--- a/tickets/0201-strip-black-formatter-churn-from-test-wo.erg
+++ b/tickets/0201-strip-black-formatter-churn-from-test-wo.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Strip black-formatter churn from test_worktree_tools.py or adopt it repo-wide
+Created: 2026-06-04
+Author: MinhHaDuong
+
+--- log ---
+2026-06-04T07:53Z MinhHaDuong created
+
+--- body ---
+## Context
+
+PR #258 (ticket 0195) carried black-style formatter churn in
+`tests/test_worktree_tools.py` on functions unrelated to the GC change
+(`_guard`, `_preflight`, ...). The verify-gate assigned it TICKETED
+scope-overflow disposition: harmless but it pollutes blame and makes
+review diffs noisier than their semantic content.
+
+## Actions
+
+1. Decide: either revert the incidental reformatting in
+   `tests/test_worktree_tools.py` to pre-#258 style, or adopt the
+   formatter repo-wide (add it to lint tooling + one bulk-format commit)
+   so per-PR churn can never recur.
+2. Apply the chosen option.
+
+## Test
+
+`git log -p --follow tests/test_worktree_tools.py` — the next functional
+PR touching the file shows no formatting-only hunks.
+
+## Exit criteria
+- [ ] Formatting of tests/ is deliberate (either reverted or adopted repo-wide), not per-PR drift


### PR DESCRIPTION
## Summary

`scripts/worktree-gc.sh` already enumerates candidates via `git worktree list --porcelain` — the ticket's diagnosis (directory-glob enumeration) was a false premise. The real bug was the `case "$base" in agent-*) ;; *) reset; return ;; esac` block: any worktree whose basename was not `agent-*` was silently skipped. That is how `/tmp/erg-migrate-216/claude-harness` lingered for hours holding the only copy of a stranded ticket — registered and gone-branched, but invisible to GC because of its name.

This PR deletes the basename filter so the existing clean + upstream-gone rails govern removal for any path or name, and adds a self-skip rail.

## RED → GREEN evidence

RED (before the fix), new tests failed because the filter made GC a silent no-op:

```
[FAIL] test_gc_removes_out_of_tree_worktree
  assert 'removed claude-harness' in res.stdout
  AssertionError: assert 'removed claude-harness' in ''
[FAIL] test_gc_keeps_dirty_out_of_tree_worktree
  assert 'skip claude-harness (uncommitted WIP)' in res.stdout
  AssertionError: assert 'skip claude-harness (uncommitted WIP)' in ''
```

GREEN (after the fix): `python3 -m pytest tests/test_worktree_tools.py -q` → **23 passed**. Full suite `python3 -m pytest tests/ -q` → **355 passed, 1 failed**; the single failure is the pre-existing `test_pretooluse_worktree_path_guard.sh` (red from inside a worktree, addressed by ticket 0192 in a sibling PR — confirmed it fails identically with this PR's changes stashed, and this PR touches neither that script nor its test).

Tests added/changed:
- `test_gc_removes_out_of_tree_worktree` — clean, gone-branch worktree at an arbitrary `/tmp`-like path on branch `raid-session-01` is removed.
- `test_gc_keeps_dirty_out_of_tree_worktree` — same, but dirty → skipped and preserved.
- `test_gc_ignores_non_agent_worktree` → renamed to `test_gc_removes_non_agent_named_worktree_on_gone_branch` with its final assertion inverted (the old test codified the bug).

## Safety analysis

- **Branches and commits survive removal.** `git worktree remove` only detaches the worktree from the registry; the branch ref and its commits are untouched, and the script never force-deletes directories. A mistaken removal loses no history.
- **Dirty check protects WIP.** The `git status --porcelain` rail runs before removal regardless of path, so any uncommitted work blocks GC and is reported as skipped (covered by `test_gc_keeps_dirty_out_of_tree_worktree`).
- **Self-skip rail closes the invoker race.** Dropping the filter exposes a new race: a live session on a just-merged, now-gone branch could GC its own worktree. The added `[ "$path" = "$PWD" ]` skip prevents GC from removing the worktree it runs from. Note: this rail is **argued, not exercised** by the suite — `_gc(primary)` runs from pytest's cwd, which never equals a fixture worktree path, so the rail never fires in tests. The failure mode it guards is bounded by the history-safety above.

**Ticket:** tickets/0195-worktree-gc-blind-to-out-of-tree-worktrees.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Scope overflow: tickets/0201-strip-black-formatter-churn-from-test-wo.erg — formatter churn ticketed per verify-gate disposition (bundled on this branch, stays open on merge).
