### PR TITLE
memory: Workflow agents are session-bound

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Workflow agents are session-bound](feedback_workflow_agents_session_bound.md) — Workflow agent() runs in the SESSION checkout unless isolation:'worktree'; worktrees cut from the SESSION repo — cross-repo skills need a session in the target repo; probe before expensive fan-outs
 - [Next move: git-erg migration](project_git_erg_migration_next.md) — Author's declared focus as of 2026-06-04; 0216 dogfood migration in git-erg; IDH tickets 0190/0191 are companions; check git-erg tickets ~0216 first
 - [gh pr edit broken — use REST](feedback_gh_pr_edit_broken_use_rest.md) — gh pr edit hits a Projects-classic GraphQL deprecation; PATCH via gh api repos/.../pulls/N instead
 - [Harness repo setup](project_harness_repo.md) — ~/.claude tracks ImperialDragonHarness, daily pull via systemd timer; each machine needs source line in ~/.bashrc

--- a/projects/-home-haduong--claude/memory/feedback_workflow_agents_session_bound.md
+++ b/projects/-home-haduong--claude/memory/feedback_workflow_agents_session_bound.md
@@ -1,0 +1,31 @@
+---
+name: workflow-agents-session-bound
+description: Workflow-tool agents run in the SESSION checkout by default and worktrees are cut from the SESSION repo — isolation is opt-in, cross-repo runs need a session in the target repo
+metadata:
+  type: feedback
+---
+
+Workflow-tool `agent()` calls run in the session's checkout unless
+`isolation: 'worktree'` is passed explicitly, and that worktree is cut
+from the SESSION's repository — never from a path named in config.
+
+**Why:** Probe-verified 2026-06-05 (ticket 0221) before the fang-audit
+validating run: both the proven May prototype and its faithful
+extraction omitted isolation — 16 concurrent mutate→test→revert agents
+would have corrupted one shared tree — and a git-erg audit could not
+launch from an IDH session at all (agents land in a tree without
+src/go). A prompt line telling the agent "you are in an isolated
+worktree" does not make it true; some agents then hand-roll /tmp
+scratch worktrees to make it true, leaving detached-HEAD residue.
+
+**How to apply:** Any Workflow script whose agents mutate files gets
+`isolation: 'worktree'` on those call sites (read-only judges stay
+non-isolated — worktrees are expensive). Any skill auditing a TARGET
+repo must be invoked from a session rooted in that repo — say so in
+its SKILL.md as a hard requirement. Cheap pre-spend check for any new
+fan-out: a one-agent probe returning pwd/toplevel/worktree-list
+(~22k tokens) before the expensive run. After runs, `git worktree
+prune` the target repo — dirty (seeded) agent worktrees and /tmp
+scratch worktrees survive auto-cleanup. See also
+[[feedback-fork-skills-bare-context]] for the sibling fork-isolation
+modes.


### PR DESCRIPTION
Roar step-6 memory from the fang-audit campaign: Workflow agent() defaults to the session checkout; isolation:'worktree' is opt-in and cut from the session repo. Probe before expensive fan-outs.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)