### PR TITLE
skill(0211): freshen installed erg before housekeeping erg checks

### DIFF
--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -35,6 +35,33 @@ Run full repo housekeeping and act on every finding.
 
    Exception: `BEAT_HOUSEKEEPING_BRANCH` is set — beat.py manages concurrency itself; skip this guard.
 
+0.7. **Freshen the erg binary (before any erg check).** Refresh the installed
+   `erg` *before* step 1's git phase, because both erg-driven surfaces a sweep
+   acts on run against whatever binary is on `PATH`: the corpus check
+   `erg check tickets/` inside `housekeeping-git.sh`, and `erg ready` inside the
+   step-2 healthcheck probe (`project-state.py` prefers `which erg`). A stale
+   installed binary produces *false* violations on tickets using format the old
+   binary predates — six bogus folder/header hits on closed tickets carrying the
+   newer `Label:` header, 2026-06-04 — and an autonomous sweep would file
+   tickets on them.
+
+   ```bash
+   erg update   # refresh the INSTALLED binary. Offline-safe by design: fetch
+                # errors (no remote, no network, not a git repo) exit 0, so the
+                # sweep never fails on an isolated machine.
+   ```
+
+   `erg update` only ever replaces the binary it runs as (the installed
+   `~/.local/bin/erg`), never the committed `tickets/erg`. If a visited repo's
+   committed `tickets/erg` lags its remote, **surface that as an `open-ticket`
+   finding (step 4) — do not run `tickets/erg update` and do not commit a
+   refreshed binary here.** The committed binary is durable state that travels
+   via a merge request, not via a sweep's direct mutation.
+
+   Ordering this before step 1 means every later erg-driven finding runs against
+   the fresh binary: a violation that survives the refresh is real and may be
+   ticketed; one that does not was a stale-binary artifact and is dropped.
+
 1. **Git phase.**
    - If `BEAT_HOUSEKEEPING_BRANCH` is **not** set (interactive run): `Bash(~/.claude/scripts/housekeeping-git.sh)` from the project root. Then cut a dated branch: `git switch -c housekeeping-$(date -u +%Y%m%d) origin/main`. All subsequent commits in this run land on that branch.
    - If `BEAT_HOUSEKEEPING_BRANCH` **is** set (beat.py run): skip — beat.py already ran the git phase before invoking this skill.

--- a/tickets/closed/0211-housekeeping-refresh-erg-binaries-erg-up.erg
+++ b/tickets/closed/0211-housekeeping-refresh-erg-binaries-erg-up.erg
@@ -2,10 +2,12 @@
 Title: housekeeping: refresh erg binaries (erg update) as a sweep step
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: autoclosed — PR #287
 
 --- log ---
 2026-06-04T09:03Z MinhHaDuong created
 
+2026-06-05T06:09Z Claude closed — autoclosed — PR #287
 --- body ---
 ## Source
 2026-06-04 git-erg queue preflight: ~/.local/bin/erg had gone stale in


### PR DESCRIPTION
## Summary

Adds an `erg update` freshness step to the housekeeping skill, ordered **before** step 1's git phase so it runs ahead of both erg-driven surfaces a sweep acts on:
- `erg check tickets/` inside `scripts/housekeeping-git.sh`
- `erg ready` inside the step-2 healthcheck probe (`project-state.py` prefers `which erg`)

## Why

On 2026-06-04 a stale installed `erg` produced six **false** corpus-check violations on closed tickets carrying the newer `Label:` header. Caught interactively, but an autonomous sweep would have filed tickets on the bogus findings.

Chose `housekeeping` over `healthcheck` as the owner because housekeeping is the sweep that turns findings into tickets — the layer where a stale-binary false positive actually causes harm.

## Exit criteria

- [x] housekeeping skill doc includes the `erg update` step with the offline-safe rationale (fetch errors exit 0 → sweep never fails on an isolated machine)
- [x] Step is ordered before any `erg check` whose findings can spawn tickets (placed before step 1)
- [x] Stale committed `tickets/erg` is reported as an `open-ticket` finding, never auto-committed (`erg update` refreshes only the installed binary; the committed one travels via a merge request)

## Test plan

- [x] `make check` — skills-catalog in sync, agnostic guards clean
- [x] `erg check tickets/` — PASS (warnings only, non-fatal)
- No automated test (doc-only change); reviewed before landing.

**Ticket:** tickets/0211-housekeeping-refresh-erg-binaries-erg-up.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjxjkhXMCyEzCPKZcVxUuV)_