### PR TITLE
raid: complete the balance-rule sweep — two sibling restatements

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_harness_is_the_deliverable.md
+++ b/projects/-home-haduong--claude/memory/feedback_harness_is_the_deliverable.md
@@ -19,5 +19,9 @@ a fixed papers/slides list. The category flips with the project type.
 deliverable-balance justification and STATE.md should not carry a "balance
 debt — all tooling" warning. Apply the ≥60/≤40 ratio only where the north
 star names a non-tooling product (manuscripts, data, slides). Author
-correction, 2026-06-08. Fixed in skills/raid/SKILL.md § Balance rule.
+correction, 2026-06-08. The assumption lives in three spots in
+skills/raid/SKILL.md — § Balance rule (definition), Phase 1 "Prioritize"
+("north-star deliverables first"), and the mid-session checkpoint (ratio
+N/A for tooling projects); a roar sweep caught the latter two after the
+first fix touched only the definition. Edit all three together.
 Related: [[feedback_skills_just_work_no_config_blocks]].

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -34,7 +34,7 @@ If $ARGUMENTS is "all open": read open tickets from git-erg `tickets/` or forge.
 Otherwise: parse comma-separated ticket IDs.
 
 Prioritize:
-1. Scientific deliverables first
+1. North-star deliverables first (what the project's product is — manuscripts/figures for a science project, skills/rules/tests for this harness or git-erg; see § Balance rule)
 2. Gaps with north star (STATE.md)
 3. Ripest open issues
 4. Inline markers (FIXME, TODO, HACK)
@@ -188,8 +188,8 @@ HEAD origin/main`) passes because HEAD is main after the pull.
 
 ## Mid-session checkpoint (~50% effort)
 
-- [ ] Opened at least one deliverable-forward merge request?
-- [ ] Tooling/deliverable ratio within bounds?
+- [ ] Opened at least one north-star-forward merge request?
+- [ ] Tooling/deliverable ratio within bounds? (N/A for a tooling/library project — the harness IS the deliverable; see § Balance rule)
 - [ ] Self-reviewed at least one merge request?
 - [ ] `make check` passes on main?
 


### PR DESCRIPTION
Roar step-3 sweep follow-up to PR #339. The balance-rule fix corrected the § Balance rule definition but missed two downstream restatements of the same 'science project' assumption in the same skill:

- Phase 1 'Prioritize': 'Scientific deliverables first' → 'North-star deliverables first' (names the project's actual product)
- Mid-session checkpoint: 'deliverable-forward MR' + 'ratio within bounds' → north-star-forward; ratio marked N/A for tooling/library projects

No frontmatter change, so the catalog is unaffected.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)