### PR TITLE
feat(0198): erg-pr-merge queues auto-merge, drops the CI-watch loop

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-06-03 -->
+<!-- last-reviewed: 2026-06-04 -->
 # Git Discipline
 
 - **Always work on a branch.** Main is read-only — no exceptions. Everything (code, docs, tickets, STATE, memory, config) lands via branch + PR. See `rules/workflow.md` § Worktree paths.
@@ -11,8 +11,6 @@
 - **Rebase before merge.** Before merging any PR, rebase onto current `origin/main`, push `--force-with-lease`, and wait for CI to pass. This prevents "Base branch was modified" failures mid-merge and keeps history linear.
 - **After an APPROVED `/verify`, sync before merging.** `/verify` may commit and push fixes from its own review worktree, leaving your local branch behind `origin`. Run `git fetch origin && git merge --ff-only origin/<branch>` before you rebase/merge — otherwise a rebase + `--force-with-lease` silently drops the verify fix.
 - **Merge-bounce recovery.** `erg-pr-merge` legitimately bounces in sequence; each bounce has a specific retry — do not blanket-fall back to `gh pr merge`:
-  - *Mergeability `UNKNOWN` / "not mergeable" right after a `--force-with-lease` push or the ticket-close commit* — GitHub is recomputing mergeability/checks. Wait for the live check (`gh run watch <run-id>`), then re-invoke `erg-pr-merge`.
-  - *"CI has N check(s) still running"* — `gh run watch` the pending run to completion, then re-invoke.
   - *"close: no ticket found" on a retry* — the FIRST run already `erg close`d + archived + pushed the close commit (the script is **not** idempotent past that step). Do NOT re-run it and do NOT hand-close the ticket; the close commit is already on the branch, so finish with `gh pr merge <N> --merge` directly once CI is green.
   - *"must run from PR branch" after a fast-forward* — HEAD detached after `merge --ff-only`; `git checkout <branch>`, then retry.
 - **Delete branches after merge.** All repos use `deleteBranchOnMerge: true` on GitHub, so the remote branch disappears automatically when a PR merges. Clean up stale local branches with:

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -19,3 +19,5 @@ and checking out the PR branch before the call. The script itself is
 cwd-based — it never takes a repo or path argument.
 
 Report stdout/stderr verbatim. If the script exits non-zero, stop and show the error.
+
+Merge is queued via auto-merge; it lands when required checks pass (falls back to watch-then-merge where auto-merge is disabled).

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -14,7 +14,7 @@
 #   0. Verify: on PR head branch, CI green, no conflicts
 #   1. Find ticket ID(s) from "Ticket: tickets/NNNN-..." lines in PR body (or title fallback)
 #   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push (always)
-#   3. Queue auto-merge (gh pr merge --merge --auto); falls back to watch-then-merge if auto-merge disabled
+#   3. Queue auto-merge via the forge CLI; falls back to watch-then-merge if auto-merge disabled
 #   4. If not in worktree: git checkout base && git pull --rebase
 
 set -euo pipefail
@@ -131,7 +131,7 @@ if gh pr merge "$PR" "${MERGE_FLAGS[@]}"; then  # harness-extension-point
 else
     # Fallback: repo has auto-merge disabled. Legacy watch-then-merge path
     # so the script stays usable without allow_auto_merge. (ticket 0198)
-    echo "Auto-merge unavailable — falling back to watch-then-merge..."
+    echo "Auto-merge unavailable — falling back to watch-then-merge..."  # harness-extension-point
     timeout 600 gh pr checks "$PR" --watch --fail-fast \
         || die "CI did not pass within 600s (failed or timed out) — aborting merge"  # harness-extension-point
     if in_worktree; then

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -13,9 +13,8 @@
 # Happy path:
 #   0. Verify: on PR head branch, CI green, no conflicts
 #   1. Find ticket ID(s) from "Ticket: tickets/NNNN-..." lines in PR body (or title fallback)
-#   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push
-#   2a. Wait for CI to pass on ticket-close commit (timeout 600s)
-#   3. Merge + delete remote branch (forge CLI — harness-extension-point)
+#   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push (always)
+#   3. Queue auto-merge (gh pr merge --merge --auto); falls back to watch-then-merge if auto-merge disabled
 #   4. If not in worktree: git checkout base && git pull --rebase
 
 set -euo pipefail
@@ -103,37 +102,52 @@ if [[ -n "$TICKET_IDS" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; 
         git commit -m "ticket(${CLOSED_LIST}): close and archive — PR #${PR}"
     fi
 
-    # Check if this is an erg-only branch (no changes outside tickets/)
-    DIFF_SIZE=$(git diff origin/${BASE_BRANCH}...HEAD -- . ':(exclude)tickets/' | wc -c)
-
-    if [[ "$DIFF_SIZE" -eq 0 ]]; then
-        echo "Erg-only branch detected — skipping CI wait (no code changes)"
-    else
-        git push origin HEAD
-        echo "Waiting for CI after ticket-close commit..."
-        # harness-extension-point
-        timeout 600 gh pr checks "$PR" --watch --fail-fast \
-            || die "CI did not pass within 600s (failed or timed out) — aborting merge"
-    fi
+    # Push the close commit unconditionally. The erg-only fast path used to
+    # skip this push, stranding the close commit locally — it was lost when
+    # the remote branch auto-deleted on merge (git-erg#256, ticket 0198).
+    git push origin HEAD
 elif [[ -n "$TICKET_IDS" ]]; then
     echo "Note: ticket(s) ${TICKET_IDS//$'\n'/, } found but no erg available — skipping close"
 fi
 
-# ── Step 3: merge via forge CLI (works in worktrees and on VMs) ──────────────
-
-echo "Merging PR #${PR}..."
+# ── Step 3: queue auto-merge via forge CLI (works in worktrees and on VMs) ────
+#
+# --auto lets GitHub gate on required checks itself: the PR lands when checks
+# go green (or immediately if none are required). No more CI babysitting.
+# (ticket 0198)
+#
+# in_worktree: deleteBranchOnMerge cleans the remote; the local --delete-branch
+# flag would fail on the primary worktree's main-lock (ticket 0170).
+echo "Queueing merge for PR #${PR}..."
 if in_worktree; then
-    # deleteBranchOnMerge cleans the remote; the local flag would fail
-    # on the primary worktree's main-lock (see ticket 0170).
-    gh pr merge "$PR" --merge # harness-extension-point
+    MERGE_FLAGS=(--merge --auto)
 else
-    gh pr merge "$PR" --merge --delete-branch # harness-extension-point
+    MERGE_FLAGS=(--merge --auto --delete-branch)
+fi
+
+if gh pr merge "$PR" "${MERGE_FLAGS[@]}"; then  # harness-extension-point
+    echo "Merge queued; lands when required checks pass."
+    AUTO_QUEUED=1
+else
+    # Fallback: repo has auto-merge disabled. Legacy watch-then-merge path
+    # so the script stays usable without allow_auto_merge. (ticket 0198)
+    echo "Auto-merge unavailable — falling back to watch-then-merge..."
+    timeout 600 gh pr checks "$PR" --watch --fail-fast \
+        || die "CI did not pass within 600s (failed or timed out) — aborting merge"  # harness-extension-point
+    if in_worktree; then
+        gh pr merge "$PR" --merge          # harness-extension-point
+    else
+        gh pr merge "$PR" --merge --delete-branch  # harness-extension-point
+    fi
+    AUTO_QUEUED=0
 fi
 
 # ── Step 4: return to base branch (skipped inside a worktree) ────────────────
 
 if in_worktree; then
-    echo "In git worktree — skipping checkout of ${BASE_BRANCH}; exit the worktree when done."
+    echo "In git worktree — exit the worktree when done."
+elif [[ "${AUTO_QUEUED:-0}" -eq 1 ]]; then
+    echo "Auto-merge queued — leaving local ${BASE_BRANCH} untouched; sync after the PR lands."
 else
     git checkout "$BASE_BRANCH"
     # Safe fast-forward: skip when local branch has unpushed commits

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -45,8 +45,14 @@ case "$1 $2" in
       '{number:($n|tonumber),headRefName:$h,baseRefName:$b,mergeable:"MERGEABLE",statusCheckRollup:[],body:$body}'
     exit 0 ;;
   "pr merge")
+    echo "$*" >> "${STUB_MERGE_LOG:-/dev/null}"
+    if [[ "$*" == *"--auto"* && "${STUB_AUTO_FAILS:-0}" == "1" ]]; then
+      echo "stub: auto-merge not allowed for this repository" >&2
+      exit 1
+    fi
     echo "stub: merged $3"; exit 0 ;;
   "pr checks")
+    echo "$*" >> "${STUB_CHECKS_LOG:-/dev/null}"
     echo "stub: checks ok"; exit 0 ;;
   *)
     echo "stub gh: unexpected: $*" >&2; exit 1 ;;
@@ -91,6 +97,10 @@ ERG
     git -C "$REPO" commit -q -m "init: open tickets"
     # self as origin so origin/<base> resolves (script line ~99)
     git -C "$REPO" remote add origin "$REPO"
+    # The script now pushes the close commit unconditionally (ticket 0198).
+    # origin is the repo itself with $BRANCH checked out, so allow pushing to
+    # the current branch of this non-bare self-origin (deviation: fixture-only).
+    git -C "$REPO" config receive.denyCurrentBranch ignore
     git -C "$REPO" fetch -q origin
     BASE=$(git -C "$REPO" branch --show-current)
     BRANCH="pr-$name"
@@ -103,6 +113,9 @@ run_merge() {  # $1 body, $2 title  — runs the script with cwd in the repo
       ERG="$ERG_LOCAL" \
       STUB_PR="42" STUB_BRANCH="$BRANCH" STUB_BASE="$BASE" \
       STUB_BODY="$1" STUB_TITLE="$2" \
+      STUB_AUTO_FAILS="${STUB_AUTO_FAILS:-0}" \
+      STUB_MERGE_LOG="${STUB_MERGE_LOG:-/dev/null}" \
+      STUB_CHECKS_LOG="${STUB_CHECKS_LOG:-/dev/null}" \
       bash "$SCRIPT" 42 )
 }
 
@@ -156,6 +169,62 @@ if run_merge "$BODY3" "ticket(0195): dup" >/dev/null 2>&1; then
     fi
 else
     echo "FAIL: erg-pr-merge crashed on duplicated Ticket line"; fail=1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 4: auto-merge happy path — queues --auto, no CI-watch poll (ticket 0198)
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo automerge 0196
+MLOG="$WORK/merge4.log"; CLOG="$WORK/checks4.log"
+: > "$MLOG"; : > "$CLOG"
+BODY4=$'Summary.\n\n**Ticket:** tickets/0196-fixture.erg\n'
+if STUB_AUTO_FAILS=0 STUB_MERGE_LOG="$MLOG" STUB_CHECKS_LOG="$CLOG" \
+   run_merge "$BODY4" "ticket(0196): auto" >/dev/null 2>&1; then
+    auto_miss=0
+    grep -q -- '--auto' "$MLOG" || { echo "  merge log has no --auto"; auto_miss=1; }
+    grep -q -- '--watch' "$CLOG" && { echo "  checks log unexpectedly watched"; auto_miss=1; }
+    if (( auto_miss )); then echo "FAIL: auto-merge happy path did not queue --auto / watched CI"; fail=1
+    else echo "PASS: auto-merge queued (--auto), no CI-watch poll"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on auto-merge happy path"; fail=1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 5: fallback — auto-merge disabled -> watch-then-merge (ticket 0198)
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo fallback 0197
+MLOG="$WORK/merge5.log"; CLOG="$WORK/checks5.log"
+: > "$MLOG"; : > "$CLOG"
+BODY5=$'Summary.\n\n**Ticket:** tickets/0197-fixture.erg\n'
+if STUB_AUTO_FAILS=1 STUB_MERGE_LOG="$MLOG" STUB_CHECKS_LOG="$CLOG" \
+   run_merge "$BODY5" "ticket(0197): fallback" >/dev/null 2>&1; then
+    fb_miss=0
+    grep -q -- '--auto' "$MLOG" || { echo "  no --auto attempt logged"; fb_miss=1; }
+    grep -q -- '--watch' "$CLOG" || { echo "  fallback did not watch checks"; fb_miss=1; }
+    # A bare --merge (no --auto) must have been issued after the watch.
+    grep -v -- '--auto' "$MLOG" | grep -q -- '--merge' \
+        || { echo "  no plain --merge after fallback"; fb_miss=1; }
+    if (( fb_miss )); then echo "FAIL: fallback path incomplete"; fail=1
+    else echo "PASS: fallback to watch-then-merge when auto-merge disabled"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on fallback path"; fail=1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 6: close commit pushed before merge — erg-only branch (git-erg#256)
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo strand 0199
+MLOG="$WORK/merge6.log"; CLOG="$WORK/checks6.log"
+: > "$MLOG"; : > "$CLOG"
+BODY6=$'Summary.\n\n**Ticket:** tickets/0199-fixture.erg\n'
+if STUB_AUTO_FAILS=0 STUB_MERGE_LOG="$MLOG" STUB_CHECKS_LOG="$CLOG" \
+   run_merge "$BODY6" "ticket(0199): strand" >/dev/null 2>&1; then
+    git -C "$REPO" rev-parse --verify "origin/$BRANCH" >/dev/null 2>&1 \
+      && git -C "$REPO" merge-base --is-ancestor "$(git -C "$REPO" rev-parse "$BRANCH")" "$(git -C "$REPO" rev-parse "origin/$BRANCH")" \
+      && echo "PASS: close commit pushed before merge (no strand)" \
+      || { echo "FAIL: close commit not pushed before merge"; fail=1; }
+else
+    echo "FAIL: erg-pr-merge exited non-zero on erg-only strand case"; fail=1
 fi
 
 if (( fail )); then exit 1; fi

--- a/tickets/0198-erg-pr-merge-use-auto-merge.erg
+++ b/tickets/0198-erg-pr-merge-use-auto-merge.erg
@@ -8,6 +8,7 @@ Author: claude
 
 2026-06-04T06:33Z claude note edge from 0216 runs: the erg-only fast path (DIFF_SIZE=0, skips CI wait, plain gh pr merge) is also broken by the main-required-checks ruleset -- ticket-only PRs now bounce at merge until checks pass; apply --auto there too, not only in the CI-wait block
 2026-06-04T06:47Z claude note live failure PR git-erg#256: the erg-only fast path committed the ticket-close locally and never pushed it before gh pr merge -- the close commit was stranded and the remote branch auto-deleted; the rewrite must push before --auto. Past close commits survived only because non-erg-only PRs hit the push branch.
+2026-06-04T07:11Z claude note implemented: unconditional push + --auto queue + exit-code fallback + Step-4 gate; tests 6 pass
 --- body ---
 ## Context
 

--- a/tickets/closed/0198-erg-pr-merge-use-auto-merge.erg
+++ b/tickets/closed/0198-erg-pr-merge-use-auto-merge.erg
@@ -2,6 +2,7 @@
 Title: erg-pr-merge: queue auto-merge after the close commit, drop the CI-watch loop
 Created: 2026-06-04
 Author: claude
+Closed: autoclosed — PR #259
 
 --- log ---
 2026-06-04T08:40Z claude created — enabled by allow_auto_merge + main-required-checks ruleset (both 2026-06-04)
@@ -9,6 +10,7 @@ Author: claude
 2026-06-04T06:33Z claude note edge from 0216 runs: the erg-only fast path (DIFF_SIZE=0, skips CI wait, plain gh pr merge) is also broken by the main-required-checks ruleset -- ticket-only PRs now bounce at merge until checks pass; apply --auto there too, not only in the CI-wait block
 2026-06-04T06:47Z claude note live failure PR git-erg#256: the erg-only fast path committed the ticket-close locally and never pushed it before gh pr merge -- the close commit was stranded and the remote branch auto-deleted; the rewrite must push before --auto. Past close commits survived only because non-erg-only PRs hit the push branch.
 2026-06-04T07:11Z claude note implemented: unconditional push + --auto queue + exit-code fallback + Step-4 gate; tests 6 pass
+2026-06-04T07:20Z MinhHaDuong closed — autoclosed — PR #259
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`erg-pr-merge` no longer babysits CI. It now:
- Pushes the ticket-close commit **unconditionally** (drops the erg-only fast path that skipped the push and stranded the close commit — git-erg#256).
- Queues the merge with `gh pr merge --merge --auto`, letting GitHub's `main-required-checks` ruleset gate the landing. The `--auto` call is the condition of an `if` so the exit code drives a fallback.
- **Fallback** for repos without `allow_auto_merge`: the legacy `timeout 600 gh pr checks --watch` then plain `gh pr merge`.
- **Step 4 gating**: the return-to-base fast-forward now runs only on the fallback path. With `--auto` the merge is deferred, so fast-forwarding the local base immediately would be wrong; instead it prints a sync-after-it-lands note.
- Prunes the two CI-race bullets (mergeability `UNKNOWN`, "N checks still running") from the `rules/git.md` merge-bounce recovery section; keeps the idempotency and detached-HEAD bullets. Stamp bumped to 2026-06-04.
- Adds a one-line note to `skills/merge/SKILL.md`.

## Test plan

`bash tests/test_erg_pr_merge.sh` — 3 pre-existing cases unchanged, 3 new cases added (RED-verified against the unmodified script, GREEN after the edits):

1. **Auto-merge happy path** — asserts the merge log contains `--auto` and the checks log has NO `--watch` line (no CI poll).
2. **Fallback** — `STUB_AUTO_FAILS=1`: asserts a `--auto` attempt was made, the checks log was watched (`--watch`), and a plain `--merge` (without `--auto`) followed (`grep -v -- '--auto' | grep -q -- '--merge'`, not a tautological grep).
3. **Push-before-merge regression** (git-erg#256 strand) — erg-only branch: asserts `origin/$BRANCH` exists and `$BRANCH` is an ancestor of it, proving the close commit was pushed before the merge.

Fixture deviation (justified): added `git config receive.denyCurrentBranch ignore` in `seed_repo` because the close commit is now pushed unconditionally to the self-origin whose `$BRANCH` is checked out. Without it the real push would be refused and abort under `set -e`. This is also what makes case 3 assertable (the push is real).

`make check` passes (skills-drift + agnostic-tickets). The one failing entry in `test_bash_suites.py` (`test_pretooluse_worktree_path_guard.sh`) is a pre-existing, environment-specific failure byte-identical to `origin/main`, unrelated to this change.

**Ticket:** tickets/0198-erg-pr-merge-use-auto-merge.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)