### PR TITLE
feat(healthcheck): detect closed-but-unarchived tickets

### DIFF
--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -108,6 +108,27 @@ def housekeeping_state(project):
     }
 
 
+def _scan_top_level_tickets(tickets_dir):
+    """Scan tickets/*.erg (non-recursive — tickets/closed/ is excluded).
+
+    Returns (open_count, closed_unarchived_ids). A .erg file sitting directly in
+    tickets/ with a `Closed:` header is a closed ticket that was never archived
+    into tickets/closed/ — the close-without-archive escape that happens when a
+    PR merges outside erg-pr-merge (which would have run `erg archive`). This is
+    a deliberately narrow structural check, not the full `erg check` folder/header
+    warning: it never fires on a stale-binary false positive, only on the loophole.
+    """
+    open_count = 0
+    closed_unarchived = []
+    for f in sorted(tickets_dir.glob("*.erg")):
+        text = f.read_text(errors="replace")
+        if any(line.startswith("Closed:") for line in text.splitlines()[:10]):
+            closed_unarchived.append(f.stem.split("-")[0])
+        else:
+            open_count += 1
+    return open_count, closed_unarchived
+
+
 def ticket_state(project):
     tickets_dir = project / "tickets"
     if not tickets_dir.is_dir():
@@ -115,6 +136,7 @@ def ticket_state(project):
             "ready": None,
             "open": None,
             "ready_ids": [],
+            "closed_unarchived": [],
             "error": "no tickets/ directory",
         }
 
@@ -127,33 +149,29 @@ def ticket_state(project):
                 "ready": None,
                 "open": None,
                 "ready_ids": [],
+                "closed_unarchived": [],
                 "error": f"erg failed: {r.stderr.strip()}",
             }
         ready_list = json.loads(r.stdout)
     except FileNotFoundError:
-        erg_files = list(tickets_dir.glob("*.erg"))
-        open_count = 0
-        for f in erg_files:
-            text = f.read_text(errors="replace")
-            if not any(line.startswith("Closed:") for line in text.splitlines()[:10]):
-                open_count += 1
+        open_count, closed_unarchived = _scan_top_level_tickets(tickets_dir)
         return {
             "ready": None,
             "open": open_count,
             "ready_ids": [],
+            "closed_unarchived": closed_unarchived,
             "error": "erg not found",
         }
 
     ready_ids = [t["id"] for t in ready_list]
+    open_count, closed_unarchived = _scan_top_level_tickets(tickets_dir)
 
-    erg_files = list(tickets_dir.glob("*.erg"))
-    open_count = 0
-    for f in erg_files:
-        text = f.read_text(errors="replace")
-        if not any(line.startswith("Closed:") for line in text.splitlines()[:10]):
-            open_count += 1
-
-    return {"ready": len(ready_ids), "open": open_count, "ready_ids": ready_ids}
+    return {
+        "ready": len(ready_ids),
+        "open": open_count,
+        "ready_ids": ready_ids,
+        "closed_unarchived": closed_unarchived,
+    }
 
 
 def branch_state(project):

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -20,7 +20,7 @@ First, run the mechanical probe to collect structured state:
 python3 ~/.claude/scripts/project-state.py "$(git rev-parse --show-toplevel)" --tests
 ```
 
-Parse the JSON output. Use its fields to populate checks 1–9 below without re-running git commands — the probe covers everything through check 8; only check 9 requires additional file reads. If the script is missing or fails, fall back to ad-hoc commands per check.
+Parse the JSON output. Use its fields to populate checks 1–10 below without re-running git commands — the probe covers everything through check 9; only check 10 requires additional file reads. If the script is missing or fails, fall back to ad-hoc commands per check.
 
 ## Checks
 
@@ -50,7 +50,8 @@ Parse the JSON output. Use its fields to populate checks 1–9 below without re-
 6. **Working tree** — from `git.clean` / `git.dirty_files`. List uncommitted files if dirty.
 7. **Tests green** — from `tests.status` / `tests.detail`. Skip if `tests.runner == "none"`.
 8. **Housekeeping** — from `housekeeping.state` / `housekeeping.age_hours` / `housekeeping.branch`. Report `ok` if `state == "clean"` (age ≤ 12 h), `warn` if `state == "needed"` (overdue) or `state == "tidying"` (a `claude/housekeeping-*` branch is in flight). Skip if probe missing.
-9. **Docs freshness (deep verification)** — cross-check status/directive docs (`STATE.md`, `README.md`, etc.):
+9. **Ticket archival** — from `tickets.closed_unarchived` (list of ticket IDs sitting in `tickets/*.erg` with a `Closed:` header, never moved to `tickets/closed/`). `ok` if empty; `warn` listing the IDs otherwise. This is the close-without-archive escape: a PR merged outside `erg-pr-merge` skips the `erg archive` step. Classify the fix as **fix-now** — `tickets/erg archive` (moves all closed tickets to `tickets/closed/`; commit the move). Skip if `tickets.error` is set or no `tickets/` directory.
+10. **Docs freshness (deep verification)** — cross-check status/directive docs (`STATE.md`, `README.md`, etc.):
    - **Staleness** — flag docs whose content predates recent repo activity
    - **Ticket cross-check** — references to tickets whose status contradicts
      the doc (todo but closed, done but open, broken ref). Skip if no `.erg` tickets.
@@ -75,6 +76,7 @@ Parse the JSON output. Use its fields to populate checks 1–9 below without re-
 | Working tree     | ...    | clean / N changes            |
 | Tests green      | ...    | N passed / K failed          |
 | Housekeeping     | ...    | clean / needed / tidying     |
+| Ticket archival  | ...    | N closed-but-unarchived      |
 | Docs freshness   | ...    | N docs scanned, K stale refs |
 ```
 

--- a/tests/test_project_state.py
+++ b/tests/test_project_state.py
@@ -130,6 +130,7 @@ def test_ticket_state_no_tickets_dir(tmp_path):
     out = ps.ticket_state(tmp_path)  # no tickets/ subdir
     assert out["ready"] is None
     assert out["error"] == "no tickets/ directory"
+    assert out["closed_unarchived"] == []  # key present in every return path
 
 
 def test_ticket_state_erg_missing_falls_back_to_file_count(tmp_path, monkeypatch):
@@ -149,6 +150,36 @@ def test_ticket_state_erg_missing_falls_back_to_file_count(tmp_path, monkeypatch
     out = ps.ticket_state(tmp_path)
     assert out["error"] == "erg not found"
     assert out["open"] == 1  # only the non-Closed ticket counted
+    # The closed ticket sits in tickets/ (not tickets/closed/) — unarchived.
+    assert out["closed_unarchived"] == ["0002"]
+
+
+def test_ticket_state_flags_closed_but_unarchived(tmp_path, monkeypatch):
+    """A top-level tickets/*.erg carrying a Closed: header is the
+    close-without-archive escape — flag its id, exclude it from `open`."""
+    tickets = tmp_path / "tickets"
+    tickets.mkdir()
+    (tickets / "closed").mkdir()
+    # Two genuinely open, one closed-but-unarchived in tickets/, one properly archived.
+    (tickets / "0010-open-a.erg").write_text("%erg 0.1\nTitle: A\n")
+    (tickets / "0011-open-b.erg").write_text("%erg 0.1\nTitle: B\n")
+    (tickets / "0012-done.erg").write_text("%erg 0.1\nClosed: 2026-06-01\nTitle: done\n")
+    (tickets / "closed" / "0009-archived.erg").write_text(
+        "%erg 0.1\nClosed: 2026-05-01\nTitle: archived\n"
+    )
+    erg_output = (
+        '[{"id": "0010", "title": "A", "file": "0010-open-a.erg", "closed": null,'
+        ' "refs": [], "tags": [], "blocked_by": []},'
+        ' {"id": "0011", "title": "B", "file": "0011-open-b.erg", "closed": null,'
+        ' "refs": [], "tags": [], "blocked_by": []}]'
+    )
+    monkeypatch.setattr(ps.shutil, "which", lambda _x: "/usr/bin/erg")
+    monkeypatch.setattr(ps, "run", lambda args, cwd: _cp(erg_output))
+
+    out = ps.ticket_state(tmp_path)
+    assert out["closed_unarchived"] == ["0012"]  # only the unarchived closed one
+    assert out["open"] == 2  # the archived ticket in closed/ is not scanned
+    assert out["ready"] == 2
 
 
 def test_ticket_state_ready_ids_populated(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

The close-vs-archive gap is a recurring loophole: when a PR merges **outside** `erg-pr-merge`, the `erg archive` step is skipped and the closed ticket lingers in `tickets/` instead of `tickets/closed/`. `/gaze` catches it only inconsistently, and `housekeeping-git.sh:20` runs `erg check tickets/` but **discards the warning** (`2>/dev/null || true`) — so today the escape surfaces only by luck.

## Fix — a structured detector

`scripts/project-state.py` gains `tickets.closed_unarchived`: the IDs of top-level `tickets/*.erg` files carrying a `Closed:` header (archived tickets live under `tickets/closed/` and aren't scanned). Surfaced as **healthcheck check 9 "Ticket archival"** (`warn` + the IDs), with `tickets/erg archive` classified **fix-now** — so `/molt`, which parses the Action plan, repairs it automatically. "Caught by luck" → "caught every sweep."

## Deliberately narrow — not "surfacing erg check"

This is an **independent structural check**, a strict subset of `erg check`'s bidirectional folder/header warning. It targets *only* the merge-skipped-archive loophole and is immune to erg's stale-binary false positives (cf. `/molt` step 0.7's "six bogus folder/header hits"). The one benign edge case (a `…-closed.erg` path that erg considers fine) just gets a harmless `erg archive`.

## Scope

A detection net, **not** a root-cause fix — archiving stays coupled to the `erg-pr-merge` path, so escapes will keep happening and getting caught here. Closing the root cause (archive on every merge path) is a larger design change, left open.

## Verification

- **RED-first**: the three `ticket_state` tests `KeyError` before the field exists; green after. `make check-fast` → 464 passed.
- Field present in all four `ticket_state` return paths (schema consistency).
- Ran across the 8 registry repos: **zero false positives, zero current hits**.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)