### PR TITLE
tickets: undefer 0183, file 0229 (static test-hygiene tier)

### DIFF
--- a/tickets/0183-llm-test-audit-sibling-skill.erg
+++ b/tickets/0183-llm-test-audit-sibling-skill.erg
@@ -2,11 +2,12 @@
 Title: LLM read-and-judge test-audit (faithfulness, intent, negative-space, change-detector)
 Created: 2026-05-30
 Author: claude
-Label: deferred
 
 --- log ---
 2026-05-30T10:30Z claude created — sibling to 0182; different mechanism (judge, no execution)
 
+2026-06-06T12:09Z MinhHaDuong unlabel deferred
+2026-06-06T12:09Z MinhHaDuong unlabel deferred — parking condition met (0182 PR #305, 0219 PR #316, 0226 PR #319 all merged; harness shape proven thrice). Note: 0226 waived the pass-shape dedup (runPass/expandRules extraction) to this ticket — the next lens pays for the abstraction. Composition target renamed maw-audit (PR #323).
 --- body ---
 ## Context
 

--- a/tickets/0229-static-test-hygiene-tier-for-the-test-qu.erg
+++ b/tickets/0229-static-test-hygiene-tier-for-the-test-qu.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: Static test-hygiene tier for the test-quality family: AST-enforced integration markers
+Created: 2026-06-06
+Author: MinhHaDuong
+
+--- log ---
+2026-06-06T12:10Z MinhHaDuong created
+
+--- body ---
+## Context
+
+During the 0224 raid, /gaze observed that the coding-python.md rule
+"tests using subprocess.run() or time.sleep() must be marked
+@pytest.mark.integration" is enforced by reviewer vigilance only — the
+raid under review had just hand-added such markers. The suggestion was a
+quick AST-based adherence test; author directive (2026-06-06): test-suite
+verification belongs to the maw-audit / test-quality FAMILY, not an
+ad-hoc one-off PR. This ticket places it there.
+
+The family, by mechanism:
+- maw-audit — mutation (expensive, on-demand): fang / handcuff / scope
+- [[0183]] — LLM read-and-judge (no execution): faithfulness, intent,
+  negative-space, change-detector
+- 0184 (closed) — empirical re-run: flakiness / independence / speed
+  (scripts/test-quality.py, the cheap per-PR tier)
+- THIS ticket — STATIC analysis (zero execution, zero tokens, ms-fast):
+  structural hygiene a parser can prove
+
+## Actions
+
+1. Add a `static` lens to scripts/test-quality.py (the cheap per-PR
+   tier is its natural home — same report identity `<package>::<Test>`,
+   same ratchet/baseline machinery), starting with one check:
+   marker hygiene — parse each test file with Python's `ast` module,
+   walk every test function's body for `subprocess.*` / `time.sleep`
+   calls (including aliased imports), and flag functions lacking the
+   `integration` marker (decorator or module-level pytestmark).
+   AST not grep: grep cannot tie a call site to its enclosing
+   function's decorator list (false positives on imports/comments,
+   false negatives on aliases).
+2. Language-pluggable like the existing lenses: the Python AST checker
+   is the first adapter; the lens interface must not assume Python.
+3. Wire into the harness's own suite as an adherence test (the IDH
+   repo dogfoods the check via make check-fast).
+4. Ratchet mode applies: fail only on NEW violations, baseline the rest.
+
+## Exit criteria
+
+- [ ] `test-quality.py static` (or equivalent lens) reports marker
+      violations with `<file>::<function>` identities; JSON output
+- [ ] AST-based: catches aliased `from subprocess import run as X`;
+      ignores subprocess mentions in comments/strings (teeth test
+      proves both, RED on a violating fixture)
+- [ ] Ratchet/baseline semantics consistent with the existing lenses
+- [ ] IDH repo runs it in make check-fast; suite currently clean
+- [ ] make check passes
+
+## Related
+
+- Family: maw-audit skill, [[0183]] (LLM judge), 0184 (empirical tier)
+- Origin: /gaze suggestion on PR #315 (ticket 0224)


### PR DESCRIPTION
Undefers 0183 (LLM read-and-judge test audit — parking condition met by 0182/0219/0226) with a log note carrying the 0226-waived pass-shape dedup. Files 0229: the AST integration-marker check placed in the test-quality family (static tier of scripts/test-quality.py), per author directive that test-suite verification belongs to the maw-audit family.

Ticket-ref: tickets/0183-llm-test-audit-sibling-skill.erg
Ticket-ref: tickets/0229-static-test-hygiene-tier-for-the-test-qu.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)