### PR TITLE
tickets: split 0227 — file child 0230 (harness-repo wrapper deletion)

### DIFF
--- a/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
+++ b/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-06-06T11:43Z claude created
 
 2026-06-06T11:52Z claude note ride-along: fix ~/.claude pre-commit hook error text 'Run make build first' — binary is vendored at tickets/erg, there is no make build; refresh via erg install --hooks
+2026-06-06T13:11Z claude note split: harness-repo portion (actions 1-3, 5, hook ride-along) moved to child 0230 for the raid; this parent retains the multi-repo sweep (action 4), one PR per repo, stays open until all repos done
 --- body ---
 ## Context
 
@@ -24,38 +25,24 @@ delete. Skills are for multi-step orchestration only.
 
 ## Actions
 
-1. Audit every skill in ~/.claude/skills/ against the wrapper test.
-   Known candidate: ticket-new (thin `$ERG new` wrapper; the global
-   tickets/AGENTS.md already documents direct erg usage). Judge each of
-   the others on the same criterion — most (raid, gaze, roar...) are
-   genuine orchestration and stay.
-2. Delete the wrappers found. Where the deleted skill carried a unique
-   fact, move that line to the relevant AGENTS.md/CLAUDE.md/rules file.
-3. Update skills that *reference* deleted wrappers to direct CLI calls:
-   at minimum raid (Phase 7 "Token economy rule": invoke /ticket-new)
-   and roar (step 3: file tickets via /ticket-new). Their reason for
-   delegating — erg owns next-id/validate — is preserved by calling erg
-   directly.
-4. Sweep every repo on padme for project-level wrapper skills and
+(Harness-repo portion — skill audit, wrapper deletion, reference fixes,
+catalog regen, pre-commit hook ride-along — split to child [[0230]].)
+
+1. Sweep every repo on padme for project-level wrapper skills and
    v1-era ticket residue (`.claude/skills/ticket-*`, `%erg v1`,
    `Status:` mutation guidance, `tickets/tools/go`): padme (already
    clean, PRs #5–#7), chemin-de-voix, git-erg, aedist-technical-report
    (+ -docs, -experiments, -slides), Climate-finance,
    Oeconomia-Climate-finance, cadens, fuzzy-corpus, llm-benchmarks,
-   and the home-dir repo. One branch+PR per affected repo.
-5. After harness-repo deletions: `make skills-catalog` and verify
-   `make check-skills-drift` passes.
+   and the home-dir repo. One branch+PR per affected repo, run from a
+   session in that repo (agents are session-bound).
 
 ## Test
 
-For the harness repo: a sweep listing each skill with a one-line
-verdict (orchestration / wrapper-deleted), committed in the PR body or
-ticket log. For each swept project repo: grep transcript showing zero
-hits for the residue patterns.
+For each swept project repo: grep transcript showing zero hits for the
+residue patterns.
 
 ## Exit criteria
 
-- [ ] No skill in ~/.claude/skills/ fails the wrapper test
-- [ ] No skill text references a deleted wrapper (/ticket-new etc.)
+- [ ] Child [[0230]] (harness repo) closed
 - [ ] Every padme repo swept; residue removed or justified in ticket log
-- [ ] make check-skills-drift passes after catalog regeneration

--- a/tickets/0230-harness-repo-wrapper-skill-deletion-tick.erg
+++ b/tickets/0230-harness-repo-wrapper-skill-deletion-tick.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: Harness-repo wrapper-skill deletion: ticket-new removal, raid/roar reference fixes, catalog regen
+Created: 2026-06-06
+Author: claude
+
+--- log ---
+2026-06-06T13:11Z claude created — child of 0227, split per multi-PR ticket discipline (harness-repo portion only; parent retains the multi-repo sweep)
+
+2026-06-06T13:11Z claude note filed as wave-1 raid target (slate: 0216, 0229, 0230 / wave 2: 0228, 0183)
+--- body ---
+## Context
+
+Child of [[0227]] (delete thin CLI-wrapper skills). 0227's work lands as
+one PR per repo; per ticket discipline each PR closes its own child.
+This child covers ONLY the harness repo (~/.claude). The parent keeps
+the per-repo sweep of the other padme repos and stays open until all
+are done.
+
+Author's call (padme session 2026-06-06): skills that are thin
+delegations to a self-documenting CLI should not exist. The wrapper
+test: does the skill add logic beyond invoking one tool? If not,
+replace with an instruction line and delete. Rationale memorized:
+projects/-home-haduong-padme/memory/feedback_no_wrapper_skills.md
+
+## Actions
+
+1. Audit every skill in ~/.claude/skills/ against the wrapper test.
+   Known candidate: ticket-new (thin `$ERG new` wrapper; the global
+   tickets/AGENTS.md already documents direct erg usage). Most others
+   (raid, gaze, roar...) are genuine orchestration and stay.
+2. Delete the wrappers found. Where a deleted skill carried a unique
+   fact, move that line to the relevant AGENTS.md/CLAUDE.md/rules file.
+3. Update skills that *reference* deleted wrappers to direct CLI calls:
+   at minimum raid (Phase 7 "Token economy rule": invoke /ticket-new)
+   and roar (step 3: file tickets via /ticket-new). Their reason for
+   delegating — erg owns next-id/validate — is preserved by calling
+   erg directly.
+4. Ride-along from 0227's log: fix the ~/.claude pre-commit hook error
+   text 'Run make build first' — the binary is vendored at tickets/erg,
+   there is no make build; refresh via erg install --hooks.
+5. `make skills-catalog`; verify `make check-skills-drift` passes.
+
+## Test
+
+A sweep listing each skill with a one-line verdict (orchestration /
+wrapper-deleted), committed in the PR body or ticket log.
+
+## Exit criteria
+
+- [ ] No skill in ~/.claude/skills/ fails the wrapper test
+- [ ] No skill text references a deleted wrapper (/ticket-new etc.)
+- [ ] Pre-commit hook error text no longer says 'Run make build first'
+- [ ] make check-skills-drift passes after catalog regeneration


### PR DESCRIPTION
Pre-flight for the next raid: 0227's multi-repo sweep lands as one PR per repo, so per ticket discipline the harness-repo portion is split into child 0230 before work starts. Parent 0227 is rescoped to the per-repo sweep and stays open.

0230 is the wave-1 raid target alongside 0216 and 0229 (wave 2: 0228, 0183).

Ticket-ref: tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)