### PR TITLE
dream: consolidate padme memory (2026-06-08)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -1071,6 +1071,62 @@
       "first_seen": "2026-06-08T10:21:56Z",
       "last_confirmed": "2026-06-08T10:21:56Z",
       "promoted": false
+    },
+    "project_server_management": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
+    },
+    "padme-llm-backend-llama-server": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
+    },
+    "project_pending_reboot_kernel_635": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
+    },
+    "user_profile": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
+    },
+    "feedback_languages": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
+    },
+    "feedback_no_wrapper_skills": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
+    },
+    "feedback_worktree_stale_after_agent": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-06-08T11:08:32Z",
+      "last_confirmed": "2026-06-08T11:08:32Z",
+      "promoted": false
     }
   }
 }

--- a/projects/-home-haduong-padme/memory/MEMORY.md
+++ b/projects/-home-haduong-padme/memory/MEMORY.md
@@ -1,0 +1,17 @@
+## Key insights
+
+- padme is a layered monitoring system (L0 hardware → L4 planned rust loop) where higher levels can override lower; L3 is observe-only by design. Don't duplicate checks across levels.
+- Deployment is via `/usr/local/bin` symlinks into the **main checkout working tree** — a merge isn't live until `git pull` runs in `/home/haduong/padme`, and if the primary is on a feature branch the cutover is gated on syncing it.
+- Local LLM inference is **llama-server** (llama.cpp), not ollama: reasoning models (Qwen3) need `enable_thinking=false`, ollama GGUF blobs aren't llama.cpp-loadable, and llama-server 400s on context overflow where ollama silently truncated.
+- The user is a KISS homelab sysadmin: bash for system scripts, python for LLM glue, rust for high-frequency infra; uv/apt only; don't wrap self-documenting CLIs in skills.
+- Verify via `git show`/`git -C`, not the working tree, after worktree/isolation agents; long-running GPU/server processes need systemd (Bash-spawned ones get SIGTERM'd when the call returns).
+
+## Entries
+
+- [Server management](project_server_management.md) — padme monitoring architecture: bash L2, python L3, rust L4 planned
+- [LLM backend: llama-server](padme-llm-backend-llama-server.md) — local inference is llama-server (llama.cpp) :8080 serving Qwen3.6-35B-A3B; ollama removed (0010); config + gotchas
+- [Pending reboot: kernel 6.17.0-35](project_pending_reboot_kernel_635.md) — installed 2026-06-06, reboot pending; post-reboot checks + re-hold kernel metas (TTL 2026-06-20)
+- [User profile](user_profile.md) — senior researcher, homelab sysadmin, KISS philosophy, prefers uv/apt-only
+- [Language preferences](feedback_languages.md) — bash for system scripts, python for LLM integration, rust for high-frequency infra
+- [No wrapper skills](feedback_no_wrapper_skills.md) — don't wrap self-documenting CLIs in skills; CLAUDE.md instructions + direct invocation
+- [Worktree stale after agent](feedback_worktree_stale_after_agent.md) — verify via git show, not working tree, after isolation:worktree agents rename files

--- a/projects/-home-haduong-padme/memory/feedback_languages.md
+++ b/projects/-home-haduong-padme/memory/feedback_languages.md
@@ -1,0 +1,10 @@
+---
+name: language preferences per domain
+description: bash for system scripts, python for LLM/API integration, rust for high-frequency infra
+type: feedback
+originSessionId: 373c4915-d420-4c58-8931-74f68c620ede
+---
+Use bash for mechanistic system scripts (monitoring, backups). Use python for LLM integration (JSON encoding of arbitrary text is fragile in bash). Rust planned for high-frequency infrastructure loops.
+
+**Why:** Bash JSON encoding broke on multilingual text with special chars. User confirmed python acceptable for daily LLM agent. User wants rust for the high-frequency conscious loop (startup time, performance).
+**How to apply:** Don't write LLM API calls in bash. For new system scripts, bash is fine. For anything touching LLM APIs or complex data, use python.

--- a/projects/-home-haduong-padme/memory/feedback_no_sudo.md
+++ b/projects/-home-haduong-padme/memory/feedback_no_sudo.md
@@ -1,0 +1,11 @@
+---
+name: No sudo — ask the user
+description: Never run sudo commands; ask the user to run them and paste output.
+type: feedback
+originSessionId: bac3c7fd-350c-4179-9b07-72ad2c7e85b5
+---
+Ne jamais invoquer `sudo` directement. Si une opération requiert root (lire `/etc/snapper/configs/*`, `btrfs quota`, éditer `/etc/cron.d/`, etc.), demander à l'utilisateur d'exécuter la commande et de coller la sortie.
+
+**Why:** l'utilisateur a explicitement rejeté un `sudo -n` et corrigé "You cannot sudo. Ask me." — il garde le contrôle des actions privilégiées.
+
+**How to apply:** avant toute commande nécessitant root, soit proposer la commande exacte à l'utilisateur (`! sudo ...` pour qu'il la lance dans la session), soit demander la sortie. Les lectures de fichiers sous `/etc/` ou `/root/` qui échouent en non-root tombent sous cette règle.

--- a/projects/-home-haduong-padme/memory/feedback_no_wrapper_skills.md
+++ b/projects/-home-haduong-padme/memory/feedback_no_wrapper_skills.md
@@ -1,0 +1,14 @@
+---
+name: no-wrapper-skills-for-cli-tools
+description: "Don't create/keep skills that merely wrap a self-documenting CLI — instructions in CLAUDE.md suffice for the model to call the tool directly"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 327d71bf-21b9-4042-9f61-6851340154c2
+---
+
+When a skill would be a thin delegation to a self-documenting CLI (e.g. `tickets/erg` with `--help --all`), the user wants NO skill at all: a few lines in CLAUDE.md naming the direct invocations is the whole interface. Stated 2026-06-06 after PR #6 rewrote three ticket wrapper skills that PR #7 then deleted ("/ticket-new, /ticket-ready, /ticket-close should not exist at all. Our instructions should be sufficient so that the smart model do erg new, erg ready and erg close.").
+
+**Why:** KISS — a wrapper skill adds an indirection layer to maintain (it drifted badly once: v1-era skills survived two format generations), and the model reads `--help` as easily as skill text.
+
+**How to apply:** Before writing or rewriting a skill, ask: does it add logic beyond invoking one tool? If not, document the direct invocation in CLAUDE.md instead, and propose deleting any existing wrapper. Skills are for multi-step orchestration, not command aliasing. See [[padme monitoring architecture]] for the user's broader KISS stance.

--- a/projects/-home-haduong-padme/memory/feedback_worktree_stale_after_agent.md
+++ b/projects/-home-haduong-padme/memory/feedback_worktree_stale_after_agent.md
@@ -1,0 +1,14 @@
+---
+name: feedback-worktree-stale-after-agent
+description: "After an isolation:worktree agent pushes, the parent worktree's working tree has phantom old-name files — exit and re-enter instead of manual cleanup"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d376c398-65f4-4a0d-8b7f-0ed9717b3dbd
+---
+
+When an `Agent(isolation: "worktree")` renames files and pushes to a shared branch, the parent worktree retains the old-name files on disk. `git checkout -- .` restores tracked content but doesn't clean up untracked old names; `git clean` is guarded.
+
+**Why:** The agent works in its own worktree copy; `git mv` renames happen there, not in the parent. The parent's working tree becomes stale relative to the branch HEAD it shares.
+
+**How to apply:** After a worktree-isolated agent finishes a rename-heavy operation, don't try to sync the parent worktree manually. Either (a) verify via `git show`/`git grep` on the committed tree, or (b) exit the worktree and re-enter to get a fresh checkout.

--- a/projects/-home-haduong-padme/memory/padme-llm-backend-llama-server.md
+++ b/projects/-home-haduong-padme/memory/padme-llm-backend-llama-server.md
@@ -1,0 +1,22 @@
+---
+name: padme-llm-backend-llama-server
+description: "padme local LLM backend is llama-server (llama.cpp) on :8080, not ollama — config + migration gotchas"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 9c170357-d13b-4620-ba42-63123659fb6a
+---
+
+The local LLM backend is **llama-server** (llama.cpp), serving an
+OpenAI-compatible API. ollama was fully removed in ticket 0010 (2026-06-08).
+
+**Config:**
+- systemd unit `tools/llama-server.service` (symlinked into `/etc/systemd/system/`, so a `git pull` in the main checkout updates it). Runs as `User=haduong` — home is `0750` so a service user can't reach the `~/llama.cpp` binary, and `/dev/nvidia*` is world-accessible so no `video`/`render` group is needed.
+- Serves **Qwen3.6-35B-A3B** (`/data/models/gguf/qwen/`), port **8080**, `--ctx-size 16384`, `--tensor-split 16,12 --n-gpu-layers 999` across A4000 (16 GB) + 3060 (12 GB). GGUF cache lives under `/data/models/gguf/` (qwen, devstral).
+- Binary built with CUDA at `~/llama.cpp/build/bin` (build 9125). Consumer: L3 `reflect-monitoring-history.py` — endpoint/model via `PADME_LLM_URL`/`PADME_REFLECT_MODEL`/`PADME_LLM_CTX`. See [[padme monitoring architecture]].
+
+**Gotchas that cost time (verify before re-tripping):**
+1. **ollama GGUF blobs are NOT loadable by llama.cpp** — gemma4's blob failed `wrong number of tensors; expected 1014, got 658`. ollama uses its own internal layout. Migrate from a clean HF GGUF in the cache, not the ollama blob store.
+2. **Qwen3 is a reasoning model** — without `chat_template_kwargs:{enable_thinking:false}`, llama-server routes the chain-of-thought into `reasoning_content` and returns **empty `content`** (the token budget is spent thinking). The `/no_think` soft switch does NOT work for it.
+3. **llama-server 400s on context overflow** where ollama silently truncated. The L3 agent runs as root and builds a ~10k-token prompt from full dmesg/journalctl; size `--ctx-size` accordingly.
+4. **Harness:** long-running GPU/server processes spawned from a Bash call get SIGTERM'd (exit 144) when the call returns — even `run_in_background`. Use **systemd** for a persistent server; use `llama-cli` one-shot (`-no-cnv -n N -p ...`) for load/compat tests.

--- a/projects/-home-haduong-padme/memory/project_pending_reboot_kernel_635.md
+++ b/projects/-home-haduong-padme/memory/project_pending_reboot_kernel_635.md
@@ -1,0 +1,40 @@
+---
+name: project-pending-reboot-kernel-635
+description: "Kernel 6.17.0-35 installed 2026-06-06, reboot pending; post-reboot checklist and re-hold commands"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: e0805b18-2519-4e53-8939-4f2db85f8a94
+---
+
+Kernel upgrade 6.17.0-29 → 6.17.0-35 (noble-security) installed on padme on
+2026-06-06 via the manual procedure in `main-logbook.md` §I (snapper snapshot
+`pre-upgrade-6.17.0-35` taken). **Reboot pending** — user will reboot later.
+TTL: file a ticket or delete if not done by 2026-06-20.
+
+**Post-reboot checklist:**
+1. `uname -r` → expect `6.17.0-35-generic`
+2. `nvidia-smi` → driver 580.159.04, both GPUs visible (RTX A4000 + RTX 3060)
+3. `systemctl status fan2go` — came back cleanly
+4. Re-hold the packages unheld for this upgrade:
+   ```
+   sudo apt-mark hold linux-generic-hwe-24.04 linux-headers-generic-hwe-24.04 \
+     linux-image-generic-hwe-24.04 linux-modules-nvidia-580-generic-hwe-24.04
+   ```
+5. Only after all checks pass: `apt autoremove --dry-run` and review before any
+   real autoremove (mid-transaction apt falsely listed the new -35 NVIDIA
+   modules as removable).
+
+**Do not touch:** CUDA-repo userland packages (`nvidia-modprobe`,
+`nvidia-settings`, `nvidia-persistenced`, `libxnvctrl0/-dev`) stay held at 595
+— the offered 610 is two branches ahead of the running 580 driver, no benefit.
+The held-back 595→610 daily "updates could not be installed" nag is **accepted
+as expected friction** (Option 1, decided 2026-06-08): the 26.04 LTS upgrade is
+imminent and retires the whole 580-pin scheme, so uniform-580 downgrade churn
+would be throwaway.
+
+The post-reboot re-hold (step 4) is now tracked by **ticket 0019** (child of
+tracker 0009); 0019 stays open until done on the host. Closing this reboot also
+closes 0019.
+
+Related: [[project-server-management]]

--- a/projects/-home-haduong-padme/memory/project_server_management.md
+++ b/projects/-home-haduong-padme/memory/project_server_management.md
@@ -1,0 +1,16 @@
+---
+name: padme monitoring architecture
+description: Multi-level monitoring stack — bash mechanistic, python reflective (llama-server), rust conscious loop planned
+type: project
+originSessionId: 373c4915-d420-4c58-8931-74f68c620ede
+---
+padme has a layered monitoring architecture:
+- **Level 0-1**: Hardware/OS (BIOS, systemd, btrfs, fan2go)
+- **Level 2**: Mechanistic bash scripts (check-resources.sh daily, quarterly-check.sh, backup-restic.sh). Threshold-based, no reasoning.
+- **Level 3**: Reflective python agent (reflect-monitoring-history.py, daily 07:30). Feeds L2 history to local **llama-server** (Qwen3.6-35B-A3B, OpenAI `/v1/chat/completions` on :8080), reasons about trends/correlations. Read-only, never acts. Migrated off Ollama in ticket 0010 (2026-06-08); see [[padme-llm-backend-llama-server]].
+- **Level 4**: High-frequency conscious loop in Rust — planned, not yet implemented. Higher-order reasoning/override capability.
+
+**Why:** Higher levels CAN override lower — cybernetics principle user explicitly endorsed. L3 currently observe-only by design (cautious start).
+**How to apply:** When discussing monitoring, respect the layered architecture. Don't duplicate checks across levels.
+
+Deployment model (verified 2026-06-06): L2 scripts run from `/usr/local/bin/*.sh` symlinks pointing at the **main checkout working tree** (`/home/haduong/padme/tools/`). A merged fix is NOT live until `git pull` runs in `/home/haduong/padme`. Desktop alerts come from `desktop-monitor-notify.sh` via XDG autostart at login (not a timer). Bash checks carry their own smoke tests: `check-resources.sh --smoke-test`, plus the stdin hook in `btrfs_chunk_check` — extend these rather than testing in throwaway shell sessions ([[padme-monitoring-fails-loud]] incident, ticket 0014).

--- a/projects/-home-haduong-padme/memory/user_profile.md
+++ b/projects/-home-haduong-padme/memory/user_profile.md
@@ -1,0 +1,15 @@
+---
+name: user profile
+description: Senior researcher running AI homelab, strong opinions on KISS, systems theory, package management
+type: user
+originSessionId: 373c4915-d420-4c58-8931-74f68c620ede
+---
+- Senior researcher (energy/climate domain, Vietnamese context)
+- Runs padme as personal AI homelab (ThinkStation P620, 2 GPUs)
+- Strong KISS philosophy — "toute complexité doit avoir un ROI clair et immédiat"
+- Prefers apt-only for system packages, no third-party repos unless unavoidable
+- Python via uv exclusively (no pip, no conda)
+- Bilingual French/English in docs and logs
+- Systems theory background — understands cybernetics, hierarchical control, higher levels overriding lower
+- Does NOT want Claude to sudo — guide instead
+- Expects intervention-log.txt and main-logbook.md updated after significant changes


### PR DESCRIPTION
Memory consolidation from the padme ollama→llama-server session: updated monitoring-architecture memory off ollama, added padme-llm-backend-llama-server memory (config + 4 gotchas), regenerated MEMORY.md with 5 insights. 7 entries NOOP; no promotions/decay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)