### PR TITLE
memory: sync uncommitted AEDIST session writes

### DIFF
--- a/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
@@ -11,6 +11,13 @@
 
 ## Entries
 
+- [Phase build layout](project_phase_build_layout.md) — one .mk per phase since 2026-06-04 (acquire/score/render + root staleness/world); old root verbs tables/figures/census/measurements DELETED
+- [Archive move: outputs/ is record-only](project_archive_move_record_only_outputs.md) — raw replies in archive/outputs/ since edda724b; rules/scripts reading raw data must point at archive; tab_decomposition_fix FROZEN (0424)
+- [Concurrent author-session raids](feedback_concurrent_author_session_raids.md) — re-verify ticket open/closed on origin/main before every execute launch; never touch sibling-session worktrees; don't bundle whole tickets/ snapshots into content PRs
+- [Pre-commit hook commit ordering](feedback_precommit_hook_commit_ordering.md) — adherence hook runs working-tree tests against the index; order multi-commit series green, slice with `git commit -- <paths>`
+- [Optimistic concurrency for ticket IDs](feedback_optimistic_concurrency_ticket_ids.md) — no reservation machinery (wontfix 0427, git-erg#282); collision = renumber; CI detects (0418)
+- [erg close bookkeeping conflict](feedback_erg_close_bookkeeping_conflict.md) — parallel closes of sibling blockers conflict in the THIRD ticket's Blocked-by lines; keep both notes, drop both headers
+- [quickpr limitations](feedback_quickpr_limitations.md) — no renames/deletions; restoring the starting branch reverts working-tree edits
 - [Parallel push during investigation](feedback_parallel_push_during_investigation.md) — always branch from `origin/main` after fetch, not local HEAD; user may push directly while agent investigates
 
 - [Argparse defaults drift](feedback_argparse_defaults_drift.md) — when Makefile output paths change, update argparse defaults + docstrings in generating scripts too; grep src/ before declaring done

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_erg_pr_merge_partial_success.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_erg_pr_merge_partial_success.md
@@ -1,14 +1,14 @@
 ---
 name: feedback-erg-pr-merge-partial-success
-description: erg-pr-merge may close ticket but fail to merge; retrying then fails because ticket is already closed
+description: erg-pr-merge may close ticket but fail to merge; recovery is gh pr merge --auto, never a re-run
 metadata: 
   node_type: memory
   type: feedback
   originSessionId: ea153b57-2f67-4fd5-80a6-62e7f8014652
 ---
 
-When `erg-pr-merge` closes the ticket and pushes the close commit but then hits a merge conflict, retrying `erg-pr-merge` fails with "no ticket found for ID NNNN" because the ticket is already in `tickets/closed/`.
+When `erg-pr-merge` closes the ticket and pushes the close commit but then fails to merge, retrying `erg-pr-merge` fails with "no ticket found for ID NNNN" because the ticket is already in `tickets/closed/`.
 
-**Why:** The script closes the ticket and pushes before attempting the GitHub merge. On a merge conflict, the ticket state is already committed, so retry attempts to close it again.
+**Why:** The script closes the ticket and pushes before attempting the GitHub merge. The close-commit push itself re-triggers CI and invalidates the previous green round, so the immediate queue attempt reports "not mergeable", and the watch-then-merge fallback can time out on "no checks reported" before the new CI round even registers (observed twice, raid 419-420, 2026-06-04).
 
-**How to apply:** If `erg-pr-merge` fails partway through (ticket-close push succeeded, GitHub merge failed), skip `erg-pr-merge` on retry and go straight to `gh api repos/.../pulls/N/merge -X PUT -f merge_method=merge`. Verify via `gh pr view N --json state` that the PR is MERGED before stopping.
+**How to apply:** If `erg-pr-merge` fails after the ticket-close push succeeded, do NOT re-run it. Run `gh pr merge N --merge --auto` — auto-merge waits out the close-commit CI round and lands by itself. Verify via `gh pr view N --json state`. If mergeability is CONFLICTING (parallel work landed on main mid-flight), rebase + `--force-with-lease` first, then re-queue auto-merge; see [[feedback-erg-close-bookkeeping-conflict]] for the typical conflict shape.

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_ticket_id_collision_check.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_ticket_id_collision_check.md
@@ -17,3 +17,5 @@ Before creating a new ticket file, `git fetch origin --quiet && git ls-tree -r -
 - If a collision is discovered post-PR, file the rename + comment trail on the PR (branch name and title may stay; the file path and PR body's `**Ticket:**` line are what matter for auto-close).
 
 Related: [[feedback-gh-pr-edit-blocked]] documents the gh api workaround used in recovery.
+
+**Second incident (2026-06-04):** ID 0412 allocated twice — a raid bundled its ticket on a PR branch (#698) while a parallel session committed 0412 directly to main. Even the fetch+check discipline cannot fully prevent this (the window is between check and merge); a duplicate then sat ON MAIN with `erg check` failing and zero CI signal, because lint runs only the log-placement validator and the chore-bypass path filter skips lint on tickets-only diffs. Mechanical gate ticketed: 0418 (erg check in CI). Recovery cost stayed low (one git mv + chore PR #701) because the collision was caught the same day — check `erg check tickets/` after every fetch when working ticket-heavy sessions.


### PR DESCRIPTION
Lands three AEDIST memory files found dirty in the primary checkout (write-commit-atomicity failure mode — blocked the next beat cycle's dirty-tree gate). Content: 7 new MEMORY.md index entries, improved erg-pr-merge recovery (`gh pr merge --auto`), second 0412 ID-collision incident record.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)