### PR TITLE
fix(fang-audit): test-identity normalization, gate enforcement, report parity (0226)

### DIFF
--- a/skills/fang-audit/SKILL.md
+++ b/skills/fang-audit/SKILL.md
@@ -54,8 +54,9 @@ file to run an audit.** At run start a **DISCOVERY** phase reads the LAUNCH repo
 - the **test↔source pairing table** (each test mapped to the source file(s) it
   actually exercises, with the import/call-site evidence recorded),
 - language-specific mutation + refactor heuristics,
-- the `test-quality.py` flakiness-gate invocation for the language (if an adapter
-  exists).
+- the `test-quality.py` flakiness-gate invocation **if** the language has an
+  adapter (`test-quality.py` ships a **Go adapter only** today — a Python/other
+  suite gets an empty `PRECHECK_CMD` and the determinism gate skips openly).
 
 This is **informed derivation by reading** — allowed. The **BANNED** thing is the
 blind filename-glob heuristic (`X_test → X.go`), which returned a *nonexistent*
@@ -82,6 +83,15 @@ cannot come from the environment — pre-expand to absolute form when in doubt).
 explicit human **opt-in** — never auto-discovered. With no guards designated the
 canary gate is **skipped openly** (the report says so); it is never faked on an
 empty set.
+
+> **Reproducing the git-erg reference run** (the one with a live canary gate)
+> therefore needs **two overrides discovery cannot derive**: `GUARDS` (the
+> designated canary file + its primary canary mutation — an opt-in, never
+> auto-discovered) and `UNTRACKED_SEED` (the uncommitted build inputs the guard
+> build needs, which a fresh worktree lacks — only the committed tree
+> propagates). A `GUARDS`-only reproduction whose guard test depends on an
+> untracked input will fail at the guard baseline; pair the two. Without
+> `GUARDS` the run still completes — the canary gate just skips openly.
 
 ## How it runs
 
@@ -164,6 +174,11 @@ sorted by **risk × churn** (churn = commit count per file from `git log --follo
 risk = the human-supplied `CONFIG.RISK` weight, default 1) so the highest
 blast-radius × change-frequency findings surface first.
 
+> **`RISK` override keys are the full repo-root-relative test path** (e.g.
+> `{"tests/test_foo.py": 2.0}`), matching the identity discovery returns — not a
+> bare basename. Test identity is one canonical path everywhere in the engine
+> (0226); a basename key silently weights nothing on a path-prefixed repo.
+
 ## Steps
 
 0. **Open the session in the target repo** (see the hard requirement above).
@@ -193,8 +208,13 @@ second-language target is **`~/aedist-technical-report`** (a `uv` Python project
    opt-in only if desired). Discovery reads `pyproject.toml` / `pytest.ini` and
    the `tests/` tree, derives `pytest -p no:cacheprovider ...` (cache-buster
    included) and the test↔source pairing table from imports.
-3. The precheck uses the Python adapter of `~/.claude/scripts/test-quality.py`
-   if one exists for the suite; otherwise it skips openly (warn-and-proceed).
+3. The precheck. `~/.claude/scripts/test-quality.py` ships a **Go adapter only**
+   (`--adapter` accepts `go`; there is no Python adapter today), so for a Python
+   suite discovery returns an empty `PRECHECK_CMD` and the determinism gate
+   **skips openly** (warn-and-proceed; the report carries a ⏭️ banner). Do NOT
+   hand-wire `PRECHECK_CMD` with `--adapter python` — argparse rejects it (exit
+   2) and the precheck aborts the run. Stabilize a Python suite manually (or add
+   a Python adapter to `test-quality.py`) before trusting the toothless rows.
 4. **Expected cost scale.** The git-erg reference run was ~1.3M tokens / ~29 min
    for 19 files, fang-only. AEDIST has ~30+ test files and the v2 workflow adds a
    handcuff pass and a scope pass, so budget on the order of **2–4×** the git-erg

--- a/skills/fang-audit/fang-audit.js
+++ b/skills/fang-audit/fang-audit.js
@@ -112,7 +112,7 @@ const DISCOVERY_SCHEMA = {
     LANGUAGE: { type: 'string' },
     PACKAGE_HINT: { type: 'string' },
     SRC_DIR: { type: 'string', description: 'directory the test command runs in, relative to repo root' },
-    RUN_TEST: { type: 'string', description: 'the cache-busting test command; <TAGS> placeholder for build-tag flags' },
+    RUN_TEST: { type: 'string', minLength: 1, description: 'the cache-busting test command; <TAGS> placeholder for build-tag flags' },  // 0226 d2: minLength so the Workflow runtime rejects+retries a blank command (an empty RUN_TEST gives every audit agent a no-op gate → every mutation trivially "survives")
     DEFAULT_TAGS: { type: 'string' },
     GUARD_TAGS: { type: 'string' },
     PRECHECK_CMD: { type: 'string', description: 'the 0184 test-quality.py flakiness gate invocation for this repo' },
@@ -123,9 +123,14 @@ const DISCOVERY_SCHEMA = {
       properties: {
         test: { type: 'string' },
         src: { type: 'array', items: { type: 'string' } },
-        rationale: { type: 'string', description: 'WHY this pairing — the import/call-site evidence, proving it is read-derived not glob-derived' },
+        rationale: { type: 'string', minLength: 1, description: 'WHY this pairing — the import/call-site evidence, proving it is read-derived not glob-derived' },
       },
-      required: ['test', 'src'],
+      // 0226 advisory: require `rationale`. Without it, a glob-derived pairing
+      // table (the BANNED X_test→X.go heuristic) passes the only machine gate —
+      // the import/call-site evidence is the sole structural proof the pairing
+      // was READ-derived, not name-derived. The runtime rejects+retries a
+      // pairing with a missing or empty rationale.
+      required: ['test', 'src', 'rationale'],
     } },
     evidence: { type: 'string', description: 'what files were read (Makefile/pyproject/go.mod/test tree) and how the command + pairings were derived' },
   },
@@ -175,6 +180,19 @@ CONFIG.RISK = CONFIG.RISK || {}
 CONFIG.OUTPUT = expand(CONFIG.OUTPUT)
 CONFIG.UNTRACKED_SEED = (CONFIG.UNTRACKED_SEED || []).map(s => ({ ...s, from: expand(s.from) }))
 log(`discovery: ${CONFIG.BEHAVIORAL.length} test↔source pairings, RUN_TEST="${CONFIG.RUN_TEST}", ${CONFIG.GUARDS.length} designated guard(s).`)
+
+// 0226 d2: an empty RUN_TEST is the silent killer — every audit agent gets a
+// blank test command, so EVERY mutation trivially "survives" (a false-accusation
+// flood) and the canary never trips. The schema minLength makes the Workflow
+// runtime reject+retry a blank from discovery, but an explicit `RUN_TEST: ''`
+// override (or a degenerate discovery the runtime accepted) can still reach
+// here. FALLBACKS carries no RUN_TEST, so a missing value stays undefined.
+// Abort affirmatively on a missing-or-blank command rather than fan out a no-op.
+if (!CONFIG.RUN_TEST || !String(CONFIG.RUN_TEST).trim()) {
+  const msg = 'ABORT: RUN_TEST is empty — no test command to run. Every mutation would trivially "survive" a blank gate (a false-accusation flood). Discovery must derive a cache-busting test command, or pass a non-empty RUN_TEST override.'
+  log(msg)
+  return { aborted: true, reason: msg, discovered }
+}
 
 const { BEHAVIORAL, GUARDS } = CONFIG
 
@@ -226,7 +244,11 @@ const PRECHECK_SCHEMA = {
   additionalProperties: false,
   properties: {
     exitCode: { type: 'integer', description: 'exit code of the flakiness gate (0 = stable, 2 = new flakiness)' },
-    gate: { type: 'string', description: 'the "gate" field from the JSON report: "pass" or "fail"' },
+    // 0226 d3: enum, not a bare string. The Workflow runtime validates agent
+    // returns against this schema and retries on mismatch, so a real agent
+    // reporting 'skipped'/'Pass'/'unknown' is REJECTED rather than slipping
+    // through the flakiness gate masquerading as a pass.
+    gate: { type: 'string', enum: ['pass', 'fail'], description: 'the "gate" field from the JSON report: "pass" or "fail"' },
     flakyTests: { type: 'array', items: { type: 'string' }, description: 'identities flagged flaky, if any' },
     evidence: { type: 'string', description: 'the raw command + a short excerpt of its JSON stdout' },
   },
@@ -557,10 +579,16 @@ This is the 0184 test-quality utility's flakiness gate. Exit-code contract:
   - exit 0 = suite is stable (or all flakiness is baselined) -> gate "pass"
   - exit 2 = NEW flakiness found -> gate "fail"
 The JSON report on stdout carries a "gate" field ("pass"/"fail"); read it to confirm. Report exitCode, gate, any flaky test identities, and a short evidence excerpt. Do NOT mutate anything.`,
-  { label: 'precheck:flakiness', phase: 'Precheck', schema: PRECHECK_SCHEMA }
+  { label: 'precheck:flakiness', phase: 'Precheck', model: 'sonnet', schema: PRECHECK_SCHEMA }  // 0226 advisory: a mechanical run-the-command-and-report agent — pin the cheap model (mirrors the skeptics), don't burn Opus
 ).catch(() => null)  // Δ10: a precheck agent error falls into the abort path below, not an opaque crash
 
-if (!precheck || precheck.exitCode !== 0 || precheck.gate === 'fail') {
+// 0226 d3: require an AFFIRMATIVE pass on the real-agent path — `gate === 'pass'`,
+// not merely `!== 'fail'`. With the PRECHECK_SCHEMA enum now constraining gate to
+// ['pass','fail'] the runtime already rejects+retries a stray 'skipped'/'Pass'/
+// 'unknown', but defence-in-depth: a value that is neither 'pass' nor 'fail' must
+// ABORT, never slip through. The OPEN skip (precheckSkipped, synthetic
+// gate:'skipped') is a deliberate warn-and-proceed and is exempt from the gate.
+if (!precheckSkipped && (!precheck || precheck.exitCode !== 0 || precheck.gate !== 'pass')) {
   const detail = precheck
     ? `exit ${precheck.exitCode}, gate=${precheck.gate}${precheck.flakyTests && precheck.flakyTests.length ? ', flaky: ' + precheck.flakyTests.join(', ') : ''}`
     : 'precheck agent returned nothing'
@@ -586,7 +614,7 @@ phase('Audit')
 const behavioral = await pipeline(
   BEHAVIORAL,
   file => agent(auditPrompt(file), { label: `audit:${file.test}`, phase: 'Audit', schema: AUDIT_SCHEMA, isolation: 'worktree' })
-            .then(a => { if (a) a.testFile = a.testFile || file.test; return a }),
+            .then(a => { if (a) a.testFile = file.test; return a }),  // 0226 d1: identity from DISPATCH, not the agent's self-report (mirrors the canary-tag rule below — never read it back from the agent)
   (audit, file) => skepticize(audit, file),
 )
 
@@ -602,17 +630,26 @@ for (const file of GUARDS) {
   // Δ7: tag findings from this run STRUCTURALLY as canary-guard findings.
   // Canary designation comes from CONFIG.GUARDS (the workflow knows which
   // agent it dispatched), NEVER from a read-back of the agent's isCanary flag.
-  if (a) { a.testFile = a.testFile || file.test; a._isGuardFile = true; a = await skepticize(a, file) }
+  if (a) { a.testFile = file.test; a._isGuardFile = true; a = await skepticize(a, file) }  // 0226 d1: identity from DISPATCH (see audit wrapper)
   guards.push(a)
   log(`guard ${file.test}: ${a ? (a.findings.filter(f => f.isCanary).map(f => f.result).join(',') || a.findings[0]?.result) : 'null'}`)
 }
 
 const all = [...behavioral, ...guards].filter(Boolean)
 
-// Report helpers — hoisted above the handcuff/scope phases (which key fang
-// counts and caught-operators by basename) so they are in scope there too.
+// Report helper — hoisted above the handcuff/scope phases so it is in scope
+// there too.
+//
+// 0226 d1: there is intentionally NO basename helper. Test identity is the full
+// repo-root-relative path discovery returns (e.g. `tests/test_foo.py` on a
+// Python layout), established ONCE at the BEHAVIORAL mapping and bound through
+// dispatch (`a.testFile = file.test` in every wrapper above). The former
+// basename-of-testFile keys split the WRITE side (basename) from the READ side
+// (`BEHAVIORAL[].test`, full path), so on a path-prefixed repo the scope /
+// handcuff / three-axis joins all missed — the AEDIST-blocking defect. Keying
+// on one canonical string everywhere is the fix; a per-site basename would just
+// reintroduce the split.
 const esc = s => String(s == null ? '' : s).replace(/\n+/g, ' ').replace(/\|/g, '\\|').trim()
-const base = p => String(p || '').split('/').pop()
 
 // ---- Phase 4: HANDCUFF pass (robustness — INVERTED oracle, own skeptic) ----
 // Pipelined AFTER the fang pass in the SAME workflow (shared discovery,
@@ -620,9 +657,15 @@ const base = p => String(p || '').split('/').pop()
 // are non-trivial — a file with no fang is unlikely to be over-scoped, and the
 // budget is better spent on the ones doing real assertion work.
 phase('Handcuff')
+// 0226 advisory: fangByFile feeds ONLY the BEHAVIORAL handcuff-priority sort, so
+// count fangs from behavioral findings only. Iterating `all` (behavioral +
+// guards) double-counts a file designated as BOTH a behavioral pairing and a
+// guard (same path in BEHAVIORAL and GUARDS): its guard-pass caught mutations
+// would inflate its behavioral fang count and distort the sort. Filter on the
+// structural _isGuardFile tag.
 const fangByFile = {}
-all.forEach(a => (a.findings || []).forEach(f => {
-  if (f.result === 'caught') fangByFile[base(a.testFile)] = (fangByFile[base(a.testFile)] || 0) + 1
+all.filter(a => !a._isGuardFile).forEach(a => (a.findings || []).forEach(f => {
+  if (f.result === 'caught') fangByFile[a.testFile] = (fangByFile[a.testFile] || 0) + 1
 }))
 const handcuffTargets = [...BEHAVIORAL].sort((x, y) => (fangByFile[x.test] || 0) < (fangByFile[y.test] || 0) ? 1 : -1)
 const handcuffs = await pipeline(
@@ -631,7 +674,7 @@ const handcuffs = await pipeline(
   // and runs the suite; concurrent loops on a shared checkout corrupt each
   // other, exactly as in the fang pass.
   file => agent(handcuffPrompt(file), { label: `handcuff:${file.test}`, phase: 'Handcuff', schema: HANDCUFF_SCHEMA, isolation: 'worktree' })
-            .then(a => { if (a) a.testFile = a.testFile || file.test; return a }),
+            .then(a => { if (a) a.testFile = file.test; return a }),  // 0226 d1: identity from DISPATCH (see audit wrapper)
   (audit, file) => handcuffSkepticize(audit, file),
 )
 
@@ -641,7 +684,7 @@ const handcuffs = await pipeline(
 phase('Scope')
 const caughtOpsByFile = {}
 behavioral.filter(Boolean).forEach(a => {
-  const fileName = base(a.testFile)
+  const fileName = a.testFile
   ;(a.findings || []).filter(f => f.result === 'caught').forEach(f => {
     (caughtOpsByFile[fileName] = caughtOpsByFile[fileName] || []).push({ testFunc: f.testFunc, mutation: f.mutation })
   })
@@ -651,7 +694,7 @@ const scopes = await parallel(scopeTargets.map(file => () =>
   // Δ8: isolation:'worktree' — the scope agent MUTATES (replays operators at
   // sibling sites) and runs the suite; must be isolated like fang/handcuff.
   agent(scopePrompt(file, caughtOpsByFile[file.test]), { label: `scope:${file.test}`, phase: 'Scope', schema: SCOPE_SCHEMA, isolation: 'worktree' })
-    .then(a => { if (a) a.testFile = a.testFile || file.test; return a })
+    .then(a => { if (a) a.testFile = file.test; return a })  // 0226 d1: identity from DISPATCH (see audit wrapper)
     .catch(e => { log(`scope ${file.test} agent error: ${e}`); return null })
 ))
 
@@ -676,14 +719,14 @@ PROCEDURE (read-then-act, conservatively):
 4. Report which paths you removed (or "none found").
 
 If \`git worktree list\` shows no /tmp/fang- entries, do nothing and report "none found". Do NOT mutate source, do NOT remove anything outside the /tmp/fang- prefix.`,
-  { label: 'cleanup:scratch-worktrees', phase: 'Cleanup' }
+  { label: 'cleanup:scratch-worktrees', phase: 'Cleanup', model: 'sonnet' }  // 0226 advisory: mechanical list-then-prune — pin the cheap model
 ).catch(e => log(`cleanup agent error (non-fatal): ${e}`))
 
 // ---- Deterministic report assembly (no LLM formatting of N objects) ----
-// (esc/base hoisted above the handcuff/scope phases.)
+// (esc hoisted above the handcuff/scope phases.)
 // Δ7: carry _isGuardFile down onto each finding so canary scoping is by
 // CONFIG-dispatched role, not by a self-asserted flag.
-const flat = all.flatMap(a => (a.findings || []).map(f => ({ ...f, _file: base(a.testFile), _isGuardFile: !!a._isGuardFile })))
+const flat = all.flatMap(a => (a.findings || []).map(f => ({ ...f, _file: a.testFile, _isGuardFile: !!a._isGuardFile })))
 const survived = flat.filter(f => f.result === 'survived')
 const equivalent = flat.filter(f => f.result === 'equivalent')
 const caught = flat.filter(f => f.result === 'caught')
@@ -705,11 +748,11 @@ const canarySkipped = GUARDS.length === 0
 const canaryOK = !canarySkipped && canaryFindings.length >= GUARDS.length && canaryFindings.every(f => f.result === 'caught')
 
 // ---- 0219: flatten the HANDCUFF (robustness) and SCOPE (altitude) passes ----
-const hcFlat = (handcuffs || []).filter(Boolean).flatMap(a => (a.findings || []).map(f => ({ ...f, _file: base(a.testFile) })))
+const hcFlat = (handcuffs || []).filter(Boolean).flatMap(a => (a.findings || []).map(f => ({ ...f, _file: a.testFile })))
 const handcuffHits = hcFlat.filter(f => f.result === 'handcuff')        // over-scoped (red on a true refactor)
 const robust = hcFlat.filter(f => f.result === 'robust')
 const notPreserving = hcFlat.filter(f => f.result === 'not-preserving') // refactor secretly changed behavior — a fang, not a handcuff
-const scFlat = (scopes || []).filter(Boolean).flatMap(a => (a.findings || []).map(f => ({ ...f, _file: base(a.testFile) })))
+const scFlat = (scopes || []).filter(Boolean).flatMap(a => (a.findings || []).map(f => ({ ...f, _file: a.testFile })))
 const instancePinned = scFlat.filter(f => f.result === 'instance-pinned') // under-scoped: guards one instance, not the class
 const classGuarded = scFlat.filter(f => f.result === 'class-guarded')
 
@@ -750,7 +793,7 @@ const churnByFile = await (async () => {
   try {
     const res = await agent(
       `For ${CONFIG.PROJECT}, report the git churn (number of commits that touched the file) for each of these test files, using \`git log --follow --oneline -- <file> | wc -l\` from the repo root. Files: ${files.join(', ')}. Return a JSON object mapping each filename to its commit count (a plain number; a numeric string is also accepted).`,
-      { label: 'churn:git-log', phase: 'Guards',
+      { label: 'churn:git-log', phase: 'Guards', model: 'sonnet',  // 0226 advisory: mechanical git-log-and-count — pin the cheap model
         schema: { type: 'object', additionalProperties: { type: ['integer', 'string'] } } }
     )
     return Object.fromEntries(Object.entries(res || {}).map(([k, v]) => [k, parseInt(v, 10) || 0]))
@@ -808,6 +851,18 @@ if (canarySkipped) {
   L.push('🛑 **FAIL / SUSPECT** — a guard canary did not classify as `caught`. The harness may be miswired (or the guard-tag / untracked-input setup failed). **Treat the toothless list with caution.** Canary results:')
   canaryFindings.forEach(f => L.push(`- \`${f._file}\` → **${f.result}** — ${esc(f.mutation)}`))
   if (canaryFindings.length < GUARDS.length) L.push(`- (only ${canaryFindings.length} canary finding(s) reported; expected ${GUARDS.length})`)
+}
+L.push('')
+// 0226 advisory: the precheck OPEN-skip was invisible in the report (only
+// log() + a return field), while the canary open-skip carries a ⏭️ banner.
+// Mirror it here so a reader of the Markdown sees the un-vetted-determinism
+// caveat without trawling the run log.
+L.push('## Determinism precheck')
+L.push('')
+if (precheckSkipped) {
+  L.push('⏭️ **SKIPPED (openly)** — discovery found no 0184 flakiness adapter for this language, so the suite was NOT determinism-vetted before the audit. A flaky test can masquerade as a toothless one (a mutation "survives" only because the suite is non-deterministic). **Stabilize the suite manually before trusting the toothless rows below.** To gate determinism, pass a `PRECHECK_CMD` override naming the flakiness command for this language.')
+} else {
+  L.push('✅ **PASS** — the suite ran deterministically across the flakiness gate\'s re-runs, so a "survived" verdict reflects a real coverage gap, not suite noise.')
 }
 L.push('')
 L.push('## Summary')

--- a/tests/test_fang_audit_skill.py
+++ b/tests/test_fang_audit_skill.py
@@ -380,6 +380,100 @@ def test_skill_md_states_target_repo_requirement():
     )
 
 
+# ── 0226 defect 1: ONE canonical test-identity normalization ─────────────────
+
+
+def test_test_identity_keyed_consistently_no_per_site_basename():
+    """0226 defect 1 (the headline). The fang/handcuff/scope dicts were WRITTEN
+    with ``base(a.testFile)`` (basename) but READ with the raw
+    ``BEHAVIORAL[].test`` path. On a path-prefixed repo (Python ``tests/``
+    layout) discovery returns ``tests/test_foo.py`` while ``base()`` yields
+    ``test_foo.py`` — the join misses, so the scope pass never dispatches, the
+    handcuff priority sort is a no-op, and the three-axis table is all-n/a.
+
+    Root fix: identity is the full repo-root-relative path, established once at
+    the BEHAVIORAL mapping and bound through DISPATCH (``a.testFile =
+    file.test``), never a per-site basename. So:
+      * NO ``base(`` call survives — every former key site now holds the
+        canonical full path the read sites already use.
+      * Each MUTATING wrapper pins identity from the dispatched ``file.test``,
+        not the agent's self-reported ``a.testFile`` (the ``|| file.test``
+        fallback let the agent's claim win — same anti-pattern the canary gate
+        already bans, l.602-604).
+
+    This test FAILS on the pre-fix code (``base(a.testFile)`` present, wrappers
+    use ``a.testFile || file.test``) and passes once identity is canonical."""
+    src = js()
+    # No per-site basename normalization on a key/identity site survives.
+    assert "base(" not in src, (
+        "a per-site base()/basename on a test-identity key survives — the "
+        "write-key (basename) and read-key (full path) split that makes the "
+        "scope/handcuff/three-axis joins miss on path-prefixed repos (0226 d1)"
+    )
+    # Every mutating wrapper must pin identity from the DISPATCHED file, never
+    # the agent's self-reported testFile (no `|| file.test` fallback).
+    assert "a.testFile || file.test" not in src and "a.testFile||file.test" not in src, (
+        "a mutating wrapper still lets the agent's self-reported testFile win "
+        "over the dispatched file.test — identity must come from dispatch (0226 d1)"
+    )
+    assert src.count("a.testFile = file.test") >= 4, (
+        "expected all four mutating wrappers (audit/guard/handcuff/scope) to "
+        "pin a.testFile = file.test from dispatch (0226 d1)"
+    )
+
+
+def test_run_test_validated_non_empty_before_fanout():
+    """0226 defect 2. An empty RUN_TEST gives every audit agent a blank test
+    command, so every mutation trivially 'survives' → a false-accusation flood.
+    The discovery schema must require a non-empty RUN_TEST (minLength) so the
+    Workflow runtime rejects+retries a blank, AND the engine must abort if it is
+    still empty after merge."""
+    src = js()
+    # Schema enforces a non-empty RUN_TEST.
+    sch = src[src.index("DISCOVERY_SCHEMA"):src.index("phase('Discovery')")]
+    assert "minLength" in sch, (
+        "DISCOVERY_SCHEMA does not enforce a non-empty RUN_TEST (minLength) — "
+        "an empty test command passes every gate (0226 d2)"
+    )
+    # Engine aborts on an empty RUN_TEST before the fan-out.
+    assert re.search(r"!CONFIG\.RUN_TEST", src) or "RUN_TEST.trim()" in src, (
+        "engine does not abort on an empty RUN_TEST after merge (0226 d2)"
+    )
+
+
+def test_precheck_gate_enum_and_affirmative_pass():
+    """0226 defect 3. The precheck gate must be an ENUM ['pass','fail'] (the
+    Workflow runtime validates + retries on mismatch, so a real agent returning
+    'skipped'/'Pass'/'unknown' is rejected, not silently passed), and the
+    no-abort condition must require ``gate === 'pass'`` AFFIRMATIVELY — not
+    merely ``!== 'fail'``."""
+    src = js()
+    psch = src[src.index("PRECHECK_SCHEMA"):src.index("const RULES")]
+    assert re.search(r"gate:\s*\{[^}]*enum:\s*\[\s*'pass'\s*,\s*'fail'\s*\]", psch), (
+        "PRECHECK_SCHEMA.gate is not an enum ['pass','fail'] — a real agent "
+        "returning 'skipped'/'Pass' would pass the flakiness gate (0226 d3)"
+    )
+    # The abort must require an affirmative pass.
+    assert "gate !== 'pass'" in src or "gate === 'pass'" in src, (
+        "precheck abort does not require an affirmative gate === 'pass' (0226 d3)"
+    )
+
+
+def test_precheck_skip_banner_in_report():
+    """0226 advisory. The precheck open-skip was invisible in the Markdown
+    report (only log() + a return field); the canary open-skip has a ⏭️ banner.
+    The report must mirror that banner for a precheck skip."""
+    src = js()
+    # The L (report) assembly must reference precheckSkipped to emit a banner.
+    lasm = src[src.index("const L = []"):]
+    assert "precheckSkipped" in lasm, (
+        "precheck skip is not surfaced in the Markdown report (0226 advisory)"
+    )
+    assert lasm.count("⏭️") >= 2, (
+        "precheck skip banner does not mirror the canary ⏭️ banner (0226 advisory)"
+    )
+
+
 # ── 0223: args may arrive as a JSON-encoded string ───────────────────────────
 
 

--- a/tickets/0226-fang-audit-v2-test-identity-normalizatio.erg
+++ b/tickets/0226-fang-audit-v2-test-identity-normalizatio.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-06-06T10:55Z claude created — post-merge /code-review of PR #316 (high effort, 7 finder angles, adversarial verify); 3 CONFIRMED correctness defects + verified advisories
 
+2026-06-06T10:01Z claude note RED→GREEN teeth evidence: pre-fix 4 new tests FAILED on unedited fang-audit.js (base( present, wrappers a.testFile||file.test, gate no enum, RUN_TEST no minLength, 1 banner); post-fix 37 passed. Defect-1 root fix: identity=full repo-root-relative path pinned via dispatch (a.testFile=file.test x4 wrappers), all base() removed (5 sites incl hcFlat/scFlat). Full suite 449 passed, make check clean.
 --- body ---
 ## Context
 

--- a/tickets/closed/0226-fang-audit-v2-test-identity-normalizatio.erg
+++ b/tickets/closed/0226-fang-audit-v2-test-identity-normalizatio.erg
@@ -2,11 +2,13 @@
 Title: fang-audit v2 hardening: test-identity normalization, gate enforcement, report parity
 Created: 2026-06-06
 Author: claude
+Closed: autoclosed — PR #319
 
 --- log ---
 2026-06-06T10:55Z claude created — post-merge /code-review of PR #316 (high effort, 7 finder angles, adversarial verify); 3 CONFIRMED correctness defects + verified advisories
 
 2026-06-06T10:01Z claude note RED→GREEN teeth evidence: pre-fix 4 new tests FAILED on unedited fang-audit.js (base( present, wrappers a.testFile||file.test, gate no enum, RUN_TEST no minLength, 1 banner); post-fix 37 passed. Defect-1 root fix: identity=full repo-root-relative path pinned via dispatch (a.testFile=file.test x4 wrappers), all base() removed (5 sites incl hcFlat/scFlat). Full suite 449 passed, make check clean.
+2026-06-06T10:22Z MinhHaDuong closed — autoclosed — PR #319
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0226-fang-audit-v2-test-identity-normalizatio.erg

Post-merge `/code-review` of PR #316 (ticket 0219) found three runtime-semantics defects the string-presence adherence tests cannot see, plus verified advisories. This hardens all three at the root and addresses the endorsed advisories. **Blocks the AEDIST validation run** — defect 1 fires on exactly that repo's path-prefixed (`tests/`) layout.

## Confirmed defects (all fixed)

**1. Test-identity key mismatch (headline).** Dicts WRITTEN with `base(a.testFile)` (basename) but READ with raw `BEHAVIORAL[].test` (full path). On a path-prefixed repo, `base('tests/test_foo.py') = 'test_foo.py'` ≠ `'tests/test_foo.py'`, so the scope dispatch, handcuff-priority sort, and all three three-axis columns silently joined nothing.

Root fix (author-endorsed): **one canonical identity = the full repo-root-relative path**, established once at the BEHAVIORAL mapping and bound through **dispatch** — every wrapper now pins `a.testFile = file.test` (was `a.testFile || file.test`, which let the agent's self-report win), mirroring the existing canary-tag rule. **Every `base()` call deleted** and the helper removed — *five* key sites, not the three the ticket named: `fangByFile`, `caughtOpsByFile`, `flat/_file`, **`hcFlat/_file` and `scFlat/_file`** (the latter two feed the handcuff and right-scope columns). Read sites already used the full path, so all joins now key on one string. A per-site basename was explicitly rejected — it would reintroduce the split.

**2. Empty RUN_TEST passes every gate.** `DISCOVERY_SCHEMA.RUN_TEST` gains `minLength: 1` (the Workflow runtime rejects+retries a blank) AND the engine aborts affirmatively on a missing-or-blank command after merge, before fan-out. An empty test command makes every mutation trivially "survive" — a false-accusation flood.

**3. Precheck gate not enforced.** `PRECHECK_SCHEMA.gate` becomes `enum: ['pass','fail']` (the runtime rejects a real agent's `'skipped'`/`'Pass'`/`'unknown'`) and the abort requires `gate === 'pass'` **affirmatively**, not merely `!== 'fail'`. The open-skip path (synthetic `gate: 'skipped'`) is exempted via `!precheckSkipped`.

## Advisories — disposition

| Advisory | Disposition |
|---|---|
| Precheck open-skip invisible in report | **Done** — ⏭️ banner mirroring the canary banner in the L assembly |
| DISCOVERY rationale optional (glob table passes) | **Done** — `rationale` now required (`minLength: 1`); a glob-derived table fails the machine gate |
| Adherence vacuous w.r.t. defect 1 | **Done** — new key-consistency teeth-test (RED→GREEN below) |
| fangByFile double-counts BEHAVIORAL∩GUARDS | **Done** — filters `!_isGuardFile` (sort is BEHAVIORAL-only) |
| Mechanical agents on Opus | **Done (models)** — precheck/cleanup/churn pinned to `sonnet`. **Waived (concurrency)** — "dispatch churn concurrently" is a control-flow restructure (kick the IIFE promise early, await later) on a script with no local JS runtime to verify; same risk class as the dedup below |
| Pass-shape 3 hand-wired copies (extract `expandRules`/`runSkeptic`) | **Waived** — no local JS runtime (no node) and the adherence tests are string-presence only, so an extraction refactor's semantic regression is unverifiable. This ticket blocks AEDIST; the bar is introduce-no-unverifiable-risk. The ticket itself names 0183 (the 4th lens) as the forcing function — extract then, when the new lens exercises the shared helper |
| SKILL.md doc-drift (Go-only adapter; GUARDS+UNTRACKED_SEED) | **Done** — documented the Go-only `test-quality.py` adapter (no Python adapter; `--adapter python` → argparse exit 2), the GUARDS+UNTRACKED_SEED overrides needed to reproduce the git-erg reference run, and that `RISK` keys are now full paths |

## Exit criterion 1(b) — live-fixture clause: WAIVED (no-node)

Criterion 1 asks the scope/handcuff/three-axis joins be "verified **live** on a
path-prefixed fixture (`tests/` subdir layout)." There is no JS runtime in the
build/CI environment (no `node`), so an engine-level run on a fixture is not
possible here — the same no-node constraint that waives the pass-shape and
churn-concurrency advisories above. The fix is instead proven by **inspection +
regression test**: `base()` and its five call-sites are deleted, every write-site
now keys on the dispatch-pinned `a.testFile = file.test`, and every read-site
already keyed on the full `BEHAVIORAL[].test` path — so both sides reduce to one
canonical string for *any* layout, not merely one fixture. The new
`test_test_identity_keyed_consistently_no_per_site_basename` fails RED on the
pre-fix split and passes GREEN post-fix. **Live join-firing proof is deferred to
the AEDIST validation run** this PR unblocks (the first real path-prefixed
engine run).

## Teeth — RED/GREEN evidence

New adherence test `test_test_identity_keyed_consistently_no_per_site_basename` (+ `test_run_test_validated_non_empty_before_fanout`, `test_precheck_gate_enum_and_affirmative_pass`, `test_precheck_skip_banner_in_report`).

- **Pre-fix (RED):** 4 FAILED on the unedited `fang-audit.js` — `base(` present, wrappers used `a.testFile || file.test`, gate had no enum, RUN_TEST had no minLength, only 1 ⏭️ banner.
- **Post-fix (GREEN):** 37 passed.

Full suite: **449 passed**, `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)