### PR TITLE
housekeeping(state): refresh Status, reconcile 0227 sweep progress

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,21 +1,21 @@
 # Imperial Dragon Harness — State
 
-Last updated: 2026-06-08T00:00Z
+Last updated: 2026-06-08T10:15Z
 
 ## North star
 
 A reusable, science-backed personal harness for AI-assisted research: code and prose, day and night, across projects and machines. The harness itself is the deliverable.
 
 ## Status
-<!-- generated 2026-06-08T00:00Z -->
+<!-- generated 2026-06-08T10:15Z -->
 
 **Tickets:** 7 ready · 2 blocked — `erg ready tickets/` for full list
 **Recent commits:**
-  c8e8f01 Merge pull request #339 from MinhHaDuong/fix-balance-rule-idh
-  138534e raid: balance rule reads deliverable off the north star, not a fixed list
-  e548f55 Merge pull request #337 from MinhHaDuong/roar-followups-20260606
-  f63e0ff Merge pull request #336 from MinhHaDuong/dream-aedist-v21-leftovers
-  6077cf3 roar: file raid follow-ups 0233/0234, save staleness memory
+  a106406 Merge pull request #344 from MinhHaDuong/adopt-aedist-orphan-memory
+  b23e847 memory(aedist): adopt orphaned dream output from #336 (make-stamp-discipline)
+  d99af53 Merge pull request #343 from MinhHaDuong/feedback/verify-each-before-batch
+  c71407a memory(feedback): verify each item before a batch action
+  e29db98 Merge pull request #340 from MinhHaDuong/chore/healthcheck-unarchived-probe
 
 ## Blockers
 
@@ -24,7 +24,7 @@ A reusable, science-backed personal harness for AI-assisted research: code and p
 ## Next actions
 
 - **0216 fan-out evidence**: the next substantive PR /gaze completes 0216's criterion-2 proof (PR #334's gaze hit agents=0 on a trivial diff) — no action, just observe and append to the closed ticket
-- **0227 multi-repo wrapper sweep**: parent open; one session per repo (chemin-de-voix, git-erg, aedist, Climate-finance, cadens, fuzzy-corpus, llm-benchmarks, home-dir)
+- **0227 multi-repo wrapper sweep**: mostly done 2026-06-08 (PRs #60/#794/#783/#19; chemin-de-voix/git-erg/.claude clean; child 0230 closed). Remaining: cadens (deferred), llm-benchmarks, home-dir, aedist -docs/-experiments/-slides
 - **AEDIST maw-audit run**: unblocked (0226), author-deferred — launch from a session rooted in `~/aedist-technical-report`, no args, ~3-5M tokens; resolve untracked `census_bars.csv` first
 - **Harden 0217 seat-runner**: network isolation (drop `--network=host`), `fs/read` path-allowlist, credential denyRead, BASH_ENV-stripped minimal env — unblocks 0207
 - **0062 trigger**: re-open Firecracker isolation when IDH agents run against secret-bearing projects

--- a/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
+++ b/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
@@ -8,6 +8,7 @@ Author: claude
 
 2026-06-06T11:52Z claude note ride-along: fix ~/.claude pre-commit hook error text 'Run make build first' — binary is vendored at tickets/erg, there is no make build; refresh via erg install --hooks
 2026-06-06T13:11Z claude note split: harness-repo portion (actions 1-3, 5, hook ride-along) moved to child 0230 for the raid; this parent retains the multi-repo sweep (action 4), one PR per repo, stays open until all repos done
+2026-06-08T10:16Z claude note erg-footprint sweep executed via /scry 2026-06-08: fuzzy-corpus #60, Oeconomia-Climate-finance #794, aedist #783, padme #19 (CLAUDE.md to @tickets/AGENTS.md, deleted ticket-* skills + stale rules/tickets.md). chemin-de-voix/git-erg/.claude verified clean. Those PRs were filed Ticket:none — linking retroactively. Remaining: cadens (deferred, 149-file untracked scaffold), llm-benchmarks, home-dir, aedist -docs/-experiments/-slides
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

`/lair` end-of-session housekeeping:
- **STATE.md** — regenerate `## Status` from current git (now reflects this session's merges #340/#343/#344), bump `Last updated:`. Update the 0227 Next-action line with the 2026-06-08 erg-footprint sweep result + remaining repos.
- **Ticket 0227** — log note linking the four cleanup PRs (#60/#794/#783/#19) that executed its multi-repo wrapper sweep (filed `Ticket: none`, linked retroactively); records what's clean (chemin-de-voix/git-erg/.claude), deferred (cadens), and remaining (llm-benchmarks, home-dir, aedist sub-repos). Child 0230 already closed. Tracker stays open.

Ticket-ref: tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)