### PR TITLE
tickets(0205-0208): external-reviewer panel tree

### DIFF
--- a/tickets/0205-external-reviewer-panel-for-verify-contr.erg
+++ b/tickets/0205-external-reviewer-panel-for-verify-contr.erg
@@ -1,0 +1,63 @@
+%erg 0.1
+Title: External-reviewer panel for verify — contract, decorrelation rule, trial tracker
+Created: 2026-06-04
+Author: MinhHaDuong
+Blocked-by: 0206
+Blocked-by: 0207
+Blocked-by: 0208
+
+--- log ---
+2026-06-04T08:41Z MinhHaDuong created
+
+--- body ---
+## Context
+
+The verify panel is single-vendor: every member (adherence, review-pr,
+simplify, gate) is a Claude model orchestrating itself, and the 0193
+incident catalog (9 incidents, 2026-06-03/04) shows they share failure
+modes. Author directive (2026-06-04, imagine-copilot session): add
+externally-decorrelated reviewers behind one contract. TRACKING TICKET —
+stays open until children merge + integration review (celebrate step 7).
+
+## Children
+
+- tickets/0206 — Copilot review (forge bot; subscription confirmed)
+- tickets/0207 — aider adapter (OpenRouter + llama-server configs)
+- tickets/0208 — reviewer-management helper skill
+
+## Design rules (bind the children)
+
+1. **Contract**: every external reviewer yields findings in the gate's
+   comment shape (`verifiable:` / `consider:` + file:line + rationale).
+   The gate dispositions all reviewers identically.
+2. **Advisory → required**: each new reviewer runs advisory (logged,
+   only verifiable-class findings may bounce) for an observation period
+   of **at least 5 merge requests spanning at least 3 projects** before
+   promotion to required disposition in the gate.
+3. **Decorrelation rule rewording** (this ticket's own change), replacing
+   the "Sonnet reviews Opus" instance in rules/workflow.md § Subagents:
+   "Reviewer decorrelation. The verify panel never shares the coding
+   agent's model. Minimum: the sibling tier of the same family.
+   Stronger: a different vendor or harness entirely (forge review bot,
+   independent CLI agent, local model). Prefer the most-decorrelated
+   reviewer available for the change's risk level."
+4. **Helper naming exception** (author, 2026-06-04): helper skills and
+   scripts that wrap a concrete tool are NAMED for that tool (copilot,
+   aider, llama-server) — the forge/stack-agnostic language rule applies
+   to generic skill prose, not to tool-specific helpers. Mechanical
+   agnostic-guard patterns still require `<!-- harness-extension-point -->`
+   escape hatches where literals appear under skills/.
+
+## Actions
+
+1. Land the decorrelation rewording in rules/workflow.md.
+2. Record the contract (finding shape, advisory protocol, observation
+   period) in skills/verify/SKILL.md as the panel-extension section.
+3. After children merge: integration review across ≥5 trial MRs / ≥3
+   projects; promote or drop each reviewer; close this tracker.
+
+## Exit criteria
+
+- [ ] Decorrelation rule reworded (agnostic, gradient stated)
+- [ ] Panel-extension contract documented in skills/verify/SKILL.md
+- [ ] All children merged; trial scorecards reviewed; promote/drop decided

--- a/tickets/0206-copilot-review-in-the-verify-panel-auto.erg
+++ b/tickets/0206-copilot-review-in-the-verify-panel-auto.erg
@@ -1,0 +1,51 @@
+%erg 0.1
+Title: Copilot review in the verify panel — auto-request, gate harvest, advisory trial
+Created: 2026-06-04
+Author: MinhHaDuong
+Blocked-by: 0193
+
+--- log ---
+2026-06-04T08:41Z MinhHaDuong created
+
+--- body ---
+## Context
+
+Child of tickets/0205 (external-reviewer panel). GitHub Copilot code
+review = cross-vendor reviewer at zero token cost, server-side, async.
+Subscription confirmed (author, 2026-06-04). Copilot comments but never
+approves, so "required" is enforced as a verify-gate disposition
+precondition, never a forge approval rule.
+
+## Relevant files
+
+- skills/verify/SKILL.md — setup phase + gate-inputs clause
+- Forge settings — auto-request lever (repo setting or ruleset
+  parameter; identify exact mechanism at implementation)
+- tickets/0205 — contract + observation-period definition
+
+## Actions
+
+1. Enable auto-request of Copilot review on every merge request
+   (forge-side config; document the exact lever in this ticket's log).
+2. skills/verify/SKILL.md: (a) setup notes the forge-review status;
+   (b) gate's comment-validation step includes "the forge's automated
+   reviewer, when present" — findings dispositioned like any panel
+   comment; correctness-class only may bounce, style is noted-not-blocking.
+   If the review is pending when all else is ready: bounded wait
+   (few minutes), then proceed with a logged WARN — fail-open.
+   GitHub-specific mechanics carry <!-- harness-extension-point -->.
+3. Advisory trial per 0205: at least 5 merge requests across at least
+   3 projects; log a one-line scorecard per MR (findings, true/false
+   positives) in this ticket.
+
+## Test
+
+First MR of the trial shows a harvested Copilot comment dispositioned
+in the gate verdict's evidence table.
+
+## Exit criteria
+
+- [ ] Auto-request live; lever documented
+- [ ] Gate clause merged (advisory disposition, fail-open pending-wait)
+- [ ] Trial scorecard: ≥5 MRs, ≥3 projects, logged here
+- [ ] Promote/drop recommendation recorded for 0205's integration review

--- a/tickets/0207-aider-as-external-verifier-one-adapter-o.erg
+++ b/tickets/0207-aider-as-external-verifier-one-adapter-o.erg
@@ -1,0 +1,58 @@
+%erg 0.1
+Title: aider as external verifier — one adapter, OpenRouter and llama-server configs
+Created: 2026-06-04
+Author: MinhHaDuong
+Blocked-by: 0193
+
+--- log ---
+2026-06-04T08:41Z MinhHaDuong created
+
+--- body ---
+## Context
+
+Child of tickets/0205. aider driven as a read-only reviewer gives
+vendor+harness decorrelation; pointing the same adapter at llama-server
+adds a fully local, free, private reviewer. Both speak OpenAI-compatible
+endpoints, so the experiment matrix is configuration, not code:
+{adapter: aider} x {endpoint: OpenRouter-hosted model, local llama-server}.
+Helper is tool-NAMED per the 0205 naming exception.
+
+## Credential path (decided before implementation, per standing rule)
+
+OPENROUTER_API_KEY loads via the BASH_ENV -> bash-env.sh pattern — never
+argv, never CLAUDE_ENV_FILE (argv leaks to ps -ef). llama-server endpoint
+is plain config (host:port), no secret.
+
+## Relevant files
+
+- skills/verify/SKILL.md — panel-extension section (from 0205)
+- new helper: skills/verify/external-review-aider (tool-named; pure I/O:
+  PR ref in, findings file out; no model API calls hand-rolled — aider is
+  the engine)
+- ~/.claude/scripts/bash-env.sh — credential loading reference
+
+## Actions
+
+1. Helper `external-review-aider <pr-number> --endpoint <url> --model <id>`:
+   temp read-only checkout of the MR branch, drive aider with a review
+   prompt over the diff, normalize output to the 0205 contract shape
+   (verifiable:/consider: + file:line), write findings file, exit.
+2. Smoke both configs manually on one merged PR (no gate wiring yet):
+   record model used, latency, finding quality in this ticket's log.
+3. Wire as advisory panel member per 0205's contract (gate dispositions
+   findings; only verifiable-class may bounce).
+4. Advisory trial: at least 5 merge requests across at least 3 projects
+   PER CONFIG (OpenRouter, llama-server) — scorecard lines in this log.
+
+## Test
+
+Helper unit test (tests/test_external_review_aider.sh): stub aider on
+PATH emitting canned review text; assert normalized findings file shape
+and non-zero exit when the endpoint is unreachable (fail-loud).
+
+## Exit criteria
+
+- [ ] Helper exists, tool-named, credentials via BASH_ENV path only
+- [ ] Both endpoint configs smoke-tested and logged
+- [ ] Advisory trial: ≥5 MRs, ≥3 projects per config, scorecards logged
+- [ ] Promote/drop recommendation recorded for 0205's integration review

--- a/tickets/0208-reviewer-management-helper-skill-request.erg
+++ b/tickets/0208-reviewer-management-helper-skill-request.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: Reviewer-management helper skill — request, harvest, normalize, scorecard
+Created: 2026-06-04
+Author: MinhHaDuong
+
+--- log ---
+2026-06-04T08:41Z MinhHaDuong created
+
+--- body ---
+## Context
+
+Child of tickets/0205. With three reviewer kinds (forge bot, aider
+endpoints, sibling Claude tier), panel membership and trial bookkeeping
+need a management surface so verify stays thin. Author directive
+(2026-06-04): "add helper skills for reviewers management". Helpers are
+tool-named where they wrap one tool (0205 naming exception); the
+umbrella skill itself is generic.
+
+## Relevant files
+
+- new: skills/reviewers/SKILL.md (+ pure-I/O helpers per reviewer kind)
+- skills/verify/SKILL.md — calls into this instead of inlining mechanics
+- tickets/0206, tickets/0207 — the reviewers being managed
+
+## Actions
+
+1. `/reviewers list` — panel members, their kind, advisory/required
+   status, trial progress (MRs observed / projects covered).
+2. `/reviewers request <pr>` — fire all configured external reviewers
+   for a merge request (forge-bot request, aider adapter invocations).
+3. `/reviewers harvest <pr>` — collect all external findings, normalize
+   to the 0205 contract shape, emit one findings file for the gate.
+4. `/reviewers scorecard <pr> <verdict-summary>` — append the per-MR
+   trial line to the owning ticket's log (the 0206/0207 observation
+   bookkeeping, mechanized).
+5. Config lives in one place (panel roster + endpoints); no secrets in
+   config — credentials via BASH_ENV path (see 0207).
+
+## Test
+
+Shell test with stubbed forge CLI + stubbed adapters: `request` invokes
+each configured reviewer once; `harvest` merges two stub finding files
+into one normalized output; `scorecard` appends a valid erg log line
+(verbs: created/note/closed only) that `erg validate` accepts.
+
+## Exit criteria
+
+- [ ] /reviewers skill with list/request/harvest/scorecard, catalog-registered
+- [ ] verify's panel-extension section delegates mechanics to it
+- [ ] Stubbed shell test green; make check green


### PR DESCRIPTION
Four filings from the imagine-copilot session — no implementation:

- **0205** parent/tracker: finding contract, advisory→required protocol (**≥5 MRs across ≥3 projects**), decorrelation-rule rewording, helper naming exception
- **0206** Copilot trial (Blocked-by: 0193)
- **0207** aider adapter — OpenRouter + llama-server as two configs of one tool-named helper (Blocked-by: 0193)
- **0208** /reviewers management skill (request / harvest / normalize / scorecard)

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)