### PR TITLE
fix(0204): repo-relative script paths in skills; lint guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check
+.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check
 
 skills-catalog:
 	./scripts/update-skills-catalog.py
@@ -9,4 +9,7 @@ check-skills-drift:
 check-agnostic-tickets:
 	./scripts/check-agnostic.sh tickets
 
-check: check-skills-drift check-agnostic-tickets
+check-agnostic-skills:
+	./scripts/check-agnostic.sh skills
+
+check: check-skills-drift check-agnostic-tickets check-agnostic-skills

--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -26,7 +26,7 @@ SKILL_PATTERNS=(
     'uv run pytest'   # stack-specific; skills must be stack-agnostic
     '\bgh '           # GitHub CLI; skills must be forge-agnostic
     'github\.com'     # GitHub URL; skills must be forge-agnostic
-    '[^.~/]scripts/[a-z-]\+\.\(sh\|py\)'  # repo-relative script path; use ~/.claude/scripts/ or $HARNESS_DIR
+    '\(^\|[^.~/]\)scripts/[a-z-]\+\.\(sh\|py\)'  # repo-relative script path; use ~/.claude/scripts/ or $HARNESS_DIR
 )
 
 fail=0

--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -26,6 +26,7 @@ SKILL_PATTERNS=(
     'uv run pytest'   # stack-specific; skills must be stack-agnostic
     '\bgh '           # GitHub CLI; skills must be forge-agnostic
     'github\.com'     # GitHub URL; skills must be forge-agnostic
+    '[^.~/]scripts/[a-z-]\+\.\(sh\|py\)'  # repo-relative script path; use ~/.claude/scripts/ or $HARNESS_DIR
 )
 
 fail=0

--- a/skills/celebrate/SKILL.md
+++ b/skills/celebrate/SKILL.md
@@ -44,20 +44,24 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
 9. **Exit worktree** (if in one):
     a. Preflight from inside the worktree:
        ```bash
-       scripts/worktree-exit-preflight.sh
+       ~/.claude/scripts/worktree-exit-preflight.sh
        ```
        Refuses (exit 1) when there are uncommitted/untracked files — including a fresh ticket draft `/ticket-new` wrote but never committed. The `Bash(git worktree remove*)` PreToolUse matcher does NOT fire on `ExitWorktree`, so this is the only gate. If it blocks, commit (or `~/.claude/scripts/worktree-salvage.sh`) and re-run. See ticket 0174.
-    b. Call `ExitWorktree` with action `remove`.
+    b. Call `ExitWorktree` with action `remove`. When the pre-check
+       (`git merge-base --is-ancestor HEAD origin/main`) has already
+       passed, the worktree branch is fully merged — ExitWorktree's
+       "N commits would be discarded" warning is a false alarm from a
+       stale local main. Authorize `discard_changes` in that case.
     Skip if not in a worktree.
-9.5. **GC stale worktrees** (from the main repo): prune any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
+10. **GC stale worktrees** (from the main repo): prune any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
     ```bash
     git fetch --prune origin
     ~/.claude/scripts/worktree-gc.sh
     ```
     Removes only worktrees with no uncommitted changes (and never the one it runs from); never `rm -rf`s, silent when there is nothing to clean. See tickets 0169, 0195.
-10. **Verify hygiene**:
+11. **Verify hygiene**:
     - `git branch -a` → no stale remote branches
     - Check for stale merge requests
-11. **Offer** to improve workflow rules if lessons were learned.
+12. **Offer** to improve workflow rules if lessons were learned.
 
 Note: STATE.md is updated on main during `/end-session`, not here.

--- a/skills/end-session/SKILL.md
+++ b/skills/end-session/SKILL.md
@@ -20,7 +20,7 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
 5. **Commit WIP if needed** — uncommitted work gets `wip:` prefix, committed to the current branch, and pushed.
 6. **Handoff notes** — for in-progress tickets with unpushed context, add a comment to the ticket: what's done, what's next, blockers.
 7. **Exit worktree** — if in a worktree:
-    a. Preflight from inside the worktree: `scripts/worktree-exit-preflight.sh` (refuses on any uncommitted/untracked state; closes the ExitWorktree gap, ticket 0174). If it blocks, finish step 5/6 (commit WIP, handoff notes) and re-run.
+    a. Preflight from inside the worktree: `~/.claude/scripts/worktree-exit-preflight.sh` (refuses on any uncommitted/untracked state; closes the ExitWorktree gap, ticket 0174). If it blocks, finish step 5/6 (commit WIP, handoff notes) and re-run.
     b. Call `ExitWorktree` to return to the main working tree. All remaining steps run on main.
 8. **Hygiene sweep**:
    - `git worktree list` → remove any stale worktrees (`git worktree prune`)

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -36,7 +36,7 @@ Run full repo housekeeping and act on every finding.
    Exception: `BEAT_HOUSEKEEPING_BRANCH` is set — beat.py manages concurrency itself; skip this guard.
 
 1. **Git phase.**
-   - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(scripts/housekeeping-git.sh)` from the project root. Then cut a dated branch: `git switch -c housekeeping-$(date -u +%Y%m%d) origin/main`. All subsequent commits in this run land on that branch.
+   - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(~/.claude/scripts/housekeeping-git.sh)` from the project root. Then cut a dated branch: `git switch -c housekeeping-$(date -u +%Y%m%d) origin/main`. All subsequent commits in this run land on that branch.
    - If `BEAT_HOUSEKEEPING_BRANCH` **is** set (beat.py run): skip — beat.py already ran the git phase before invoking this skill.
 
 1.5. **GC stale worktrees.** Remove any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` (intact dirs that `git worktree prune` misses):

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -14,7 +14,7 @@ failures to their root cause, repair within authority, escalate when stuck.
 timer before editing `beat.py`, restart after; never edit skill SKILL.md files.
 
 **Commit tracked writes immediately.** Every write to a tracked file in
-`$HARNESS_DIR` (`settings.json`, `scripts/beat.py`, `tickets/*.erg`) must be
+`$HARNESS_DIR` (`settings.json`, `scripts/beat.py`, `tickets/*.erg`) must be <!-- harness-extension-point -->
 followed by `git add <file> && git commit -m 'chore(supervisor): <description>'`
 before proceeding to the next action. Uncommitted tracked files cause the next
 beat cycle's dirty-tree pre-flight to abort.
@@ -82,12 +82,12 @@ When you reach a root cause, repair if within authority:
   If neither guard triggers: raise the per-project `ProjectConfig` field in
   `beat.py` by 20%, capped at 2× the module-level constant; never touch the
   module-level constant. Then
-  `git add scripts/beat.py && git commit -m 'chore(supervisor): raise <field> budget for <project>'`.
+  `git add scripts/beat.py && git commit -m 'chore(supervisor): raise <field> budget for <project>'`. <!-- harness-extension-point -->
 - **Raid timeout during verify/review** (`outcome=timeout` AND why-chain
   shows verify/review slowness, not implementation slowness) → raise
   `raid_timeout_s` in the per-project config by 20%, capped at
   2× `RAID_TIMEOUT_S` (3600 s). Then
-  `git add scripts/beat.py && git commit -m 'chore(supervisor): raise raid_timeout_s for <project>'`.
+  `git add scripts/beat.py && git commit -m 'chore(supervisor): raise raid_timeout_s for <project>'`. <!-- harness-extension-point -->
   Implementation slowness is a "ticket too
   large" signal — do not raise the timeout for that.
 - **Ticket too large to finish in one beat** → split into one ticket per

--- a/tickets/0213-pin-regression-fixture-for-the-repo-rela.erg
+++ b/tickets/0213-pin-regression-fixture-for-the-repo-rela.erg
@@ -1,0 +1,44 @@
+%erg 0.1
+Title: Pin regression fixture for the repo-relative scripts pattern in check-agnostic
+Created: 2026-06-04
+Author: MinhHaDuong
+
+--- log ---
+2026-06-04T11:01Z MinhHaDuong created
+
+--- body ---
+## Context
+
+Ticket 0204 (PR #277) added a SKILL_PATTERNS entry to
+scripts/check-agnostic.sh catching repo-relative `scripts/<name>.(sh|py)`
+references, wired into `make check` via the check-agnostic-skills target.
+The /verify gate flagged (non-blocking): the pattern is live-enforced but
+has no committed regression-pin fixture — tests/test_check_agnostic.py
+and the CI self-test only exercise the older home-path pattern.
+If the new pattern regresses (BRE typo, refactor), nothing fails.
+
+review-pr also noted the pattern stem `[a-z-]` misses uppercase / digit /
+underscore script names — broaden while pinning.
+
+## Relevant files
+
+- `scripts/check-agnostic.sh` — the new SKILL_PATTERNS entry
+- `tests/test_check_agnostic.py` — where the fixture-based pin belongs
+
+## Actions
+
+1. Add a fixture test: a temp markdown file with a bare `scripts/foo.sh`
+   reference must make check-agnostic.sh exit 1; `~/.claude/scripts/foo.sh`,
+   `$HARNESS_DIR/scripts/foo.py`, and `./scripts/foo.sh` forms must pass.
+2. Broaden the stem to cover uppercase/digit/underscore script names;
+   pin that too.
+
+## Test
+
+The fixture test above — red first against a deliberately broken pattern.
+
+## Exit criteria
+
+- [ ] Regression-pin fixture for the repo-relative pattern in tests/
+- [ ] Stem covers [A-Za-z0-9_-] script names
+- [ ] make check green

--- a/tickets/closed/0204-skills-reference-harness-scripts-repo-re.erg
+++ b/tickets/closed/0204-skills-reference-harness-scripts-repo-re.erg
@@ -2,10 +2,12 @@
 Title: Skills reference harness scripts repo-relatively; breaks cross-project runs
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: autoclosed — PR #277
 
 --- log ---
 2026-06-04T08:12Z MinhHaDuong created
 
+2026-06-04T20:11Z MinhHaDuong closed — autoclosed — PR #277
 --- body ---
 ## Source
 Two live failures within one hour on 2026-06-04, both running IDH skills


### PR DESCRIPTION
## Summary

- **Fix 3 repo-relative script references** in celebrate, end-session, and housekeeping SKILL.md files — prefixed with `~/.claude/` so they resolve when skills run against non-harness projects.
- **Document is-ancestor discard-safety rule** in celebrate step 9b — ExitWorktree's "N commits would be discarded" warning is a false alarm from a stale local main when the merge pre-check already passed.
- **Renumber celebrate steps** 9.5/10/11 to 10/11/12 — the fractional step was a lazy insert, not a genuine subdivision.
- **Add lint guard** to `check-agnostic.sh` catching bare `scripts/*.{sh,py}` references in SKILL.md files (BRE pattern in SKILL_PATTERNS array).
- **Escape-hatch** 3 nightbeat-supervisor lines where `scripts/beat.py` legitimately appears in `$HARNESS_DIR`-scoped git-add commands.

## Test plan

- [x] `bash scripts/check-agnostic.sh skills` passes with zero violations
- [x] Fixture test: bare `scripts/my-tool.sh` in a skills/ dir is caught by the new pattern
- [x] `make check` passes
- [x] Exit criteria grep returns only `$HARNESS_DIR`-scoped or escape-hatched lines
- [x] `grep -n '^[0-9]' skills/celebrate/SKILL.md` shows steps 1-12 with no fractional steps

**Ticket:** tickets/0204-skills-reference-harness-scripts-repo-re.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Scope overflow: tickets/0213 (regression-pin fixture for the new lint pattern — bundled on this branch)