### PR TITLE
skills: fix worktree-exit-preflight.sh path (celebrate + end-session)

### DIFF
--- a/skills/celebrate/SKILL.md
+++ b/skills/celebrate/SKILL.md
@@ -44,7 +44,7 @@ If the current branch is not merged into origin/main, stop and tell the user. Do
 9. **Exit worktree** (if in one):
     a. Preflight from inside the worktree:
        ```bash
-       scripts/worktree-exit-preflight.sh
+       ~/.claude/scripts/worktree-exit-preflight.sh
        ```
        Refuses (exit 1) when there are uncommitted/untracked files — including a fresh ticket draft `/ticket-new` wrote but never committed. The `Bash(git worktree remove*)` PreToolUse matcher does NOT fire on `ExitWorktree`, so this is the only gate. If it blocks, commit (or `~/.claude/scripts/worktree-salvage.sh`) and re-run. See ticket 0174.
     b. Call `ExitWorktree` with action `remove`.

--- a/skills/end-session/SKILL.md
+++ b/skills/end-session/SKILL.md
@@ -20,7 +20,7 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
 5. **Commit WIP if needed** — uncommitted work gets `wip:` prefix, committed to the current branch, and pushed.
 6. **Handoff notes** — for in-progress tickets with unpushed context, add a comment to the ticket: what's done, what's next, blockers.
 7. **Exit worktree** — if in a worktree:
-    a. Preflight from inside the worktree: `scripts/worktree-exit-preflight.sh` (refuses on any uncommitted/untracked state; closes the ExitWorktree gap, ticket 0174). If it blocks, finish step 5/6 (commit WIP, handoff notes) and re-run.
+    a. Preflight from inside the worktree: `~/.claude/scripts/worktree-exit-preflight.sh` (refuses on any uncommitted/untracked state; closes the ExitWorktree gap, ticket 0174). If it blocks, finish step 5/6 (commit WIP, handoff notes) and re-run.
     b. Call `ExitWorktree` to return to the main working tree. All remaining steps run on main.
 8. **Hygiene sweep**:
    - `git worktree list` → remove any stale worktrees (`git worktree prune`)


### PR DESCRIPTION
Both skills invoked the exit preflight as `scripts/worktree-exit-preflight.sh` — project-relative, so it 404s in every project repo (exit 127 observed during AEDIST /celebrate, 2026-06-04). The script lives in `~/.claude/scripts/`; siblings `worktree-gc.sh` and `worktree-salvage.sh` were already referenced with the harness-global path.

Swept `skills/` and `rules/` for the pattern — these two lines were the only offenders.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)