### PR TITLE
hooks(0212): drop ruff format from lint-on-edit, keep lint

### DIFF
--- a/scripts/lint-on-edit.sh
+++ b/scripts/lint-on-edit.sh
@@ -13,13 +13,16 @@ file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
 [ -z "$file_path" ] && exit 0
 [[ "$file_path" == *.py ]] || exit 0
 
-# Run ruff check (fix safe violations) then format
+# Run ruff check (fix safe violations) only — deliberately NOT `ruff format`.
+# The repo has no repo-wide formatter (ticket 0201, PR #275): running
+# `ruff format` here silently reinstated the exact per-PR churn 0201 reverted,
+# every time an agent touched a .py file via Edit/Write. Lint stays (advisory,
+# self-correcting); formatting is a no-op until a formatter is adopted
+# repo-wide. See ticket 0212.
 if command -v uv &>/dev/null; then
     output=$(uv run ruff check --fix --quiet "$file_path" 2>&1 || true)
-    uv run ruff format --quiet "$file_path" 2>/dev/null || true
 elif command -v ruff &>/dev/null; then
     output=$(ruff check --fix --quiet "$file_path" 2>&1 || true)
-    ruff format --quiet "$file_path" 2>/dev/null || true
 else
     exit 0  # no linter available
 fi

--- a/tests/test_lint_on_edit.sh
+++ b/tests/test_lint_on_edit.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests for scripts/lint-on-edit.sh — the PostToolUse hook that runs ruff on
+# edited Python files. Policy (ticket 0212, building on 0201/PR #275): the repo
+# has NO repo-wide formatter, so the hook must LINT but never `ruff format` —
+# otherwise it silently reinstates the per-PR formatting churn 0201 reverted.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HOOK="$PWD/scripts/lint-on-edit.sh"
+fail=0
+
+# --- static ratchet: the hook source must not invoke `ruff format` -----------
+# Strip comment lines first so an explanatory comment mentioning `ruff format`
+# is not mistaken for an actual invocation.
+if grep -vE '^[[:space:]]*#' "$HOOK" | grep -qE 'ruff format'; then
+    echo "FAIL: scripts/lint-on-edit.sh invokes 'ruff format' — reinstates the"
+    echo "      formatting churn ticket 0201 reverted (no repo-wide formatter)."
+    fail=1
+else
+    echo "PASS: hook does not invoke 'ruff format'"
+fi
+
+# --- static ratchet: lint is retained ----------------------------------------
+if grep -qE 'ruff check' "$HOOK"; then
+    echo "PASS: hook still runs 'ruff check' (lint retained)"
+else
+    echo "FAIL: hook no longer runs 'ruff check' — lint was dropped, not just format."
+    fail=1
+fi
+
+# --- behavioral: running the hook must not reformat a lint-clean file ---------
+# `x = {'a':1}` is untouched by `ruff check --fix` (quote/spacing are not in
+# ruff's default lint select) but WOULD be rewritten to `x = {"a": 1}` by
+# `ruff format`. So a byte-identical file after the hook proves format is off.
+# Gate on the same capability the hook uses (uv-run ruff OR bare ruff), so the
+# check still runs in a uv-only environment where bare `ruff` isn't on PATH.
+if command -v uv &>/dev/null || command -v ruff &>/dev/null; then
+    probe=$(mktemp --suffix=.py)
+    printf "x = {'a':1}\n" > "$probe"
+    before=$(cat "$probe")
+    printf '{"tool_name":"Edit","tool_input":{"file_path":%s}}' \
+        "$(printf '%s' "$probe" | jq -Rs .)" \
+        | bash "$HOOK" >/dev/null 2>&1 || true
+    after=$(cat "$probe")
+    rm -f "$probe"
+    if [[ "$before" == "$after" ]]; then
+        echo "PASS: hook leaves a format-only deviation untouched"
+    else
+        echo "FAIL: hook reformatted the file (before: [$before] after: [$after])"
+        fail=1
+    fi
+else
+    echo "SKIP: ruff not installed — behavioral reformat check not run"
+fi
+
+if (( fail )); then
+    exit 1
+fi
+echo "PASS: lint-on-edit lints without formatting"

--- a/tickets/closed/0212-align-lint-on-edit-ruff-format-hook-with.erg
+++ b/tickets/closed/0212-align-lint-on-edit-ruff-format-hook-with.erg
@@ -2,10 +2,13 @@
 Title: Align lint-on-edit ruff format hook with the repo formatting policy
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: Hook aligned with no-formatter policy; ratchet test added — PR pending
 
 --- log ---
 2026-06-04T11:01Z MinhHaDuong created
 
+2026-06-05T04:05Z claude decided option (a): drop 'ruff format' from scripts/lint-on-edit.sh, keep 'ruff check --fix'. Aligns with 0201/PR #275 (no repo-wide formatter). Added tests/test_lint_on_edit.sh ratchet (static: no 'ruff format'; behavioral: hook leaves a format-only deviation byte-identical).
+2026-06-05T04:05Z Claude closed — Hook aligned with no-formatter policy; ratchet test added — PR pending
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

The PostToolUse `lint-on-edit.sh` hook ran `ruff format` on every Python file after every Edit/Write, silently reinstating the exact formatting churn ticket 0201 (PR #275) reverted — the repo deliberately has **no** repo-wide formatter. The 0201 agent had to bypass the hook with `cp` to keep its revert, leaving that revert fragile until this contradiction is resolved.

Resolved per 0212 **option (a)**: keep `ruff check --fix` (advisory, self-correcting lint), drop both `ruff format` invocations. Formatting stays a no-op until a formatter is adopted repo-wide.

## Changes

- `scripts/lint-on-edit.sh` — removed the two `ruff format` calls (uv and bare-ruff branches); kept `ruff check --fix`. Comment documents the why and points at 0201/0212.
- `tests/test_lint_on_edit.sh` (new, auto-discovered by `test_bash_suites.py`):
  - **static ratchet** — non-comment hook source must not invoke `ruff format`, and must still run `ruff check`;
  - **behavioral** — feeding a lint-clean, format-only deviation (`x = {'a':1}` — untouched by ruff's default lint select, but rewritten by `ruff format`) through the hook leaves the file byte-identical.

## Test plan

- [x] `bash tests/test_lint_on_edit.sh` — 4/4 pass
- [x] `make check` — skills-catalog in sync, agnostic checks clean
- [x] `erg check` — PASS (pre-existing 0213 archive WARN only)
- [ ] Verify PR review clears gate

Note: `test_guard_commit_on_main.sh` / `test_guard_skills_catalog.sh` fail in this sandbox due to the commit-signing server returning 400 (`fatal: failed to write commit object`) — an environment limitation, not introduced by this change; neither suite touches the hook or ruff.

## Exit criteria (ticket 0212)

- [x] Hook behavior and repo formatting policy agree
- [x] Editing a Python file via Edit produces no formatting-only diff hunks (behavioral test proves the hook no longer reformats)
- [x] Decision documented in the ticket log

**Ticket:** tickets/0212-align-lint-on-edit-ruff-format-hook-with.erg

---
_Generated by [Claude Code](https://claude.ai/code/session_018TabYctPPeRdd52JDgU48z)_