### PR TITLE
rules: raise concurrent-agent cap 4 → 8 (authorized 2026-06-08)

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -78,7 +78,7 @@ misdiagnosed as a "broken toolchain" and nearly got a spurious reinstall ticket.
 - **Don't spawn for simple tasks.** Single-file edits, grep, reading files — work directly.
 - **Reviewers use a different model than the coder.** Sonnet reviews Opus's work; different blind spots catch more.
 - **Pin `model` per-invocation on every fan-out launch — frontmatter does not propagate.** A skill's `model:` frontmatter never reaches the agents it spawns (an Agent-tool child resolves to the session model; a Workflow `agent()` inherits it), so for fan-out it is decorative. Set `model` on each launch: reviewers below the coder tier, mechanical lookups at `haiku`, coders at the top tier. Use the short enum token (`sonnet|opus|haiku|fable`) on a launch — a full `claude-*` id is valid only in frontmatter. `effort` is **not** a launch parameter: a spawned child runs at the *session* effort, not pinnable per-call (set the session effort before a fan-out). Enforced by `tests/test_model_rightsizing.py`; mechanics in memory `feedback_subagent_model_effort_levers`.
-- **Max 4 concurrent agents.** Beyond that, coordination overhead exceeds the gains.
+- **Max 8 concurrent agents** (authorized 2026-06-08). Beyond that, coordination overhead exceeds the gains. Keep watch: when 3+ agents touch the same file or registry, open a coordination PR first (see Phase 5.0 in raid skill).
 - **One well-prompted agent first.** Only add agents when a single agent clearly can't handle the task.
 
 # Ticket discipline for multi-PR work


### PR DESCRIPTION
## What

Updates `rules/workflow.md` § Subagents: **Max 4 concurrent agents → Max 8 (authorized 2026-06-08)**, with the "3+ agents on the same file → coordination PR first" caution.

## Why

`origin/main` said "Max 4", but the live `~/.claude` working tree has run every session with **"Max 8 concurrent agents (authorized 2026-06-08)"** — present in **no commit anywhere**, sitting as a dangling uncommitted edit on the primary checkout's `dream-consolidate-2026-06-09` branch. The 8-cap was authoritative in practice (injected into every session) but one `git checkout` from loss. This lands it durably so main matches reality. Text is byte-identical to the live working-tree line.

## Follow-up for the human

The primary checkout still has this as an uncommitted edit on the `dream-consolidate` branch. Once this merges and that checkout's main catches up, discard the now-redundant working-tree edit (`git checkout -- rules/workflow.md` on the primary) so it can't accidentally ride into the dream PR.

Docs-only; `make check` clean.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)