### PR TITLE
skill(raid): declare parallel verify fan-out in Phase 6

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -98,6 +98,8 @@ When compacting, preserve the list of modified files, test commands, and current
 
 **Hook output framing**: Use declarative wording ("Worktree isolation is enabled…") not imperative commands ("INSTRUCTION: call EnterWorktree now"). The model classifies imperative hook instructions as prompt injection and ignores them.
 
+**Concurrency discipline**: Every multi-item skill step declares whether items run parallel-background or sequential-blocking, and states why. Model defaults differ across versions; the skill text is the contract.
+
 # Autonomous Action Rules
 
 **Sweep results are decisions.** When a skill sweep (celebrate step 3, healthcheck, etc.) returns multiple hits, act directly — file the ticket, open the PR, flag for review. Don't prompt the user to confirm. The data is the decision. Silent no-op if the sweep is empty.

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -121,7 +121,11 @@ Wait for wave to complete.
 
 Mood: Be strict, skeptical, nit-picky, detail-oriented. Aim for code excellence and integrity.
 
-**Per-ticket:** invoke `/verify <pr-number>` on each merge request.
+**Per-ticket:** launch per-ticket `/verify` runs in parallel (background agents,
+one per merge request) when the PR branches touch disjoint files. Verify
+file-sharing PRs sequentially to avoid concurrent-fix collisions. Respect the
+max-concurrent-agents cap (see Subagents in rules/workflow.md). Phase 7 merges
+stay strictly sequential.
 
 **Per-wave:** after all per-ticket `/verify` runs complete, launch one integration-review
 subagent (read-only) to check:

--- a/tickets/0203-skills-declare-concurrency-explicitly-pa.erg
+++ b/tickets/0203-skills-declare-concurrency-explicitly-pa.erg
@@ -5,6 +5,7 @@ Author: MinhHaDuong
 
 --- log ---
 2026-06-04T08:07Z MinhHaDuong created
+2026-06-04T12:30Z claude note sweep: healthcheck — checks 1-9 are inline sequential bash, no agent fan-out, no annotation needed; review-pr — already declares "parallel" fan-out (lines 21, 28), compliant; dream — steps 1-7 sequential single-agent inline, no fan-out, no annotation needed
 
 --- body ---
 ## Context
@@ -52,6 +53,6 @@ Grep-able: `grep -n "parallel" skills/raid/SKILL.md` includes Phase 6;
 
 ## Exit criteria
 
-- [ ] Writing-Skills principle present in rules/workflow.md
-- [ ] Raid Phase 6 declares parallel fan-out + sequential-merge contract
-- [ ] One sweep pass over existing skills' multi-item steps documented in this ticket's log
+- [x] Writing-Skills principle present in rules/workflow.md
+- [x] Raid Phase 6 declares parallel fan-out + sequential-merge contract
+- [x] One sweep pass over existing skills' multi-item steps documented in this ticket's log

--- a/tickets/closed/0203-skills-declare-concurrency-explicitly-pa.erg
+++ b/tickets/closed/0203-skills-declare-concurrency-explicitly-pa.erg
@@ -2,11 +2,13 @@
 Title: Skills declare concurrency explicitly — parallel verify fan-out in raid Phase 6
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: autoclosed — PR #274
 
 --- log ---
 2026-06-04T08:07Z MinhHaDuong created
 2026-06-04T12:30Z claude note sweep: healthcheck — checks 1-9 are inline sequential bash, no agent fan-out, no annotation needed; review-pr — already declares "parallel" fan-out (lines 21, 28), compliant; dream — steps 1-7 sequential single-agent inline, no fan-out, no annotation needed
 
+2026-06-04T20:03Z MinhHaDuong closed — autoclosed — PR #274
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- Add **Concurrency discipline** principle to `rules/workflow.md` § Writing Skills: every multi-item skill step must declare parallel vs sequential execution and state why — the skill text is the contract, not model defaults.
- Rewrite raid Phase 6 per-ticket section: parallel background agents for disjoint-file PRs, sequential for file-sharing PRs, Phase 7 merges stay sequential.
- Sweep log: healthcheck (sequential inline, ok), review-pr (already declares parallel, ok), dream (sequential inline, ok).

## Why

Raid Phase 6 said "invoke `/verify` on each merge request" — ambiguous on concurrency. Opus 4.8 serialized four verifies; Opus 4.7 parallelized them. The skill text, not the model's disposition, must be the contract.

**Ticket:** tickets/0203-skills-declare-concurrency-explicitly-pa.erg

## Test plan

- [ ] `grep -n "concurrency\|Concurrency" rules/workflow.md` hits the new principle
- [ ] `grep -n "parallel" skills/raid/SKILL.md | grep -i "per-ticket\|verify"` hits Phase 6
- [ ] Ticket log contains sweep findings for healthcheck, review-pr, dream