### PR TITLE
ticket(0215): close with upstream wontfix verdict — optimistic ID allocation

### DIFF
--- a/tickets/0215-upstream-git-erg-id-allocation-races-acr.erg
+++ b/tickets/0215-upstream-git-erg-id-allocation-races-acr.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-06-04T16:24Z Minh Ha-Duong created
 
+2026-06-05T10:28Z claude note Upstream verdict in: git-erg#282 closed wontfix — author retained optimistic concurrency (collisions are cheap: renumber to next free ID; erg check in CI detects). No reservation machinery in binary or skill. Both ticket actions resolved: issue was filed 2026-06-04 from an AEDIST session; answer adopted as-is, nothing to pull into the traveling binary.
 --- body ---
 ## Context
 
@@ -41,9 +42,11 @@ allocation time (not merge time).
 
 ## Exit criteria
 
-- [ ] Upstream issue filed and linked here
-- [ ] Decision recorded (fix adopted, or convention documented in
-      tickets/AGENTS.md template)
+- [x] Upstream issue filed and linked here — git-erg#282 (closed wontfix:
+      optimistic concurrency retained, renumber on collision, CI detects)
+- [x] Decision recorded (fix adopted, or convention documented in
+      tickets/AGENTS.md template) — convention added to tickets/AGENTS.md
+      "Rules agents must know"
 
 ## Related
 

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -35,6 +35,7 @@ Rules agents must know:
 - Closed/not-closed is inferred from path conventions or a non-empty `Closed:` header
 - `Label:` is optional and repeatable; accepted values are defined in `tickets/.ergrc` (defaults: `needs-human`, `deferred`)
 - Log entries are append-only: `YYYY-MM-DDTHH:MMZ author verb detail`
+- ID allocation is optimistic (git-erg#282, wontfix): `erg new` scans only the local checkout, so parallel sessions on different branches/checkouts can hand out the same ID. Fetch before allocating, run `erg check` after every fetch in ticket-heavy sessions, and on collision simply renumber to the next free ID (`git mv` + fix cross-references). No reservation machinery exists or is planned — seat taken, move to the next one.
 - Artifacts a ticket consumes or produces (reports, data, generated files, scripts) live in their natural location in the project tree and are referenced from the body by path, not embedded wholesale, and not kept as a filename-twinned `0002-slug.md` sidecar the tooling cannot track.
 
 On GitHub, `tickets/erg-github` (a separate committed helper, not an `erg` subcommand) adds a `verify` check that fails a PR referencing a still-open ticket -- so close the ticket in the same PR (`erg close`).

--- a/tickets/closed/0215-upstream-git-erg-id-allocation-races-acr.erg
+++ b/tickets/closed/0215-upstream-git-erg-id-allocation-races-acr.erg
@@ -2,11 +2,13 @@
 Title: Upstream git-erg: ID allocation races across parallel checkouts
 Created: 2026-06-04
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #297
 
 --- log ---
 2026-06-04T16:24Z Minh Ha-Duong created
 
 2026-06-05T10:28Z claude note Upstream verdict in: git-erg#282 closed wontfix — author retained optimistic concurrency (collisions are cheap: renumber to next free ID; erg check in CI detects). No reservation machinery in binary or skill. Both ticket actions resolved: issue was filed 2026-06-04 from an AEDIST session; answer adopted as-is, nothing to pull into the traveling binary.
+2026-06-05T10:31Z MinhHaDuong closed — autoclosed — PR #297
 --- body ---
 ## Context
 


### PR DESCRIPTION
git-erg#282 is closed wontfix: optimistic concurrency retained, collisions renumber, `erg check` in CI detects. Both exit criteria satisfied: issue filed + linked, convention documented in tickets/AGENTS.md.

**Ticket:** tickets/0215-upstream-git-erg-id-allocation-races-acr.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)