### PR TITLE
fix(0221): fang-audit — isolate mutating agents, target-repo binding

### DIFF
--- a/skills/fang-audit/SKILL.md
+++ b/skills/fang-audit/SKILL.md
@@ -29,6 +29,12 @@ blocked follow-up — do not expect them here.
 
 ## How it runs
 
+> **HARD REQUIREMENT: invoke from a session rooted in the TARGET repo.**
+> The Workflow tool cuts each agent's throwaway worktree from the *session's*
+> repository (probe-verified, ticket 0221). Launched from any other repo,
+> every agent lands in a tree without the configured sources and fails at
+> baseline. To audit `~/git-erg`, open the Claude session in `~/git-erg`.
+
 The workflow is a `Workflow`-tool script: `skills/fang-audit/fang-audit.js`.
 You configure it, then run it with the Workflow tool. Phases:
 
@@ -111,6 +117,7 @@ from `git log --follow`; risk = the human-supplied `CONFIG.RISK` weight, default
 
 ## Steps
 
+0. **Open the session in the target repo** (see the hard requirement above).
 1. Confirm the suite is worth a 1.3M-token audit and is reasonably stable.
 2. Edit the `CONFIG` block in `skills/fang-audit/fang-audit.js` for the target
    repo (pairing table, run command, guards/canaries, precheck command).

--- a/skills/fang-audit/fang-audit.js
+++ b/skills/fang-audit/fang-audit.js
@@ -323,9 +323,15 @@ log(`precheck PASS — suite stable (exit ${precheck.exitCode}, gate=${precheck.
 
 // ---- Phase 1+2: behavioral audit -> skeptic (pipeline, no barrier) ----
 phase('Audit')
+// Δ8: isolation:'worktree' — Workflow agents run in the SESSION checkout by
+// default (probe-verified 2026-06-05, ticket 0221); without per-agent
+// worktrees the concurrent mutate→test→revert loops corrupt each other.
+// This also binds the run to the session's repo: invoke from a session
+// rooted in the TARGET repo (see SKILL.md). Skeptics stay non-isolated —
+// read-and-judge, no execution.
 const behavioral = await pipeline(
   BEHAVIORAL,
-  file => agent(auditPrompt(file), { label: `audit:${file.test}`, phase: 'Audit', schema: AUDIT_SCHEMA })
+  file => agent(auditPrompt(file), { label: `audit:${file.test}`, phase: 'Audit', schema: AUDIT_SCHEMA, isolation: 'worktree' })
             .then(a => { if (a) a.testFile = a.testFile || file.test; return a }),
   (audit, file) => skepticize(audit, file),
 )
@@ -334,7 +340,7 @@ const behavioral = await pipeline(
 phase('Guards')
 const guards = []
 for (const file of GUARDS) {
-  let a = await agent(guardPrompt(file), { label: `audit:${file.test}`, phase: 'Guards', schema: AUDIT_SCHEMA })
+  let a = await agent(guardPrompt(file), { label: `audit:${file.test}`, phase: 'Guards', schema: AUDIT_SCHEMA, isolation: 'worktree' })  // Δ8
   // Δ7: tag findings from this run STRUCTURALLY as canary-guard findings.
   // Canary designation comes from CONFIG.GUARDS (the workflow knows which
   // agent it dispatched), NEVER from a read-back of the agent's isCanary flag.

--- a/tests/test_fang_audit_skill.py
+++ b/tests/test_fang_audit_skill.py
@@ -169,3 +169,28 @@ def test_no_hardcoded_home_paths():
         text = f.read_text()
         assert not re.search(r"/home/[a-z]", text), f"{f.name} has a /home path"
         assert "github.com" not in text, f"{f.name} references github.com"
+
+
+# ── 0221: per-agent worktree isolation on the mutating call sites ────────────
+
+
+def test_mutating_agents_are_worktree_isolated():
+    """Workflow agents share the session checkout by default (probe-verified,
+    ticket 0221); the mutate->test->revert loops MUST run in per-agent
+    worktrees or they corrupt each other. Skeptics are read-only and stay
+    non-isolated (worktrees are expensive)."""
+    lines = js().splitlines()
+    mutating = [ln for ln in lines
+                if "agent(auditPrompt(file)" in ln or "agent(guardPrompt(file)" in ln]
+    assert len(mutating) == 2, "expected exactly one audit + one guard agent call"
+    for ln in mutating:
+        assert "isolation: 'worktree'" in ln, f"mutating agent not isolated: {ln.strip()[:80]}"
+    # Skeptic stays non-isolated: read-and-judge, no execution.
+    (idx,) = [i for i, ln in enumerate(lines) if "agent(skepticPrompt" in ln]
+    skeptic_call = "\n".join(lines[idx:idx + 5])
+    assert "isolation" not in skeptic_call, "skeptic must stay non-isolated"
+
+
+def test_skill_md_states_target_repo_requirement():
+    text = MD.read_text()
+    assert "TARGET repo" in text, "SKILL.md missing the target-repo session requirement"

--- a/tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
+++ b/tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
@@ -9,6 +9,7 @@ Label: deferred
 
 2026-06-05T11:56Z MinhHaDuong label deferred
 2026-06-05T13:32Z MinhHaDuong note blocker 0182 closed — Blocked-by removed.
+2026-06-05T14:12Z claude note parking condition NOT yet met: the authorized validating run hit a setup blocker pre-spend — Workflow agents proved non-isolated and session-repo-bound (probe, ticket 0221). Run again after 0221 merges, from a session rooted in the target repo
 --- body ---
 ## Context
 

--- a/tickets/0221-fang-audit-runtime-per-agent-worktree-is.erg
+++ b/tickets/0221-fang-audit-runtime-per-agent-worktree-is.erg
@@ -1,0 +1,54 @@
+%erg 0.1
+Title: Fang-audit runtime: per-agent worktree isolation and target-repo session binding
+Created: 2026-06-05
+Author: MinhHaDuong
+
+--- log ---
+2026-06-05T14:10Z MinhHaDuong created
+
+--- body ---
+## Context
+
+First-contact findings from the authorized 0182 validating run
+(2026-06-05, pre-spend). A one-agent Workflow probe (~22k tokens)
+proved both empirically:
+
+1. **No per-agent isolation.** Workflow `agent()` calls run in the
+   SESSION checkout by default — `isolation: 'worktree'` is opt-in,
+   and neither the merged skill nor the May prototype passes it. As
+   shipped, the fan-out would run 16 concurrent mutate→test→revert
+   loops in one shared tree, corrupting each other's verdicts. The
+   prompt's "You are in an isolated throwaway git worktree" line is
+   false as shipped. (PR #305's verify checked extraction FIDELITY,
+   so it faithfully preserved the prototype's own omission.)
+2. **Target-repo session binding.** Workflow worktrees are cut from
+   the session's repo; an audit of git-erg cannot launch from an IDH
+   session — every agent would land in a tree with no src/go.
+
+## Actions
+
+1. fang-audit.js: add `isolation: 'worktree'` (marked Δ8) to the
+   behavioral-audit and guard `agent()` calls. Skeptics stay
+   non-isolated (read-and-judge, no execution — isolation is
+   expensive and useless there).
+2. SKILL.md: state the hard requirement — invoke from a session
+   rooted in the TARGET repo; the worktrees are cut from it.
+3. tests/test_fang_audit_skill.py: source-inspection test pinning
+   `isolation: 'worktree'` on both mutating agent() call sites.
+
+## Test
+
+Source-inspection: the audit and guard agent() calls carry
+isolation: 'worktree'; the skeptic call does not.
+
+## Exit criteria
+
+- [x] Audit + guard agents isolated (Δ8, both call sites) — fang-audit.js:334,343
+- [x] SKILL.md documents the target-repo session requirement — "HARD REQUIREMENT" block + step 0
+- [x] Regression test pins both call sites — test_mutating_agents_are_worktree_isolated, test_skill_md_states_target_repo_requirement
+- [x] make check passes — 15 skill tests, 422 full suite, drift + agnostic clean
+
+## Related
+
+- tickets/closed/0182 (the extraction), tickets/0219 (parking
+  condition NOT met by this — the validating run is still pending)

--- a/tickets/closed/0221-fang-audit-runtime-per-agent-worktree-is.erg
+++ b/tickets/closed/0221-fang-audit-runtime-per-agent-worktree-is.erg
@@ -2,10 +2,12 @@
 Title: Fang-audit runtime: per-agent worktree isolation and target-repo session binding
 Created: 2026-06-05
 Author: MinhHaDuong
+Closed: autoclosed — PR #307
 
 --- log ---
 2026-06-05T14:10Z MinhHaDuong created
 
+2026-06-05T14:31Z MinhHaDuong closed — autoclosed — PR #307
 --- body ---
 ## Context
 


### PR DESCRIPTION
Probe-verified pre-spend: Workflow agents share the session checkout by default and worktrees are session-repo-bound. Δ8 adds isolation:'worktree' to the two mutating call sites; SKILL.md gains the hard "invoke from a session rooted in the target repo" requirement; two regression tests pin it. Skeptics stay non-isolated by design.

**Ticket:** tickets/0221-fang-audit-runtime-per-agent-worktree-is.erg
Ticket-ref: tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)