### PR TITLE
test(0213): pin repo-relative scripts pattern, broaden stem to [A-Za-z0-9_-]

### DIFF
--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -26,7 +26,7 @@ SKILL_PATTERNS=(
     'uv run pytest'   # stack-specific; skills must be stack-agnostic
     '\bgh '           # GitHub CLI; skills must be forge-agnostic
     'github\.com'     # GitHub URL; skills must be forge-agnostic
-    '\(^\|[^.~/]\)scripts/[a-z-]\+\.\(sh\|py\)'  # repo-relative script path; use ~/.claude/scripts/ or $HARNESS_DIR
+    '\(^\|[^.~/]\)scripts/[A-Za-z0-9_-]\+\.\(sh\|py\)'  # repo-relative script path; use ~/.claude/scripts/ or $HARNESS_DIR
 )
 
 fail=0

--- a/tests/test_check_agnostic.py
+++ b/tests/test_check_agnostic.py
@@ -65,3 +65,61 @@ def test_escape_hatch_suppresses_violation(tmp_path):
     )
     result = _run(tmp_path)
     assert result.returncode == 0, result.stdout
+
+
+# --- Repo-relative script path pattern (ticket 0204, pinned by ticket 0213) ---
+#
+# The SKILL_PATTERNS entry catching repo-relative `scripts/<name>.(sh|py)`
+# references only runs against directories matching the skills case (`skills*`
+# or `*/skills*`), so these fixtures live under a `skills` subdir. Skills must
+# reference scripts via `~/.claude/scripts/` or `$HARNESS_DIR`, never as a bare
+# repo-relative `scripts/foo.sh` that assumes the harness IS the cwd.
+
+
+def _skill_dir(tmp_path):
+    """A directory whose name makes check-agnostic.sh apply SKILL_PATTERNS."""
+    d = tmp_path / "skills"
+    d.mkdir()
+    return d
+
+
+def _skill_doc(tmp_path, body):
+    d = _skill_dir(tmp_path)
+    (d / "SKILL.md").write_text(f"# Example skill\n\n{body}\n")
+    return d
+
+
+def test_fails_on_repo_relative_script_path(tmp_path):
+    """A bare `scripts/foo.sh` reference in a skill must fail the check."""
+    d = _skill_doc(tmp_path, "Run `scripts/foo.sh` to do the thing.")
+    result = _run(d)
+    assert result.returncode != 0, result.stdout
+    assert "VIOLATION" in result.stdout
+    assert "scripts/foo.sh" in result.stdout
+
+
+def test_passes_on_agnostic_script_path_forms(tmp_path):
+    """Home-anchored, HARNESS_DIR, and ./-prefixed forms are all agnostic."""
+    for body in (
+        "Run `~/.claude/scripts/foo.sh` to do the thing.",
+        "Run `$HARNESS_DIR/scripts/foo.py` to do the thing.",
+        "Run `./scripts/foo.sh` to do the thing.",
+    ):
+        sub = tmp_path / f"case_{abs(hash(body))}"
+        sub.mkdir()
+        d = _skill_doc(sub, body)
+        result = _run(d)
+        assert result.returncode == 0, f"{body!r} -> {result.stdout}"
+
+
+def test_catches_mixed_case_and_underscore_script_names(tmp_path):
+    """Stem must cover uppercase/digit/underscore names, not just [a-z-].
+
+    Red against the original `[a-z-]\\+` stem; green once broadened to
+    `[A-Za-z0-9_-]`. This is the deliberately-broken-pattern pin.
+    """
+    d = _skill_doc(tmp_path, "Run `scripts/Build_Step2.py` to do the thing.")
+    result = _run(d)
+    assert result.returncode != 0, result.stdout
+    assert "VIOLATION" in result.stdout
+    assert "scripts/Build_Step2.py" in result.stdout

--- a/tickets/0213-pin-regression-fixture-for-the-repo-rela.erg
+++ b/tickets/0213-pin-regression-fixture-for-the-repo-rela.erg
@@ -2,10 +2,12 @@
 Title: Pin regression fixture for the repo-relative scripts pattern in check-agnostic
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: Pinned regression fixture for repo-relative scripts pattern; broadened stem to [A-Za-z0-9_-]
 
 --- log ---
 2026-06-04T11:01Z MinhHaDuong created
 
+2026-06-05T00:11Z Claude closed — Pinned regression fixture for repo-relative scripts pattern; broadened stem to [A-Za-z0-9_-]
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

The `SKILL_PATTERNS` entry in `scripts/check-agnostic.sh` that catches
repo-relative `scripts/<name>.(sh|py)` references (added in ticket 0204 /
PR #277) was live-enforced via `make check` but had **no committed
regression-pin fixture** — only the older home-path pattern was exercised by
`tests/test_check_agnostic.py`. A BRE typo or refactor could silently disable
it. The /verify gate flagged this (non-blocking) on 0204.

This PR:

- Adds fixture tests under a `skills`-named tmp dir (so `SKILL_PATTERNS`
  actually apply): a bare `scripts/foo.sh` reference **fails**, while
  `~/.claude/scripts/foo.sh`, `$HARNESS_DIR/scripts/foo.py`, and
  `./scripts/foo.sh` forms all **pass**.
- Broadens the stem from `[a-z-]` to `[A-Za-z0-9_-]` so uppercase, digit, and
  underscore script names are caught too — pinned by a red-first test that
  fails against the old stem and passes after broadening.

## Test plan

- [x] New mixed-case test is **red** against the original `[a-z-]` stem,
      **green** after broadening (the deliberately-broken-pattern pin).
- [x] `uv run pytest tests/test_check_agnostic.py` — 7/7 pass.
- [x] `make check` — skills-catalog in sync, agnostic checks clean (no new
      violations introduced in `skills/` by the broadened stem).
- [x] Full suite: 364 passed. The only 2 failures
      (`test_guard_commit_on_main.sh`, `test_guard_skills_catalog.sh`) are
      pre-existing on pristine `origin/main` — a sandbox commit-signing
      server error (HTTP 400), unrelated to this change.

**Ticket:** tickets/0213-pin-regression-fixture-for-the-repo-rela.erg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ME2mYVpDRC3DwPyBUyFXu5)_