### PR TITLE
fix(dream): atomic provenance write to prevent torn reads (0225)

### DIFF
--- a/skills/dream/provenance.py
+++ b/skills/dream/provenance.py
@@ -14,6 +14,7 @@ import fcntl
 import json
 import os
 import sys
+import tempfile
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -26,9 +27,17 @@ PROJECTS_BASE = Path.home() / ".claude" / "projects"
 DECAY_DAYS = 90
 
 # Test-only hook: seconds to sleep between read and write inside a locked
-# mutation, used to force critical-section overlap in the race test. Unset in
-# production. See tests/test_dream.py::test_provenance_concurrent_record_*.
+# mutation, used to force critical-section overlap in the lost-write race test.
+# Unset in production. See tests/test_dream.py::test_provenance_concurrent_record_*.
 _TEST_DELAY_ENV = "DREAM_PROVENANCE_TEST_DELAY"
+
+# Test-only hook: seconds to sleep mid-write — after the full content is staged
+# in the temp file but before os.replace publishes it. Lets the torn-read test
+# land a reader inside the write window. In the atomic implementation the live
+# file is still the intact old document here, so a reader sees old-or-new but
+# never a tear. Unset in production.
+# See tests/test_dream.py::test_provenance_read_during_write_never_torn.
+_WRITE_DELAY_ENV = "DREAM_PROVENANCE_WRITE_DELAY"
 
 
 @contextmanager
@@ -59,13 +68,45 @@ def _load_provenance() -> dict:
 
 
 def _save_provenance(data: dict) -> None:
+    """Atomically replace the provenance file.
+
+    Readers take no lock and load lock-free (ticket 0225), so the write must be
+    all-or-nothing: a non-atomic write_text truncates then writes, exposing a
+    window where a concurrent reader sees a partial file and raises
+    JSONDecodeError. We stage the full content in a temp file in the same
+    directory (same filesystem — os.replace requires it), then os.replace onto
+    the live path. The rename is atomic, so a reader always observes the
+    complete old-or-new document, never a tear — without serializing readers
+    against writers."""
     PROVENANCE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    PROVENANCE_PATH.write_text(json.dumps(data, indent=2) + "\n")
+    text = json.dumps(data, indent=2) + "\n"
+    fd, tmp = tempfile.mkstemp(
+        dir=PROVENANCE_PATH.parent, prefix=".provenance.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        _write_delay()
+        os.replace(tmp, PROVENANCE_PATH)
+    except BaseException:
+        # Leave no orphan temp file if staging or replace fails.
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def _test_delay() -> None:
     """Sleep between read and write when the test hook is set (no-op in prod)."""
     delay = os.environ.get(_TEST_DELAY_ENV)
+    if delay:
+        time.sleep(float(delay))
+
+
+def _write_delay() -> None:
+    """Sleep mid-write when the write hook is set (no-op in prod)."""
+    delay = os.environ.get(_WRITE_DELAY_ENV)
     if delay:
         time.sleep(float(delay))
 

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -301,3 +301,58 @@ def test_provenance_concurrent_record_loses_neither_write(provenance_env):
     data = json.loads(_run_provenance("show", home=provenance_env).stdout)
     assert "slug_one" in data["entries"], "lost write: slug_one missing"
     assert "slug_two" in data["entries"], "lost write: slug_two missing"
+
+
+@pytest.mark.integration
+def test_provenance_read_during_write_never_torn(provenance_env):
+    """A reader interleaved with a writer never observes a half-written file.
+
+    Writes truncate-then-write are non-atomic: a reader landing between the
+    truncate and the content flush sees a partial (or empty) file and raises
+    JSONDecodeError (ticket 0225). The atomic _save_provenance stages the full
+    document in a temp file and os.replace()s it, so the live file is never
+    partial — a reader sees the complete old-or-new document.
+
+    The DREAM_PROVENANCE_WRITE_DELAY hook pins the writer mid-write (after the
+    temp file is staged, before the replace). We launch the read solidly inside
+    that window and assert it loads a valid document with the pre-existing entry
+    intact.
+
+    Teeth check: replace the atomic body of _save_provenance with the
+    instrumented non-atomic form
+
+        with open(PROVENANCE_PATH, "w") as f:   # truncates the live file
+            _write_delay()                        # reader sees 0 bytes here
+            f.write(text)
+
+    and this test FAILS — the reader subprocess exits nonzero on
+    json.loads("") — confirming it catches the torn read, not merely a
+    different implementation.
+    """
+    import concurrent.futures
+    import time
+
+    # Seed a valid old document with no delay.
+    seed = _run_provenance("record", "slug_old", "project-x", home=provenance_env)
+    assert seed.returncode == 0, seed.stderr
+
+    write_delay_env = {"DREAM_PROVENANCE_WRITE_DELAY": "0.5"}
+
+    def write():
+        return _run_provenance(
+            "record", "slug_new", "project-y", home=provenance_env, extra_env=write_delay_env
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        writer = ex.submit(write)
+        # Let the writer reach its mid-write delay, then read inside the window.
+        time.sleep(0.2)
+        reader = _run_provenance("show", home=provenance_env)
+        w = writer.result()
+
+    assert w.returncode == 0, w.stderr
+    assert reader.returncode == 0, f"reader saw a torn file: {reader.stderr}"
+    data = json.loads(reader.stdout)  # raises if reader captured a partial write
+    # The reader must see a complete document: the old entry is always present
+    # (the new entry may or may not have landed, depending on old-or-new).
+    assert "slug_old" in data["entries"], "reader lost the pre-existing entry"

--- a/tickets/closed/0225-dream-v2-atomic-provenance-write-to-prev.erg
+++ b/tickets/closed/0225-dream-v2-atomic-provenance-write-to-prev.erg
@@ -2,10 +2,12 @@
 Title: Dream v2: atomic provenance write to prevent torn reads under concurrency
 Created: 2026-06-06
 Author: MinhHaDuong
+Closed: fixed — atomic provenance write (temp + os.replace), torn-read test with teeth
 
 --- log ---
 2026-06-06T08:19Z MinhHaDuong created
 
+2026-06-06T09:34Z MinhHaDuong closed — fixed — atomic provenance write (temp + os.replace), torn-read test with teeth
 --- body ---
 ## Context
 
@@ -48,6 +50,18 @@ and PASS after the `os.replace` change.
 
 ## Exit criteria
 
-- [ ] Provenance writes are atomic (temp + `os.replace`)
-- [ ] A reader interleaved with a writer never observes a torn file
-- [ ] Test covers the path and fails against non-atomic write; `make check` passes
+- [x] Provenance writes are atomic (temp + `os.replace`)
+- [x] A reader interleaved with a writer never observes a torn file
+- [x] Test covers the path and fails against non-atomic write; `make check` passes
+
+## Implementation note
+
+The ticket suggested reusing `DREAM_PROVENANCE_TEST_DELAY` to land the read
+mid-write. That hook fires *between* `_load_provenance` and `_save_provenance`
+— i.e. before the write begins, when the on-disk file is still the intact old
+document — so it cannot create a torn-read window. The fix adds a sibling hook
+`DREAM_PROVENANCE_WRITE_DELAY` firing *inside* `_save_provenance` at the safe
+point (temp staged, live file intact, before `os.replace`). Same mechanism,
+correct call site; the two race tests keep independent windows. Teeth check
+verified by reverting `_save_provenance` to an instrumented non-atomic
+`open(...,"w")` form: the reader subprocess goes RED on `json.loads("")`.


### PR DESCRIPTION
## Summary

Closes the torn-read gap left open by PR #315 (ticket 0224). That PR serialized provenance WRITERS under an `fcntl.flock` but kept READERS lock-free; `_save_provenance` still used `Path.write_text`, which truncates then writes. A reader (`candidates`/`decay`/`show`/`_load_provenance`) landing between truncate and content-flush sees a partial file and raises `JSONDecodeError`. Under the 02:00 cron fan-out this is a real, if narrow, window.

## Fix

Make the write atomic rather than locking the read path: stage the full document in a temp file in the same directory (`tempfile.mkstemp`), then `os.replace()` onto the live path. The rename is atomic, so a reader always observes the complete old-or-new document — no tear — without serializing readers against writers. This is the cheaper of the two options the ticket weighed; the read-lock alternative would extend the critical section for no added safety. No `fsync`: tear-prevention comes from the atomic rename, not durability.

## Test (teeth verified)

The existing `DREAM_PROVENANCE_TEST_DELAY` hook fires *between* load and save — before the write begins, when the on-disk file is still the intact old document — so it cannot create a torn-read window. Added a sibling `DREAM_PROVENANCE_WRITE_DELAY` hook firing *inside* `_save_provenance` at the safe point (temp staged, live file intact, before `os.replace`). `test_provenance_read_during_write_never_torn` interleaves a reader into that window and asserts the reader loads a valid document with the pre-existing entry intact.

Teeth check (exit criterion 3): reverting `_save_provenance` to an instrumented non-atomic `open(...,"w")` form turns the test RED — the reader subprocess exits nonzero on `json.loads("")` (`JSONDecodeError: Expecting value, char 0`). The atomic form is GREEN. 445 tests pass; `make check` passes.

## Exit criteria

- [x] Provenance writes are atomic (temp + `os.replace`)
- [x] A reader interleaved with a writer never observes a torn file
- [x] Test covers the path and fails against non-atomic write; `make check` passes

**Ticket:** tickets/0225-dream-v2-atomic-provenance-write-to-prev.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)