### PR TITLE
feat(0184): empirical test-quality utility (flakiness/independence/speed)

### DIFF
--- a/scripts/test-quality.py
+++ b/scripts/test-quality.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Empirical test-quality utility — flakiness / independence / speed.
+
+The CHEAP, DETERMINISTIC tier of the test-quality family (siblings: 0182
+mutation oracles, 0183 LLM judge). Every signal here is produced by *re-running
+the existing suite* — no mutation, no LLM, zero tokens — so these are the only
+test-quality checks fast enough to gate a single PR.
+
+Three lenses, one entry point:
+
+  * flakiness    run the unchanged suite N times; a test whose verdict varies
+                 across runs is flaky. Flaky tests train teams to ignore red,
+                 and you cannot mutation-test a flaky suite — so this lens is
+                 also the PRECONDITION gate that 0182's fang-audit calls before
+                 it spends a token. Exposed as the `flakiness` subcommand with a
+                 hard exit-code contract (see below).
+  * independence run the suite shuffled; a test whose verdict depends on order
+                 is not isolated. The reference Go runner randomizes order via
+                 `-shuffle`. Parallel execution (`go test -p`, or another
+                 runner's equivalent) surfaces shared-state races and is a
+                 documented runner extension: a runner that emits per-test
+                 records under parallel execution feeds the same lenses
+                 unchanged — no lens code changes needed.
+  * speed        time each test; flag the slow tail so the fast feedback loop
+                 stays fast.
+
+Architecture (only the Runner touches a subprocess; everything else is pure and
+fixture-testable):
+
+  Runner   spawns the test command (N times / shuffled). Injected, so a stub
+           replaces it in tests.
+  Adapter  parses a runner's machine-readable output into TestRecord rows.
+           The Go adapter parses `go test -json`. Documented interface below.
+  Lenses   pure functions over the parsed records.
+  Ratchet  pure diff of (current findings) against a baseline of known-bad
+           test identities; fail only on regressions the diff introduced.
+
+Test identity — the join key shared with 0182/0183 — is the string
+``<package>::<TestName>`` (``::<TestName>`` when the adapter has no package).
+
+Exit-code contract (this is a GATE, not just a probe):
+
+  report mode   (`run`)        always exit 0, emit the full JSON report.
+  gate mode     (`flakiness`,  exit 0 when clean, exit 2 when the lens (after
+                `gate`)         the ratchet) finds a regression. JSON still on
+                                stdout. 0182 shells out to `flakiness` and keys
+                                on this exit code — language-agnostic, robust to
+                                this file's hyphenated, non-importable name.
+
+The Runner interface for a new language is a callable:
+
+    runner(*, shuffle: bool, seed: int | None) -> str   # raw runner output
+
+paired with an Adapter ``parse(raw: str) -> list[TestRecord]``. Implement those
+two and the lenses + ratchet work unchanged. See ``GoAdapter`` /
+``GoTestRunner`` for the reference Go implementation.
+"""
+
+import argparse
+import json
+import logging
+import random
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+log = logging.getLogger("test-quality")
+
+# Exit code a gate-mode invocation returns when it finds a regression. Distinct
+# from 1 so a crash (argparse / uncaught exception) is not mistaken for "flaky".
+EXIT_REGRESSION = 2
+
+# Terminal go-test actions, mapped to our normalized verdicts.
+_GO_TERMINAL = {"pass": "pass", "fail": "fail", "skip": "skip"}
+
+
+# ── data model ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TestRecord:
+    """One test's outcome in one run of the suite."""
+
+    identity: str  # "<package>::<TestName>" — the cross-tool join key
+    verdict: str  # "pass" | "fail" | "skip"
+    duration: float  # seconds; 0.0 if the runner reports none
+
+
+@dataclass
+class RunResult:
+    """All records from a single suite run, plus how it was invoked."""
+
+    records: list[TestRecord]
+    shuffle: bool = False
+    seed: int | None = None
+
+
+# ── Go adapter ───────────────────────────────────────────────────────────────
+
+
+def go_identity(package: str | None, test: str | None) -> str:
+    """Build the cross-tool test identity from go-test's package + test name."""
+    pkg = package or ""
+    name = test or ""
+    return f"{pkg}::{name}"
+
+
+class GoAdapter:
+    """Parse `go test -json` output into TestRecord rows.
+
+    `go test -json` emits one JSON object per line (the test2json event stream).
+    We key on the documented fields ``Action`` (run/output/pass/fail/skip/...),
+    ``Package``, ``Test`` and ``Elapsed``. Events without a ``Test`` field are
+    package-level and ignored — we report per-test, not per-package. The verdict
+    is the terminal Action for each test identity; ``Elapsed`` on that terminal
+    event is the duration in seconds.
+    """
+
+    @staticmethod
+    def parse(raw: str) -> list[TestRecord]:
+        records: list[TestRecord] = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                # go test prepends plain build-error lines before the JSON
+                # stream; skip anything that is not a JSON event.
+                continue
+            action = event.get("Action")
+            test = event.get("Test")
+            if not test or action not in _GO_TERMINAL:
+                continue
+            records.append(
+                TestRecord(
+                    identity=go_identity(event.get("Package"), test),
+                    verdict=_GO_TERMINAL[action],
+                    duration=float(event.get("Elapsed") or 0.0),
+                )
+            )
+        return records
+
+
+class GoTestRunner:
+    """Runner adapter for a Go package tree: `go test -count=1 -json [...]`.
+
+    This is the ONLY layer that spawns a subprocess. `-count=1` defeats Go's
+    test cache so each invocation actually re-executes (essential for the
+    flakiness lens). `-shuffle` randomizes intra-package test order for the
+    independence lens.
+    """
+
+    def __init__(self, package_dir: str, pattern: str = "./...", timeout: int = 600):
+        self.package_dir = package_dir
+        self.pattern = pattern
+        self.timeout = timeout
+
+    def __call__(self, *, shuffle: bool = False, seed: int | None = None) -> str:
+        cmd = ["go", "test", "-count=1", "-json"]
+        if shuffle:
+            cmd.append(f"-shuffle={seed if seed is not None else 'on'}")
+        cmd.append(self.pattern)
+        log.debug("running: %s (cwd=%s)", " ".join(cmd), self.package_dir)
+        proc = subprocess.run(
+            cmd,
+            cwd=self.package_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=self.timeout,
+        )
+        # A failing suite is normal input here, so we don't raise on returncode;
+        # the JSON stream carries the verdicts.
+        return proc.stdout
+
+
+# ── core: run the suite N times via an injected (runner, adapter) ─────────────
+
+
+def collect_runs(
+    runner,
+    adapter,
+    *,
+    n: int,
+    shuffle: bool = False,
+    seed: int | None = None,
+    rng: random.Random | None = None,
+) -> list[RunResult]:
+    """Invoke `runner` n times, parse each via `adapter`.
+
+    `runner` and `adapter` are injected so tests pass a stub and never spawn a
+    real toolchain. When `shuffle` is set, each run gets a distinct seed
+    (derived from `rng`) so order varies run-to-run.
+    """
+    rng = rng or random.Random(seed)
+    runs: list[RunResult] = []
+    for _ in range(max(1, n)):
+        run_seed = rng.randrange(2**31) if shuffle else seed
+        raw = runner(shuffle=shuffle, seed=run_seed)
+        runs.append(
+            RunResult(records=adapter.parse(raw), shuffle=shuffle, seed=run_seed)
+        )
+    return runs
+
+
+# ── lenses (pure functions over RunResult lists) ─────────────────────────────
+
+
+def _verdicts_by_identity(runs: list[RunResult]) -> dict[str, list[str]]:
+    by_id: dict[str, list[str]] = defaultdict(list)
+    for run in runs:
+        for rec in run.records:
+            by_id[rec.identity].append(rec.verdict)
+    return by_id
+
+
+def flakiness_lens(runs: list[RunResult]) -> dict:
+    """A test is flaky if its verdict is not identical across all N runs.
+
+    A test that is missing from some runs (appears, then doesn't) is also
+    non-deterministic and is flagged.
+    """
+    n_runs = len(runs)
+    by_id = _verdicts_by_identity(runs)
+    flaky: list[dict] = []
+    for identity, verdicts in sorted(by_id.items()):
+        distinct = sorted(set(verdicts))
+        inconsistent_presence = len(verdicts) != n_runs
+        if len(distinct) > 1 or inconsistent_presence:
+            flaky.append(
+                {
+                    "identity": identity,
+                    "verdicts": verdicts,
+                    "distinct": distinct,
+                    "runs_seen": len(verdicts),
+                    "runs_total": n_runs,
+                }
+            )
+    return {
+        "lens": "flakiness",
+        "runs": n_runs,
+        "tests": len(by_id),
+        "flaky": flaky,
+        "stable": len(by_id) - len(flaky),
+    }
+
+
+def independence_lens(
+    ordered: list[RunResult], shuffled: list[RunResult]
+) -> dict:
+    """A test is order-dependent if its verdict differs between the ordered and
+    shuffled runs (controlling for tests already flaky under fixed order)."""
+    ordered_v = _verdicts_by_identity(ordered)
+    shuffled_v = _verdicts_by_identity(shuffled)
+
+    def stable_verdict(verdicts: list[str]) -> str | None:
+        s = set(verdicts)
+        return next(iter(s)) if len(s) == 1 else None
+
+    dependent: list[dict] = []
+    for identity in sorted(set(ordered_v) | set(shuffled_v)):
+        o = stable_verdict(ordered_v.get(identity, []))
+        s = stable_verdict(shuffled_v.get(identity, []))
+        # Only call it order-dependent when BOTH directions are internally
+        # stable but disagree — otherwise it's flakiness, not order-dependence.
+        if o is not None and s is not None and o != s:
+            dependent.append(
+                {"identity": identity, "ordered": o, "shuffled": s}
+            )
+    return {
+        "lens": "independence",
+        "ordered_runs": len(ordered),
+        "shuffled_runs": len(shuffled),
+        "order_dependent": dependent,
+    }
+
+
+def speed_lens(runs: list[RunResult], *, slow_seconds: float, top: int = 10) -> dict:
+    """Max observed duration per test; flag the slow tail above a threshold."""
+    max_dur: dict[str, float] = {}
+    for run in runs:
+        for rec in run.records:
+            if rec.duration > max_dur.get(rec.identity, -1.0):
+                max_dur[rec.identity] = rec.duration
+    ranked = sorted(max_dur.items(), key=lambda kv: kv[1], reverse=True)
+    slow = [
+        {"identity": i, "duration": d, "suggest_tag": True}
+        for i, d in ranked
+        if d >= slow_seconds
+    ]
+    return {
+        "lens": "speed",
+        "threshold_seconds": slow_seconds,
+        "slowest": [{"identity": i, "duration": d} for i, d in ranked[:top]],
+        "slow_tail": slow,
+    }
+
+
+# ── ratchet (pure diff against a baseline of known-bad identities) ───────────
+
+
+@dataclass
+class Baseline:
+    """Known-bad test identities, partitioned by lens. New regressions are bad
+    identities NOT already recorded here."""
+
+    flaky: set = field(default_factory=set)
+    order_dependent: set = field(default_factory=set)
+    slow: set = field(default_factory=set)
+
+    @classmethod
+    def load(cls, path: Path) -> "Baseline":
+        if not path.exists():
+            return cls()
+        data = json.loads(path.read_text())
+        return cls(
+            flaky=set(data.get("flaky", [])),
+            order_dependent=set(data.get("order_dependent", [])),
+            slow=set(data.get("slow", [])),
+        )
+
+    def to_json(self) -> dict:
+        return {
+            "flaky": sorted(self.flaky),
+            "order_dependent": sorted(self.order_dependent),
+            "slow": sorted(self.slow),
+        }
+
+
+def current_bad(report: dict) -> Baseline:
+    """Extract the set of currently-bad identities from a full report."""
+    return Baseline(
+        flaky={f["identity"] for f in report["flakiness"]["flaky"]},
+        order_dependent={
+            f["identity"] for f in report["independence"]["order_dependent"]
+        },
+        slow={f["identity"] for f in report["speed"]["slow_tail"]},
+    )
+
+
+def ratchet(report: dict, baseline: Baseline) -> dict:
+    """Regressions = currently-bad identities not present in the baseline."""
+    cur = current_bad(report)
+    new_flaky = sorted(cur.flaky - baseline.flaky)
+    new_order = sorted(cur.order_dependent - baseline.order_dependent)
+    new_slow = sorted(cur.slow - baseline.slow)
+    regressed = bool(new_flaky or new_order or new_slow)
+    return {
+        "regressed": regressed,
+        "new_flaky": new_flaky,
+        "new_order_dependent": new_order,
+        "new_slow": new_slow,
+        "baselined": {
+            "flaky": sorted(baseline.flaky & cur.flaky),
+            "order_dependent": sorted(baseline.order_dependent & cur.order_dependent),
+            "slow": sorted(baseline.slow & cur.slow),
+        },
+    }
+
+
+# ── top-level orchestration: the single entry point that runs all 3 lenses ───
+
+
+def build_report(
+    runner,
+    adapter,
+    *,
+    n: int,
+    slow_seconds: float,
+    seed: int | None = None,
+    rng: random.Random | None = None,
+) -> dict:
+    """Run all three lenses from one set of suite invocations."""
+    rng = rng or random.Random(seed)
+    ordered = collect_runs(runner, adapter, n=n, shuffle=False, seed=seed, rng=rng)
+    shuffled = collect_runs(runner, adapter, n=n, shuffle=True, seed=seed, rng=rng)
+    return {
+        "n": n,
+        "flakiness": flakiness_lens(ordered),
+        "independence": independence_lens(ordered, shuffled),
+        "speed": speed_lens(ordered, slow_seconds=slow_seconds),
+    }
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def _make_go(args) -> tuple:
+    runner = GoTestRunner(
+        package_dir=str(Path(args.package_dir).expanduser().resolve()),
+        pattern=args.pattern,
+        timeout=args.timeout,
+    )
+    return runner, GoAdapter()
+
+
+def _emit(report: dict) -> None:
+    print(json.dumps(report, indent=2))
+
+
+def cmd_run(args) -> int:
+    """report mode: full report, optional ratchet gate. Exit reflects ratchet."""
+    runner, adapter = _make_go(args)
+    report = build_report(
+        runner, adapter, n=args.runs, slow_seconds=args.slow_seconds, seed=args.seed
+    )
+    if args.baseline:
+        baseline = Baseline.load(Path(args.baseline))
+        rr = ratchet(report, baseline)
+        report["ratchet"] = rr
+        if args.update_baseline:
+            Path(args.baseline).write_text(
+                json.dumps(current_bad(report).to_json(), indent=2) + "\n"
+            )
+            report["ratchet"]["baseline_updated"] = True
+        _emit(report)
+        return EXIT_REGRESSION if rr["regressed"] and not args.update_baseline else 0
+    _emit(report)
+    return 0
+
+
+def cmd_flakiness(args) -> int:
+    """GATE: the reusable flakiness precheck 0182 shells out to.
+
+    Exit 0 = suite is stable (or all flakiness is baselined). Exit
+    EXIT_REGRESSION = new flakiness found. JSON report on stdout either way.
+    """
+    runner, adapter = _make_go(args)
+    runs = collect_runs(runner, adapter, n=args.runs, shuffle=False, seed=args.seed)
+    lens = flakiness_lens(runs)
+    flaky_ids = {f["identity"] for f in lens["flaky"]}
+    new_flaky = sorted(flaky_ids)
+    if args.baseline:
+        baseline = Baseline.load(Path(args.baseline))
+        new_flaky = sorted(flaky_ids - baseline.flaky)
+        lens["baselined_flaky"] = sorted(flaky_ids & baseline.flaky)
+    lens["new_flaky"] = new_flaky
+    lens["gate"] = "fail" if new_flaky else "pass"
+    _emit(lens)
+    return EXIT_REGRESSION if new_flaky else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Empirical test-quality utility: flakiness / independence / speed. "
+            "Re-runs an existing suite; zero LLM tokens."
+        )
+    )
+    p.add_argument(
+        "--log-level",
+        default="WARNING",
+        help="Python logging level for diagnostics (default: WARNING)",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    def add_runner_args(sp, *, with_lens_args: bool, with_ratchet: bool):
+        sp.add_argument(
+            "--adapter",
+            choices=["go"],
+            default="go",
+            help="Runner/parser adapter (default: go)",
+        )
+        sp.add_argument(
+            "--package-dir",
+            required=True,
+            help="Directory the test command runs in (e.g. a Go module root)",
+        )
+        sp.add_argument(
+            "--pattern", default="./...", help="Go package pattern (default: ./...)"
+        )
+        sp.add_argument(
+            "--runs",
+            type=int,
+            default=3,
+            help="Times to re-run the suite (bounds runtime; default: 3)",
+        )
+        sp.add_argument(
+            "--seed", type=int, default=None, help="Base RNG seed (reproducibility)"
+        )
+        sp.add_argument(
+            "--timeout",
+            type=int,
+            default=600,
+            help="Per-run subprocess timeout, seconds (default: 600)",
+        )
+        if with_lens_args:
+            sp.add_argument(
+                "--slow-seconds",
+                type=float,
+                default=1.0,
+                help="Duration at/above which a test is slow-tail (default: 1.0)",
+            )
+        if with_ratchet:
+            sp.add_argument(
+                "--baseline",
+                default=None,
+                help="Path to a baseline JSON of known-bad identities (ratchet)",
+            )
+            sp.add_argument(
+                "--update-baseline",
+                action="store_true",
+                help="Rewrite the baseline from current findings; never gates",
+            )
+
+    run_p = sub.add_parser(
+        "run", help="Run all three lenses; emit full JSON report (report mode)"
+    )
+    add_runner_args(run_p, with_lens_args=True, with_ratchet=True)
+    run_p.set_defaults(func=cmd_run)
+
+    fl_p = sub.add_parser(
+        "flakiness",
+        help="GATE: re-run N times; exit nonzero on new flakiness (0182 precheck)",
+    )
+    add_runner_args(fl_p, with_lens_args=False, with_ratchet=False)
+    fl_p.add_argument(
+        "--baseline",
+        default=None,
+        help="Baseline JSON; flakiness already listed does not gate",
+    )
+    fl_p.set_defaults(func=cmd_flakiness)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.WARNING),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-quality.py
+++ b/scripts/test-quality.py
@@ -252,8 +252,18 @@ def flakiness_lens(runs: list[RunResult]) -> dict:
 def independence_lens(
     ordered: list[RunResult], shuffled: list[RunResult]
 ) -> dict:
-    """A test is order-dependent if its verdict differs between the ordered and
-    shuffled runs (controlling for tests already flaky under fixed order)."""
+    """A test is order-dependent when shuffling changes its behaviour.
+
+    Two signatures, both flagged:
+    - stable in BOTH directions but the verdicts disagree (deterministic
+      order dependence);
+    - stable under fixed order but UNSTABLE under shuffle (the canonical
+      isolation bug: the verdict depends on which neighbours ran first).
+      Reported with shuffled="unstable" plus the observed verdicts.
+
+    A test already unstable under fixed order is flakiness, not order
+    dependence — the flakiness lens (which sees the ordered runs) owns it.
+    """
     ordered_v = _verdicts_by_identity(ordered)
     shuffled_v = _verdicts_by_identity(shuffled)
 
@@ -264,12 +274,22 @@ def independence_lens(
     dependent: list[dict] = []
     for identity in sorted(set(ordered_v) | set(shuffled_v)):
         o = stable_verdict(ordered_v.get(identity, []))
-        s = stable_verdict(shuffled_v.get(identity, []))
-        # Only call it order-dependent when BOTH directions are internally
-        # stable but disagree — otherwise it's flakiness, not order-dependence.
-        if o is not None and s is not None and o != s:
+        shuffled_verdicts = shuffled_v.get(identity, [])
+        s = stable_verdict(shuffled_verdicts)
+        if o is None:
+            continue  # unstable under fixed order = flaky, owned by flakiness_lens
+        if s is not None and o != s:
             dependent.append(
                 {"identity": identity, "ordered": o, "shuffled": s}
+            )
+        elif s is None and shuffled_verdicts:
+            dependent.append(
+                {
+                    "identity": identity,
+                    "ordered": o,
+                    "shuffled": "unstable",
+                    "shuffled_verdicts": shuffled_verdicts,
+                }
             )
     return {
         "lens": "independence",

--- a/tests/fixtures/go_test_mixed.json
+++ b/tests/fixtures/go_test_mixed.json
@@ -1,0 +1,23 @@
+{"Time":"2026-06-05T14:04:34.7207673+02:00","Action":"start","Package":"gqdemo"}
+{"Time":"2026-06-05T14:04:34.722370587+02:00","Action":"run","Package":"gqdemo","Test":"TestAlpha"}
+{"Time":"2026-06-05T14:04:34.722420221+02:00","Action":"output","Package":"gqdemo","Test":"TestAlpha","Output":"=== RUN   TestAlpha\n"}
+{"Time":"2026-06-05T14:04:34.722447993+02:00","Action":"output","Package":"gqdemo","Test":"TestAlpha","Output":"--- PASS: TestAlpha (0.00s)\n"}
+{"Time":"2026-06-05T14:04:34.722454035+02:00","Action":"pass","Package":"gqdemo","Test":"TestAlpha","Elapsed":0}
+{"Time":"2026-06-05T14:04:34.722463472+02:00","Action":"run","Package":"gqdemo","Test":"TestBeta"}
+{"Time":"2026-06-05T14:04:34.722468923+02:00","Action":"output","Package":"gqdemo","Test":"TestBeta","Output":"=== RUN   TestBeta\n"}
+{"Time":"2026-06-05T14:04:34.722474283+02:00","Action":"output","Package":"gqdemo","Test":"TestBeta","Output":"    demo_test.go:6: hello\n"}
+{"Time":"2026-06-05T14:04:34.722480044+02:00","Action":"output","Package":"gqdemo","Test":"TestBeta","Output":"--- PASS: TestBeta (0.00s)\n"}
+{"Time":"2026-06-05T14:04:34.722485384+02:00","Action":"pass","Package":"gqdemo","Test":"TestBeta","Elapsed":0}
+{"Time":"2026-06-05T14:04:34.722490734+02:00","Action":"run","Package":"gqdemo","Test":"TestGammaFails"}
+{"Time":"2026-06-05T14:04:34.722495753+02:00","Action":"output","Package":"gqdemo","Test":"TestGammaFails","Output":"=== RUN   TestGammaFails\n"}
+{"Time":"2026-06-05T14:04:34.722501073+02:00","Action":"output","Package":"gqdemo","Test":"TestGammaFails","Output":"    demo_test.go:7: boom\n"}
+{"Time":"2026-06-05T14:04:34.722506814+02:00","Action":"output","Package":"gqdemo","Test":"TestGammaFails","Output":"--- FAIL: TestGammaFails (0.00s)\n"}
+{"Time":"2026-06-05T14:04:34.722512134+02:00","Action":"fail","Package":"gqdemo","Test":"TestGammaFails","Elapsed":0}
+{"Time":"2026-06-05T14:04:34.722517785+02:00","Action":"run","Package":"gqdemo","Test":"TestSkipped"}
+{"Time":"2026-06-05T14:04:34.722522724+02:00","Action":"output","Package":"gqdemo","Test":"TestSkipped","Output":"=== RUN   TestSkipped\n"}
+{"Time":"2026-06-05T14:04:34.722527814+02:00","Action":"output","Package":"gqdemo","Test":"TestSkipped","Output":"    demo_test.go:8: nope\n"}
+{"Time":"2026-06-05T14:04:34.722533344+02:00","Action":"output","Package":"gqdemo","Test":"TestSkipped","Output":"--- SKIP: TestSkipped (0.00s)\n"}
+{"Time":"2026-06-05T14:04:34.722538624+02:00","Action":"skip","Package":"gqdemo","Test":"TestSkipped","Elapsed":0}
+{"Time":"2026-06-05T14:04:34.722546078+02:00","Action":"output","Package":"gqdemo","Output":"FAIL\n"}
+{"Time":"2026-06-05T14:04:34.722780411+02:00","Action":"output","Package":"gqdemo","Output":"FAIL\tgqdemo\t0.002s\n"}
+{"Time":"2026-06-05T14:04:34.72280094+02:00","Action":"fail","Package":"gqdemo","Elapsed":0.002}

--- a/tests/test_test_quality.py
+++ b/tests/test_test_quality.py
@@ -147,6 +147,25 @@ def test_independence_lens_ignores_intrinsically_flaky_test():
     assert out["order_dependent"] == []
 
 
+def test_independence_lens_flags_stable_ordered_unstable_shuffled():
+    # The canonical isolation bug: deterministic under fixed order, verdict
+    # varies under shuffle (depends which neighbours ran first). Reproduces
+    # the PR #303 round-1 reviewer finding: neither lens flagged this.
+    ordered = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass")))) for _ in range(3)
+    ]
+    shuffled = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", v))), shuffle=True)
+        for v in ("pass", "fail", "pass")
+    ]
+    out = tq.independence_lens(ordered, shuffled)
+    (dep,) = out["order_dependent"]
+    assert dep["identity"] == "pkg::TestA"
+    assert dep["ordered"] == "pass"
+    assert dep["shuffled"] == "unstable"
+    assert dep["shuffled_verdicts"] == ["pass", "fail", "pass"]
+
+
 # ── speed lens ───────────────────────────────────────────────────────────────
 
 

--- a/tests/test_test_quality.py
+++ b/tests/test_test_quality.py
@@ -1,0 +1,358 @@
+"""Tests for scripts/test-quality.py — the empirical test-quality utility.
+
+The module is loaded via importlib (hyphenated filename, not importable),
+exactly like tests/test_project_state.py loads project-state.py.
+
+Design under test: only the Runner layer spawns a subprocess. Every lens, the
+Go adapter, and the ratchet are pure, so these tests inject a StubRunner /
+parse recorded JSON and never touch a real Go toolchain. One CLI-level test
+drives the `flakiness` and `run` subcommands end-to-end through a stub.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+spec = importlib.util.spec_from_file_location("test_quality", SCRIPTS / "test-quality.py")
+tq = importlib.util.module_from_spec(spec)
+sys.modules["test_quality"] = tq
+spec.loader.exec_module(tq)
+
+
+# ── stub runner/adapter: feed canned outputs, exercise lenses without Go ──────
+
+
+class StubRunner:
+    """Returns a pre-scripted raw output per call. `scripts` is a list of raw
+    strings; calls beyond the list repeat the last. Records how it was called."""
+
+    def __init__(self, scripts):
+        self._scripts = scripts
+        self.calls = []
+
+    def __call__(self, *, shuffle=False, seed=None):
+        idx = min(len(self.calls), len(self._scripts) - 1)
+        self.calls.append({"shuffle": shuffle, "seed": seed})
+        return self._scripts[idx]
+
+
+def _line(action, test, pkg="pkg", elapsed=0.0):
+    return json.dumps(
+        {"Action": action, "Test": test, "Package": pkg, "Elapsed": elapsed}
+    )
+
+
+def _raw(*verdicts, durations=None):
+    """Build a fake go-json blob: verdicts is (test_name, action) tuples."""
+    durations = durations or {}
+    lines = []
+    for name, action in verdicts:
+        lines.append(_line("run", name))
+        lines.append(_line(action, name, elapsed=durations.get(name, 0.0)))
+    return "\n".join(lines)
+
+
+# ── Go adapter (fixture-tested; never invokes go) ────────────────────────────
+
+
+def test_go_adapter_parses_recorded_fixture():
+    raw = (FIXTURES / "go_test_mixed.json").read_text()
+    records = tq.GoAdapter.parse(raw)
+    by_id = {r.identity: r for r in records}
+    assert by_id["gqdemo::TestAlpha"].verdict == "pass"
+    assert by_id["gqdemo::TestBeta"].verdict == "pass"
+    assert by_id["gqdemo::TestGammaFails"].verdict == "fail"
+    assert by_id["gqdemo::TestSkipped"].verdict == "skip"
+    # Exactly the four per-test terminal events; package-level events dropped.
+    assert len(records) == 4
+
+
+def test_go_adapter_ignores_package_events_and_build_noise():
+    raw = "\n".join(
+        [
+            "# gqdemo  (a non-JSON build line go prepends)",
+            _line("output", "TestX"),  # non-terminal: ignored
+            _line("pass", "TestX", elapsed=0.5),
+            json.dumps({"Action": "pass", "Package": "gqdemo", "Elapsed": 1.2}),  # no Test
+        ]
+    )
+    records = tq.GoAdapter.parse(raw)
+    assert len(records) == 1
+    assert records[0].identity == "pkg::TestX"
+    assert records[0].duration == 0.5
+
+
+def test_go_identity_handles_missing_package():
+    assert tq.go_identity(None, "TestFoo") == "::TestFoo"
+
+
+# ── flakiness lens ───────────────────────────────────────────────────────────
+
+
+def test_flakiness_lens_flags_varying_verdict():
+    runs = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass"), ("TestB", "pass")))),
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass"), ("TestB", "fail")))),
+    ]
+    out = tq.flakiness_lens(runs)
+    flaky_ids = {f["identity"] for f in out["flaky"]}
+    assert flaky_ids == {"pkg::TestB"}
+    assert out["stable"] == 1
+
+
+def test_flakiness_lens_flags_inconsistent_presence():
+    runs = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass"), ("TestB", "pass")))),
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass")))),  # B missing
+    ]
+    out = tq.flakiness_lens(runs)
+    flaky_ids = {f["identity"] for f in out["flaky"]}
+    assert "pkg::TestB" in flaky_ids
+
+
+def test_flakiness_lens_stable_suite_has_no_flakes():
+    raw = _raw(("TestA", "pass"), ("TestB", "fail"))
+    runs = [tq.RunResult(tq.GoAdapter.parse(raw)) for _ in range(4)]
+    out = tq.flakiness_lens(runs)
+    assert out["flaky"] == []
+    assert out["stable"] == 2
+
+
+# ── independence lens ────────────────────────────────────────────────────────
+
+
+def test_independence_lens_flags_order_dependent_test():
+    ordered = [tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass"))))]
+    shuffled = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "fail"))), shuffle=True)
+    ]
+    out = tq.independence_lens(ordered, shuffled)
+    ids = {d["identity"] for d in out["order_dependent"]}
+    assert ids == {"pkg::TestA"}
+
+
+def test_independence_lens_ignores_intrinsically_flaky_test():
+    # Test is flaky under fixed order (pass then fail) -> not order-dependent.
+    ordered = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "pass")))),
+        tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "fail")))),
+    ]
+    shuffled = [tq.RunResult(tq.GoAdapter.parse(_raw(("TestA", "fail"))), shuffle=True)]
+    out = tq.independence_lens(ordered, shuffled)
+    assert out["order_dependent"] == []
+
+
+# ── speed lens ───────────────────────────────────────────────────────────────
+
+
+def test_speed_lens_flags_slow_tail():
+    raw = _raw(
+        ("Fast", "pass"),
+        ("Slow", "pass"),
+        durations={"Fast": 0.1, "Slow": 3.0},
+    )
+    runs = [tq.RunResult(tq.GoAdapter.parse(raw))]
+    out = tq.speed_lens(runs, slow_seconds=1.0)
+    slow_ids = {s["identity"] for s in out["slow_tail"]}
+    assert slow_ids == {"pkg::Slow"}
+    assert out["slowest"][0]["identity"] == "pkg::Slow"
+
+
+def test_speed_lens_takes_max_duration_across_runs():
+    runs = [
+        tq.RunResult(tq.GoAdapter.parse(_raw(("T", "pass"), durations={"T": 0.2}))),
+        tq.RunResult(tq.GoAdapter.parse(_raw(("T", "pass"), durations={"T": 2.5}))),
+    ]
+    out = tq.speed_lens(runs, slow_seconds=1.0)
+    assert {s["identity"] for s in out["slow_tail"]} == {"pkg::T"}
+
+
+# ── ratchet ──────────────────────────────────────────────────────────────────
+
+
+def _report_with(flaky=(), order=(), slow=()):
+    return {
+        "flakiness": {"flaky": [{"identity": i} for i in flaky]},
+        "independence": {"order_dependent": [{"identity": i} for i in order]},
+        "speed": {"slow_tail": [{"identity": i} for i in slow]},
+    }
+
+
+def test_ratchet_passes_when_all_bad_is_baselined():
+    report = _report_with(flaky=["pkg::Old"])
+    baseline = tq.Baseline(flaky={"pkg::Old"})
+    out = tq.ratchet(report, baseline)
+    assert out["regressed"] is False
+    assert out["new_flaky"] == []
+    assert out["baselined"]["flaky"] == ["pkg::Old"]
+
+
+def test_ratchet_fails_on_new_regression():
+    report = _report_with(flaky=["pkg::Old", "pkg::New"], slow=["pkg::SlowNew"])
+    baseline = tq.Baseline(flaky={"pkg::Old"})
+    out = tq.ratchet(report, baseline)
+    assert out["regressed"] is True
+    assert out["new_flaky"] == ["pkg::New"]
+    assert out["new_slow"] == ["pkg::SlowNew"]
+
+
+def test_baseline_roundtrips_through_json(tmp_path):
+    b = tq.Baseline(flaky={"a"}, order_dependent={"b"}, slow={"c"})
+    p = tmp_path / "baseline.json"
+    p.write_text(json.dumps(b.to_json()))
+    loaded = tq.Baseline.load(p)
+    assert loaded.flaky == {"a"}
+    assert loaded.order_dependent == {"b"}
+    assert loaded.slow == {"c"}
+
+
+def test_baseline_load_missing_file_is_empty(tmp_path):
+    loaded = tq.Baseline.load(tmp_path / "nope.json")
+    assert loaded.flaky == set()
+
+
+# ── collect_runs: shuffle gives distinct seeds, runner injected ──────────────
+
+
+def test_collect_runs_shuffle_uses_distinct_seeds():
+    runner = StubRunner([_raw(("T", "pass"))])
+    runs = tq.collect_runs(runner, tq.GoAdapter, n=3, shuffle=True, seed=1)
+    assert len(runs) == 3
+    assert all(c["shuffle"] for c in runner.calls)
+    seeds = [c["seed"] for c in runner.calls]
+    assert len(set(seeds)) == 3  # each run got its own shuffle seed
+
+
+def test_collect_runs_no_shuffle_keeps_order():
+    runner = StubRunner([_raw(("T", "pass"))])
+    tq.collect_runs(runner, tq.GoAdapter, n=2, shuffle=False, seed=None)
+    assert all(c["shuffle"] is False for c in runner.calls)
+
+
+# ── full report orchestration ────────────────────────────────────────────────
+
+
+def test_build_report_runs_all_three_lenses():
+    runner = StubRunner([_raw(("TestA", "pass"), durations={"TestA": 2.0})])
+    report = tq.build_report(
+        runner, tq.GoAdapter, n=2, slow_seconds=1.0, seed=7
+    )
+    assert set(report) >= {"flakiness", "independence", "speed"}
+    assert report["speed"]["slow_tail"][0]["identity"] == "pkg::TestA"
+
+
+# ── CLI / gate contract (the EC2 contract 0182 depends on) ───────────────────
+
+
+def _patch_go_runner(monkeypatch, runner):
+    """Make _make_go return our stub runner + the real GoAdapter."""
+    monkeypatch.setattr(tq, "_make_go", lambda args: (runner, tq.GoAdapter))
+
+
+def test_flakiness_subcommand_exit_zero_when_stable(monkeypatch, capsys):
+    runner = StubRunner([_raw(("TestA", "pass"), ("TestB", "fail"))])
+    _patch_go_runner(monkeypatch, runner)
+    rc = tq.main(["flakiness", "--package-dir", "/x", "--runs", "3"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["gate"] == "pass"
+    assert out["new_flaky"] == []
+
+
+def test_flakiness_subcommand_exit_nonzero_when_flaky(monkeypatch, capsys):
+    runner = StubRunner([_raw(("T", "pass")), _raw(("T", "fail"))])
+    _patch_go_runner(monkeypatch, runner)
+    rc = tq.main(["flakiness", "--package-dir", "/x", "--runs", "2"])
+    assert rc == tq.EXIT_REGRESSION
+    out = json.loads(capsys.readouterr().out)
+    assert out["gate"] == "fail"
+    assert out["new_flaky"] == ["pkg::T"]
+
+
+def test_flakiness_subcommand_baseline_suppresses_known_flake(
+    monkeypatch, capsys, tmp_path
+):
+    bpath = tmp_path / "b.json"
+    bpath.write_text(json.dumps({"flaky": ["pkg::T"]}))
+    runner = StubRunner([_raw(("T", "pass")), _raw(("T", "fail"))])
+    _patch_go_runner(monkeypatch, runner)
+    rc = tq.main(
+        ["flakiness", "--package-dir", "/x", "--runs", "2", "--baseline", str(bpath)]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["new_flaky"] == []
+    assert out["baselined_flaky"] == ["pkg::T"]
+
+
+def test_run_subcommand_emits_report_and_exits_zero(monkeypatch, capsys):
+    runner = StubRunner([_raw(("TestA", "pass"))])
+    _patch_go_runner(monkeypatch, runner)
+    rc = tq.main(["run", "--package-dir", "/x", "--runs", "2"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "flakiness" in out and "independence" in out and "speed" in out
+
+
+def test_run_subcommand_gates_on_ratchet_regression(monkeypatch, capsys, tmp_path):
+    # New slow test, empty baseline -> regression -> exit nonzero.
+    runner = StubRunner([_raw(("Slow", "pass"), durations={"Slow": 5.0})])
+    _patch_go_runner(monkeypatch, runner)
+    bpath = tmp_path / "b.json"
+    rc = tq.main(
+        [
+            "run",
+            "--package-dir",
+            "/x",
+            "--runs",
+            "1",
+            "--slow-seconds",
+            "1.0",
+            "--baseline",
+            str(bpath),
+        ]
+    )
+    assert rc == tq.EXIT_REGRESSION
+    out = json.loads(capsys.readouterr().out)
+    assert out["ratchet"]["regressed"] is True
+    assert "pkg::Slow" in out["ratchet"]["new_slow"]
+
+
+def test_run_subcommand_update_baseline_never_gates(monkeypatch, capsys, tmp_path):
+    runner = StubRunner([_raw(("Slow", "pass"), durations={"Slow": 5.0})])
+    _patch_go_runner(monkeypatch, runner)
+    bpath = tmp_path / "b.json"
+    rc = tq.main(
+        [
+            "run",
+            "--package-dir",
+            "/x",
+            "--runs",
+            "1",
+            "--slow-seconds",
+            "1.0",
+            "--baseline",
+            str(bpath),
+            "--update-baseline",
+        ]
+    )
+    assert rc == 0
+    written = json.loads(bpath.read_text())
+    assert "pkg::Slow" in written["slow"]
+
+
+# ── CLI flag presence (source inspection, not subprocess --help) ─────────────
+
+
+def test_cli_exposes_flakiness_gate_and_run_subcommands():
+    src = (SCRIPTS / "test-quality.py").read_text()
+    assert '"flakiness"' in src
+    assert '"run"' in src
+    assert "EXIT_REGRESSION" in src
+    assert "--baseline" in src
+    assert "--update-baseline" in src

--- a/tickets/0184-empirical-test-quality-ci-utility.erg
+++ b/tickets/0184-empirical-test-quality-ci-utility.erg
@@ -9,6 +9,7 @@ Author: claude
 2026-06-05T11:57Z MinhHaDuong unlabel deferred
 2026-06-05T11:57Z Minh Ha-Duong note un-deferred for raid (author directive): the trio splits — 0184 raids now (it provides the flakiness gate 0182 imports as precheck), 0182 raids fang-only, 0219 carries the rest, 0183 stays deferred
 2026-06-05T12:03Z claude note raid execute: building scripts/test-quality.py — pure-Python utility (runner/adapter/lenses/ratchet layers), Go go-test-json adapter, flakiness gate subcommand w/ exit-code contract for 0182, ratchet baseline mode; tests via importlib + recorded go-json fixture
+2026-06-05T12:09Z claude note raid execute complete: scripts/test-quality.py + tests (24 pass, full suite 395 pass, make check pass, ruff clean); PR #303 opened; all 5 exit criteria ticked w/ evidence
 --- body ---
 ## Context
 

--- a/tickets/0184-empirical-test-quality-ci-utility.erg
+++ b/tickets/0184-empirical-test-quality-ci-utility.erg
@@ -8,6 +8,7 @@ Author: claude
 
 2026-06-05T11:57Z MinhHaDuong unlabel deferred
 2026-06-05T11:57Z Minh Ha-Duong note un-deferred for raid (author directive): the trio splits — 0184 raids now (it provides the flakiness gate 0182 imports as precheck), 0182 raids fang-only, 0219 carries the rest, 0183 stays deferred
+2026-06-05T12:03Z claude note raid execute: building scripts/test-quality.py — pure-Python utility (runner/adapter/lenses/ratchet layers), Go go-test-json adapter, flakiness gate subcommand w/ exit-code contract for 0182, ratchet baseline mode; tests via importlib + recorded go-json fixture
 --- body ---
 ## Context
 
@@ -38,8 +39,34 @@ adds (erg's wiring would be a small erg-project task, NOT this ticket).
   only on NEW flakiness/slowness introduced by the diff, not pre-existing debt.
 
 ## Exit criteria
-- [ ] Utility runs the three checks from a single entry point; machine-readable output.
-- [ ] Flakiness check is exposed as a reusable gate that 0182 calls as its precheck.
-- [ ] Go adapter implemented; the runner interface is documented for other languages.
-- [ ] Ratchet mode: fail only on diff-introduced regressions, baseline the rest.
-- [ ] Cost note honored: zero LLM tokens; runtime bounded for per-PR use.
+- [x] Utility runs the three checks from a single entry point; machine-readable output.
+      `scripts/test-quality.py run` builds flakiness + independence + speed lenses from one
+      set of suite invocations (`build_report`) and prints JSON on stdout. Verified by
+      `tests/test_test_quality.py::test_build_report_runs_all_three_lenses` and
+      `::test_run_subcommand_emits_report_and_exits_zero`, plus a live run against a real Go
+      package (slow_tail correctly flags the sleeping test).
+- [x] Flakiness check is exposed as a reusable gate that 0182 calls as its precheck.
+      `flakiness` subcommand: exit 0 = stable, exit `EXIT_REGRESSION` (2) = new flakiness,
+      JSON either way. 0182 shells out and keys on the exit code (contract documented in the
+      module docstring "Exit-code contract"; language-agnostic, robust to the hyphenated,
+      non-importable filename). Tests: `::test_flakiness_subcommand_exit_zero_when_stable`,
+      `::test_flakiness_subcommand_exit_nonzero_when_flaky`,
+      `::test_flakiness_subcommand_baseline_suppresses_known_flake`.
+- [x] Go adapter implemented; the runner interface is documented for other languages.
+      `GoAdapter.parse` consumes the `go test -json` event stream (keys Action/Test/Package/
+      Elapsed); `GoTestRunner` is the only subprocess layer (`go test -count=1 -json`,
+      `-shuffle` for independence). The pluggable runner+adapter interface (callable
+      `runner(*, shuffle, seed) -> str` + `adapter.parse(raw) -> list[TestRecord]`) is
+      documented in the module docstring. Adapter tested against a recorded fixture
+      (`tests/fixtures/go_test_mixed.json`), never invoking go:
+      `::test_go_adapter_parses_recorded_fixture`, `::test_go_adapter_ignores_package_events_and_build_noise`.
+- [x] Ratchet mode: fail only on diff-introduced regressions, baseline the rest.
+      `Baseline` = known-bad identities per lens; `ratchet()` fails only on bad identities
+      NOT in the baseline; `--update-baseline` re-baselines (never gates). Test identity =
+      `<package>::<TestName>` (the shared join key for 0182/0183 composition). Tests:
+      `::test_ratchet_passes_when_all_bad_is_baselined`, `::test_ratchet_fails_on_new_regression`,
+      `::test_run_subcommand_gates_on_ratchet_regression`, `::test_run_subcommand_update_baseline_never_gates`.
+- [x] Cost note honored: zero LLM tokens; runtime bounded for per-PR use.
+      Pure stdlib re-run/parse — no `anthropic`, no network, no agents (grep-clean).
+      `--runs` (default 3) and `--timeout` (default 600s) bound runtime; `--runs` is the
+      knob CI tunes per repo. Tested end-to-end via stub runner + a real Go package.

--- a/tickets/closed/0184-empirical-test-quality-ci-utility.erg
+++ b/tickets/closed/0184-empirical-test-quality-ci-utility.erg
@@ -2,6 +2,7 @@
 Title: Empirical test-quality CI utility (flakiness / independence / speed)
 Created: 2026-05-30
 Author: claude
+Closed: autoclosed — PR #303
 
 --- log ---
 2026-05-30T10:45Z claude created — cheap-tier sibling to 0182/0183; the per-PR-gateable lenses
@@ -10,6 +11,7 @@ Author: claude
 2026-06-05T11:57Z Minh Ha-Duong note un-deferred for raid (author directive): the trio splits — 0184 raids now (it provides the flakiness gate 0182 imports as precheck), 0182 raids fang-only, 0219 carries the rest, 0183 stays deferred
 2026-06-05T12:03Z claude note raid execute: building scripts/test-quality.py — pure-Python utility (runner/adapter/lenses/ratchet layers), Go go-test-json adapter, flakiness gate subcommand w/ exit-code contract for 0182, ratchet baseline mode; tests via importlib + recorded go-json fixture
 2026-06-05T12:09Z claude note raid execute complete: scripts/test-quality.py + tests (24 pass, full suite 395 pass, make check pass, ruff clean); PR #303 opened; all 5 exit criteria ticked w/ evidence
+2026-06-05T12:55Z MinhHaDuong closed — autoclosed — PR #303
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

The cheap, deterministic tier of the test-quality family (siblings: 0182 mutation oracles, 0183 LLM judge). Every signal is produced by re-running the existing suite — no mutation, no LLM, **zero tokens** — so these are the only test-quality lenses fast enough to gate a single PR.

`scripts/test-quality.py` — pure-stdlib Python utility (not a skill), four layers, only the Runner touches a subprocess so lenses/adapter/ratchet are pure and fixture-testable:

- **Runner** (injected) spawns `go test -count=1 -json [-shuffle]`.
- **Adapter** parses the `go test -json` event stream into `TestRecord` rows.
- **Lenses** flakiness / independence / speed — pure over records.
- **Ratchet** pure diff of current findings vs a baseline of known-bad ids.

## Exit criteria (all met, evidence in the ticket)

1. **Single entry point, machine-readable** — `run` subcommand builds all three lenses from one set of invocations, JSON on stdout.
2. **Flakiness gate for 0182** — `flakiness` subcommand with a hard exit-code contract (0 = stable, 2 = new flakiness, JSON either way). 0182 shells out and keys on the exit code — language-agnostic, robust to this file's hyphenated, non-importable name.
3. **Go adapter + documented runner interface** — `GoAdapter.parse` / `GoTestRunner`; the pluggable `runner(*, shuffle, seed) -> str` + `adapter.parse(raw) -> list[TestRecord]` interface is documented in the module docstring. Adapter tested against a recorded fixture, never invoking go.
4. **Ratchet mode** — baselines pre-existing debt, fails only on diff-introduced regressions; `--update-baseline` re-baselines. Test identity `<package>::<TestName>` is the shared join key for 0182/0183 composition.
5. **Cost note** — pure stdlib re-run/parse, no LLM/network/agents; `--runs` (default 3) and `--timeout` bound runtime.

## Testing

- `tests/test_test_quality.py` — 24 tests: Go adapter against recorded `tests/fixtures/go_test_mixed.json` (never invokes go), all three lenses, ratchet, and CLI gate/exit-code contract via a stub runner.
- Full suite green (395 passed); `make check` passes; ruff clean.
- Verified end-to-end against a live Go package: stable suite gates exit 0; speed lens flags a sleeping test.

Per-repo CI wiring is a thin adapter each repo adds — out of scope here.

**Ticket:** tickets/0184-empirical-test-quality-ci-utility.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)