### PR TITLE
skill(0208): /reviewers panel management wired to the 0217 seat-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automaticall
 | `/release` | Pre-release audit, GPG tag signing, and download-URL update for a target repo. Runs audits autonomously; pauses at the human-only signing step. |
 | `/review-pr` | Multi-perspective code review with parallel agents. Covers correctness, consistency, scope, red team, and doc propagation. |
 | `/review-pr-prose` | Simulated peer review panel for manuscript prose. Spins discipline-specific agents for multi-perspective review. |
+| `/reviewers` | "Reviewer-panel management for /verify — list, request, harvest, scorecard (review-is-CI seats)" |
 | `/skill-doctor` | Weekly failure-pattern analysis across journals, logs, and git history. Clusters recurring failures and opens tickets with proposed patches. Never auto-applies fixes. |
 | `/smoke` | Agent environment smoke test — reports runtime identity, auth method, and harness context. |
 | `/start-ticket` | Begin work on a ticket. Creates worktree, writes first test, transitions to Execute phase. |

--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: reviewers
+description: "Reviewer-panel management for /verify — list, request, harvest, scorecard (review-is-CI seats)"
+disable-model-invocation: false
+user-invocable: true
+argument-hint: "<subcommand> [args]"
+---
+
+Manage the external reviewer panel for `/verify`. Each seat is a sandboxed
+CI-style reviewer job (ticket 0205, "review is CI"): `request` runs the
+0217 seat-runner once per roster seat — one OS-sandboxed container per
+seat — and `harvest` normalizes every seat's findings to the gate's
+contract shape. Containment comes from the seat-runner's sandbox, not from
+this skill. All I/O routes through `skills/reviewers/reviewers.sh`.
+
+## Subcommands
+
+### `/reviewers list`
+
+Show panel members, their kind (forge-bot / cli-agent / local-model),
+advisory/required status, and trial ticket. Empty roster → prints
+`no reviewers configured`, exits 0.
+
+### `/reviewers request <pr> [branch]`
+
+For each roster seat, run the 0217 seat-runner over the merge request's
+diff (the branch is resolved from the PR, or passed explicitly):
+
+- **cli-agent / local-model**: the seat-runner launches the agnostic CLI
+  reviewer inside an OS sandbox over an OpenAI-compatible endpoint
+  (OpenRouter or local llama-server), writing per-seat findings.
+- **forge-bot**: requested via the forge's review API.
+  <!-- harness-extension-point -->
+
+**Per-seat fail-open**: a seat that errors or hangs WARNs and the others
+proceed — one seat never blocks the verdict (0205). Empty roster → no-op,
+exits 0. No secrets in config; seat credentials load via the BASH_ENV path.
+
+### `/reviewers harvest <pr>`
+
+Collect every seat's findings and normalize the seat-runner's
+`FINDING|severity=…|file=…|rationale=…` output to the 0205 contract shape:
+
+```
+verifiable: <file>:<line> — <rationale>  [seat]
+consider: <file>:<line> — <rationale>  [seat]
+```
+
+A line that does not parse is surfaced as a `WARN` on stderr, never
+silently dropped. No findings (empty panel / no seats ran) → empty output,
+exit 0.
+
+### `/reviewers scorecard <pr> <seat> <verdict-summary>`
+
+Append a fixed-schema trial line to the seat's trial ticket via `erg log`
+(verbs: `created`, `note`, `closed` only), so 0205's integration review is
+evidence-based:
+
+```
+MR #42 seat=local-qwen verdict: PASS — 0 verifiable, 2 consider
+```
+
+## Configuration
+
+`skills/reviewers/panel.yml` is the single roster file (schema in its
+header). No secrets in config — credentials load via BASH_ENV (0207).
+
+## Dependencies
+
+- `~/.claude/scripts/seat-runner-prototype.sh` (ticket 0217) — the
+  sandboxed seat execution mechanism `request` invokes. Override with
+  `SEAT_RUNNER` for testing.
+- `tickets/erg` — `scorecard` appends the trial log line.

--- a/skills/reviewers/panel.yml
+++ b/skills/reviewers/panel.yml
@@ -1,0 +1,27 @@
+# Reviewer panel roster — managed by the /reviewers skill.
+#
+# Each seat is a sandboxed CI-style reviewer job (see ticket 0205, "review
+# is CI"). A seat is run by the 0217 seat-runner inside an OS sandbox; this
+# file holds NO secrets — credentials load via the BASH_ENV path (0207).
+#
+# Seat schema:
+#   - name:         unique identifier
+#     kind:         forge-bot | cli-agent | local-model
+#     status:       advisory | required   (start advisory; see 0205 rule 2)
+#     trial-ticket: tickets/NNNN-...       (where scorecards are logged)
+#     # cli-agent / local-model seats also carry:
+#     endpoint:     OpenAI-compatible base URL (e.g. http://127.0.0.1:8012/v1)
+#     model:        model id passed to the seat-runner
+#
+# Default: empty roster → /reviewers is a no-op until seats are configured.
+# Example (commented; uncomment + adjust to enable):
+#
+# reviewers:
+#   - name: local-qwen
+#     kind: local-model
+#     status: advisory
+#     trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+#     endpoint: http://127.0.0.1:8012/v1
+#     model: openai/qwen3.6-35b-a3b
+
+reviewers: []

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Reviewer-management dispatcher — pure I/O helper for the /reviewers skill.
+# Case-switch dispatch; no plugin architecture.
+#
+# "Review is CI" (ticket 0205): each seat is a sandboxed CI-style reviewer
+# job. `request` runs the 0217 seat-runner once per roster seat (one
+# container per seat); `harvest` normalizes every seat's findings to the
+# 0205 contract shape; `scorecard` appends a fixed-schema trial line.
+#
+# Containment is the seat-runner's OS sandbox (0217), NOT this script.
+# This script holds no secrets; seat credentials load via BASH_ENV (0207).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${REVIEWERS_REPO:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+PANEL="${REVIEWERS_PANEL:-${SCRIPT_DIR}/panel.yml}"
+# The 0217 seat-runner. Overridable so the test suite can stub it.
+SEAT_RUNNER="${SEAT_RUNNER:-${SCRIPT_DIR}/../../scripts/seat-runner-prototype.sh}"
+# Where per-seat findings land for harvest to collect (per merge request).
+FINDINGS_DIR="${REVIEWERS_FINDINGS_DIR:-${TMPDIR:-/tmp}/reviewers}"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: reviewers.sh <subcommand> [args]
+
+Subcommands:
+  list                          Show panel members and trial progress
+  request <pr> [branch]         Run each seat (0217 seat-runner) over the MR
+  harvest <pr>                  Normalize all seats' findings to one file
+  scorecard <pr> <seat> <ver>   Append a fixed-schema trial line via erg note
+EOF
+    exit 1
+}
+
+# ── roster parsing ───────────────────────────────────────────────────────────
+# Emit one TAB-separated record per seat: name kind status endpoint model
+# trial-ticket. Minimal block parser for the flat panel.yml schema; comment
+# and blank lines are ignored, and an explicit `reviewers: []` yields nothing.
+roster_records() {
+    awk '
+        /^[[:space:]]*#/        { next }
+        /^reviewers:[[:space:]]*\[\][[:space:]]*$/ { exit }
+        /^[[:space:]]*-[[:space:]]*name:/ {
+            if (have) print rec(); have=1; name=val($0); kind=st=ep=mo=tt=""; next
+        }
+        /^[[:space:]]+kind:/          { kind=val($0) }
+        /^[[:space:]]+status:/        { st=val($0) }
+        /^[[:space:]]+endpoint:/      { ep=val($0) }
+        /^[[:space:]]+model:/         { mo=val($0) }
+        /^[[:space:]]+trial-ticket:/  { tt=val($0) }
+        END { if (have) print rec() }
+        function val(line,  v) { sub(/^[^:]*:[[:space:]]*/, "", line); gsub(/^[[:space:]]+|[[:space:]]+$/, "", line); return line }
+        function rec() { return name"\t"kind"\t"st"\t"ep"\t"mo"\t"tt }
+    ' "$PANEL" 2>/dev/null
+}
+
+panel_is_empty() { [ -z "$(roster_records)" ]; }
+
+# ── PR → branch resolution (forge-specific; overridable for tests) ───────────
+pr_branch() {  # $1 pr; honor an explicit override first
+    local pr="$1"
+    if [ -n "${REVIEWERS_PR_BRANCH:-}" ]; then echo "$REVIEWERS_PR_BRANCH"; return 0; fi
+    gh pr view "$pr" --json headRefName --jq '.headRefName'  # harness-extension-point
+}
+
+subcmd="${1:-}"; shift || true
+
+case "$subcmd" in
+    list)
+        if panel_is_empty; then echo "no reviewers configured"; exit 0; fi
+        printf '%-18s %-12s %-9s %s\n' NAME KIND STATUS TRIAL-TICKET
+        while IFS=$'\t' read -r name kind st ep mo tt; do
+            printf '%-18s %-12s %-9s %s\n' "$name" "$kind" "${st:-advisory}" "$tt"
+        done < <(roster_records)
+        ;;
+
+    request)
+        pr="${1:-}"; [ -n "$pr" ] || { echo "error: request requires a merge request identifier" >&2; exit 1; }
+        if panel_is_empty; then echo "no reviewers configured"; exit 0; fi
+        branch="${2:-$(pr_branch "$pr")}"
+        [ -n "$branch" ] || { echo "error: could not resolve branch for MR #${pr}" >&2; exit 1; }
+        dest="${FINDINGS_DIR}/${pr}"; mkdir -p "$dest"
+        ran=0
+        while IFS=$'\t' read -r name kind st ep mo tt; do
+            case "$kind" in
+                forge-bot)
+                    # Server-side reviewer; requested via the forge API.
+                    echo "request: forge-bot seat '${name}' — request via forge review API" >&2  # harness-extension-point
+                    ;;
+                cli-agent|local-model)
+                    # Per-seat fail-open: a seat that errors WARNs and the
+                    # others proceed — one seat never blocks the verdict (0205).
+                    if "$SEAT_RUNNER" --repo "$REPO_ROOT" --branch "$branch" \
+                        --endpoint "$ep" --model "$mo" --out "${dest}/${name}.findings" \
+                        >/dev/null 2>"${dest}/${name}.err"; then
+                        echo "request: seat '${name}' ok → ${dest}/${name}.findings" >&2
+                        ran=$((ran+1))
+                    else
+                        echo "request: WARN seat '${name}' failed (fail-open; see ${dest}/${name}.err)" >&2
+                    fi
+                    ;;
+                *)
+                    echo "request: WARN seat '${name}' has unknown kind '${kind}' — skipped" >&2
+                    ;;
+            esac
+        done < <(roster_records)
+        echo "request: ${ran} cli/model seat(s) ran for MR #${pr}" >&2
+        ;;
+
+    harvest)
+        pr="${1:-}"; [ -n "$pr" ] || { echo "error: harvest requires a merge request identifier" >&2; exit 1; }
+        dest="${FINDINGS_DIR}/${pr}"
+        # No seats ran / empty panel → empty normalized output, exit 0.
+        [ -d "$dest" ] || exit 0
+        shopt -s nullglob
+        for f in "$dest"/*.findings; do
+            seat="$(basename "$f" .findings)"
+            while IFS= read -r line; do
+                case "$line" in
+                    FINDING\|*)
+                        # FINDING|severity=X|file=P:L|rationale=R → contract shape.
+                        sev=$(sed -n 's/.*severity=\([^|]*\).*/\1/p' <<<"$line")
+                        loc=$(sed -n 's/.*file=\([^|]*\).*/\1/p' <<<"$line")
+                        rat=$(sed -n 's/.*rationale=\(.*\)$/\1/p' <<<"$line")
+                        if [ -n "$sev" ] && [ -n "$loc" ]; then
+                            echo "${sev}: ${loc} — ${rat}  [${seat}]"
+                        else
+                            echo "harvest: WARN unparseable finding from '${seat}': ${line}" >&2
+                        fi
+                        ;;
+                    SUMMARY\|*) : ;;  # per-seat summary line, not a finding
+                    "") : ;;
+                    *) echo "harvest: WARN non-contract line from '${seat}': ${line}" >&2 ;;
+                esac
+            done < "$f"
+        done
+        ;;
+
+    scorecard)
+        pr="${1:-}"; seat="${2:-}"; verdict="${3:-}"
+        [ -n "$pr" ] && [ -n "$seat" ] && [ -n "$verdict" ] || { echo "error: scorecard requires <pr> <seat> <verdict-summary>" >&2; exit 1; }
+        # Resolve the seat's trial ticket from the roster.
+        tt=""
+        while IFS=$'\t' read -r n k s e m t; do [ "$n" = "$seat" ] && tt="$t"; done < <(roster_records)
+        [ -n "$tt" ] || { echo "error: seat '${seat}' not in roster (no trial-ticket)" >&2; exit 1; }
+        tid=$(sed -n 's#.*/\([0-9]\{4\}\)-.*#\1#p' <<<"$tt")
+        # Fixed schema so 0205's integration review is evidence-based, not vibes.
+        line="MR #${pr} seat=${seat} verdict: ${verdict}"
+        ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
+        "$ERG" log "$tid" "claude note ${line}"
+        ;;
+
+    ""|--help|-h) usage ;;
+    *) echo "error: unknown subcommand '${subcmd}'" >&2; usage ;;
+esac

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -210,6 +210,15 @@ Explicit human override. Usage: `/verify <pr-number> --force-approve <reason>`.
   `/verify-wave` (not yet drafted) for post-merge integration testing of a batch.
 - **Merging.** Ever. That is the caller's job.
 
+## External reviewer panel (delegation stub)
+
+The external, decorrelated reviewer panel — sandboxed CI-style seats over
+agnostic CLI reviewers — is managed by the `/reviewers` skill, not inlined
+here. Its findings are **advisory**: the gate dispositions them like any
+panel comment (only verifiable-class may bounce). The full panel-extension
+contract is ticket 0205's deliverable; seat execution is the 0217
+seat-runner. See `skills/reviewers/SKILL.md`.
+
 ## Output shape
 
 Post a single top-level PR comment at end of skill. Two sections,

--- a/tests/test_reviewers.sh
+++ b/tests/test_reviewers.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Tests for the /reviewers skill dispatcher (review-is-CI wiring).
+# Covers: empty-roster no-op; a configured seat firing the (stubbed)
+# 0217 seat-runner; per-seat fail-open; harvest normalization to the 0205
+# contract shape with a WARN on unparseable input; scorecard appending a
+# valid erg log line.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REVIEWERS="${REPO_ROOT}/skills/reviewers/reviewers.sh"
+PASS=0; FAIL=0
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then echo "PASS: $label"; PASS=$((PASS+1))
+    else echo "FAIL: $label"; echo "  expected: $(printf '%q' "$expected")"; echo "  actual:   $(printf '%q' "$actual")"; FAIL=$((FAIL+1)); fi
+}
+assert_contains() {
+    local label="$1" needle="$2" hay="$3"
+    if printf '%s' "$hay" | grep -qF -- "$needle"; then echo "PASS: $label"; PASS=$((PASS+1))
+    else echo "FAIL: $label (missing: $needle)"; echo "  in: $hay"; FAIL=$((FAIL+1)); fi
+}
+assert_exit_0() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then echo "PASS: $label"; PASS=$((PASS+1)); else echo "FAIL: $label (exit $?)"; FAIL=$((FAIL+1)); fi; }
+
+# ── empty-roster roster (default behaviour) ──────────────────────────────────
+EMPTY="$WORK/empty.yml"; printf 'reviewers: []\n' > "$EMPTY"
+
+out=$(REVIEWERS_PANEL="$EMPTY" "$REVIEWERS" list)
+assert_eq "list: empty roster" "no reviewers configured" "$out"
+
+out=$(REVIEWERS_PANEL="$EMPTY" "$REVIEWERS" request 42)
+assert_eq "request: empty roster" "no reviewers configured" "$out"
+assert_exit_0 "request: empty roster exits 0" env REVIEWERS_PANEL="$EMPTY" "$REVIEWERS" request 42
+
+out=$(REVIEWERS_PANEL="$EMPTY" "$REVIEWERS" harvest 42)
+assert_eq "harvest: empty roster, empty output" "" "$out"
+
+# ── configured roster + stub seat-runner ─────────────────────────────────────
+ROSTER="$WORK/panel.yml"
+cat > "$ROSTER" <<'YAML'
+reviewers:
+  - name: stub-good
+    kind: local-model
+    status: advisory
+    trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+    endpoint: http://127.0.0.1:9/v1
+    model: openai/stub
+  - name: stub-bad
+    kind: local-model
+    status: advisory
+    trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+    endpoint: http://127.0.0.1:9/v1
+    model: openai/stub
+YAML
+
+# Stub seat-runner: 'stub-bad' (by --out basename) exits non-zero to exercise
+# fail-open; everyone else emits one contract-shaped FINDING + a SUMMARY.
+STUB="$WORK/seat-runner-stub.sh"
+cat > "$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""; while [ $# -gt 0 ]; do [ "$1" = "--out" ] && { out="$2"; shift 2; continue; }; shift; done
+name="$(basename "$out" .findings)"
+if [ "$name" = "stub-bad" ]; then echo "stub: boom" >&2; exit 1; fi
+{ echo "FINDING|severity=verifiable|file=foo.sh:10|rationale=off-by-one"; echo "SUMMARY|findings=1|verdict=revise"; } > "$out"
+STUBEOF
+chmod +x "$STUB"
+
+list_out=$(REVIEWERS_PANEL="$ROSTER" "$REVIEWERS" list)
+assert_contains "list: shows configured seat" "stub-good" "$list_out"
+
+FDIR="$WORK/findings"
+req_err=$(REVIEWERS_PANEL="$ROSTER" SEAT_RUNNER="$STUB" REVIEWERS_FINDINGS_DIR="$FDIR" \
+          REVIEWERS_PR_BRANCH="some-branch" "$REVIEWERS" request 42 2>&1 >/dev/null)
+assert_contains "request: good seat ran" "seat 'stub-good' ok" "$req_err"
+assert_contains "request: bad seat fail-open WARN" "WARN seat 'stub-bad' failed" "$req_err"
+assert_eq "request: good seat wrote findings" "yes" "$([ -s "$FDIR/42/stub-good.findings" ] && echo yes || echo no)"
+
+harv_out=$(REVIEWERS_PANEL="$ROSTER" REVIEWERS_FINDINGS_DIR="$FDIR" "$REVIEWERS" harvest 42 2>/dev/null)
+assert_contains "harvest: normalized to contract shape" "verifiable: foo.sh:10 — off-by-one" "$harv_out"
+assert_contains "harvest: tags the seat" "[stub-good]" "$harv_out"
+
+# Unparseable input → WARN, not silently dropped.
+mkdir -p "$FDIR/99"; printf 'garbage line not a finding\n' > "$FDIR/99/x.findings"
+harv_warn=$(REVIEWERS_FINDINGS_DIR="$FDIR" "$REVIEWERS" harvest 99 2>&1 >/dev/null)
+assert_contains "harvest: WARN on non-contract line" "WARN non-contract line" "$harv_warn"
+
+# ── scorecard appends a valid erg log line ───────────────────────────────────
+# Build a throwaway erg ticket store so the real erg accepts the note.
+ERG_BIN="${REPO_ROOT}/tickets/erg"
+if [ -x "$ERG_BIN" ]; then
+    TSTORE="$WORK/tickets"; mkdir -p "$TSTORE"; cp "$ERG_BIN" "$TSTORE/erg"
+    cat > "$TSTORE/0207-agnostic-cli-reviewer-seat-one-config-op.erg" <<'ERG'
+%erg 0.1
+Title: Fixture
+Created: 2026-06-05
+Author: test
+
+--- log ---
+2026-06-05T00:00Z test created
+
+--- body ---
+## Context
+Fixture.
+ERG
+    SCROSTER="$WORK/sc.yml"
+    cat > "$SCROSTER" <<YAML
+reviewers:
+  - name: stub-good
+    kind: local-model
+    status: advisory
+    trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+    endpoint: http://127.0.0.1:9/v1
+    model: openai/stub
+YAML
+    ( cd "$WORK" && REVIEWERS_PANEL="$SCROSTER" ERG="$TSTORE/erg" \
+        "$REVIEWERS" scorecard 42 stub-good "PASS — 0 verifiable, 2 consider" ) >/dev/null 2>&1
+    if "$TSTORE/erg" validate "$TSTORE/0207-agnostic-cli-reviewer-seat-one-config-op.erg" >/dev/null 2>&1 \
+       && grep -q 'MR #42 seat=stub-good' "$TSTORE/0207-agnostic-cli-reviewer-seat-one-config-op.erg"; then
+        echo "PASS: scorecard appends a valid erg log line"; PASS=$((PASS+1))
+    else
+        echo "FAIL: scorecard did not append a valid erg log line"; FAIL=$((FAIL+1))
+    fi
+else
+    echo "SKIP: erg binary absent — scorecard erg-integration test"
+fi
+
+# ── arg validation ───────────────────────────────────────────────────────────
+if "$REVIEWERS" request >/dev/null 2>&1; then echo "FAIL: request missing arg should fail"; FAIL=$((FAIL+1)); else echo "PASS: request missing arg fails"; PASS=$((PASS+1)); fi
+
+echo ""; echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tickets/0208-reviewer-management-helper-skill-request.erg
+++ b/tickets/0208-reviewer-management-helper-skill-request.erg
@@ -12,6 +12,7 @@ Blocked-by: 0217
 2026-06-05T06:55Z claude note panel review (PR #289): reworded exit-criterion #3 to a delegation stub (the full panel-extension section is 0205's deliverable, which lands AFTER this child, so the original criterion was unverifiable at close). Open panel blockers held for author: ACP fs/read must be path-allowlisted (red-team), per-seat fail-open vs the verify circuit breaker (operational), scorecard schema (operational)
 
 2026-06-05T09:10Z claude note re-scoped off ACP (author "review is CI" directive): no ACP client harness — this is the management surface over the 0217 sandbox-runner. Blocked-by 0217 added (the runner is the seat execution mechanism). Seats are invoked by running the 0217 runner per roster entry; containment is the runner's OS sandbox, not protocol grants. The red-team's path-allowlist + per-seat fail-open blockers move to 0217 (where the sandbox lives); the scorecard-schema blocker stays here
+2026-06-05T09:25Z claude note /reviewers skill scaffold landed (PR supersedes #276): list/request/harvest/scorecard wired to the 0217 seat-runner — request runs the runner per roster seat with per-seat fail-open, harvest normalizes FINDING| output to the contract shape (unparseable→WARN), scorecard writes a fixed-schema erg line; empty-roster-safe; tests/test_reviewers.sh 13/13. NOT closing: blocked-by 0217 and the advisory trial (>=5 MRs) is pending
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Takes over **#276** (which I'll close), rebuilt on current main around the **review-is-CI** model. The #276 scaffold predated the 0205/0208 rewrite and conflicted (DIRTY); its skeleton was forward-compatible, so this re-applies it and **wires it to the 0217 seat-runner**.

## What it does

- **`skills/reviewers/{SKILL.md,panel.yml,reviewers.sh}`** — `list` / `request` / `harvest` / `scorecard`:
  - `request <pr>` runs the 0217 seat-runner once per roster seat (one OS-sandboxed container per seat) with **per-seat fail-open** — a seat that errors WARNs and the others proceed; one seat never blocks the verdict.
  - `harvest <pr>` normalizes the runner's `FINDING|severity=…|file=…|rationale=…` output to the 0205 contract shape (`verifiable:/consider: file:line — rationale [seat]`); an unparseable line is surfaced as **WARN, never dropped**.
  - `scorecard <pr> <seat> <verdict>` appends a fixed-schema trial line via `erg log`.
  - Empty roster (default) = no-op. No secrets in config (BASH_ENV path); containment is the seat-runner's OS sandbox.
- **`tests/test_reviewers.sh`** — 13 cases: empty-roster no-op, configured seat fires the stubbed runner, fail-open on a failing seat, normalization + WARN, scorecard writes a valid erg line.
- **`skills/verify/SKILL.md`** — delegation stub pointing to `/reviewers` (0208 exit criterion).
- README catalog regenerated.

`make check` (drift + agnostic) green; `tests/test_reviewers.sh` 13/13.

**Not closing 0208** — it's blocked-by 0217 and the advisory trial (≥5 MRs) is pending.

Ticket-ref: tickets/0208-reviewer-management-helper-skill-request.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)