### PR TITLE
ticket(0227): decompose into tracker + file children 0235/0236

### DIFF
--- a/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
+++ b/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
@@ -9,6 +9,7 @@ Author: claude
 2026-06-06T11:52Z claude note ride-along: fix ~/.claude pre-commit hook error text 'Run make build first' — binary is vendored at tickets/erg, there is no make build; refresh via erg install --hooks
 2026-06-06T13:11Z claude note split: harness-repo portion (actions 1-3, 5, hook ride-along) moved to child 0230 for the raid; this parent retains the multi-repo sweep (action 4), one PR per repo, stays open until all repos done
 2026-06-08T10:16Z claude note erg-footprint sweep executed via /scry 2026-06-08: fuzzy-corpus #60, Oeconomia-Climate-finance #794, aedist #783, padme #19 (CLAUDE.md to @tickets/AGENTS.md, deleted ticket-* skills + stale rules/tickets.md). chemin-de-voix/git-erg/.claude verified clean. Those PRs were filed Ticket:none — linking retroactively. Remaining: cadens (deferred, 149-file untracked scaffold), llm-benchmarks, home-dir, aedist -docs/-experiments/-slides
+2026-06-08T12:43Z claude note decomposed into a tracking ticket: remaining-repo sweep → child 0235, cadens (deferred) → child 0236. This ticket stays open until both children close. Body restructured as a tracker.
 --- body ---
 ## Context
 
@@ -24,26 +25,48 @@ The wrapper test: does the skill add logic beyond invoking one tool?
 If not, it is command aliasing — replace with an instruction line and
 delete. Skills are for multi-step orchestration only.
 
-## Actions
+## Tracker
 
-(Harness-repo portion — skill audit, wrapper deletion, reference fixes,
-catalog regen, pre-commit hook ride-along — split to child [[0230]].)
+This is a **tracking ticket** (rules/workflow.md § tracking-ticket
+convention). The actual sweeps land as per-repo PRs in their own repos
+(agents are session-bound); this ticket stays open until every repo below
+is resolved and both children close. The wrapper test: does the skill add
+logic beyond invoking one tool? If not, it is command aliasing — replace
+with an instruction line and delete.
 
-1. Sweep every repo on padme for project-level wrapper skills and
-   v1-era ticket residue (`.claude/skills/ticket-*`, `%erg v1`,
-   `Status:` mutation guidance, `tickets/tools/go`): padme (already
-   clean, PRs #5–#7), chemin-de-voix, git-erg, aedist-technical-report
-   (+ -docs, -experiments, -slides), Climate-finance,
-   Oeconomia-Climate-finance, cadens, fuzzy-corpus, llm-benchmarks,
-   and the home-dir repo. One branch+PR per affected repo, run from a
-   session in that repo (agents are session-bound).
+Children:
+- [[0230]] — harness repo (skill audit, wrapper deletion, catalog, hook). CLOSED.
+- [[0235]] — remaining repos: llm-benchmarks, home-dir, aedist-docs/-experiments/-slides. OPEN.
+- [[0236]] — cadens (deferred; blocked on 149-file untracked scaffold). OPEN.
+
+Per-repo status:
+
+| Repo | Status |
+|------|--------|
+| padme | done (PRs #5–#7) |
+| fuzzy-corpus | done (#60) |
+| Oeconomia-Climate-finance | done (#794) |
+| aedist-technical-report | done (#783) |
+| chemin-de-voix | clean |
+| git-erg | clean |
+| .claude (harness) | done (child 0230) |
+| llm-benchmarks | pending → 0235 |
+| home-dir | pending → 0235 |
+| aedist-docs | pending → 0235 |
+| aedist-experiments | pending → 0235 |
+| aedist-slides | pending → 0235 |
+| cadens | deferred → 0236 |
+| Climate-finance | not yet assessed (assess under 0235) |
 
 ## Test
 
-For each swept project repo: grep transcript showing zero hits for the
-residue patterns.
+For each swept repo: grep transcript showing zero hits for the residue
+patterns (`.claude/skills/ticket-*`, `%erg v1`, `Status:` mutation
+guidance, `tickets/tools/go`), or a merged removal PR.
 
 ## Exit criteria
 
-- [ ] Child [[0230]] (harness repo) closed
-- [ ] Every padme repo swept; residue removed or justified in ticket log
+- [x] Child [[0230]] (harness repo) closed
+- [ ] Child [[0235]] (remaining repos) closed
+- [ ] Child [[0236]] (cadens) closed
+- [ ] Every padme repo in the table above resolved (done / clean / justified)

--- a/tickets/0235-sweep-remaining-padme-repos-for-wrapper.erg
+++ b/tickets/0235-sweep-remaining-padme-repos-for-wrapper.erg
@@ -1,0 +1,70 @@
+%erg 0.1
+Title: Sweep remaining padme repos for wrapper-skill and v1-ticket residue
+Created: 2026-06-08
+Author: Integration Test
+
+--- log ---
+2026-06-08T12:42Z Integration Test created
+
+--- body ---
+## Context
+
+Child of tracker [[0227]] (delete thin CLI-wrapper skills; sweep all
+padme repos for residue). The 2026-06-08 `/scry` pass swept fuzzy-corpus
+(#60), Oeconomia-Climate-finance (#794), aedist (#783), and padme (#19),
+and verified chemin-de-voix / git-erg / .claude clean. This child carries
+the repos that pass did NOT reach: **llm-benchmarks**, the **home-dir**
+repo, the three aedist siblings **aedist-docs**, **aedist-experiments**,
+**aedist-slides**, and **Climate-finance** (distinct from the already-swept
+Oeconomia-Climate-finance #794 — assess whether it is a separate repo or an
+alias, then sweep or fold). (cadens is split to deferred child [[0236]].)
+
+The wrapper test (author's call, 2026-06-06): a skill that only delegates
+to a self-documenting CLI is command-aliasing — replace with an instruction
+line and delete. Skills are for multi-step orchestration only.
+
+## Relevant files (per swept repo)
+
+- `.claude/skills/ticket-*` — v1-era wrapper skills to delete
+- `CLAUDE.md` — should reduce to `@tickets/AGENTS.md` (canonical adopter shape)
+- `rules/tickets.md` / stale `tickets/tools/go` — pre-0013 footprints to remove
+
+## Actions
+
+Agents are session-bound — run one session **rooted in each target repo**
+(or one `/scry` multi-repo pass, the precedent mechanism). For each repo:
+
+1. Grep for residue patterns: `.claude/skills/ticket-*`, `%erg v1`,
+   `Status:` mutation guidance, `tickets/tools/go`.
+2. If clean: log "verified clean" in this ticket and move on (no PR needed).
+3. If residue: one branch + PR **in that repo** removing it
+   (`CLAUDE.md` → `@tickets/AGENTS.md`, delete `ticket-*` skills, drop stale
+   `rules/tickets.md`). Those repos may lack an 0235 ticket, so the PR is
+   `Ticket: none`; record the PR number + verdict back in this ticket's log.
+
+## Test
+
+For each repo: a transcript grep showing zero hits for the residue patterns
+(clean), or a merged PR removing them.
+
+## Verification
+
+- [ ] llm-benchmarks swept (clean or PR)
+- [ ] home-dir repo swept (clean or PR)
+- [ ] aedist-docs swept (clean or PR)
+- [ ] aedist-experiments swept (clean or PR)
+- [ ] aedist-slides swept (clean or PR)
+- [ ] Climate-finance assessed (separate repo → swept; or alias → folded)
+
+## Invariants
+
+- Deleting a wrapper skill must not orphan a reference: sweep the repo for
+  callers of the deleted skill in the same PR (rename/refactor sweeps cover
+  the full logical unit).
+- Each repo's own `make check` / CI stays green.
+
+## Exit criteria
+
+- All five repos above swept; residue removed via per-repo PR or justified
+  "clean" in this log.
+- Tracker [[0227]] updated as each repo lands.

--- a/tickets/0236-sweep-cadens-for-wrapper-skill-and-v1-ti.erg
+++ b/tickets/0236-sweep-cadens-for-wrapper-skill-and-v1-ti.erg
@@ -1,0 +1,37 @@
+%erg 0.1
+Title: Sweep cadens for wrapper-skill and v1-ticket residue
+Created: 2026-06-08
+Author: Integration Test
+Label: deferred
+
+--- log ---
+2026-06-08T12:42Z Integration Test created
+
+--- body ---
+## Context
+
+Child of tracker [[0227]], split out as **deferred**. cadens was held back
+from the 2026-06-08 `/scry` sweep because it carries a **149-file untracked
+scaffold** (recorded in 0227's log): a residue grep there is unreliable and
+a sweep PR risks entangling the scaffold. The wrapper/v1 sweep is the same
+as sibling child [[0235]], but cadens needs its working tree resolved first.
+
+## Blocker
+
+The untracked 149-file scaffold must be committed, gitignored, or removed
+so the repo has a clean baseline before the sweep. This is the author's
+call — cadens's scaffold intent is not derivable from this repo.
+
+## Actions
+
+1. Resolve the untracked scaffold (commit / gitignore / remove — author decides).
+2. Then run the standard residue sweep from a session rooted in cadens:
+   grep `.claude/skills/ticket-*`, `%erg v1`, `Status:` mutation guidance,
+   `tickets/tools/go`; remove via PR or justify clean.
+3. Record the outcome in tracker [[0227]].
+
+## Exit criteria
+
+- cadens scaffold baseline resolved.
+- cadens swept; residue removed via PR or justified clean.
+- Tracker [[0227]] updated.


### PR DESCRIPTION
Restructures ticket 0227 (delete thin CLI-wrapper skills; multi-repo residue sweep) as a **tracking ticket**, and files its remaining work as handoff children.

## Why
0227's remaining work is entirely in *other* repos (cadens, llm-benchmarks, home-dir, aedist-docs/-experiments/-slides, Climate-finance). Agents are session-bound, so it cannot be completed from this checkout — and its exit criterion is "every repo swept," not "work delegated." Closing it on the strength of filed downstream tickets would be a rubber-stamp. Per `rules/workflow.md` § tracking-ticket convention, the honest shape is: keep 0227 open as a tracker, file children, close the tracker only when the children land.

## What
- **0227** → rewritten as a tracker: per-repo status table + child list; stays open.
- **0235** (new) → handoff ticket for the remaining sweepable repos (llm-benchmarks, home-dir, aedist trio) plus a Climate-finance assess-or-fold step. One per-repo PR each (`Ticket: none` in those repos), logged back to 0227.
- **0236** (new, `Label: deferred`) → cadens, blocked on its 149-file untracked scaffold (needs an author baseline decision before a residue grep is reliable).

## Scope
Ticket-admin only — no skill/code changes. This PR closes nothing; the tracker and both children all stay open.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)