### PR TITLE
ticket(0219): un-defer — fang-v1 validated, parking condition met

### DIFF
--- a/tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
+++ b/tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
@@ -2,7 +2,6 @@
 Title: Handcuff and scope-altitude mutation modes for the fang-audit skill
 Created: 2026-06-05
 Author: MinhHaDuong
-Label: deferred
 
 --- log ---
 2026-06-05T11:56Z MinhHaDuong created
@@ -10,6 +9,9 @@ Label: deferred
 2026-06-05T11:56Z MinhHaDuong label deferred
 2026-06-05T13:32Z MinhHaDuong note blocker 0182 closed — Blocked-by removed.
 2026-06-05T14:12Z claude note parking condition NOT yet met: the authorized validating run hit a setup blocker pre-spend — Workflow agents proved non-isolated and session-repo-bound (probe, ticket 0221). Run again after 0221 merges, from a session rooted in the target repo
+2026-06-05T18:12Z MinhHaDuong unlabel deferred
+2026-06-05T18:12Z Minh Ha-Duong note parking condition MET (2026-06-05): authorized fang-v1 validating run completed on git-erg — canary gate PASS (both guards caught their primary canaries), 86 caught / 3 toothless (all true coverage gaps) / 3 equivalent; report at ~/git-erg/FANG-AUDIT.md. Count drift vs the May prototype (90/8/4) explained by test improvements since and per-run mutation sampling; the methodology reproduced end-to-end (precheck gate, 17 isolated audits, skeptics, serialized guards). Remaining input before raid: pick the second-language validation target (AEDIST Python suite is the candidate)
+2026-06-05T18:12Z claude note run residue findings to absorb in this ticket's scaffolding work: (1) seeded guard worktrees skip auto-reclaim (untracked seed file makes them dirty); (2) audit agents hand-roll /tmp/fang-erg-* scratch worktrees on detached HEAD — add a post-run cleanup step to the skill when touching the workflow here
 --- body ---
 ## Context
 


### PR DESCRIPTION
Validating run complete on git-erg (canary PASS, 86/3/3). 0219 re-enters the ready pool; residue findings logged for its scaffolding work.

Ticket-ref: tickets/0219-handcuff-and-scope-altitude-mutation-mod.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)