### PR TITLE
ticket(0227): close — all repos resolved, cadens adopted canonically

### DIFF
--- a/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
+++ b/tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
@@ -12,6 +12,7 @@ Author: claude
 2026-06-08T12:43Z claude note decomposed into a tracking ticket: remaining-repo sweep → child 0235, cadens (deferred) → child 0236. This ticket stays open until both children close. Body restructured as a tracker.
 2026-06-08T13:05Z claude note reversed the 0235/0236 split (author call): those children described work in OTHER repos but lived in IDH's store, where the destination-repo session never looks. Per AGENTS.md tickets are per-repo; cross-repo work is filed in the destination repo (or a forge issue), not parked here. Removed 0235/0236; folded the remaining-repo sweep back into a self-contained per-repo checklist above. The actionable per-repo ticket, when a substantive change is needed, is created in that repo at sweep time.
 2026-06-08T13:20Z claude note read-only residue recon of the remaining repos: llm_benchmarks clean (no erg), Climate_finance clean for this scope (no wrapper skills; one v1 closed ticket only). home-dir + aedist -docs/-experiments/-slides do not exist on this machine (over-enumerated). cadens is the lone residue, but it is UNTRACKED/local-only on cadens main (half-applied adoption scaffold) — the 149-file deferral is stale; remaining work is an author decision on cadens's adoption shape, not a mechanical sweep. Checklist updated accordingly.
+2026-06-08T14:05Z claude note cadens adopted canonically (author go-ahead): removed the untracked wrapper scaffold and wired CLAUDE.md to @tickets/AGENTS.md (cadens PR #45, merged). All checklist repos now resolved — closing 0227.
 --- body ---
 ## Context
 
@@ -57,7 +58,7 @@ Per-repo checklist:
 | Climate_finance | [x] clean — no wrapper skills / tools-go / rules-tickets; CLAUDE.md→@AGENTS.md (root + tickets/AGENTS.md both present, valid variant); one %erg v1 *closed* ticket (cosmetic, optional `erg migrate`) |
 | home-dir repo | [x] n/a — no such repo on this machine |
 | aedist-docs / -experiments / -slides | [x] n/a — no such repos here; only aedist-technical-report exists (swept #783) |
-| cadens | [ ] **author decision** — residue (.claude/skills/ticket-{close,new,ready}, rules/tickets.md, CLAUDE.md) is UNTRACKED/local-only on cadens main, not committed: a half-applied adoption scaffold. The "149-file" deferral is stale. Decide: drop the untracked wrappers (no PR), or adopt canonically (commit .claude with CLAUDE.md=@tickets/AGENTS.md, no wrapper skills). |
+| cadens | [x] done — adopted canonically. Untracked wrapper scaffold (.claude/skills/ticket-*, rules/tickets.md, stale .claude/CLAUDE.md) removed; CLAUDE.md wired to @tickets/AGENTS.md (cadens PR #45). It already ran the canonical store (%erg 0.1, vendored binary). |
 
 ## Test
 
@@ -68,4 +69,4 @@ patterns above, or a merged removal PR in that repo. Record the outcome
 ## Exit criteria
 
 - [x] Harness-repo child [[0230]] closed
-- [ ] Every repo in the checklist above resolved (done / clean / justified)
+- [x] Every repo in the checklist above resolved (done / clean / justified)

--- a/tickets/closed/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
+++ b/tickets/closed/0227-delete-thin-cli-wrapper-skills-sweep-all.erg
@@ -2,6 +2,7 @@
 Title: Delete thin CLI-wrapper skills; sweep all padme repos for residue
 Created: 2026-06-06
 Author: claude
+Closed: autoclosed — PR #355
 
 --- log ---
 2026-06-06T11:43Z claude created
@@ -13,6 +14,7 @@ Author: claude
 2026-06-08T13:05Z claude note reversed the 0235/0236 split (author call): those children described work in OTHER repos but lived in IDH's store, where the destination-repo session never looks. Per AGENTS.md tickets are per-repo; cross-repo work is filed in the destination repo (or a forge issue), not parked here. Removed 0235/0236; folded the remaining-repo sweep back into a self-contained per-repo checklist above. The actionable per-repo ticket, when a substantive change is needed, is created in that repo at sweep time.
 2026-06-08T13:20Z claude note read-only residue recon of the remaining repos: llm_benchmarks clean (no erg), Climate_finance clean for this scope (no wrapper skills; one v1 closed ticket only). home-dir + aedist -docs/-experiments/-slides do not exist on this machine (over-enumerated). cadens is the lone residue, but it is UNTRACKED/local-only on cadens main (half-applied adoption scaffold) — the 149-file deferral is stale; remaining work is an author decision on cadens's adoption shape, not a mechanical sweep. Checklist updated accordingly.
 2026-06-08T14:05Z claude note cadens adopted canonically (author go-ahead): removed the untracked wrapper scaffold and wired CLAUDE.md to @tickets/AGENTS.md (cadens PR #45, merged). All checklist repos now resolved — closing 0227.
+2026-06-08T13:24Z Integration Test closed — autoclosed — PR #355
 --- body ---
 ## Context
 


### PR DESCRIPTION
Closes the 0227 campaign tracker. cadens — its last open item — is now canonical.

## cadens, resolved (author go-ahead)
- Removed the untracked, never-committed old-pattern scaffold: wrapper skills `ticket-{close,new,ready}`, `rules/tickets.md`, and a stale `.claude/CLAUDE.md` whose "`%erg v1` … no CLI needed" text contradicted the vendored binary.
- Wired root `CLAUDE.md` → `@tickets/AGENTS.md` (**cadens PR #45, merged**), preserving its number-precision conventions.
- It already ran the canonical store (`%erg 0.1`, vendored `tickets/erg`, `tickets/AGENTS.md`).

## Whole checklist now resolved
padme, fuzzy-corpus, Oeconomia-Climate-finance, aedist-technical-report, chemin-de-voix, git-erg, .claude (child 0230), **llm_benchmarks** (clean), **Climate_finance** (clean), **cadens** (done). home-dir + aedist -docs/-experiments/-slides don't exist on this machine (over-enumerated).

**Ticket:** tickets/0227-delete-thin-cli-wrapper-skills-sweep-all.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)