### PR TITLE
fix(fang-audit): remove process.env dependency — Workflow sandbox has no Node globals

### DIFF
--- a/skills/fang-audit/SKILL.md
+++ b/skills/fang-audit/SKILL.md
@@ -66,7 +66,10 @@ read that file and pass its parsed content as the Workflow `args` input —
 the script merges it over the built-in DEFAULTS (the validated git-erg
 reference values, kept in `fang-audit.js` as living documentation of every
 knob). Path values (`OUTPUT`, `UNTRACKED_SEED[].from`) may use a leading
-`~/`; the script expands it.
+`~/`; the script expands it **only if you also pass `HOME` in `args`** (set
+it to the user's home directory). The Workflow sandbox has no Node `process`
+global, so the script cannot read `$HOME` itself — when in doubt, pre-expand
+all paths to absolute form in the `args` you pass.
 
 If `.fang-audit.json` is missing, STOP and hand the user a template built
 from the DEFAULTS block — do not edit `fang-audit.js`, do not guess a

--- a/skills/fang-audit/fang-audit.js
+++ b/skills/fang-audit/fang-audit.js
@@ -32,9 +32,10 @@ const DEFAULTS = {
 
   // Where the workflow writes the final report. Throwaway worktrees die with
   // the run, so this MUST be an absolute path in the MAIN repo (untracked is
-  // fine). NO hardcoded /home — use an absolute path you control, e.g.
-  // `${process.env.HOME}/your-repo/FANG-AUDIT.md`.
-  OUTPUT: `${process.env.HOME}/YOUR-REPO/FANG-AUDIT.md`,
+  // fine). NO hardcoded /home — use `~/your-repo/FANG-AUDIT.md`; the engine
+  // expands a leading `~/` via the args.HOME knob (the workflow sandbox has
+  // no Node `process` global, so HOME cannot come from the environment).
+  OUTPUT: '~/YOUR-REPO/FANG-AUDIT.md',
 
   // <TAGS> = build-tag flags for the DEFAULT suite (usually empty string).
   DEFAULT_TAGS: '',
@@ -60,12 +61,12 @@ const DEFAULTS = {
   // so a fresh worktree (which only has the committed tree) lacks them. The
   // guard agent copies each from `from` into `dest` if missing, BEFORE the
   // baseline check. Empty list = no seeding (fully generic). Keep `from` paths
-  // out of the /home/[a-z] form — use ${process.env.HOME}.
+  // out of the /home/[a-z] form — use a leading `~/` (expanded via args.HOME).
   // (The git-erg guard build references an untracked resource_test.go that
   // shares the //go:build scaling compile unit with scaling_test.go; without
   // it the scaling build fails to compile and the canary falsely FAILs.)
   UNTRACKED_SEED: [
-    { dest: 'src/go/resource_test.go', from: `${process.env.HOME}/git-erg/src/go/resource_test.go` },
+    { dest: 'src/go/resource_test.go', from: '~/git-erg/src/go/resource_test.go' },
   ],
 
   // Mutation heuristics — language-specific examples of a MINIMAL, COMPILING,
@@ -131,9 +132,12 @@ const DEFAULTS = {
 
 // Δ9: per-repo config arrives via the Workflow `args` input (read from the
 // target repo's `.fang-audit.json` by the SKILL.md invocation) and overrides
-// DEFAULTS key-by-key. Tilde-expand the two path-bearing knobs script-side —
-// JSON cannot carry `${process.env.HOME}`.
-const expand = p => typeof p === 'string' ? p.replace(/^~(?=\/)/, process.env.HOME) : p
+// DEFAULTS key-by-key. Tilde-expand the two path-bearing knobs script-side.
+// The workflow sandbox has NO Node `process` global, so HOME must be supplied
+// by the invoker as args.HOME; without it, `~/` paths pass through unchanged
+// (the invoker should then pre-expand them in the config it passes).
+const HOME = (args && typeof args === 'object' && typeof args.HOME === 'string') ? args.HOME : ''
+const expand = p => (typeof p === 'string' && HOME) ? p.replace(/^~(?=\/)/, HOME) : p
 const CONFIG = Object.assign({}, DEFAULTS, (args && typeof args === 'object') ? args : {})
 CONFIG.OUTPUT = expand(CONFIG.OUTPUT)
 CONFIG.UNTRACKED_SEED = (CONFIG.UNTRACKED_SEED || []).map(s => ({ ...s, from: expand(s.from) }))

--- a/skills/fang-audit/fang-audit.js
+++ b/skills/fang-audit/fang-audit.js
@@ -136,9 +136,16 @@ const DEFAULTS = {
 // The workflow sandbox has NO Node `process` global, so HOME must be supplied
 // by the invoker as args.HOME; without it, `~/` paths pass through unchanged
 // (the invoker should then pre-expand them in the config it passes).
-const HOME = (args && typeof args === 'object' && typeof args.HOME === 'string') ? args.HOME : ''
+// Δ10: tolerate args delivered as a JSON-encoded STRING — observed 2026-06-05:
+// the harness handed the object through as a string, the old typeof check
+// silently dropped it, and the whole run fell back to DEFAULTS (harmless only
+// because the git-erg config IS the DEFAULTS reference; fatal for any other repo).
+let _cfg = args
+if (typeof _cfg === 'string') { try { _cfg = JSON.parse(_cfg) } catch { _cfg = null } }
+if (!(_cfg && typeof _cfg === 'object')) _cfg = {}
+const HOME = typeof _cfg.HOME === 'string' ? _cfg.HOME : ''
 const expand = p => (typeof p === 'string' && HOME) ? p.replace(/^~(?=\/)/, HOME) : p
-const CONFIG = Object.assign({}, DEFAULTS, (args && typeof args === 'object') ? args : {})
+const CONFIG = Object.assign({}, DEFAULTS, _cfg)
 CONFIG.OUTPUT = expand(CONFIG.OUTPUT)
 CONFIG.UNTRACKED_SEED = (CONFIG.UNTRACKED_SEED || []).map(s => ({ ...s, from: expand(s.from) }))
 
@@ -319,7 +326,7 @@ This is the 0184 test-quality utility's flakiness gate. Exit-code contract:
   - exit 2 = NEW flakiness found -> gate "fail"
 The JSON report on stdout carries a "gate" field ("pass"/"fail"); read it to confirm. Report exitCode, gate, any flaky test identities, and a short evidence excerpt. Do NOT mutate anything.`,
   { label: 'precheck:flakiness', phase: 'Precheck', schema: PRECHECK_SCHEMA }
-)
+).catch(() => null)  // Δ10: a precheck agent error falls into the abort path below, not an opaque crash
 
 if (!precheck || precheck.exitCode !== 0 || precheck.gate === 'fail') {
   const detail = precheck
@@ -355,7 +362,11 @@ const behavioral = await pipeline(
 phase('Guards')
 const guards = []
 for (const file of GUARDS) {
+  // Δ10: a single guard-agent failure must not discard the behavioral results
+  // already collected — degrade to null (the canary gate then reports SUSPECT,
+  // which is the honest verdict when a guard agent dies).
   let a = await agent(guardPrompt(file), { label: `audit:${file.test}`, phase: 'Guards', schema: AUDIT_SCHEMA, isolation: 'worktree' })  // Δ8
+    .catch(e => { log(`guard ${file.test} agent error: ${e}`); return null })
   // Δ7: tag findings from this run STRUCTURALLY as canary-guard findings.
   // Canary designation comes from CONFIG.GUARDS (the workflow knows which
   // agent it dispatched), NEVER from a read-back of the agent's isCanary flag.
@@ -414,14 +425,25 @@ const oracleStrength = Object.entries(oracleByFunc)
 // inferred — per the ticket, the human owns that judgment.
 // `churnByFile` is populated by the churn agent below; default 0 keeps the
 // sort total even if churn is unavailable.
+// Δ10: churn is DECORATION (a sort weight) — it must never kill the run. The
+// 2026-06-05 run died HERE at the finish line: the tool layer serialized the
+// agent's integer values as strings, the integer-typed schema rejected them,
+// and the uncaught throw discarded 1.36M tokens of completed audit work.
+// Tolerant schema (string|integer) + parseInt + try/catch => worst case is a
+// flat churn of 0 and a degraded sort, never a dead run.
 const churnByFile = await (async () => {
   const files = [...new Set(flat.map(f => f._file))]
-  const res = await agent(
-    `For ${CONFIG.PROJECT}, report the git churn (number of commits that touched the file) for each of these test files, using \`git log --follow --oneline -- <file> | wc -l\` from the repo root. Files: ${files.join(', ')}. Return a JSON object mapping each filename to its commit count.`,
-    { label: 'churn:git-log', phase: 'Guards',
-      schema: { type: 'object', additionalProperties: { type: 'integer' } } }
-  )
-  return res || {}
+  try {
+    const res = await agent(
+      `For ${CONFIG.PROJECT}, report the git churn (number of commits that touched the file) for each of these test files, using \`git log --follow --oneline -- <file> | wc -l\` from the repo root. Files: ${files.join(', ')}. Return a JSON object mapping each filename to its commit count (a plain number; a numeric string is also accepted).`,
+      { label: 'churn:git-log', phase: 'Guards',
+        schema: { type: 'object', additionalProperties: { type: ['integer', 'string'] } } }
+    )
+    return Object.fromEntries(Object.entries(res || {}).map(([k, v]) => [k, parseInt(v, 10) || 0]))
+  } catch (e) {
+    log(`churn agent failed (${e}); risk×churn sort degrades to churn=0 — report otherwise valid`)
+    return {}
+  }
 })()
 
 const riskWeight = f => (CONFIG.RISK[f._file] || 1.0)

--- a/tests/test_fang_audit_skill.py
+++ b/tests/test_fang_audit_skill.py
@@ -202,11 +202,19 @@ def test_skill_md_states_target_repo_requirement():
 def test_config_is_defaults_merged_with_args():
     """Per-repo config arrives as the Workflow args input (read from the
     target repo's .fang-audit.json); the engine consumes only the merged
-    CONFIG. Editing this file per repo is the defect 0222 removes."""
+    CONFIG. Editing this file per repo is the defect 0222 removes. The
+    harness may deliver args as a JSON-encoded STRING (observed 2026-06-05,
+    ticket 0223), so the engine must normalize before the merge."""
     src = js()
     assert "const DEFAULTS = {" in src, "DEFAULTS block missing"
-    assert re.search(r"const CONFIG = Object\.assign\(\{\}, DEFAULTS,.*args", src), (
-        "CONFIG must merge args over DEFAULTS"
+    assert re.search(r"let _cfg = args", src), (
+        "config must derive from the Workflow args input"
+    )
+    assert re.search(r"JSON\.parse\(_cfg\)", src), (
+        "string-delivered args must be JSON.parse'd (0223)"
+    )
+    assert re.search(r"const CONFIG = Object\.assign\(\{\}, DEFAULTS, _cfg\)", src), (
+        "CONFIG must merge the normalized args over DEFAULTS"
     )
 
 

--- a/tickets/0223-fang-audit-workflow-crashes-sandbox-has.erg
+++ b/tickets/0223-fang-audit-workflow-crashes-sandbox-has.erg
@@ -1,0 +1,36 @@
+%erg 0.1
+Title: fang-audit workflow crashes: sandbox has no process global
+Created: 2026-06-05
+Author: MinhHaDuong
+
+--- log ---
+2026-06-05T15:13Z MinhHaDuong created
+
+--- body ---
+## Context
+Launching the fang-audit Workflow on 2026-06-05 failed instantly (7 ms, 0 agents):
+
+    Error: process is not defined
+        at <anonymous> (workflow.js:19:21)
+
+`fang-audit.js` used `process.env.HOME` in its DEFAULTS block (OUTPUT,
+UNTRACKED_SEED) and in the `expand` tilde-expander. The Workflow sandbox
+exposes no Node `process` global (consistent with its documented "no
+filesystem or Node.js API access" contract), so the script dies at parse-time
+before the precheck phase. The validating 1.3M-token run predates this; the
+runtime contract has since tightened.
+
+## Fix
+- DEFAULTS path knobs become plain `~/` strings (no template interpolation).
+- `expand` reads HOME from a new `args.HOME` knob supplied by the invoker;
+  without it, `~/` paths pass through unchanged.
+- SKILL.md invocation contract updated: pass `HOME` in `args`, or pre-expand
+  all paths to absolute form.
+
+Verified empirically: the relaunch with `args.HOME` + pre-expanded paths got
+past parse and into the Precheck phase (run wf_356ca0b7-db6).
+
+## Exit criteria
+- [ ] `grep -c 'process\.' skills/fang-audit/fang-audit.js` returns 0 (comments may mention the word, code may not)
+- [ ] SKILL.md documents the `HOME` args knob
+- [ ] A fang-audit Workflow launch reaches the Precheck phase instead of dying at parse

--- a/tickets/0223-fang-audit-workflow-crashes-sandbox-has.erg
+++ b/tickets/0223-fang-audit-workflow-crashes-sandbox-has.erg
@@ -20,17 +20,42 @@ filesystem or Node.js API access" contract), so the script dies at parse-time
 before the precheck phase. The validating 1.3M-token run predates this; the
 runtime contract has since tightened.
 
+## Context (widened after the relaunch)
+The relaunch surfaced two more instances of the same failure class — the
+script trusting Workflow-runtime contracts that don't hold:
+
+2. **args delivered as a JSON-encoded string.** The harness handed the
+   `args` object through as a string; the old `typeof args === 'object'`
+   check silently dropped it and the entire run fell back to DEFAULTS.
+   Harmless here only because git-erg's `.fang-audit.json` IS the DEFAULTS
+   reference config — fatal misconfiguration for any other repo (evidence:
+   churn agent prompt read "For YOUR-PROJECT").
+3. **Schema-rejected integers killed a finished run.** The churn agent's
+   tool layer serialized integer values as strings; the
+   `additionalProperties: {type:'integer'}` schema rejected every attempt,
+   the engine threw after 2 nudges, and the uncaught throw discarded a
+   1.36M-token run at the finish line — with all 17 behavioral audits, all
+   skeptics, and both guard canaries already complete.
+
 ## Fix
 - DEFAULTS path knobs become plain `~/` strings (no template interpolation).
 - `expand` reads HOME from a new `args.HOME` knob supplied by the invoker;
   without it, `~/` paths pass through unchanged.
 - SKILL.md invocation contract updated: pass `HOME` in `args`, or pre-expand
   all paths to absolute form.
+- args accepted as object OR JSON-encoded string (script-side JSON.parse).
+- Decorative/terminal agents can no longer kill the run (Δ10): churn gets a
+  tolerant string|integer schema + parseInt + try/catch (degrades to
+  churn=0); guard agents degrade to null (canary gate then reports SUSPECT,
+  the honest verdict); precheck errors fall into the existing abort path.
 
-Verified empirically: the relaunch with `args.HOME` + pre-expanded paths got
-past parse and into the Precheck phase (run wf_356ca0b7-db6).
+Verified empirically: relaunch passed parse and ran the full audit
+(27 agents, 1.36M tokens); after the Δ10 fixes the resume from
+wf_356ca0b7-db6 replayed all cached agents and completed.
 
 ## Exit criteria
-- [ ] `grep -c 'process\.' skills/fang-audit/fang-audit.js` returns 0 (comments may mention the word, code may not)
+- [ ] `grep -cE '\bprocess\.' skills/fang-audit/fang-audit.js` returns 0 (comments may mention the word, code may not)
 - [ ] SKILL.md documents the `HOME` args knob
 - [ ] A fang-audit Workflow launch reaches the Precheck phase instead of dying at parse
+- [ ] args passed as a JSON-encoded string produces the same CONFIG as the object form
+- [ ] A churn/guard agent failure degrades the report instead of discarding the run

--- a/tickets/closed/0223-fang-audit-workflow-crashes-sandbox-has.erg
+++ b/tickets/closed/0223-fang-audit-workflow-crashes-sandbox-has.erg
@@ -2,10 +2,12 @@
 Title: fang-audit workflow crashes: sandbox has no process global
 Created: 2026-06-05
 Author: MinhHaDuong
+Closed: autoclosed — PR #309
 
 --- log ---
 2026-06-05T15:13Z MinhHaDuong created
 
+2026-06-05T18:13Z MinhHaDuong closed — autoclosed — PR #309
 --- body ---
 ## Context
 Launching the fang-audit Workflow on 2026-06-05 failed instantly (7 ms, 0 agents):


### PR DESCRIPTION
## Summary
- The fang-audit Workflow script crashed at parse-time with `Error: process is not defined` (0 agents, 7 ms) when launched on 2026-06-05 — the Workflow sandbox exposes no Node `process` global, and `fang-audit.js` read `process.env.HOME` in its DEFAULTS block and tilde-expander.
- DEFAULTS path knobs are now plain `~/` strings; the expander reads HOME from a new `args.HOME` knob supplied by the invoker, passing `~/` paths through unchanged when absent.
- SKILL.md invocation contract updated: pass `HOME` in `args`, or pre-expand all config paths to absolute form.

## Verification
- `grep -nE '\bprocess\.' skills/fang-audit/fang-audit.js` → no code references (two comments mention the word).
- Empirical: relaunch with `args.HOME` + pre-expanded paths passed parse and entered the Precheck phase (run `wf_356ca0b7-db6` on git-erg), where the original launch died before phase 0.

**Ticket:** tickets/0223-fang-audit-workflow-crashes-sandbox-has.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)