### PR TITLE
tickets: file 0209 (auto-merge race), 0202 baseline, unblock 0206/0207

### DIFF
--- a/tickets/0202-validate-verify-fork-containment-over-on.erg
+++ b/tickets/0202-validate-verify-fork-containment-over-on.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-06-04T07:54Z claude created
 
+2026-06-04T08:51Z baseline for validation: PR #262 coordination comment (08:12Z) catalogs three pre-contract incidents from the 0190-0196 raid — #6 adherence sub-agent on sibling branch t0196 reviewed the wrong PR; #7 verify sub-agent rebased+force-pushed the PR branch out of role; #8 orchestrator worktree found on sibling branch mid-merge-train. All three are the modes the 0193 contracts target; the raid also prototyped Agent-spawned background verify runners (PRs 263/264) which ran clean — supporting this ticket's escalation path
 --- body ---
 ## Context
 

--- a/tickets/0206-copilot-review-in-the-verify-panel-auto.erg
+++ b/tickets/0206-copilot-review-in-the-verify-panel-auto.erg
@@ -2,11 +2,11 @@
 Title: Copilot review in the verify panel — auto-request, gate harvest, advisory trial
 Created: 2026-06-04
 Author: MinhHaDuong
-Blocked-by: 0193
 
 --- log ---
 2026-06-04T08:41Z MinhHaDuong created
 
+2026-06-04T08:52Z unblocked: 0193 closed via PR #262 — stale Blocked-by removed (line was added by PR #267 in a cross-branch race with the 0193 close commit)
 --- body ---
 ## Context
 

--- a/tickets/0207-aider-as-external-verifier-one-adapter-o.erg
+++ b/tickets/0207-aider-as-external-verifier-one-adapter-o.erg
@@ -2,11 +2,11 @@
 Title: aider as external verifier — one adapter, OpenRouter and llama-server configs
 Created: 2026-06-04
 Author: MinhHaDuong
-Blocked-by: 0193
 
 --- log ---
 2026-06-04T08:41Z MinhHaDuong created
 
+2026-06-04T08:52Z unblocked: 0193 closed via PR #262 — stale Blocked-by removed (line was added by PR #267 in a cross-branch race with the 0193 close commit)
 --- body ---
 ## Context
 

--- a/tickets/0209-erg-pr-merge-auto-merge-hits-check-regis.erg
+++ b/tickets/0209-erg-pr-merge-auto-merge-hits-check-regis.erg
@@ -1,0 +1,54 @@
+%erg 0.1
+Title: erg-pr-merge auto-merge hits check-registration race — tolerate 'no checks reported' briefly
+Created: 2026-06-04
+Author: claude
+
+--- log ---
+2026-06-04T08:50Z claude created
+
+--- body ---
+## Context
+
+The 0198 auto-merge rewrite of `skills/merge/erg-pr-merge` hit the same
+bounce chain on 4 of 4 merges on 2026-06-04 (PRs #254, #255, #256 in the
+0190-0196 raid; #262 in the 0193 session):
+
+1. The close commit is pushed; GitHub starts recomputing mergeability
+   and re-registering checks.
+2. `gh pr merge --auto` fails immediately with the GraphQL error
+   "Pull Request is not mergeable (mergePullRequest)" because the PR is
+   transiently `BLOCKED`/`UNKNOWN` — the script reads this as
+   "auto-merge unavailable" and takes the legacy fallback.
+3. The fallback's `gh pr checks --watch` then reports "no checks
+   reported on the '<branch>' branch" (checks for the new head are not
+   registered yet) and the run dies with "CI did not pass within 600s".
+
+Every occurrence resolved itself ~30-60s later: re-checking showed
+checks green and a plain `gh pr merge --merge` completed. The failure
+is purely a race between the close-commit push and GitHub's check
+registration; the script's two probes both fire inside the window.
+
+First observed and diagnosed by the 0190-0196 raid session (PR #262
+coordination comment, 08:12Z); reproduced independently on #262's own
+merge at 08:46Z.
+
+## Actions
+
+1. After the close-commit push, poll mergeability until it leaves
+   `UNKNOWN` (bounded, ~60s) before attempting `gh pr merge --auto`.
+2. Distinguish the transient GraphQL "not mergeable" error from a real
+   auto-merge-disabled response; only the latter should take the
+   legacy watch-then-merge fallback.
+3. In the fallback, tolerate "no checks reported" for a bounded window
+   (~60s) before declaring failure, instead of dying on first read.
+4. Extend `tests/test_erg_pr_merge.sh` with a stub that fails the
+   first `pr merge --auto` with the GraphQL race error and reports
+   "no checks" once, then succeeds — asserting the script rides out
+   the window.
+
+## Exit criteria
+
+- [ ] A merge run started inside the registration window completes
+      without manual re-invocation
+- [ ] Test case covers the transient-race stub path
+- [ ] Real auto-merge-disabled repos still reach the legacy fallback


### PR DESCRIPTION
## Summary

Post-merge audit follow-up of the 0190–0196 raid session, cross-referenced with the 0193 work:

- **New ticket 0209**: `erg-pr-merge`'s auto-merge path hit the check-registration race on **4/4 merges today** (#254, #255, #256, #262) — GraphQL "not mergeable" while transiently BLOCKED → legacy fallback → "no checks reported" → 600s die, self-resolving ~60s later. The raid session diagnosed it and offered to ticket separately; this is that ticket, with a proposed bounded-tolerance fix and test stub.
- **0202 baseline logged**: the raid's three pre-contract incidents (#6 wrong-PR adherence review, #7 out-of-role force-push, #8 sibling-branch orchestrator worktree, per the PR #262 coordination comment) are now on the validation ticket, plus the clean Agent-spawned verify-runner prototype that supports its escalation path.
- **0206/0207 unblocked**: their `Blocked-by: 0193` lines were added by PR #267 in a cross-branch race with 0193's close commit; 0193 is closed, `erg check` flagged the staleness, lines removed and logged.

Ticket: none
Ticket-ref: tickets/0202-validate-verify-fork-containment-over-on.erg
Ticket-ref: tickets/0209-erg-pr-merge-auto-merge-hits-check-regis.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)