### PR TITLE
fix(0224): dream v2 — decay-confirmation path and provenance write race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !docs/**
 !memory/
 !memory/**
+memory/.provenance.lock
 !tickets/
 !tickets/**
 tickets/tools/go/*.test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: spawns subprocesses or uses sleep-based timing (excluded from check-fast)
+    slow: requires network access or real data (excluded from check-fast)

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -108,6 +108,23 @@ python3 ~/.claude/skills/dream/provenance.py record <entry_slug> <project>
 
 **Slug identity (v2 simplification)**: entries are keyed by filename. If the same lesson appears under different filenames in different projects, Claude should assign the same slug during consolidation to enable cross-project frequency counting. A semantic slug-matching system is deferred to v3.
 
+**7b. Confirm still-relevant promoted entries.**
+
+A promoted entry's project-level copy is a tombstone, so step 7's `record` never
+fires for it again and its `last_confirmed` would freeze — decay-flagging it at
+90 days no matter how relevant it remains (ticket 0224). For each harness-level
+entry (in `~/.claude/memory/`) that this project's surviving content still
+supports — i.e. the consolidation would have classified its lesson NOOP or
+UPDATE were it still project-local — refresh its confirmation:
+
+```bash
+python3 ~/.claude/skills/dream/provenance.py confirm <slug>
+```
+
+This resets only the decay clock; it does not re-add the project to the entry's
+origin list. Skip entries the project's content no longer supports — letting
+those decay-flag is the intended signal for human review.
+
 **8. Commit.**
 
 ```bash

--- a/skills/dream/provenance.py
+++ b/skills/dream/provenance.py
@@ -10,15 +10,46 @@ Manages ~/.claude/memory/.provenance.json which tracks:
 """
 
 import argparse
+import fcntl
 import json
+import os
 import sys
+import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
 HARNESS_MEMORY = Path.home() / ".claude" / "memory"
 PROVENANCE_PATH = HARNESS_MEMORY / ".provenance.json"
+PROVENANCE_LOCK = HARNESS_MEMORY / ".provenance.lock"
 PROJECTS_BASE = Path.home() / ".claude" / "projects"
 DECAY_DAYS = 90
+
+# Test-only hook: seconds to sleep between read and write inside a locked
+# mutation, used to force critical-section overlap in the race test. Unset in
+# production. See tests/test_dream.py::test_provenance_concurrent_record_*.
+_TEST_DELAY_ENV = "DREAM_PROVENANCE_TEST_DELAY"
+
+
+@contextmanager
+def _provenance_lock():
+    """Serialize the read-modify-write cycle across concurrent processes.
+
+    The cron recipe fires /dream for all projects at 02:00; each consolidation
+    issues an unlocked read-modify-write against the shared .provenance.json,
+    so concurrent runs could clobber each other (ticket 0224). We hold an
+    advisory flock on a sidecar lock file — not on the json itself, whose
+    write_text truncation would fight a lock held on the same fd. flock
+    auto-releases on fd close / process exit, so a crashed run leaves no stale
+    lock (unlike an O_EXCL lockfile)."""
+    PROVENANCE_LOCK.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(PROVENANCE_LOCK, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def _load_provenance() -> dict:
@@ -32,34 +63,71 @@ def _save_provenance(data: dict) -> None:
     PROVENANCE_PATH.write_text(json.dumps(data, indent=2) + "\n")
 
 
+def _test_delay() -> None:
+    """Sleep between read and write when the test hook is set (no-op in prod)."""
+    delay = os.environ.get(_TEST_DELAY_ENV)
+    if delay:
+        time.sleep(float(delay))
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def record(args):
     """Record that an entry was seen in a project consolidation."""
-    data = _load_provenance()
-    entries = data["entries"]
-
     slug = args.slug
     project = args.project
-    now = _now_iso()
+    with _provenance_lock():
+        data = _load_provenance()
+        entries = data["entries"]
+        _test_delay()
+        now = _now_iso()
 
-    if slug not in entries:
-        entries[slug] = {
-            "projects": [project],
-            "first_seen": now,
-            "last_confirmed": now,
-            "promoted": False,
-        }
-    else:
-        entry = entries[slug]
-        if project not in entry["projects"]:
-            entry["projects"].append(project)
-        entry["last_confirmed"] = now
+        if slug not in entries:
+            entries[slug] = {
+                "projects": [project],
+                "first_seen": now,
+                "last_confirmed": now,
+                "promoted": False,
+            }
+        else:
+            entry = entries[slug]
+            if project not in entry["projects"]:
+                entry["projects"].append(project)
+            entry["last_confirmed"] = now
 
-    _save_provenance(data)
-    print(json.dumps(entries[slug], indent=2))
+        _save_provenance(data)
+        result = entries[slug]
+    print(json.dumps(result, indent=2))
+
+
+def confirm(args):
+    """Refresh last_confirmed on a promoted entry.
+
+    Closes the decay-confirmation gap (ticket 0224): once an entry is promoted,
+    its project-level copy is tombstoned, so later consolidations no longer
+    `record` the slug and last_confirmed never refreshes — every promoted entry
+    decay-flags at 90 days regardless of continued relevance. When a later
+    consolidation finds a promoted harness entry still supported by the
+    project's content, it calls `confirm` to refresh the timestamp. Unlike
+    `record`, this does not mutate the project list (the harness entry has no
+    project of origin to append)."""
+    slug = args.slug
+    with _provenance_lock():
+        data = _load_provenance()
+        entries = data["entries"]
+        if slug not in entries:
+            print(f"Unknown entry: {slug}", file=sys.stderr)
+            sys.exit(1)
+        if not entries[slug].get("promoted"):
+            print(f"Not a promoted entry: {slug}", file=sys.stderr)
+            sys.exit(1)
+        _test_delay()
+        entries[slug]["last_confirmed"] = _now_iso()
+        _save_provenance(data)
+        result = entries[slug]
+    print(json.dumps(result, indent=2))
 
 
 def candidates(args):
@@ -75,14 +143,16 @@ def candidates(args):
 
 def promote(args):
     """Mark an entry as promoted."""
-    data = _load_provenance()
     slug = args.slug
-    if slug not in data["entries"]:
-        print(f"Unknown entry: {slug}", file=sys.stderr)
-        sys.exit(1)
-    data["entries"][slug]["promoted"] = True
-    data["entries"][slug]["promoted_at"] = _now_iso()
-    _save_provenance(data)
+    with _provenance_lock():
+        data = _load_provenance()
+        if slug not in data["entries"]:
+            print(f"Unknown entry: {slug}", file=sys.stderr)
+            sys.exit(1)
+        _test_delay()
+        data["entries"][slug]["promoted"] = True
+        data["entries"][slug]["promoted_at"] = _now_iso()
+        _save_provenance(data)
     print(f"Promoted: {slug}")
 
 
@@ -133,6 +203,12 @@ def main():
     promote_p = sub.add_parser("promote", help="Mark entry as promoted to harness.")
     promote_p.add_argument("slug", help="Entry slug to promote")
     promote_p.set_defaults(func=promote)
+
+    confirm_p = sub.add_parser(
+        "confirm", help="Refresh last_confirmed on a promoted entry (resets decay clock)."
+    )
+    confirm_p.add_argument("slug", help="Promoted entry slug still relevant")
+    confirm_p.set_defaults(func=confirm)
 
     decay_p = sub.add_parser(
         "decay", help=f"List promoted entries unconfirmed for >{DECAY_DAYS} days."

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -101,12 +101,15 @@ def provenance_env(tmp_path):
     return tmp_path
 
 
-def _run_provenance(*args, home):
+def _run_provenance(*args, home, extra_env=None):
+    env = {"HOME": str(home), "PATH": "/usr/bin:/bin"}
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [sys.executable, str(PROVENANCE_PY), *args],
         capture_output=True,
         text=True,
-        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        env=env,
     )
 
 
@@ -214,3 +217,87 @@ def test_provenance_show(provenance_env):
     assert result.returncode == 0
     data = json.loads(result.stdout)
     assert "feedback_vim" in data["entries"]
+
+
+# --- Decay-confirmation path (ticket 0224, defect 1) ---
+
+
+def test_provenance_confirm_unknown_slug(provenance_env):
+    result = _run_provenance("confirm", "nonexistent", home=provenance_env)
+    assert result.returncode == 1
+
+
+def test_provenance_confirm_rejects_unpromoted(provenance_env):
+    """confirm targets promoted harness entries; a project-level entry is refused."""
+    _run_provenance("record", "feedback_vim", "project-alpha", home=provenance_env)
+    result = _run_provenance("confirm", "feedback_vim", home=provenance_env)
+    assert result.returncode == 1
+
+
+def test_provenance_confirm_refreshes_promoted_entry_so_decay_skips_it(provenance_env):
+    """A promoted entry confirmed by a later consolidation must NOT decay-flag.
+
+    Reproduces the ticket-0224 gap: promote freezes last_confirmed (the
+    tombstoned project entry no longer gets `record`ed), so without `confirm`
+    the entry decay-flags at 90 days regardless of relevance. After `confirm`,
+    decay must skip it.
+    """
+    prov_path = provenance_env / ".claude" / "memory" / ".provenance.json"
+    prov_path.write_text(json.dumps({
+        "entries": {
+            "old_promoted": {
+                "projects": ["project-alpha", "project-beta"],
+                "first_seen": "2025-01-01T00:00:00Z",
+                "last_confirmed": "2025-01-01T00:00:00Z",
+                "promoted": True,
+            },
+        }
+    }))
+    # Before confirm: decay flags it (stale by >90 days).
+    before = json.loads(_run_provenance("decay", home=provenance_env).stdout)
+    assert "old_promoted" in [f["slug"] for f in before]
+
+    # A later relevant consolidation confirms it.
+    result = _run_provenance("confirm", "old_promoted", home=provenance_env)
+    assert result.returncode == 0, result.stderr
+
+    # After confirm: decay no longer flags it.
+    after = json.loads(_run_provenance("decay", home=provenance_env).stdout)
+    assert "old_promoted" not in [f["slug"] for f in after]
+
+
+# --- Provenance write-race (ticket 0224, defect 2) ---
+
+
+@pytest.mark.integration
+def test_provenance_concurrent_record_loses_neither_write(provenance_env):
+    """Two interleaved record() round-trips must preserve both entries.
+
+    The test delay hook forces the two critical sections to overlap: each
+    subprocess loads provenance, sleeps, then writes. Without the lock the
+    second writer's load predates the first writer's save, so the first write
+    is lost (classic read-modify-write race). With the lock the writes
+    serialize and both slugs survive.
+
+    Teeth check: remove the _provenance_lock() wrapper in provenance.py and
+    this test FAILS (one slug missing) — confirming it catches the defect, not
+    merely a different implementation.
+    """
+    import concurrent.futures
+
+    delay_env = {"DREAM_PROVENANCE_TEST_DELAY": "0.5"}
+
+    def write(slug):
+        return _run_provenance("record", slug, "project-x", home=provenance_env, extra_env=delay_env)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        f1 = ex.submit(write, "slug_one")
+        f2 = ex.submit(write, "slug_two")
+        r1, r2 = f1.result(), f2.result()
+
+    assert r1.returncode == 0, r1.stderr
+    assert r2.returncode == 0, r2.stderr
+
+    data = json.loads(_run_provenance("show", home=provenance_env).stdout)
+    assert "slug_one" in data["entries"], "lost write: slug_one missing"
+    assert "slug_two" in data["entries"], "lost write: slug_two missing"

--- a/tickets/0225-dream-v2-atomic-provenance-write-to-prev.erg
+++ b/tickets/0225-dream-v2-atomic-provenance-write-to-prev.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: Dream v2: atomic provenance write to prevent torn reads under concurrency
+Created: 2026-06-06
+Author: MinhHaDuong
+
+--- log ---
+2026-06-06T08:19Z MinhHaDuong created
+
+--- body ---
+## Context
+
+Surfaced by `/gaze` on PR #315 (ticket 0224). That PR closed the
+lost-**write** race on `~/.claude/memory/.provenance.json` by serializing
+the read-modify-write in `record`/`promote`/`confirm` under an `fcntl.flock`
+on a sidecar lock file. It deliberately did NOT lock the read paths.
+
+A different failure class remains: the read paths (`candidates`, `decay`,
+`show`, and `_load_provenance` itself) take no lock, and writes use
+`Path.write_text(...)` which is **not** atomic — it truncates then writes.
+A reader that loads mid-write can see a partial file and raise
+`json.JSONDecodeError`. Under the 02:00 cron fan-out this is a real (if
+narrow) window.
+
+## Relevant files
+
+- `skills/dream/provenance.py` — `_load_provenance` / `_save_provenance`,
+  read verbs (`candidates`, `decay`, `show`).
+- `tests/test_dream.py` — provenance tests; reuse the
+  `DREAM_PROVENANCE_TEST_DELAY` hook added in 0224.
+
+## Actions
+
+1. Make writes atomic: write to a temp file in the same directory, then
+   `os.replace()` onto `.provenance.json`. A reader then always sees a
+   complete old-or-new file — no lock needed on the read path, which keeps
+   readers fast and avoids extending the critical section.
+2. (Alternative, if atomic-write proves insufficient) take the shared flock
+   in `_load_provenance` for read paths too. Prefer atomic-write; it is
+   cheaper and does not serialize readers against writers.
+
+## Test
+
+Interleave a reader with a writer using the existing
+`DREAM_PROVENANCE_TEST_DELAY` hook so the read lands mid-write; assert the
+reader never raises `JSONDecodeError` and gets a valid (old or new) document.
+Teeth check: the test must FAIL against the current non-atomic `write_text`
+and PASS after the `os.replace` change.
+
+## Exit criteria
+
+- [ ] Provenance writes are atomic (temp + `os.replace`)
+- [ ] A reader interleaved with a writer never observes a torn file
+- [ ] Test covers the path and fails against non-atomic write; `make check` passes

--- a/tickets/closed/0224-dream-v2-debt-decay-confirmation-loop-an.erg
+++ b/tickets/closed/0224-dream-v2-debt-decay-confirmation-loop-an.erg
@@ -2,10 +2,12 @@
 Title: Dream v2 debt: decay-confirmation loop and provenance write race
 Created: 2026-06-05
 Author: MinhHaDuong
+Closed: autoclosed — PR #315
 
 --- log ---
 2026-06-05T19:13Z MinhHaDuong created
 
+2026-06-06T08:23Z MinhHaDuong closed — autoclosed — PR #315
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes the two non-blocking residuals from the Dream v2 verify gate (PR #302, ticket 0165).

## Defect 1 — decay-confirmation loop half-wired
Once an entry is promoted, its project-level copy is tombstoned, so the step-7 `record` call that would refresh `last_confirmed` never fires again — every promoted harness entry decay-flags at 90 days regardless of continued relevance.

Fix: new `confirm <slug>` verb in `provenance.py` refreshes `last_confirmed` on a promoted entry (no project-list mutation; errors on unknown/unpromoted slug like `promote`). Wired into `SKILL.md` as step 7b — a consolidation that still finds a promoted lesson supported by the project's content confirms it; unsupported entries are left to decay-flag (the intended human-review signal).

## Defect 2 — lost-update race on `.provenance.json`
`record()`/`promote()` were unlocked read-modify-write; the cron fires all projects at 02:00, so concurrent consolidations could clobber provenance and suppress a promotion. Serialized the full RMW under `fcntl.flock` on a sidecar `.provenance.lock` (auto-releases on exit, protects interactive runs a staggered cron would not, and avoids the truncation-vs-lock conflict of locking the json itself).

## Tests
- Confirm path: refresh makes decay skip a >90d entry; rejects unknown/unpromoted slugs.
- Race path is a genuine teeth-test — a `DREAM_PROVENANCE_TEST_DELAY` hook forces the two critical sections to overlap, so the test FAILS without the lock (verified by disabling it) and passes with it. Marked `integration`.
- Added `pytest.ini` registering the `integration`/`slow` markers (none existed) to retire the unknown-marker warning.

All 430 repo tests pass; `make check` and `ruff` clean.

**Ticket:** tickets/0224-dream-v2-debt-decay-confirmation-loop-an.erg
Related follow-up: tickets/0225-dream-v2-atomic-provenance-write-to-prev.erg (torn-read under concurrency — distinct failure class, surfaced by /gaze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
