### PR TITLE
release: add Agent C (foundations coherence) to the parallel audit panel

### DIFF
--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -32,8 +32,8 @@ skill **never signs** a tag — that is the human's sole responsibility.
 
 ## 2. Parallel audits
 
-Launch **two background agents in parallel** (single message, both as
-background agents). Wait for both to return, then consolidate.
+Launch **three background agents in parallel** (single message, all as
+background agents). Wait for all to return, then consolidate.
 
 **Agent A — security audit.** Review the release surface for:
 - supply chain (dependencies, pinned versions, fetched scripts),
@@ -46,11 +46,19 @@ audience definitions and install paths, and walk each one. If `0152` is
 absent, degrade to generic heuristics: a clean install from scratch, plus a
 first-use walkthrough of the primary command.
 
+**Agent C — foundations coherence.** Follow the target repo's
+`FOUNDATIONS-PROCESS.md` if present (sweep stated contracts across
+constitution/rationale/spec/process docs; verify the disjoint union against
+guard tests — stated-without-guard needs a test, guarded-without-statement
+needs a sentence; flag inter-doc tensions). If absent, degrade to a light
+pass: do the stated-vs-guarded comparison on whatever convention docs and
+test suites the repo has.
+
 Each agent files **one ticket per finding** via `/ticket-new`, with a severity
 of HIGH / MEDIUM / LOW in the title or body. If there is no `tickets/`
 directory, the agent prints its findings to output instead of filing.
 
-After both return, print a **consolidated summary**: count of findings by
+After all three return, print a **consolidated summary**: count of findings by
 severity, grouped by agent.
 
 ## 3. Resolve HIGH findings


### PR DESCRIPTION
## Summary
Adds a third parallel audit agent to the release skill: **foundations coherence**, following the target repo's `FOUNDATIONS-PROCESS.md` when present (git-erg ticket 0232 creates it as the third sibling of UX-PROCESS/SECURITY-PROCESS), degrading to a light stated-vs-guarded comparison otherwise — the same graceful-degradation pattern as Agents A and B.

Satisfies git-erg 0232's exit criterion 3 ("release procedure lists it alongside UX and security audits") at the layer where the release checklist actually lives.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)