### PR TITLE
ticket: split 0182 → fang-v1 + 0219; un-defer raid targets

### DIFF
--- a/tickets/0182-fang-handcuff-test-audit-skill.erg
+++ b/tickets/0182-fang-handcuff-test-audit-skill.erg
@@ -2,11 +2,12 @@
 Title: Extract test-quality audit workflow (fang/handcuff/scope) into a skill
 Created: 2026-05-30
 Author: claude
-Label: deferred
 
 --- log ---
 2026-05-30T10:00Z claude created — after the fang-audit fan-out run on git-erg validated the design
 
+2026-06-05T11:57Z MinhHaDuong unlabel deferred
+2026-06-05T11:57Z Minh Ha-Duong note re-scoped (author directive): split — this ticket keeps the feasible fang-only v1 extraction from the proven prototype; handcuff + scope/altitude + three-axis report + multi-language move to 0219 (blocked on this). Un-deferred for raid alongside 0184
 --- body ---
 ## Context
 
@@ -115,23 +116,23 @@ prototype via `f.isCanary && /scaling_test|resource_test/.test(file)` — bake t
 principle into the skill: canary designation is a workflow input, not an agent claim.)
 
 ## Exit criteria
+
+(Re-scoped 2026-06-05, author directive: fang-only v1 — the feasible
+extraction from the proven prototype. Handcuff, scope/altitude, the
+three-axis report, and multi-language validation moved to
+tickets/0219, which is blocked on this ticket.)
+
 - [ ] `skills/fang-audit/SKILL.md` + workflow script committed; registered via
       `make skills-catalog`; `make check-skills-drift` passes in CI.
 - [ ] Repo-specific knobs are explicit inputs (NOT name heuristics): `TEST_GLOB`,
       `RUN_TEST` (+ tag variants), the test↔source pairing table, designated canary
       files, language-specific mutation heuristics.
 - [ ] Fang mode reproduces the git-erg result (toothless list + canary PASS).
-- [ ] Handcuff mode implemented: behavior-preserving mutation operators + inverted
-      oracle (red = over-scoped) + behavior-preservation skeptic.
-- [ ] Scope/altitude mode implemented: replay each caught mutation's operator across
-      structurally-similar sibling sites; flag instance-pinned contracts (sibling
-      survives) for promotion to a class guard.
 - [ ] Oracle-strength + diagnosticity reported as free riders from the existing mutation
       data (mutants-killed-per-assertion; tests-fired-per-killed-mutant) — no extra runs.
 - [ ] Determinism precheck gates the run: re-run the unchanged suite N times; abort with a
-      clear "suite is flaky, verdicts untrustworthy" message if verdicts vary.
-- [ ] Unified per-test report covers all three axes (fang? / handcuff? / right-scope?)
-      and is sortable by a risk x churn weighting (churn from git log).
+      clear "suite is flaky, verdicts untrustworthy" message if verdicts vary. Use the
+      0184 utility's reusable gate (merges first in this raid).
+- [ ] Per-test fang report (toothless? + free-rider metrics) sortable by a risk x churn
+      weighting (churn from git log).
 - [ ] Canary gate scoped to designated guard files only (isCanary-pollution bug gone).
-- [ ] Forge-agnostic, language-pluggable (validated on at least one non-Go repo or a
-      documented plug-in path).

--- a/tickets/0184-empirical-test-quality-ci-utility.erg
+++ b/tickets/0184-empirical-test-quality-ci-utility.erg
@@ -2,11 +2,12 @@
 Title: Empirical test-quality CI utility (flakiness / independence / speed)
 Created: 2026-05-30
 Author: claude
-Label: deferred
 
 --- log ---
 2026-05-30T10:45Z claude created — cheap-tier sibling to 0182/0183; the per-PR-gateable lenses
 
+2026-06-05T11:57Z MinhHaDuong unlabel deferred
+2026-06-05T11:57Z Minh Ha-Duong note un-deferred for raid (author directive): the trio splits — 0184 raids now (it provides the flakiness gate 0182 imports as precheck), 0182 raids fang-only, 0219 carries the rest, 0183 stays deferred
 --- body ---
 ## Context
 

--- a/tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
+++ b/tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
@@ -1,0 +1,76 @@
+%erg 0.1
+Title: Handcuff and scope-altitude mutation modes for the fang-audit skill
+Created: 2026-06-05
+Author: MinhHaDuong
+Blocked-by: 0182
+Label: deferred
+
+--- log ---
+2026-06-05T11:56Z MinhHaDuong created
+
+2026-06-05T11:56Z MinhHaDuong label deferred
+--- body ---
+## Context
+
+Split from [[0182]] (author directive, 2026-06-05): the fang-audit
+extraction raids in two integer-numbered tickets instead of one
+monolith. 0182 keeps the feasible v1 — extract the PROVEN fang
+(sensitivity) mode from the git-erg prototype, with the determinism
+precheck, canary-gate fix, and free-rider metrics. THIS ticket carries
+the two additional mutation modes that have no validating run yet, plus
+the multi-language generalization.
+
+All design rationale (lens taxonomy, one-workflow-two-passes, the
+behavior-preservation skeptic) lives in 0182's body — read it first.
+
+## Relevant files
+
+- skills/fang-audit/ — the 0182 deliverable this extends
+- ~/.claude/plans/quizzical-booping-puffin.md — reviewed plan (M1-M4
+  fixes, pairing table, verdict rules, lens design)
+- ~/.claude/plans/fang-audit-erg-prototype.js — the proven workflow
+  script 0182 extracts from
+
+## Actions
+
+1. Handcuff mode: behavior-PRESERVING mutation operators (rename locals,
+   reorder independent statements, equivalent-construct swap, unexported
+   representation change) + inverted oracle (red = over-scoped) + its
+   own behavior-preservation skeptic (a red on a secretly
+   behavior-changing "refactor" is a legitimate catch — withdraw the
+   accusation; mirror of the equivalent-mutant skeptic).
+2. Scope/altitude mode: replay each caught mutation's operator across
+   structurally-similar sibling sites; sibling-survives = instance-pinned
+   contract; flag for promotion to a class/invariant guard.
+3. Pipeline both after the fang pass in the SAME workflow (shared
+   pairing table, worktree setup, baseline-green, canary gate); separate
+   agent roles for the two oracles (never one agent juggling red=good
+   and red=bad).
+4. Unified per-test report: has-fang? | is-handcuff? | right-scope? —
+   one row per test, sortable by risk x churn (churn from git log).
+5. Language-pluggable: validate on at least one non-Go repo or document
+   the plug-in path.
+
+## Test
+
+A fixture test file with a known over-scoped assertion (asserts mock
+call order): handcuff mode flags it; the same fixture refactored
+behavior-preservingly stays green elsewhere. A known instance-pinned
+regression test: scope mode flags the surviving sibling site.
+
+## Exit criteria
+
+- [ ] Handcuff mode implemented: behavior-preserving operators + inverted
+      oracle + behavior-preservation skeptic
+- [ ] Scope/altitude mode implemented: sibling-site replay, instance-pinned
+      contracts flagged for class-guard promotion
+- [ ] Unified per-test report covers all three axes (fang? / handcuff? /
+      right-scope?) sortable by risk x churn weighting
+- [ ] Language-pluggable: validated on at least one non-Go repo or a
+      documented plug-in path
+- [ ] make check passes
+
+## Related
+
+- Parent: [[0182]] (fang v1 — must merge first)
+- Siblings: [[0183]] (LLM judge), [[0184]] (empirical CI utility)


### PR DESCRIPTION
Author-directed split of the test-quality trio for raiding: 0182 narrows to the proven fang-only v1 extraction; new ticket 0219 carries handcuff + scope/altitude + multi-language (blocked on 0182); 0184 un-deferred (merges first — its flakiness gate is 0182's precheck); 0183 stays deferred.

Ticket-ref: tickets/0182-fang-handcuff-test-audit-skill.erg
Ticket-ref: tickets/0184-empirical-test-quality-ci-utility.erg
Ticket-ref: tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)