### PR TITLE
fix(0222): fang-audit — per-repo .fang-audit.json, zero skill-file editing

### DIFF
--- a/skills/fang-audit/SKILL.md
+++ b/skills/fang-audit/SKILL.md
@@ -58,12 +58,24 @@ You configure it, then run it with the Workflow tool. Phases:
 Then the engine assembles a deterministic report (no LLM formatting) and returns
 it; write it to `CONFIG.OUTPUT`.
 
-## Configuration — the only part you edit per repo
+## Configuration — `.fang-audit.json` in the target repo, never this skill
 
-Open `skills/fang-audit/fang-audit.js` and fill the `CONFIG` block. **These are
-explicit inputs, NOT name heuristics** — the `X_test.go → X.go` heuristic
-returned a *nonexistent* file for 5 of 19 git-erg tests, including both canaries,
-silently breaking the validity gate. Always supply the table.
+**You never edit any skill file to run an audit.** The target repo owns its
+configuration in a committed `.fang-audit.json` at its root. At invocation,
+read that file and pass its parsed content as the Workflow `args` input —
+the script merges it over the built-in DEFAULTS (the validated git-erg
+reference values, kept in `fang-audit.js` as living documentation of every
+knob). Path values (`OUTPUT`, `UNTRACKED_SEED[].from`) may use a leading
+`~/`; the script expands it.
+
+If `.fang-audit.json` is missing, STOP and hand the user a template built
+from the DEFAULTS block — do not edit `fang-audit.js`, do not guess a
+pairing table.
+
+**The knobs are explicit inputs, NOT name heuristics** — the
+`X_test.go → X.go` heuristic returned a *nonexistent* file for 5 of 19
+git-erg tests, including both canaries, silently breaking the validity gate.
+Always supply the table.
 
 | Knob | What it is |
 |---|---|
@@ -119,9 +131,10 @@ from `git log --follow`; risk = the human-supplied `CONFIG.RISK` weight, default
 
 0. **Open the session in the target repo** (see the hard requirement above).
 1. Confirm the suite is worth a 1.3M-token audit and is reasonably stable.
-2. Edit the `CONFIG` block in `skills/fang-audit/fang-audit.js` for the target
-   repo (pairing table, run command, guards/canaries, precheck command).
-3. Run `skills/fang-audit/fang-audit.js` with the Workflow tool.
+2. Read `.fang-audit.json` at the target repo root. Missing → STOP and give
+   the user a template (from the DEFAULTS block); never edit skill files.
+3. Run `skills/fang-audit/fang-audit.js` with the Workflow tool, passing the
+   parsed config as `args`.
 4. If it aborts at the precheck, stabilize the flaky tests first — the verdicts
    are untrustworthy on a flaky suite, by design.
 5. Write the returned `report` to `CONFIG.OUTPUT`. **Spot-check 2–3 toothless

--- a/skills/fang-audit/SKILL.md
+++ b/skills/fang-audit/SKILL.md
@@ -3,7 +3,7 @@ name: fang-audit
 description: "Fan-out mutation-testing audit — does each test FAIL on the defect it claims to catch? Surfaces toothless tests. EXPENSIVE on-demand (the validating run was ~1.3M tokens / ~29 min); never invoke casually."
 disable-model-invocation: false
 user-invocable: true
-argument-hint: "[after editing the CONFIG block in fang-audit.js]"
+argument-hint: "[run in the target repo; reads its committed .fang-audit.json]"
 ---
 
 # Fang Audit — does each test have teeth?

--- a/skills/fang-audit/fang-audit.js
+++ b/skills/fang-audit/fang-audit.js
@@ -5,15 +5,28 @@
 // See skills/fang-audit/SKILL.md for the prototype→skill correspondence and
 // the EXPENSIVE-RUN warning. This is fang-only v1 (ticket 0182); handcuff,
 // scope/altitude, and the three-axis report live in ticket 0219.
-//
+
+export const meta = {
+  name: 'fang-audit',
+  description: 'Mutation-test the configured test harness: does each test FAIL on the defect it claims to catch? Reports toothless tests. No source/test changes persist. EXPENSIVE on-demand audit (the validating run was ~1.3M tokens / ~29 min).',
+  phases: [
+    { title: 'Precheck', detail: 'determinism gate (flakiness re-run); abort if the suite is flaky' },
+    { title: 'Audit', detail: 'behavioral test files, one Opus agent each, mutate→test→revert in isolated worktrees' },
+    { title: 'Skeptic', detail: 'Sonnet adversarially re-checks every survived/equivalent verdict' },
+    { title: 'Guards', detail: 'designated canary guard tests, serialized (perf-sensitive)' },
+  ],
+}
+
 // ============================================================================
-// CONFIG — the ONLY part you edit per repo. Everything below CONFIG is the
-// repo-agnostic engine (verbatim from the prototype except the four marked
-// deltas: parameterized knobs, config-scoped canary gate, determinism
-// precheck, and the free-rider / risk×churn report additions).
+// DEFAULTS — the validated git-erg reference configuration, kept as living
+// documentation of every knob. Δ9: NEVER edit this file per repo — the target
+// repo owns its config in `.fang-audit.json` at its root, which the SKILL.md
+// invocation reads and passes as the Workflow `args` input; args override
+// these defaults key-by-key. Everything below the merge is the repo-agnostic
+// engine (verbatim from the prototype except the marked deltas).
 // ============================================================================
 
-const CONFIG = {
+const DEFAULTS = {
   // Human-readable name of the project under audit (report title only).
   PROJECT: 'YOUR-PROJECT',
 
@@ -116,16 +129,14 @@ const CONFIG = {
 // where marked Δ.
 // ============================================================================
 
-export const meta = {
-  name: 'fang-audit',
-  description: 'Mutation-test the configured test harness: does each test FAIL on the defect it claims to catch? Reports toothless tests. No source/test changes persist. EXPENSIVE on-demand audit (the validating run was ~1.3M tokens / ~29 min).',
-  phases: [
-    { title: 'Precheck', detail: 'determinism gate (flakiness re-run); abort if the suite is flaky' },
-    { title: 'Audit', detail: 'behavioral test files, one Opus agent each, mutate→test→revert in isolated worktrees' },
-    { title: 'Skeptic', detail: 'Sonnet adversarially re-checks every survived/equivalent verdict' },
-    { title: 'Guards', detail: 'designated canary guard tests, serialized (perf-sensitive)' },
-  ],
-}
+// Δ9: per-repo config arrives via the Workflow `args` input (read from the
+// target repo's `.fang-audit.json` by the SKILL.md invocation) and overrides
+// DEFAULTS key-by-key. Tilde-expand the two path-bearing knobs script-side —
+// JSON cannot carry `${process.env.HOME}`.
+const expand = p => typeof p === 'string' ? p.replace(/^~(?=\/)/, process.env.HOME) : p
+const CONFIG = Object.assign({}, DEFAULTS, (args && typeof args === 'object') ? args : {})
+CONFIG.OUTPUT = expand(CONFIG.OUTPUT)
+CONFIG.UNTRACKED_SEED = (CONFIG.UNTRACKED_SEED || []).map(s => ({ ...s, from: expand(s.from) }))
 
 const { BEHAVIORAL, GUARDS } = CONFIG
 

--- a/tests/test_fang_audit_skill.py
+++ b/tests/test_fang_audit_skill.py
@@ -229,3 +229,9 @@ def test_skill_md_forbids_editing_skill_files():
     assert ".fang-audit.json" in text, "config-file flow not documented"
     assert "never edit" in text.lower() or "never edit any skill file" in text.lower()
     assert "Edit the `CONFIG` block" not in text, "stale edit-the-skill instruction remains"
+    # The frontmatter argument-hint must not instruct editing the skill file
+    # either — it slipped through 0222's first pass because the body checks
+    # above match backticked phrasing only (review-pr finding, PR 308 round 1).
+    assert "editing the CONFIG block" not in text, (
+        "stale frontmatter argument-hint still instructs editing fang-audit.js"
+    )

--- a/tests/test_fang_audit_skill.py
+++ b/tests/test_fang_audit_skill.py
@@ -194,3 +194,38 @@ def test_mutating_agents_are_worktree_isolated():
 def test_skill_md_states_target_repo_requirement():
     text = MD.read_text()
     assert "TARGET repo" in text, "SKILL.md missing the target-repo session requirement"
+
+
+# ── 0222: per-repo config via args — zero skill-file editing ─────────────────
+
+
+def test_config_is_defaults_merged_with_args():
+    """Per-repo config arrives as the Workflow args input (read from the
+    target repo's .fang-audit.json); the engine consumes only the merged
+    CONFIG. Editing this file per repo is the defect 0222 removes."""
+    src = js()
+    assert "const DEFAULTS = {" in src, "DEFAULTS block missing"
+    assert re.search(r"const CONFIG = Object\.assign\(\{\}, DEFAULTS,.*args", src), (
+        "CONFIG must merge args over DEFAULTS"
+    )
+
+
+def test_path_knobs_are_tilde_expanded():
+    src = js()
+    assert "CONFIG.OUTPUT = expand(CONFIG.OUTPUT)" in src
+    assert "UNTRACKED_SEED" in src and "from: expand(s.from)" in src
+
+
+def test_meta_precedes_defaults():
+    """Workflow scripts must begin with export const meta (after comments)."""
+    src = js()
+    assert src.index("export const meta") < src.index("const DEFAULTS"), (
+        "meta block must precede DEFAULTS"
+    )
+
+
+def test_skill_md_forbids_editing_skill_files():
+    text = MD.read_text()
+    assert ".fang-audit.json" in text, "config-file flow not documented"
+    assert "never edit" in text.lower() or "never edit any skill file" in text.lower()
+    assert "Edit the `CONFIG` block" not in text, "stale edit-the-skill instruction remains"

--- a/tickets/0222-fang-audit-per-repo-config-file-zero-ski.erg
+++ b/tickets/0222-fang-audit-per-repo-config-file-zero-ski.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: Fang-audit: per-repo config file, zero skill-file editing at invocation
+Created: 2026-06-05
+Author: MinhHaDuong
+
+--- log ---
+2026-06-05T14:42Z MinhHaDuong created
+
+--- body ---
+## Context
+
+Author UX verdict on the first post-merge invocation attempt
+(2026-06-05): "a skill that needs two lines of dark magic before
+invocation" — the as-shipped flow required editing the committed
+fang-audit.js CONFIG block per target repo. That (a) dirties the
+harness repo on every run, arming beat's dirty-tree gate, and
+(b) puts per-repo data in a harness-global file, against the 0184
+doctrine (per-repo wiring is a thin adapter the repo owns).
+
+## Design
+
+- fang-audit.js: the CONFIG literal becomes DEFAULTS (the validated
+  git-erg values, kept as living documentation); the engine consumes
+  `CONFIG = {...DEFAULTS, ...args}` — the Workflow tool's args input
+  is the per-repo override channel. Tilde-expand OUTPUT and
+  UNTRACKED_SEED[].from script-side (JSON cannot carry
+  ${process.env.HOME}).
+- SKILL.md: invocation = open a session in the target repo, run
+  /fang-audit; the skill reads `.fang-audit.json` at the repo root
+  and passes it as args. Missing file → stop with a template, never
+  edit skill files.
+- The target repo owns its config: `.fang-audit.json` is committed
+  THERE (git-erg gets the reference one).
+
+## Actions
+
+1. fang-audit.js: DEFAULTS + args merge (Δ9), tilde expansion.
+2. SKILL.md: rewrite Configuration + Steps for the config-file flow.
+3. tests: pin the args merge and the no-edit invocation doc.
+4. git-erg: commit the validated `.fang-audit.json` (cross-repo PR).
+
+## Test
+
+Source-inspection: CONFIG is derived from DEFAULTS and args; SKILL.md
+documents `.fang-audit.json`; no instruction to edit the .js remains.
+
+## Exit criteria
+
+- [x] args override DEFAULTS; engine reads only the merged CONFIG — fang-audit.js Δ9 (Object.assign over DEFAULTS); meta moved first per Workflow spec
+- [x] OUTPUT and UNTRACKED_SEED paths tilde-expanded script-side — expand() on both knobs
+- [x] SKILL.md: config-file invocation, no skill-file editing step — Configuration section rewritten, Steps 2-3
+- [x] Regression tests updated/added; make check passes — 4 new tests, 19/19
+- [x] git-erg carries .fang-audit.json (reference config) — git-erg PR #292 (17 pairs + 2 guards, machine-extracted from DEFAULTS)

--- a/tickets/0222-fang-audit-per-repo-config-file-zero-ski.erg
+++ b/tickets/0222-fang-audit-per-repo-config-file-zero-ski.erg
@@ -6,6 +6,7 @@ Author: MinhHaDuong
 --- log ---
 2026-06-05T14:42Z MinhHaDuong created
 
+2026-06-05T14:59Z bump verify-reroll — round 1: exit criterion #3 incomplete — stale argument-hint at SKILL.md:6 still instructs editing CONFIG block
 --- body ---
 ## Context
 

--- a/tickets/closed/0222-fang-audit-per-repo-config-file-zero-ski.erg
+++ b/tickets/closed/0222-fang-audit-per-repo-config-file-zero-ski.erg
@@ -2,11 +2,13 @@
 Title: Fang-audit: per-repo config file, zero skill-file editing at invocation
 Created: 2026-06-05
 Author: MinhHaDuong
+Closed: autoclosed — PR #308
 
 --- log ---
 2026-06-05T14:42Z MinhHaDuong created
 
 2026-06-05T14:59Z bump verify-reroll — round 1: exit criterion #3 incomplete — stale argument-hint at SKILL.md:6 still instructs editing CONFIG block
+2026-06-05T15:05Z MinhHaDuong closed — autoclosed — PR #308
 --- body ---
 ## Context
 


### PR DESCRIPTION
Removes the edit-the-skill-before-invoking defect: per-repo config lives in the target repo's committed .fang-audit.json, read at invocation and passed as Workflow args over DEFAULTS (Δ9). Tilde expansion for path knobs; meta moved first per Workflow spec; SKILL.md rewritten (missing config → STOP with template); 4 regression tests. Companion: git-erg PR #292 ships the reference config.

Invocation: cd <target-repo> && claude → /fang-audit. No dark magic.

**Ticket:** tickets/0222-fang-audit-per-repo-config-file-zero-ski.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)