### PR TITLE
skills(0210): narrow blanket git add in skill prose + ratchet test

### DIFF
--- a/skills/check-readiness/SKILL.md
+++ b/skills/check-readiness/SKILL.md
@@ -71,7 +71,7 @@ configuration health, project readiness, and surface risk signals from prior run
 4. **Interactive triage**
    For each project flagged with issues (≥ 1 ⚠ indicator):
    Present the findings and offer:
-   a. **commit**: Stage and commit any changes (git add -A && git commit)
+   a. **commit**: Stage and commit any changes (git add -u && git commit)
    b. **branch**: Create a new branch for the changes
    c. **note**: Record an explanation without committing
    d. **skip**: Leave unchanged, move to next
@@ -140,9 +140,10 @@ compatibility until ticket 0068 (alias system) is closed.
    Record every action taken.
 
 6. **Housekeeping commit**
-   After triage, commit all modified ticket files:
+   After triage, commit all modified ticket files (`-u` stages tracked
+   edits only — a stray `.erg` left in `tickets/` is never swept in):
    ```bash
-   git add tickets/
+   git add -u tickets/
    git commit -m "chore(tickets): nightbeat risk-review triage $(date +%Y-%m-%d)"
    ```
    If no files were changed (all `skip`), print "No changes to commit."

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -71,8 +71,9 @@ Run full repo housekeeping and act on every finding.
 2.6. **Archive closed tickets.** Skip if `tickets/` is absent.
 
    ```bash
-   tickets/erg archive tickets/
-   git add tickets/closed/
+   # Stage exactly the files this archive moved (it prints `ARCHIVED <basename>`),
+   # never the whole closed/ dir — a stray file there must not ride along.
+   tickets/erg archive tickets/ | sed -n 's#^ARCHIVED #tickets/closed/#p' | xargs -r git add --
    ```
 
    This moves any ticket with a non-empty `Closed:` header from `tickets/`

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -94,8 +94,11 @@ When you reach a root cause, repair if within authority:
   independent unit of work; leave the parent open as an umbrella. Each child
   ticket must carry `Blocked-by: <umbrella-id>` so pick-ticket can auto-close
   the umbrella when all children are done (it uses inverse lookup, not a
-  `Blocks:` header — that header is not valid in %erg v1). Commit all new/modified
-  ticket files: `git add tickets/*.erg && git commit -m 'chore(supervisor): split <ticket> into children'`.
+  `Blocks:` header — that header is not valid in %erg v1). Commit the new
+  ticket files by naming each child (`git add tickets/<child-id>-*.erg`, one per
+  child), then `git commit -m 'chore(supervisor): split <ticket> into children'`
+  — never `git add` over the whole `tickets/` glob, which also sweeps a stray
+  `.erg` left by another agent in the shared checkout.
 - **Dead timer** → restart it.
 - **Dirty working tree** (`outcome=aborted-dirty-tree`) → if the dirty files
   are machine-local state (beat-outcomes.jsonl, STATE.md, build artifacts),

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -40,7 +40,9 @@ Select one ticket for the current sweep run.
    check whether the ticket is closed using `$ERG status <id>`. If any results
    are found AND all matching tickets are closed, auto-close this ticket by
    running `$ERG close <id> already-done`, then commit the ticket file
-   (`git add tickets/ && git commit -m "ticket(<id>): close — already-done"`),
+   (`git add -u tickets/ && git commit -m "ticket(<id>): close — already-done"`
+   — `-u` stages the close edit and any dependent Blocked-by removals without
+   sweeping a stray file in the shared `tickets/`),
    and output `CLOSED: <id>`. Skip scope assessment for this ticket.
 
    Convention: when splitting a ticket into children, each child ticket must
@@ -97,7 +99,8 @@ Select one ticket for the current sweep run.
    1. Run `$ERG close <id> already-done` — it writes the `Closed:` header
       and appends the audit log line `{ts} claude closed — already-done` in
       one step. Then commit the ticket file
-      (`git add tickets/ && git commit -m "ticket(<id>): close — already-done"`).
+      (`git add -u tickets/ && git commit -m "ticket(<id>): close — already-done"`
+      — `-u` stages tracked edits only, never a stray file in `tickets/`).
    2. Output `CLOSED: <id>` and stop processing this candidate (do not
       rank it). beat.py will loop back and pick again.
 

--- a/skills/start-ticket/SKILL.md
+++ b/skills/start-ticket/SKILL.md
@@ -18,7 +18,9 @@ argument-hint: <ticket-id>
      close the ticket through the **normal branch + PR flow** — never commit the close on `main`.
      Enter the worktree (step 3) and create the branch (step 4) first, then on that branch run
      `${ERG:-tickets/erg} close $ARGUMENTS already-done`, commit the ticket file
-     (`git add tickets/ && git commit -m "ticket($ARGUMENTS): close — already-done"`), and open the
+     (`git add -u tickets/ && git commit -m "ticket($ARGUMENTS): close — already-done"`
+     — `-u` stages the close edit and any dependent Blocked-by removals, never a
+     stray file in the shared `tickets/`), and open the
      merge request (step 10). Skip the test/implement steps (5–9); the merge request lands the close
      via review like any other change. Do not stop with an uncommitted-to-`main` or unpushed close.
 3. If not already in a worktree, enter one: call `EnterWorktree` with name `t$ARGUMENTS`.

--- a/tests/test_skill_blanket_add.py
+++ b/tests/test_skill_blanket_add.py
@@ -1,0 +1,98 @@
+"""Blanket-staging ratchet for skill prose (ticket 0210).
+
+PR #242 lost a stray file into a close commit because a skill instructed the
+blanket `git add` form in a shared checkout: any leftover under `tickets/`
+(stash residue, a crashed agent's draft, a cross-branch artifact) gets
+silently committed by the next skill run that follows those lines.
+`erg-pr-merge` itself was narrowed by PR #262, but the skill prose that agents
+execute by hand was not. This test pins the narrowing so it cannot regress:
+command-position `git add` in `skills/*/SKILL.md` must name what it stages
+(a specific file, or `-u` for tracked edits only), never sweep a directory,
+wildcard, `-A`, or `.`.
+
+Escape hatch: a `# blanket-add-ok: <reason>` comment on the same line marks a
+deliberate blanket add and exempts it.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILLS = REPO / "skills"
+
+ALLOWLIST_MARKER = "# blanket-add-ok:"
+
+# Capture the argument run after a `git add`, stopping at the first shell
+# terminator so we never bleed into a chained `&& git commit -m "..."`.
+_GIT_ADD = re.compile(r"git add(?P<args>(?:[^\n`&|;)])*)")
+
+
+def _is_blanket(args: str) -> bool:
+    """True when this `git add` argument run sweeps an unnamed set.
+
+    Blanket forms: `-A`, a bare `.`, a path ending in `/` (a directory), or a
+    `*` wildcard. A `<placeholder>` in the path (e.g. `tickets/<id>-*.erg`)
+    pins the add to one known ticket and is allowed, as is `-u` (tracked-only).
+    """
+    tokens = args.split()
+    if not tokens:
+        return False  # bare `git add` in prose ("…for a later `git add` to sweep")
+    if "-A" in tokens:
+        return True
+    if "-u" in tokens:
+        return False
+    for tok in tokens:
+        if tok == ".":
+            return True
+        if tok.startswith("-"):
+            continue  # other flag (e.g. the `--` end-of-options marker)
+        if "<" in tok:
+            continue  # named-file placeholder → specific, not a sweep
+        if "*" in tok or tok.endswith("/"):
+            return True
+    return False
+
+
+def _blanket_hits() -> list[str]:
+    hits = []
+    for skill in sorted(SKILLS.glob("*/SKILL.md")):
+        for lineno, line in enumerate(skill.read_text().splitlines(), start=1):
+            if ALLOWLIST_MARKER in line:
+                continue
+            if any(_is_blanket(m.group("args")) for m in _GIT_ADD.finditer(line)):
+                rel = skill.relative_to(REPO)
+                hits.append(f"{rel}:{lineno}: {line.strip()}")
+    return hits
+
+
+def test_no_blanket_git_add_in_skill_prose():
+    """No skill instructs a blanket `git add` that could sweep a stray file."""
+    hits = _blanket_hits()
+    assert not hits, (
+        "Blanket `git add` in skill prose (narrow to a named file or `git add -u`, "
+        f"or justify with a `{ALLOWLIST_MARKER} <reason>` comment):\n  "
+        + "\n  ".join(hits)
+    )
+
+
+def test_ratchet_detects_known_blanket_forms():
+    """The detector must fire on the exact forms the narrowing removed."""
+    assert _is_blanket(" -A")
+    assert _is_blanket(" .")
+    assert _is_blanket(" tickets/")
+    assert _is_blanket(" tickets/closed/")
+    assert _is_blanket(" tickets/*.erg")
+    # …and must NOT fire on the narrowed replacements.
+    assert not _is_blanket(" -u")
+    assert not _is_blanket(" -u tickets/")
+    assert not _is_blanket(" tickets/<child-id>-*.erg")
+    assert not _is_blanket(" settings.json")
+    assert not _is_blanket("")  # bare `git add` in prose
+
+
+def test_allowlist_marker_exempts_a_line():
+    """A `# blanket-add-ok:` comment marks a deliberate blanket add as allowed."""
+    assert _is_blanket(" tickets/")  # blanket in isolation…
+    # …but a line carrying the marker is skipped by the file scan.
+    sentinel = f"   git add tickets/  {ALLOWLIST_MARKER} deliberate sweep"
+    assert ALLOWLIST_MARKER in sentinel

--- a/tickets/closed/0210-blanket-git-add-in-skill-prose-narrow-staging.erg
+++ b/tickets/closed/0210-blanket-git-add-in-skill-prose-narrow-staging.erg
@@ -2,10 +2,12 @@
 Title: Narrow blanket git add in skill prose — check-readiness, pick-ticket, housekeeping, nightbeat-supervisor + ratchet test
 Created: 2026-06-04
 Author: claude
+Closed: autoclosed — PR #285
 
 --- log ---
 2026-06-04T09:05Z claude created — 0193 post-merge celebrate sweep
 
+2026-06-05T02:13Z Claude closed — autoclosed — PR #285
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Blanket `git add` in skill prose silently commits stray files in shared checkouts — the PR #242 failure class (a leftover `.erg` swept into a close commit). `erg-pr-merge` itself was narrowed by PR #262 (cases 11–12 in `tests/test_erg_pr_merge.sh`), but the prose agents execute by hand was not. This narrows every command-position blanket add and adds a standing ratchet so it cannot regress.

## Changes

Narrowed each blanket add to the exact paths the step touches:

| File:line | Before | After |
|---|---|---|
| `check-readiness:74` | `git add -A` (interactive triage) | `git add -u` |
| `check-readiness:145` | `git add tickets/` | `git add -u tickets/` |
| `pick-ticket:43` | `git add tickets/` (close path) | `git add -u tickets/` |
| `pick-ticket:100` | `git add tickets/` (close path) | `git add -u tickets/` |
| `start-ticket:21` | `git add tickets/` (close path) | `git add -u tickets/` |
| `housekeeping:75` | `git add tickets/closed/` | capture `erg`'s `ARCHIVED <basename>`, add only those paths |
| `nightbeat-supervisor:98` | `git add tickets/*.erg` (split) | name each child `git add tickets/<child-id>-*.erg` |

`-u` stages tracked edits only (close edits + dependent `Blocked-by` removals), never a stray. The archive case can't use `-u` (it creates new files in `closed/`), so it stages exactly what `erg archive` reports moving — verified that a stray `closed/STRAY.txt` is not swept.

**Scope note:** the ticket named 5 instances across 4 files; the full-unit sweep found 2 more of the same class (`start-ticket:21`, `pick-ticket:100`), narrowed here too.

## Test

`tests/test_skill_blanket_add.py` — a standing ratchet flagging command-position `git add -A`, `.`, bare `tickets/`-style directories, and `*` globs across `skills/*/SKILL.md`, while allowing `-u`, named-file placeholders, and a `# blanket-add-ok: <reason>` escape hatch.

- Red against pre-fix prose (7 hits across 5 files), green after.
- Full `pytest tests/` green except `test_guard_commit_on_main.sh` / `test_guard_skills_catalog.sh`, which fail identically on a clean `origin/main` due to the sandbox commit-signing server returning 400 (these suites make real commits) — environmental, not from this change. `make check` clean.

**Ticket:** tickets/0210-blanket-git-add-in-skill-prose-narrow-staging.erg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Krigz4EBqEzcXc569c1WVU)_