### PR TITLE
skill(0214): /update-publist — personal page + HAL SWORD deposit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Skills are available as `/celebrate`, `/review-pr`, etc. Hooks fire automaticall
 | `/smoke` | Agent environment smoke test — reports runtime identity, auth method, and harness context. |
 | `/start-ticket` | Begin work on a ticket. Creates worktree, writes first test, transitions to Execute phase. |
 | `/ticket-new` | Create a local %erg 0.1 file for agent coordination. |
+| `/update-publist` | Add or update a publication on the personal page and deposit on HAL via SWORD. Gated on user payload review before any outward API call. |
 | `/verify` | Run the full per-PR verification loop (adherence + review + review-pr + simplify), then gate through /verify-gate. Bounces the PR for at most one retry. Never merges. |
 | `/verify-adherence` | Check a branch's diff against project rules. Mechanical-first — runs hygiene tests + grep ratchet before falling back to LLM. Emits suggested tests for any semantic finding so the LLM surface shrinks over time. |
 | `/verify-gate` | Anti-rubber-stamp merge gate. Validates every ticket exit criterion and every review comment against the actual diff. Emits APPROVED / REROLL / ESCALATE with explicit evidence. Never merges. |

--- a/skills/update-publist/SKILL.md
+++ b/skills/update-publist/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: update-publist
 description: Add or update a publication on the personal page and deposit on HAL via SWORD. Gated on user payload review before any outward API call.
-disable-model-invocation: false
+disable-model-invocation: true
 user-invocable: true
 argument-hint: <pdf-path> [--hal-only] [--page-only]
 ---
 
 # Update publication list
 
-Two independent steps, either runnable alone via flags. Both are
+Two independent steps, either runnable alone via flags (`--page-only`
+runs Step 1 only; `--hal-only` runs Step 2 only). Both are
 outward-facing and irreversible once completed — every mutation requires
 explicit user confirmation before execution.
 
@@ -98,11 +99,12 @@ curl -K "$TMPCONFIG" \
   --data-binary @deposit.zip
 ```
 
-Where `$TMPCONFIG` is a chmod-600 temp file containing:
+Where `$TMPCONFIG` is created with `mktemp` in `/tmp` (outside the
+repo tree), chmod-600'd, and cleaned up via `trap 'rm -f "$TMPCONFIG"' EXIT`
+so it is deleted even on error or interruption. Contents:
 ```
 user = "HAL_ID_VALUE:HAL_PASSWORD_VALUE"
 ```
-Delete the temp config immediately after the curl call.
 
 The SWORD acknowledgement means "stored in workspace" — moderation
 status is confirmed by HAL's email, not the API response.

--- a/skills/update-publist/SKILL.md
+++ b/skills/update-publist/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: update-publist
+description: Add or update a publication on the personal page and deposit on HAL via SWORD. Gated on user payload review before any outward API call.
+disable-model-invocation: false
+user-invocable: true
+argument-hint: <pdf-path> [--hal-only] [--page-only]
+---
+
+# Update publication list
+
+Two independent steps, either runnable alone via flags. Both are
+outward-facing and irreversible once completed — every mutation requires
+explicit user confirmation before execution.
+
+## Step 1: Personal page (`~/CNRS/html/`)
+
+This directory is NOT a git repo. It deploys over FTP.
+
+1. Copy the PDF into `files/`, naming it `HaDuong-YYYY-Topic.pdf`.
+   Use a `-EN` suffix for English translations.
+
+2. Add the BibTeX entry to `src/Ha-Duong.bib`. The page section is
+   driven by the entry type:
+   - `inproceedings` maps to Scientific communications
+   - `unpublished` maps to Teaching and conferences
+   - See `TYPE_HEADINGS` in `src/bib2htm.py` for the full mapping.
+   Required fields: `file = {files/HaDuong-YYYY-Topic.pdf}`. Add
+   `eprint = {https://hal.science/hal-XXXXXXXvN}` after HAL deposit.
+
+3. **Translation pairs.** For a translated work:
+   - The translation key gets an `:EN` suffix.
+   - On the translation: `related = {OriginalKey}`,
+     `relatedtype = {translationof}`.
+   - On the original: `related = {TranslationKey:EN}`,
+     `relatedtype = {translatedin}`.
+   - The renderer merges them into one item (translation first, original
+     bracketed). Disambiguate identical titles with a marker like
+     "(En francais)".
+
+4. Build and verify:
+   ```
+   cd ~/CNRS/html && make index.html && make files/Ha-Duong.bib
+   ```
+   Verify the entry appears in the correct section (`grep` the output).
+
+5. **Publish (user confirmation required):**
+   ```
+   make sync
+   ```
+   This runs FTP using credentials from `~/.netrc`. Show the user what
+   will be synced and wait for explicit confirmation before running.
+
+## Step 2: HAL deposit via SWORD
+
+Credentials: `HAL_ID` and `HAL_PASSWORD` from the project `.env`.
+**Never echo, display, log, or commit credential values.** Pass them
+to curl via a chmod-600 temporary config file (`curl -K`), never on the
+command line. Mask `<hal:password>` in any displayed API response.
+
+### 2a. Prepare the TEI metadata
+
+Use the AOfr TEI format (template reference:
+`https://api.archives-ouvertes.fr/documents/all.xml`).
+
+Before choosing doctype and domain, check the author's previous deposits
+via the public search API to follow established conventions:
+```
+curl -s 'https://api.archives-ouvertes.fr/search/hal/?q=authIdHal_s:minh-ha-duong&fl=docType_s,domain_s&rows=5'
+```
+
+Standard values for this author:
+- Structure: `#struct-1380080` (CIRED)
+- idhal: `minh-ha-duong`
+- Typology: `COMM` for a conference talk (adjust per doctype)
+
+### 2b. Assemble and review the payload
+
+Build `meta.xml` (the TEI document) and zip it with the PDF.
+
+**MANDATORY GATE: show the user the full assembled payload** — the
+complete `meta.xml` TEI content and the zip manifest — and wait for
+explicit confirmation before any API call. The user reviews:
+- TEI well-formedness and field accuracy
+- Correct structure reference (`#struct-1380080`)
+- Correct typology and domain
+- Correct idhal
+
+Do NOT proceed to the POST without user approval.
+
+### 2c. Deposit
+
+```
+curl -K "$TMPCONFIG" \
+  -X POST https://api.archives-ouvertes.fr/sword/hal/ \
+  -H 'Content-Type: application/zip' \
+  -H 'Content-Disposition: attachment; filename=deposit.zip' \
+  -H 'Packaging: http://purl.org/net/sword-types/AOfr' \
+  --data-binary @deposit.zip
+```
+
+Where `$TMPCONFIG` is a chmod-600 temp file containing:
+```
+user = "HAL_ID_VALUE:HAL_PASSWORD_VALUE"
+```
+Delete the temp config immediately after the curl call.
+
+The SWORD acknowledgement means "stored in workspace" — moderation
+status is confirmed by HAL's email, not the API response.
+
+### 2d. Post-deposit
+
+After a successful deposit, update the BibTeX entry in
+`src/Ha-Duong.bib` with the `eprint` field pointing to the new HAL
+record, then rebuild the personal page (Step 1.4-1.5).
+
+## Credential safety rules
+
+These are non-negotiable:
+- Never display `HAL_ID` or `HAL_PASSWORD` values in chat output.
+- Never include credentials in git-tracked files.
+- Pass credentials to curl via `-K` with a chmod-600 temp file only.
+- Mask any credential that appears in API responses before displaying.
+- Delete temp credential files immediately after use.

--- a/tickets/0214-write-and-install-the-update-publist-ski.erg
+++ b/tickets/0214-write-and-install-the-update-publist-ski.erg
@@ -7,6 +7,7 @@ Author: Minh Ha-Duong
 2026-06-04T15:43Z Minh Ha-Duong created
 
 2026-06-05T11:05Z Minh Ha-Duong note amendment: drop the X-test:1 dry-run requirement — gate the HAL deposit on user review of the assembled payload (meta.xml TEI + zip manifest) plus explicit confirmation before any API call
+2026-06-05T11:13Z claude note raid execute: writing SKILL.md from the amended reference procedure
 --- body ---
 ## Context
 
@@ -72,10 +73,10 @@ credential values.
 
 ## Exit criteria
 
-- [ ] SKILL.md written here and catalog regenerated
-- [ ] Skill present in `~/.claude/skills/update-publist/`
-- [ ] HAL step gated by user review of the assembled payload + explicit confirmation before any API call
-- [ ] No credential value can reach chat output or git history
+- [x] SKILL.md written here and catalog regenerated — skills/update-publist/SKILL.md + README.md updated
+- [x] Skill present in `~/.claude/skills/update-publist/` — this repo IS ~/.claude; satisfied on merge
+- [x] HAL step gated by user review of the assembled payload + explicit confirmation before any API call — SKILL.md section 2b "MANDATORY GATE"
+- [x] No credential value can reach chat output or git history — SKILL.md "Credential safety rules" section (curl -K, chmod-600, mask, never display/commit/log)
 
 ## Related
 

--- a/tickets/closed/0214-write-and-install-the-update-publist-ski.erg
+++ b/tickets/closed/0214-write-and-install-the-update-publist-ski.erg
@@ -2,12 +2,14 @@
 Title: Write and install the /update-publist skill (in the catalog, absent from the harness)
 Created: 2026-06-04
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #300
 
 --- log ---
 2026-06-04T15:43Z Minh Ha-Duong created
 
 2026-06-05T11:05Z Minh Ha-Duong note amendment: drop the X-test:1 dry-run requirement — gate the HAL deposit on user review of the assembled payload (meta.xml TEI + zip manifest) plus explicit confirmation before any API call
 2026-06-05T11:13Z claude note raid execute: writing SKILL.md from the amended reference procedure
+2026-06-05T11:28Z MinhHaDuong closed — autoclosed — PR #300
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

- New skill for the publication archiving workflow (previously manual; reference: AEDIST deposit hal-05644906)
- Two steps: personal page BibTeX + FTP sync, and HAL SWORD deposit with user payload review gate
- Credential safety: curl -K with chmod-600 temp files only; never displayed, committed, or logged
- Catalog regenerated; skill installed on merge (this repo is ~/.claude)

**Ticket:** tickets/0214-write-and-install-the-update-publist-ski.erg

## Test plan

- [ ] Verify SKILL.md section 2b contains the mandatory payload review gate
- [ ] Verify credential safety rules section covers all leakage vectors
- [ ] `make check` passes (catalog in sync, agnostic check clean)
- [ ] First live invocation validates end-to-end (post-merge, by author)

🤖 Generated with [Claude Code](https://claude.com/claude-code)