### PR TITLE
skill(0208): /reviewers management surface for verify panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automaticall
 | `/release` | Pre-release audit, GPG tag signing, and download-URL update for a target repo. Runs audits autonomously; pauses at the human-only signing step. |
 | `/review-pr` | Multi-perspective code review with parallel agents. Covers correctness, consistency, scope, red team, and doc propagation. |
 | `/review-pr-prose` | Simulated peer review panel for manuscript prose. Spins discipline-specific agents for multi-perspective review. |
-| `/reviewers` | "Reviewer-management helper skill — request, harvest, normalize, scorecard" |
+| `/reviewers` | "Reviewer-management helper skill — list, request, harvest, scorecard" |
 | `/skill-doctor` | Weekly failure-pattern analysis across journals, logs, and git history. Clusters recurring failures and opens tickets with proposed patches. Never auto-applies fixes. |
 | `/smoke` | Agent environment smoke test — reports runtime identity, auth method, and harness context. |
 | `/start-ticket` | Begin work on a ticket. Creates worktree, writes first test, transitions to Execute phase. |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automaticall
 | `/release` | Pre-release audit, GPG tag signing, and download-URL update for a target repo. Runs audits autonomously; pauses at the human-only signing step. |
 | `/review-pr` | Multi-perspective code review with parallel agents. Covers correctness, consistency, scope, red team, and doc propagation. |
 | `/review-pr-prose` | Simulated peer review panel for manuscript prose. Spins discipline-specific agents for multi-perspective review. |
+| `/reviewers` | "Reviewer-management helper skill — request, harvest, normalize, scorecard" |
 | `/skill-doctor` | Weekly failure-pattern analysis across journals, logs, and git history. Clusters recurring failures and opens tickets with proposed patches. Never auto-applies fixes. |
 | `/smoke` | Agent environment smoke test — reports runtime identity, auth method, and harness context. |
 | `/start-ticket` | Begin work on a ticket. Creates worktree, writes first test, transitions to Execute phase. |

--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewers
-description: "Reviewer-management helper skill — request, harvest, normalize, scorecard"
+description: "Reviewer-management helper skill — list, request, harvest, scorecard"
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "<subcommand> [args]"

--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: reviewers
+description: "Reviewer-management helper skill — request, harvest, normalize, scorecard"
+disable-model-invocation: false
+user-invocable: true
+argument-hint: "<subcommand> [args]"
+---
+
+Manage the external reviewer panel for `/verify`. Delegates to
+`skills/reviewers/reviewers.sh` for all I/O.
+
+## Subcommands
+
+### `/reviewers list`
+
+Show panel members, their kind (forge-bot / cli-agent / local-model),
+advisory/required status, and trial progress (merge requests observed /
+projects covered).
+
+Reads `skills/reviewers/panel.yml`. If the roster is empty, prints
+"no reviewers configured" and exits 0.
+
+### `/reviewers request <pr>`
+
+Fire all configured external reviewers for a merge request. For each
+reviewer kind, call the appropriate mechanism:
+
+- **forge-bot**: request review via the forge's review-request API
+  <!-- harness-extension-point -->
+- **cli-agent**: invoke the adapter with the merge request diff
+  <!-- harness-extension-point -->
+- **local-model**: send the diff to the local inference endpoint
+  <!-- harness-extension-point -->
+
+Currently stubs until 0206/0207 land real reviewer adapters. Prints
+"no reviewers configured" with an empty roster and exits 0.
+
+No secrets in config — credentials via BASH_ENV path.
+
+### `/reviewers harvest <pr>`
+
+Collect all external findings, normalize to the 0205 contract shape:
+
+```
+verifiable: <file>:<line> — <rationale>
+consider: <file>:<line> — <rationale>
+```
+
+Emit one findings file for the gate. With no findings (empty panel or
+no comments returned), produce empty normalized output and exit 0.
+
+### `/reviewers scorecard <pr> <verdict-summary>`
+
+Append the per-merge-request trial line to the owning ticket's log
+using `erg note`. Log verbs: `created`, `note`, `closed` only.
+
+Example log line appended:
+
+```
+2026-06-04T12:00Z agent note MR #42 verdict: PASS — 0 blocking, 2 advisory
+```
+
+## Configuration
+
+`skills/reviewers/panel.yml` is the single roster file. Structure:
+
+```yaml
+reviewers:
+  - name: <identifier>
+    kind: forge-bot | cli-agent | local-model
+    disposition: advisory | required
+    trial-ticket: <ticket-ref>
+```
+
+No secrets in config — credentials load via BASH_ENV.
+
+## Dispatcher
+
+All subcommands route through `skills/reviewers/reviewers.sh` (pure
+I/O helper, case-switch dispatch). No plugin architecture — plain
+case switch per subcommand.

--- a/skills/reviewers/panel.yml
+++ b/skills/reviewers/panel.yml
@@ -1,0 +1,3 @@
+# Reviewer panel roster — managed by /reviewers skill
+# Each entry: name, kind (forge-bot|cli-agent|local-model), disposition (advisory|required), trial ticket
+reviewers: []

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Reviewer-management dispatcher — pure I/O helper for /reviewers skill.
+# Case-switch dispatch; no plugin architecture.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PANEL="${SCRIPT_DIR}/panel.yml"
+
+usage() {
+    echo "Usage: reviewers.sh <subcommand> [args]"
+    echo ""
+    echo "Subcommands:"
+    echo "  list                          Show panel members and trial progress"
+    echo "  request <pr>                  Fire all configured reviewers for a merge request"
+    echo "  harvest <pr>                  Collect and normalize external findings"
+    echo "  scorecard <pr> <verdict>      Append trial line to ticket log via erg note"
+    exit 1
+}
+
+# Check if panel roster has any reviewers configured
+panel_is_empty() {
+    # Matches "reviewers: []" or a file with no entries after "reviewers:"
+    if grep -qE '^reviewers:\s*\[\]' "$PANEL" 2>/dev/null; then
+        return 0
+    fi
+    # Count non-comment, non-empty lines after "reviewers:" that start with "- "
+    local count
+    count=$(sed -n '/^reviewers:/,$ { /^  - /p }' "$PANEL" 2>/dev/null | wc -l)
+    [ "$count" -eq 0 ]
+}
+
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+    list)
+        if panel_is_empty; then
+            echo "no reviewers configured"
+            exit 0
+        fi
+        # Future: parse panel.yml and display table
+        echo "no reviewers configured"
+        ;;
+
+    request)
+        pr="${1:-}"
+        if [ -z "$pr" ]; then
+            echo "error: request requires a merge request identifier" >&2
+            exit 1
+        fi
+        if panel_is_empty; then
+            echo "no reviewers configured"
+            exit 0
+        fi
+        # Future: iterate panel entries, fire each reviewer by kind
+        # harness-extension-point
+        echo "no reviewers configured"
+        ;;
+
+    harvest)
+        pr="${1:-}"
+        if [ -z "$pr" ]; then
+            echo "error: harvest requires a merge request identifier" >&2
+            exit 1
+        fi
+        if panel_is_empty; then
+            # Empty normalized output — no findings
+            exit 0
+        fi
+        # Future: collect findings from each reviewer, normalize to 0205 shape
+        # harness-extension-point
+        exit 0
+        ;;
+
+    scorecard)
+        pr="${1:-}"
+        verdict="${2:-}"
+        if [ -z "$pr" ] || [ -z "$verdict" ]; then
+            echo "error: scorecard requires <pr> and <verdict-summary>" >&2
+            exit 1
+        fi
+        # Future: resolve the owning ticket from the MR, then:
+        #   erg note <ticket-id> "MR #${pr} verdict: ${verdict}"
+        # harness-extension-point
+        echo "scorecard: stub — would log verdict for MR #${pr}: ${verdict}"
+        exit 0
+        ;;
+
+    ""|--help|-h)
+        usage
+        ;;
+
+    *)
+        echo "error: unknown subcommand '${subcmd}'" >&2
+        usage
+        ;;
+esac

--- a/skills/reviewers/test_reviewers.sh
+++ b/skills/reviewers/test_reviewers.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Shell tests for the /reviewers skill dispatcher.
+# Verifies stub behaviour with an empty panel roster.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REVIEWERS="${SCRIPT_DIR}/reviewers.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  expected: $(printf '%q' "$expected")"
+        echo "  actual:   $(printf '%q' "$actual")"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_0() {
+    local label="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label (exit code $?)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- list with empty roster ---
+out=$("$REVIEWERS" list)
+assert_eq "list: empty roster prints 'no reviewers configured'" \
+    "no reviewers configured" "$out"
+
+# --- request with empty roster ---
+out=$("$REVIEWERS" request 42)
+assert_eq "request: empty roster prints 'no reviewers configured'" \
+    "no reviewers configured" "$out"
+
+# --- request exits 0 with empty roster ---
+assert_exit_0 "request: exits 0 with empty roster" \
+    "$REVIEWERS" request 42
+
+# --- harvest with empty roster produces no output ---
+out=$("$REVIEWERS" harvest 42)
+assert_eq "harvest: empty roster produces empty output" \
+    "" "$out"
+
+# --- harvest exits 0 ---
+assert_exit_0 "harvest: exits 0 with empty roster" \
+    "$REVIEWERS" harvest 42
+
+# --- scorecard is callable ---
+assert_exit_0 "scorecard: exits 0 (smoke)" \
+    "$REVIEWERS" scorecard 42 "PASS — 0 blocking"
+
+# --- scorecard prints stub message ---
+out=$("$REVIEWERS" scorecard 42 "PASS — 0 blocking")
+assert_eq "scorecard: stub message mentions MR" \
+    "scorecard: stub — would log verdict for MR #42: PASS — 0 blocking" "$out"
+
+# --- request without arg fails ---
+if "$REVIEWERS" request 2>/dev/null; then
+    echo "FAIL: request: missing arg should fail"
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: request: missing arg fails"
+    PASS=$((PASS + 1))
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -210,6 +210,14 @@ Explicit human override. Usage: `/verify <pr-number> --force-approve <reason>`.
   `/verify-wave` (not yet drafted) for post-merge integration testing of a batch.
 - **Merging.** Ever. That is the caller's job.
 
+## Panel extension
+
+When external reviewers are configured (`/reviewers list` shows non-empty
+panel), the setup phase calls `/reviewers request <pr>` to fire all panel
+members. After phases 2–4 complete, `/reviewers harvest <pr>` collects and
+normalizes external findings into the gate's comment shape. Findings are
+dispositioned identically to built-in reviewer output.
+
 ## Output shape
 
 Post a single top-level PR comment at end of skill. Two sections,

--- a/tests/test_reviewers.sh
+++ b/tests/test_reviewers.sh
@@ -3,8 +3,8 @@
 # Verifies stub behaviour with an empty panel roster.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REVIEWERS="${SCRIPT_DIR}/reviewers.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REVIEWERS="${REPO_ROOT}/skills/reviewers/reviewers.sh"
 PASS=0
 FAIL=0
 

--- a/tickets/0205-external-reviewer-panel-for-verify-contr.erg
+++ b/tickets/0205-external-reviewer-panel-for-verify-contr.erg
@@ -4,11 +4,11 @@ Created: 2026-06-04
 Author: MinhHaDuong
 Blocked-by: 0206
 Blocked-by: 0207
-Blocked-by: 0208
 
 --- log ---
 2026-06-04T08:41Z MinhHaDuong created
 
+2026-06-04T09:13Z MinhHaDuong note blocker 0208 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0208-reviewer-management-helper-skill-request.erg
+++ b/tickets/0208-reviewer-management-helper-skill-request.erg
@@ -2,10 +2,12 @@
 Title: Reviewer-management helper skill — request, harvest, normalize, scorecard
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: Implemented: /reviewers skill with list/request/harvest/scorecard stubs, panel.yml roster, verify panel-extension section
 
 --- log ---
 2026-06-04T08:41Z MinhHaDuong created
 
+2026-06-04T09:13Z MinhHaDuong closed — Implemented: /reviewers skill with list/request/harvest/scorecard stubs, panel.yml roster, verify panel-extension section
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- New `/reviewers` skill with four subcommands: `list`, `request`, `harvest`, `scorecard` — all stubs until 0206/0207 land real reviewer adapters
- Single dispatcher (`reviewers.sh`) with case-switch, `panel.yml` empty roster, and shell test suite (8 tests, all pass)
- Adds "Panel extension" section to `verify/SKILL.md` documenting the delegation path for external reviewer findings

**Ticket:** tickets/0208-reviewer-management-helper-skill-request.erg

## Test plan

- [x] `bash skills/reviewers/test_reviewers.sh` — 8/8 pass
- [x] `make check` — skills-catalog in sync, agnostic check clean
- [ ] Verify PR review clears gate