### PR TITLE
skills: plain-function first sentence in all descriptions + ratchet

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 
 | Command | Description |
 |---------|-------------|
-| `/beat` | Trigger one beat cycle on the current project (housekeeping → pick-ticket → raid). |
+| `/beat` | Run one autonomous work cycle on the current project — housekeeping, then pick a ticket, then execute it (housekeeping → pick-ticket → raid). One beat is the heartbeat unit of the overnight autonomous pipeline (nightbeat). |
 | `/bib-merge` | Merge approved Bibliography entries from a related-work-note into the project's refs.bib. Dedupes, flags conflicts, appends new entries. Never rewrites existing entries. |
 | `/celebrate` | Deprecated — renamed to /roar. Warns, then delegates to the new name. |
 | `/check-readiness` | Alias of /scry — multi-repo pre-flight readiness check and interactive triage. |
@@ -87,15 +87,15 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/housekeeping` | Alias of /molt — repo housekeeping with git sync, healthcheck, and eager fix-now repairs. |
 | `/hunt` | Begin work on a ticket. Creates worktree, writes first test, transitions to Execute phase. |
 | `/lair` | End-of-day session wrap-up. Runs housekeeping, pushes branches, runs tests, refreshes STATE, offers autonomous session. |
-| `/maw-audit` | "Full-jaw mutation-testing audit. The maw is the beast's devouring jaws — this inspects every tooth of the test suite at once, not just one fang: does each test FAIL on the defect it claims to catch (fang), STAY GREEN under refactors (handcuff), and guard the whole defect CLASS (scope)? Surfaces toothless, over-scoped, and instance-pinned tests. Discovers its own config — no per-repo setup. EXPENSIVE on-demand (the validating fang-only run was ~1.3M tokens / ~29 min); never invoke casually. Formerly fang-audit." |
+| `/maw-audit` | "Audit test-suite quality by mutation testing: verify that each test actually catches the defect it claims to catch, stays green under harmless refactors, and guards the whole defect class rather than one instance. The three lenses: fang (a behavior-changing mutation must turn the test RED — else toothless), handcuff (a behavior-preserving refactor must keep it GREEN — else over-scoped), scope (a caught mutation replayed at sibling sites — survivors mean instance-pinned). Discovers its own config — no per-repo setup. EXPENSIVE on-demand (the validating fang-only run was ~1.3M tokens / ~29 min); never invoke casually. The name: the maw is the beast's devouring jaws — the audit inspects every tooth, not just one fang. Formerly fang-audit." |
 | `/memory` | Write, update, or sweep persistent memory. Enforces list caps, TTLs, and staleness criteria. |
 | `/merge` | Atomically close the linked ticket(s) and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI). |
 | `/molt` | Repo housekeeping — git sync, healthcheck, eager fix-now repairs, and ticket creation for open-ticket findings. Safe to call interactively or from automated sweeps. |
-| `/nightbeat-report` | Morning review of autonomous nightbeat runs. Parses logs, narrates work done, and surfaces harness improvement opportunities. |
-| `/nightbeat-supervisor` | Continuous autonomous supervisor for nightbeat. Watches beat outcomes, merges ready PRs, diagnoses and repairs failures, escalates when stuck. |
+| `/nightbeat-report` | Review what the overnight autonomous runs did, each morning: parse the logs, narrate the work done, and surface harness improvement opportunities. (Nightbeat is the overnight beat-cycle pipeline.) |
+| `/nightbeat-supervisor` | Supervise the overnight autonomous pipeline (nightbeat) continuously: watch each cycle outcome, merge ready PRs, diagnose and repair failures, escalate when stuck. |
 | `/perch` | Mid-session orientation — summarize what's done, surface unresolved points. Assesses clear-readiness and offers to do the work if conditions are right. |
 | `/pick-ticket` | Pick the lowest-risk available ticket for an autonomous sweep run. Returns PICK:<id>, CLOSED:<id>, or IDLE. |
-| `/raid` | Run an Imperial Dragon raid across multiple tickets. Picks targets, manages waves, enforces isolation. Merges APPROVED PRs after verify-gate clears. |
+| `/raid` | Work through multiple tickets autonomously: pick targets, implement each in isolated worktree waves, verify, and merge APPROVED PRs after verify-gate clears. This is the Imperial Dragon raid — parallel agents under strict isolation discipline. |
 | `/related-work-note` | Author's due-diligence note for one cited paragraph of a manuscript. Covers relevance, history, cited works (detailed), related-but-not-cited (justified), methods, verification checklist, bibliography with DOI/URL. |
 | `/related-work-note-validate` | Re-resolve every DOI/URL/eprint in a related-work-note's Bibliography. Append a provenance line to Methods. One-line verdict to stdout (PASS / WARN / FAIL). |
 | `/release` | Pre-release audit, GPG tag signing, and download-URL update for a target repo. Runs audits autonomously; pauses at the human-only signing step. |

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -100,6 +100,8 @@ When compacting, preserve the list of modified files, test commands, and current
 
 **Concurrency discipline**: Every multi-item skill step declares whether items run parallel-background or sequential-blocking, and states why. Model defaults differ across versions; the skill text is the contract.
 
+**Discoverability-first descriptions**: The first sentence of a SKILL.md `description:` states the plain, unthemed function in the keywords a naive user would search ("Audit test-suite quality…", "Review what the overnight runs did…"). Draconic theming, lore, and harness jargon come after the first sentence. Skill *names* may stay themed — the description's opening sentence is what a user scans to find them. Enforced by `tests/test_skill_descriptions.py`.
+
 # Autonomous Action Rules
 
 **Sweep results are decisions.** When a skill sweep (roar step 3, healthcheck, etc.) returns multiple hits, act directly — file the ticket, open the PR, flag for review. Don't prompt the user to confirm. The data is the decision. Silent no-op if the sweep is empty.

--- a/skills/beat/SKILL.md
+++ b/skills/beat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: beat
-description: Trigger one beat cycle on the current project (housekeeping → pick-ticket → raid).
+description: Run one autonomous work cycle on the current project — housekeeping, then pick a ticket, then execute it (housekeeping → pick-ticket → raid). One beat is the heartbeat unit of the overnight autonomous pipeline (nightbeat).
 user-invocable: true
 argument-hint:
 ---

--- a/skills/maw-audit/SKILL.md
+++ b/skills/maw-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maw-audit
-description: "Full-jaw mutation-testing audit. The maw is the beast's devouring jaws — this inspects every tooth of the test suite at once, not just one fang: does each test FAIL on the defect it claims to catch (fang), STAY GREEN under refactors (handcuff), and guard the whole defect CLASS (scope)? Surfaces toothless, over-scoped, and instance-pinned tests. Discovers its own config — no per-repo setup. EXPENSIVE on-demand (the validating fang-only run was ~1.3M tokens / ~29 min); never invoke casually. Formerly fang-audit."
+description: "Audit test-suite quality by mutation testing: verify that each test actually catches the defect it claims to catch, stays green under harmless refactors, and guards the whole defect class rather than one instance. The three lenses: fang (a behavior-changing mutation must turn the test RED — else toothless), handcuff (a behavior-preserving refactor must keep it GREEN — else over-scoped), scope (a caught mutation replayed at sibling sites — survivors mean instance-pinned). Discovers its own config — no per-repo setup. EXPENSIVE on-demand (the validating fang-only run was ~1.3M tokens / ~29 min); never invoke casually. The name: the maw is the beast's devouring jaws — the audit inspects every tooth, not just one fang. Formerly fang-audit."
 disable-model-invocation: false
 user-invocable: true
 argument-hint: "[run in the target repo; it discovers its own config — optional overrides via the Workflow args input]"

--- a/skills/nightbeat-report/SKILL.md
+++ b/skills/nightbeat-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nightbeat-report
-description: Morning review of autonomous nightbeat runs. Parses logs, narrates work done, and surfaces harness improvement opportunities.
+description: Review what the overnight autonomous runs did, each morning: parse the logs, narrate the work done, and surface harness improvement opportunities. (Nightbeat is the overnight beat-cycle pipeline.)
 user-invocable: true
 argument-hint: "[--hours N]"
 ---

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nightbeat-supervisor
-description: Continuous autonomous supervisor for nightbeat. Watches beat outcomes, merges ready PRs, diagnoses and repairs failures, escalates when stuck.
+description: Supervise the overnight autonomous pipeline (nightbeat) continuously: watch each cycle outcome, merge ready PRs, diagnose and repair failures, escalate when stuck.
 user-invocable: true
 argument-hint: "[--since ISO-TS]"
 ---

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: raid
-description: Run an Imperial Dragon raid across multiple tickets. Picks targets, manages waves, enforces isolation. Merges APPROVED PRs after verify-gate clears.
+description: Work through multiple tickets autonomously: pick targets, implement each in isolated worktree waves, verify, and merge APPROVED PRs after verify-gate clears. This is the Imperial Dragon raid — parallel agents under strict isolation discipline.
 disable-model-invocation: false
 user-invocable: true
 argument-hint: [ticket-ids or "all open"]

--- a/tests/test_skill_descriptions.py
+++ b/tests/test_skill_descriptions.py
@@ -1,0 +1,54 @@
+"""Skill descriptions lead with the plain function, not the theme.
+
+Discoverability rule (rules/workflow.md § Writing Skills and Hooks): the
+FIRST sentence of every SKILL.md ``description:`` states what the skill does
+in the keywords a naive user would search; draconic theming and harness lore
+come after. Skill *names* may stay themed — only the description's opening
+sentence is ratcheted here.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Themed lexicon banned from the FIRST sentence. Deliberately excludes words
+# that double as skill names or ordinary verbs (raid, roar, beat, dream,
+# molt, perch, scry, hunt, gaze, lair) — cross-references to those are
+# legitimate; the ban targets pure lore vocabulary.
+THEME_LEXICON = re.compile(
+    r"\b(imperial\s+dragon|dragons?|draconic|maws?|jaws?|fangs?|claws?|talons?"
+    r"|wyrms?|beasts?|devour\w*)\b",
+    re.IGNORECASE,
+)
+
+
+def iter_descriptions():
+    for md in sorted((REPO / "skills").glob("*/SKILL.md")):
+        m = re.search(r"^description:\s*(.+)$", md.read_text(), re.MULTILINE)
+        assert m, f"{md}: no description in frontmatter"
+        yield md.parent.name, m.group(1).strip().strip('"')
+
+
+def first_sentence(desc: str) -> str:
+    # Split on sentence-ending punctuation followed by whitespace; em-dash
+    # clauses and parentheses inside the first sentence are kept.
+    return re.split(r"(?<=[.!?])\s+", desc, maxsplit=1)[0]
+
+
+def test_every_skill_has_a_description():
+    names = [name for name, _ in iter_descriptions()]
+    assert names, "no skills found"
+
+
+def test_description_first_sentence_is_unthemed():
+    offenders = []
+    for name, desc in iter_descriptions():
+        sentence = first_sentence(desc)
+        hit = THEME_LEXICON.search(sentence)
+        if hit:
+            offenders.append(f"{name}: {hit.group(0)!r} in first sentence: {sentence!r}")
+    assert not offenders, (
+        "themed first sentence(s) — lead with the plain function, theme after "
+        "(rules/workflow.md § Writing Skills and Hooks):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
Author directive: skill descriptions must open with the unthemed function in naive-user keywords; theming after. Five offenders rewritten (maw-audit, raid, beat, nightbeat-report, nightbeat-supervisor); rule codified in rules/workflow.md; ratchet test added with RED/GREEN teeth evidence (catches both pre-fix descriptions). Catalog regenerated; make check exit 0.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)