### PR TITLE
erg-pr-merge: harden --auto/--watch against post-push recompute races

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -138,6 +138,72 @@ fi
 #
 # in_worktree: deleteBranchOnMerge cleans the remote; the local --delete-branch
 # flag would fail on the primary worktree's main-lock (ticket 0170).
+
+# Bounded retry tuning for the two post-push races below. Overridable so the
+# test suite drives them without sleeping (ticket 0200).
+POLL_INTERVAL="${ERG_PR_MERGE_POLL_INTERVAL:-10}"   # seconds between polls
+MERGE_POLL_TRIES="${ERG_PR_MERGE_POLL_TRIES:-5}"    # mergeability settle polls
+WATCH_RACE_TRIES="${ERG_PR_MERGE_WATCH_TRIES:-3}"   # checks-watch race retries
+
+# Poll until GitHub finishes recomputing mergeability. The Step-2 close-commit
+# push flips `mergeable` to UNKNOWN transiently; bounded so a genuinely-stuck
+# UNKNOWN still returns. Emits the last observed state. (ticket 0200)
+settle_mergeable() {
+    local state i
+    state=UNKNOWN
+    for (( i=0; i<MERGE_POLL_TRIES; i++ )); do
+        state=$(gh pr view "$PR" --json mergeable --jq '.mergeable' 2>/dev/null || echo UNKNOWN)  # harness-extension-point
+        [[ "$state" != "UNKNOWN" ]] && { echo "$state"; return 0; }
+        sleep "$POLL_INTERVAL"
+    done
+    echo "$state"
+}
+
+# Queue --auto, retrying once after the post-push mergeability recompute
+# settles. The close-commit push leaves the forge's --auto merge failing with
+# "Pull Request is not mergeable" transiently; the exit code alone cannot tell
+# that race apart from "auto-merge not allowed", so inspect the error text.
+# Only a non-mergeability failure, or a second failure after the recompute
+# settles, means auto-merge is genuinely unavailable. (ticket 0200)
+try_auto_merge() {
+    local err state
+    err=$(gh pr merge "$PR" "${MERGE_FLAGS[@]}" 2>&1) && { echo "$err"; return 0; }  # harness-extension-point
+    echo "$err" >&2
+    if echo "$err" | grep -qiE 'not mergeable|base branch was modified'; then
+        echo "Post-push mergeability recompute in flight — waiting for it to settle..."
+        state=$(settle_mergeable)
+        echo "Mergeability settled (${state}); retrying auto-merge once..."
+        err=$(gh pr merge "$PR" "${MERGE_FLAGS[@]}" 2>&1) && { echo "$err"; return 0; }  # harness-extension-point
+        echo "$err" >&2
+    fi
+    return 1
+}
+
+# Watch CI, tolerating the post-push check-registration race. A fresh push
+# leaves a brief window where the checks-watch reports "no checks reported on
+# the <branch> branch" and exits non-zero in ~1s — that is neither a red check
+# nor a timeout, so retry it a bounded number of times. On a real failure or a
+# watch timeout, die() with a message naming the actual cause rather than the
+# misleading "did not pass within 600s". (ticket 0200)
+watch_checks_or_die() {
+    local out rc i
+    for (( i=1; i<=WATCH_RACE_TRIES; i++ )); do
+        out=$(timeout 600 gh pr checks "$PR" --watch --fail-fast 2>&1) && { echo "$out"; return 0; }  # harness-extension-point
+        rc=$?
+        echo "$out" >&2
+        if echo "$out" | grep -qi 'no checks reported'; then
+            echo "No checks registered yet (attempt ${i}/${WATCH_RACE_TRIES}) — waiting for CI to register..."
+            sleep "$POLL_INTERVAL"
+            continue
+        fi
+        if [[ "$rc" -eq 124 ]]; then
+            die "CI watch timed out after 600s — aborting merge"
+        fi
+        die "CI checks failed (checks-watch exited ${rc}) — fix red checks before merging"
+    done
+    die "CI checks never registered after ${WATCH_RACE_TRIES} attempts (no checks reported) — aborting merge"
+}
+
 echo "Queueing merge for PR #${PR}..."
 if in_worktree; then
     MERGE_FLAGS=(--merge --auto)
@@ -145,15 +211,15 @@ else
     MERGE_FLAGS=(--merge --auto --delete-branch)
 fi
 
-if gh pr merge "$PR" "${MERGE_FLAGS[@]}"; then  # harness-extension-point
+if try_auto_merge; then
     echo "Merge queued; lands when required checks pass."
     AUTO_QUEUED=1
 else
-    # Fallback: repo has auto-merge disabled. Legacy watch-then-merge path
-    # so the script stays usable without allow_auto_merge. (ticket 0198)
+    # Genuine auto-merge-unavailable: repo has auto-merge disabled. Legacy
+    # watch-then-merge path so the script stays usable without
+    # allow_auto_merge. (ticket 0198)
     echo "Auto-merge unavailable — falling back to watch-then-merge..."  # harness-extension-point
-    timeout 600 gh pr checks "$PR" --watch --fail-fast \
-        || die "CI did not pass within 600s (failed or timed out) — aborting merge"  # harness-extension-point
+    watch_checks_or_die
     if in_worktree; then
         gh pr merge "$PR" --merge          # harness-extension-point
     else

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -6,6 +6,10 @@
 # carrying multiple `**Ticket:**` lines closes and archives ALL of them in one
 # close commit, that a single-ticket PR still works, and that a duplicated
 # Ticket line does not crash (exercises the load-bearing `sort -u` dedup).
+# Cases 13-14 (ticket 0200) cover the two post-push --auto/--watch races: the
+# mergeability recompute race (first --auto fails "not mergeable", retried once
+# after settle) and the check-registration race ("no checks reported" watch is
+# retried before merging).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -34,6 +38,17 @@ case "$1 $2" in
       # number-only or title-only single-field --jq queries
       if [[ "$args" == *"number"* ]]; then echo "$STUB_PR"; exit 0; fi
       if [[ "$args" == *"title"*  ]]; then echo "$STUB_TITLE"; exit 0; fi
+      # mergeability poll (settle_mergeable): simulate the post-push recompute
+      # race — first poll reports UNKNOWN, then settles to MERGEABLE.
+      if [[ "$args" == *"mergeable"* ]]; then
+        if [[ -n "${STUB_MERGEABLE_UNKNOWN_ONCE:-}" ]]; then
+          n=$(cat "$STUB_MERGEABLE_UNKNOWN_ONCE" 2>/dev/null || echo 0)
+          if [[ "$n" -eq 0 ]]; then
+            echo 1 > "$STUB_MERGEABLE_UNKNOWN_ONCE"; echo "UNKNOWN"; exit 0
+          fi
+        fi
+        echo "MERGEABLE"; exit 0
+      fi
     fi
     if [[ "$args" == *"title"* ]]; then
       jq -n --arg t "$STUB_TITLE" '{title:$t}'; exit 0
@@ -46,13 +61,36 @@ case "$1 $2" in
     exit 0 ;;
   "pr merge")
     echo "$*" >> "${STUB_MERGE_LOG:-/dev/null}"
-    if [[ "$*" == *"--auto"* && "${STUB_AUTO_FAILS:-0}" == "1" ]]; then
-      echo "stub: auto-merge not allowed for this repository" >&2
-      exit 1
+    if [[ "$*" == *"--auto"* ]]; then
+      # Post-push recompute race: first --auto fails "not mergeable", a later
+      # call (after settle_mergeable) succeeds. Distinct from STUB_AUTO_FAILS,
+      # which models genuine auto-merge-unavailable on every call.
+      if [[ -n "${STUB_AUTO_NOTMERGEABLE_ONCE:-}" ]]; then
+        n=$(cat "$STUB_AUTO_NOTMERGEABLE_ONCE" 2>/dev/null || echo 0)
+        if [[ "$n" -eq 0 ]]; then
+          echo 1 > "$STUB_AUTO_NOTMERGEABLE_ONCE"
+          echo "stub: Pull Request is not mergeable (mergePullRequest)" >&2
+          exit 1
+        fi
+      fi
+      if [[ "${STUB_AUTO_FAILS:-0}" == "1" ]]; then
+        echo "stub: auto-merge not allowed for this repository" >&2
+        exit 1
+      fi
     fi
     echo "stub: merged $3"; exit 0 ;;
   "pr checks")
     echo "$*" >> "${STUB_CHECKS_LOG:-/dev/null}"
+    # Check-registration race: first watch reports "no checks reported" and
+    # exits non-zero instantly; a later watch passes.
+    if [[ -n "${STUB_CHECKS_NOCHECKS_ONCE:-}" ]]; then
+      n=$(cat "$STUB_CHECKS_NOCHECKS_ONCE" 2>/dev/null || echo 0)
+      if [[ "$n" -eq 0 ]]; then
+        echo 1 > "$STUB_CHECKS_NOCHECKS_ONCE"
+        echo "no checks reported on the $STUB_BRANCH branch" >&2
+        exit 1
+      fi
+    fi
     echo "stub: checks ok"; exit 0 ;;
   *)
     echo "stub gh: unexpected: $*" >&2; exit 1 ;;
@@ -74,6 +112,10 @@ seed_repo() {
     git init -q "$REPO"
     git -C "$REPO" config user.email "test@example.com"
     git -C "$REPO" config user.name  "Test"
+    # Hermetic fixtures: never inherit a host's commit-signing config (a signed
+    # environment otherwise fails every fixture commit with a signing error).
+    git -C "$REPO" config commit.gpgsign false
+    git -C "$REPO" config tag.gpgsign false
     mkdir -p "$REPO/tickets"
     cp "$ERG_BIN" "$REPO/tickets/erg"
     ERG_LOCAL="$REPO/tickets/erg"
@@ -116,6 +158,10 @@ run_merge() {  # $1 body, $2 title  — runs the script with cwd in the repo
       STUB_AUTO_FAILS="${STUB_AUTO_FAILS:-0}" \
       STUB_MERGE_LOG="${STUB_MERGE_LOG:-/dev/null}" \
       STUB_CHECKS_LOG="${STUB_CHECKS_LOG:-/dev/null}" \
+      STUB_AUTO_NOTMERGEABLE_ONCE="${STUB_AUTO_NOTMERGEABLE_ONCE:-}" \
+      STUB_MERGEABLE_UNKNOWN_ONCE="${STUB_MERGEABLE_UNKNOWN_ONCE:-}" \
+      STUB_CHECKS_NOCHECKS_ONCE="${STUB_CHECKS_NOCHECKS_ONCE:-}" \
+      ERG_PR_MERGE_POLL_INTERVAL=0 \
       bash "$SCRIPT" 42 )
 }
 
@@ -359,5 +405,63 @@ else
     echo "FAIL: erg-pr-merge exited non-zero with a dependent ticket present"; fail=1
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# Case 13: post-push mergeability recompute race (ticket 0200). The close-commit
+# push flips mergeable to UNKNOWN; the first `gh pr merge --auto` fails "not
+# mergeable". The script must poll mergeability until it settles, retry --auto
+# once (which now succeeds), and NOT fall back to watch-then-merge.
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo recompute 0230
+MLOG="$WORK/merge13.log"; CLOG="$WORK/checks13.log"
+: > "$MLOG"; : > "$CLOG"
+NOTMERGE_FLAG="$WORK/notmerge13"; : > "$NOTMERGE_FLAG"; echo 0 > "$NOTMERGE_FLAG"
+UNKNOWN_FLAG="$WORK/unknown13"; echo 0 > "$UNKNOWN_FLAG"
+BODY13=$'Summary.\n\n**Ticket:** tickets/0230-fixture.erg\n'
+if STUB_AUTO_FAILS=0 STUB_MERGE_LOG="$MLOG" STUB_CHECKS_LOG="$CLOG" \
+   STUB_AUTO_NOTMERGEABLE_ONCE="$NOTMERGE_FLAG" \
+   STUB_MERGEABLE_UNKNOWN_ONCE="$UNKNOWN_FLAG" \
+   run_merge "$BODY13" "ticket(0230): recompute" >/dev/null 2>&1; then
+    rc_miss=0
+    closed_has 0230 || { echo "  not closed: 0230"; rc_miss=1; }
+    # --auto must have been attempted twice (initial fail + retry after settle).
+    autos=$(grep -c -- '--auto' "$MLOG" || true)
+    [[ "$autos" -ge 2 ]] || { echo "  expected >=2 --auto attempts, got $autos"; rc_miss=1; }
+    # Must NOT have fallen back to watch-then-merge.
+    grep -q -- '--watch' "$CLOG" && { echo "  fell back to watch on a transient race"; rc_miss=1; }
+    if (( rc_miss )); then echo "FAIL: post-push recompute race not handled"; fail=1
+    else echo "PASS: --auto retried after mergeability settles; no spurious fallback"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on post-push recompute race"; fail=1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Case 14: fallback watch survives the no-checks-reported registration race
+# (ticket 0200). Auto-merge is genuinely unavailable, so the script falls back
+# to watch-then-merge. The first `gh pr checks --watch` exits non-zero with
+# "no checks reported" (fresh-push registration race); the script must retry
+# the watch, succeed on the second, then issue a plain --merge.
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo registration 0231
+MLOG="$WORK/merge14.log"; CLOG="$WORK/checks14.log"
+: > "$MLOG"; : > "$CLOG"
+NOCHECKS_FLAG="$WORK/nochecks14"; echo 0 > "$NOCHECKS_FLAG"
+BODY14=$'Summary.\n\n**Ticket:** tickets/0231-fixture.erg\n'
+if STUB_AUTO_FAILS=1 STUB_MERGE_LOG="$MLOG" STUB_CHECKS_LOG="$CLOG" \
+   STUB_CHECKS_NOCHECKS_ONCE="$NOCHECKS_FLAG" \
+   run_merge "$BODY14" "ticket(0231): registration" >/dev/null 2>&1; then
+    reg_miss=0
+    closed_has 0231 || { echo "  not closed: 0231"; reg_miss=1; }
+    # Watch must have been retried (no-checks once, then success): >=2 watches.
+    watches=$(grep -c -- '--watch' "$CLOG" || true)
+    [[ "$watches" -ge 2 ]] || { echo "  expected >=2 --watch attempts, got $watches"; reg_miss=1; }
+    # A plain --merge (no --auto) must follow the successful watch.
+    grep -v -- '--auto' "$MLOG" | grep -q -- '--merge' \
+        || { echo "  no plain --merge after fallback watch"; reg_miss=1; }
+    if (( reg_miss )); then echo "FAIL: no-checks registration race not survived"; fail=1
+    else echo "PASS: fallback watch retries past no-checks race, then merges"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on no-checks registration race"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged"
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled"

--- a/tickets/0200-erg-pr-merge-harden-auto-boundary-agains.erg
+++ b/tickets/0200-erg-pr-merge-harden-auto-boundary-agains.erg
@@ -9,6 +9,7 @@ Author: claude
 2026-06-04T08:54Z claude note absorbed duplicate 0209: adds 5 more occurrences (PRs #254/#255/#256/#263/#262, 2026-06-04) — all self-resolved in ~30-60s, confirming the bounded-poll window calibration; test-stub framing already covered by exit criteria here
 
 2026-06-04T20:19Z claude note three more occurrences (raid merges, PRs #274/#275/#277, 2026-06-04T20:0xZ): every erg-pr-merge run hit both boundaries — gh pr merge --auto failed on post-close-push mergeability recompute ('not mergeable' 2x, 'base branch was modified' 1x), then the checks-watch fallback died instantly on 'no checks reported'. All three self-resolved in ~90s; recovered manually with gh pr merge --merge per the documented bounce recovery. The bounded-poll fix sketch stands; 8 occurrences total now
+2026-06-04T22:15Z claude note implemented: --auto retried once after settle_mergeable poll, error-text discriminates transient recompute from genuine unavailable; fallback watch bounded-retries the no-checks registration race; die() messages name registration/timeout/red. Tests cases 13-14 added, all 14 pass
 --- body ---
 ## Source
 First production run of the 0198 rewrite (aedist PR #689, 2026-06-04),
@@ -45,9 +46,9 @@ which is exactly what the script should do itself.
   cost one manual round-trip too.
 
 ## Exit criteria
-- [ ] --auto retried after mergeability recompute settles; fallback only
+- [x] --auto retried after mergeability recompute settles; fallback only
       on genuine auto-merge-unavailable
-- [ ] Fallback watch survives the no-checks-reported registration race
-- [ ] die() messages name the actual failure cause
-- [ ] tests cover both races (stub: first --auto fails "not mergeable",
+- [x] Fallback watch survives the no-checks-reported registration race
+- [x] die() messages name the actual failure cause
+- [x] tests cover both races (stub: first --auto fails "not mergeable",
       second succeeds; checks watch fails once with no-checks then passes)

--- a/tickets/closed/0200-erg-pr-merge-harden-auto-boundary-agains.erg
+++ b/tickets/closed/0200-erg-pr-merge-harden-auto-boundary-agains.erg
@@ -2,6 +2,7 @@
 Title: erg-pr-merge: harden --auto boundary against post-push recompute races
 Created: 2026-06-04
 Author: claude
+Closed: autoclosed — PR #283
 
 --- log ---
 2026-06-04T07:36Z claude created
@@ -10,6 +11,7 @@ Author: claude
 
 2026-06-04T20:19Z claude note three more occurrences (raid merges, PRs #274/#275/#277, 2026-06-04T20:0xZ): every erg-pr-merge run hit both boundaries — gh pr merge --auto failed on post-close-push mergeability recompute ('not mergeable' 2x, 'base branch was modified' 1x), then the checks-watch fallback died instantly on 'no checks reported'. All three self-resolved in ~90s; recovered manually with gh pr merge --merge per the documented bounce recovery. The bounded-poll fix sketch stands; 8 occurrences total now
 2026-06-04T22:15Z claude note implemented: --auto retried once after settle_mergeable poll, error-text discriminates transient recompute from genuine unavailable; fallback watch bounded-retries the no-checks registration race; die() messages name registration/timeout/red. Tests cases 13-14 added, all 14 pass
+2026-06-04T22:18Z Claude closed — autoclosed — PR #283
 --- body ---
 ## Source
 First production run of the 0198 rewrite (aedist PR #689, 2026-06-04),


### PR DESCRIPTION
## Summary

The 0198 rewrite's merge step failed through **both** post-push boundaries in production (8 observed occurrences, logged on the ticket) and needed manual recovery each time:

1. The Step-2 close-commit push triggers a GitHub mergeability recompute, so the immediate `--auto` merge failed transiently with *"Pull Request is not mergeable"* — and the exit code alone couldn't distinguish that race from *"auto-merge not allowed"*, so the script wrongly fell back.
2. The watch-then-merge fallback then died in ~1s on the check-registration race (*"no checks reported on the branch"*), masked by a misleading *"did not pass within 600s"* message.

## Changes

- **`try_auto_merge`** — on a mergeability-flavoured `--auto` failure, poll `settle_mergeable` until `mergeable` leaves `UNKNOWN` (bounded, 5×10s), then retry `--auto` once. Only a non-mergeability error, or a second failure after the recompute settles, falls back. The race is discriminated by **error text**, not exit code alone.
- **`watch_checks_or_die`** — bounded-retry the watch past the *"no checks reported"* registration race (3×10s); `die()` now names the actual cause (registration vs timeout vs red) instead of the blanket 600s message.
- Poll interval/tries are env-overridable (`ERG_PR_MERGE_POLL_INTERVAL` / `_POLL_TRIES` / `_WATCH_TRIES`) so the suite drives them without sleeping; fixture repos now disable commit signing to stay hermetic.
- **Tests:** cases 13–14 cover both races via a now-stateful `gh` stub (first `--auto` "not mergeable" then ok; watch "no checks" once then ok). All 14 cases pass.

## Exit criteria (all met)
- [x] `--auto` retried after mergeability recompute settles; fallback only on genuine auto-merge-unavailable
- [x] Fallback watch survives the no-checks-reported registration race
- [x] `die()` messages name the actual failure cause
- [x] tests cover both races

## Test plan
- [x] `bash tests/test_erg_pr_merge.sh` — 14/14 pass
- [x] `make check` — skills-catalog in sync, agnostic guard clean
- [x] `bash -n` on script and test

**Ticket:** tickets/0200-erg-pr-merge-harden-auto-boundary-agains.erg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLdNjxkEPJYQMQGJV51ZQJ)_