### PR TITLE
memory: skills must Just Work in launch dir — discovery over CONFIG blocks

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Skills Just Work — no per-repo CONFIG blocks](feedback_skills_just_work_no_config_blocks.md) — Author directive: skills auto-discover repo specifics at run start (0184 adapter precedent); explicit inputs are optional overrides; revise old explicit-CONFIG adherence tests deliberately
 - [Workflow agents are session-bound](feedback_workflow_agents_session_bound.md) — Workflow agent() runs in the SESSION checkout unless isolation:'worktree'; worktrees cut from the SESSION repo — cross-repo skills need a session in the target repo; probe before expensive fan-outs
 - [Next move: git-erg migration](project_git_erg_migration_next.md) — Author's declared focus as of 2026-06-04; 0216 dogfood migration in git-erg; IDH tickets 0190/0191 are companions; check git-erg tickets ~0216 first
 - [gh pr edit broken — use REST](feedback_gh_pr_edit_broken_use_rest.md) — gh pr edit hits a Projects-classic GraphQL deprecation; PATCH via gh api repos/.../pulls/N instead

--- a/projects/-home-haduong--claude/memory/feedback_skills_just_work_no_config_blocks.md
+++ b/projects/-home-haduong--claude/memory/feedback_skills_just_work_no_config_blocks.md
@@ -1,0 +1,12 @@
+---
+name: skills-just-work-no-config-blocks
+description: Author directive — skills must Just Work in the launch directory; discovery over per-repo CONFIG blocks
+metadata:
+  type: feedback
+---
+
+Skills must Just Work (tm) in whatever project directory they are launched — no per-repo CONFIG block to hand-author before a run (directive 2026-06-06, while planning the 0219 raid).
+
+**Why:** A hardcoded CONFIG block (the 0182 fang-audit shape: pairing table, RUN_TEST, canaries baked into the script) makes every new target repo a pre-authoring chore and rots as the repo evolves. The 0184 `test-quality.py` pattern is the precedent: pluggable runner/adapter, works in any repo, knobs are CLI flags with defaults.
+
+**How to apply:** Derive repo specifics at run start — a discovery phase reads the launch repo (Makefile, pyproject.toml, go.mod, test tree) and builds the pairing table / test command / language heuristics. Discovery-by-reading is NOT the banned "name heuristic" (0182's `X_test→X.go` glob that broke on non-1:1 pairs); it is informed derivation, and explicit inputs remain as optional *overrides*, not prerequisites. When evolving a skill guarded by adherence tests that enforce the old explicit-CONFIG design (0182's test_config_block_declares_explicit_knobs etc.), revise those tests deliberately under this directive — do not treat them as immovable. Related: [[workflow-agents-session-bound]] — Just-Works only helps if the session is rooted in the target repo.


### PR DESCRIPTION
Saves the author directive from today's 0219 raid planning as a feedback memory: skills auto-discover repo specifics at run start (0184 adapter precedent); explicit inputs are optional overrides; old explicit-CONFIG adherence tests get revised deliberately. Applied in PRs #316/#319.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)