### PR TITLE
tickets(trace-doctor): session-trace economics audit — tracker 0236 + census child 0237

### DIFF
--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -10,20 +10,32 @@ Author: claude
 ## Context
 
 A spot analysis of one live raid wave in aedist-technical-report (session
-96516ff3, 2026-06-10) measured ~$234 for a single wave, with this cost
-profile across 15 agents:
+96516ff3, 2026-06-10) measured this cost profile across 16 agent traces
+(deduped by message id, all-Opus pricing — an UPPER bound, since ~20% of
+messages were actually Sonnet):
 
-| Category     | Tokens | ~$  |
-|--------------|--------|-----|
-| cache_read   | 77.5 M | 116 |
-| cache_write  | 4.6 M  | 86  |
-| output       | 399 K  | 30  |
-| fresh input  | 136 K  | 2   |
+| Category     | Tokens | ~$ (upper) |
+|--------------|--------|------------|
+| cache_read   | 57.5 M | 86         |
+| cache_write  | 2.4 M  | 45         |
+| output       | 264 K  | 20         |
+| fresh input  | 74 K   | 1          |
+
+Total ~$152 upper bound, plausibly ~$130-140 with the real model mix.
+METHOD WARNING (found by skeptical review of this very ticket, the
+first version of which claimed $234): one assistant message spans
+multiple JSONL rows — one per content block — each repeating the same
+`message.usage` object. Summing usage per ROW overstates ~2.7x (248
+usage rows vs 96 unique message ids in the main trace). Any accounting
+MUST dedupe by `message.id`. This bug is now a mandatory fixture case
+in 0237.
 
 Suspected waste patterns (all N=1, hence this ticket): cache_read grows
 ~quadratically with agent turn count; a READ-ONLY recon agent drifted to
-113 turns / ~$9; /gaze cost appears independent of diff size; per-agent
-prompt preambles re-cache-write the same project context.
+113 turns; /gaze cost appears independent of diff size; per-agent
+prompt preambles re-cache-write the same project context. (Per-agent $
+figures from the first analysis pass are tainted by the row-vs-message
+bug above; rankings likely survive, magnitudes do not.)
 
 N=1 is not evidence. The author directed a systematic study — "like
 skill-doctor, but bigger": census the traces, derive empirical

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -35,27 +35,50 @@ Corpus available (verified 2026-06-10): ~2,305 session JSONL traces,
 `~/.claude/projects/`. Small enough for a full census in the
 deterministic pass; sampling is reserved for LLM-judged phases.
 
-## Study design (four phases, each a child ticket)
+## Study design (five phases, each a child ticket)
 
 1. **Census** (child: 0237) — pure-Python `scripts/trace-stats.py`, one
    row per agent with cost, shape, and waste-signature detectors. Zero
    LLM tokens. First report over the 28-day corpus.
-2. **Hypothesis testing** — turn the N=1 findings into statistics over
-   the census output: H1 cache_read dominates $; H2 cost ~ turns²; H3
+2. **Hypothesis DISCOVERY** — we cannot confirm what we never looked
+   for, and the seed hypotheses come from N=1. Two instruments:
+   a. *Mechanical anomaly mining* (zero tokens, extends the census):
+      Pareto analysis ($ concentration: which 5% of agents take 50% of
+      spend); residuals after fitting cost ~ f(turns) — agents far off
+      the curve are unexplained patterns; clustering agents by
+      tool-histogram + shape; cost per merged-PR-line joined via the
+      forge CLI; flag any distribution the census shows as bimodal or
+      heavy-tailed.
+   b. *LLM open-coding of a stratified random sample*: sample traces by
+      project x entry-skill x cost-decile — including the CHEAP deciles
+      (frugal sessions show what good looks like) — and have a
+      cheap-model reader narrate per trace "where did tokens go, what
+      was avoidably spent, what context was carried but never used".
+      Cluster the narratives into candidate waste patterns
+      (grounded-theory open coding -> axial coding), like skill-doctor
+      clusters failures. Output: a hypothesis list H1..Hn where H1-H5
+      below are merely seeds.
+3. **Hypothesis testing** — turn the discovered + seeded hypotheses
+   into statistics over the census output. Seeds from the N=1 spot
+   analysis: H1 cache_read dominates $; H2 cost ~ turns²; H3
    read-only agents drift past any reasonable budget; H4 gaze cost is
    independent of diff size (join to PR diff stats via the forge CLI);
    H5 duplicate prompt-preamble cache_writes across sibling agents are
-   material. Output: recommendations ranked by measured $/week saving,
-   plus a quality baseline (trace -> PR outcome join: merged / REROLL /
-   ESCALATE).
-3. **Counterfactual accounting** — for each recommendation, compute the
+   material. Discovered hypotheses get the same treatment: a measurable
+   statistic, tested on the FULL census (the discovery sample is
+   tainted for confirmation — discover on the sample, confirm on the
+   census, or split the corpus if a discovered pattern needs LLM
+   reading to measure). Output: recommendations ranked by measured
+   $/week saving, plus a quality baseline (trace -> PR outcome join:
+   merged / REROLL / ESCALATE).
+4. **Counterfactual accounting** — for each recommendation, compute the
    saving from existing traces before re-running anything. E.g. "cap
    recon at N turns": truncate the trace at turn N and have a cheap
    model judge whether the final report was already derivable. "Skip
    full gaze on trivial diffs": count gaze runs on small prose diffs
    that APPROVED with zero findings. Filters the list to the 1-2
    measures accounting cannot settle.
-4. **Targeted A/B** — for those 1-2 measures only: either re-run ~5
+5. **Targeted A/B** — for those 1-2 measures only: either re-run ~5
    closed tickets from their original SHA with old vs new prompt
    (compare tokens AND quality: does the PR still pass gaze), or ship
    the measure behind a flag and let a week of nightbeat be the B arm.
@@ -74,7 +97,9 @@ verify the skill runs end-to-end on live traces).
 
 Children:
 - 0237 — phase 1 census script + first report
-- (phases 2-4 to be filed once the census shows what is real)
+- (phases 2-5 to be filed once the census shows what is real; the
+  discovery phase 2 is filed FIRST, before any confirmatory work, so
+  the hypothesis list is fixed before testing begins)
 
 ## Exit criteria
 

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -1,0 +1,86 @@
+%erg 0.1
+Title: trace-doctor: session-trace economics audit (tracking)
+Created: 2026-06-10
+Author: claude
+
+--- log ---
+2026-06-10T11:18Z claude created
+
+--- body ---
+## Context
+
+A spot analysis of one live raid wave in aedist-technical-report (session
+96516ff3, 2026-06-10) measured ~$234 for a single wave, with this cost
+profile across 15 agents:
+
+| Category     | Tokens | ~$  |
+|--------------|--------|-----|
+| cache_read   | 77.5 M | 116 |
+| cache_write  | 4.6 M  | 86  |
+| output       | 399 K  | 30  |
+| fresh input  | 136 K  | 2   |
+
+Suspected waste patterns (all N=1, hence this ticket): cache_read grows
+~quadratically with agent turn count; a READ-ONLY recon agent drifted to
+113 turns / ~$9; /gaze cost appears independent of diff size; per-agent
+prompt preambles re-cache-write the same project context.
+
+N=1 is not evidence. The author directed a systematic study — "like
+skill-doctor, but bigger": census the traces, derive empirical
+recommendations, then validate cost-saving measures before adopting them.
+
+Corpus available (verified 2026-06-10): ~2,305 session JSONL traces,
+~0.7 GB, last 28 days, across 5 active projects (aedist-technical-report
+758, IDH 678, git-erg 591, chemin-de-voix 150, padme 96) under
+`~/.claude/projects/`. Small enough for a full census in the
+deterministic pass; sampling is reserved for LLM-judged phases.
+
+## Study design (four phases, each a child ticket)
+
+1. **Census** (child: 0237) — pure-Python `scripts/trace-stats.py`, one
+   row per agent with cost, shape, and waste-signature detectors. Zero
+   LLM tokens. First report over the 28-day corpus.
+2. **Hypothesis testing** — turn the N=1 findings into statistics over
+   the census output: H1 cache_read dominates $; H2 cost ~ turns²; H3
+   read-only agents drift past any reasonable budget; H4 gaze cost is
+   independent of diff size (join to PR diff stats via the forge CLI);
+   H5 duplicate prompt-preamble cache_writes across sibling agents are
+   material. Output: recommendations ranked by measured $/week saving,
+   plus a quality baseline (trace -> PR outcome join: merged / REROLL /
+   ESCALATE).
+3. **Counterfactual accounting** — for each recommendation, compute the
+   saving from existing traces before re-running anything. E.g. "cap
+   recon at N turns": truncate the trace at turn N and have a cheap
+   model judge whether the final report was already derivable. "Skip
+   full gaze on trivial diffs": count gaze runs on small prose diffs
+   that APPROVED with zero findings. Filters the list to the 1-2
+   measures accounting cannot settle.
+4. **Targeted A/B** — for those 1-2 measures only: either re-run ~5
+   closed tickets from their original SHA with old vs new prompt
+   (compare tokens AND quality: does the PR still pass gaze), or ship
+   the measure behind a flag and let a week of nightbeat be the B arm.
+   Honest constraint: LLM sessions do not replay deterministically and
+   replays burn real tokens — this phase is narrow by design.
+
+Deliverable at the end: a `trace-doctor` skill modeled on skill-doctor
+(survey script + interpretation + tickets out, never auto-applies),
+runnable monthly or on-demand.
+
+## Tracking discipline
+
+This is a tracking ticket — it stays open until all children are closed,
+and then closes only after the integration review (re-read child diffs,
+verify the skill runs end-to-end on live traces).
+
+Children:
+- 0237 — phase 1 census script + first report
+- (phases 2-4 to be filed once the census shows what is real)
+
+## Exit criteria
+
+- [ ] All child tickets closed
+- [ ] `trace-doctor` skill exists and produces a ranked recommendation
+      report from a live 28-day trace corpus
+- [ ] At least one cost-saving measure validated (phase 3 or 4) and
+      either adopted in a skill/prompt or explicitly rejected with
+      measured evidence

--- a/tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
+++ b/tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
@@ -96,5 +96,12 @@ detection. This ticket productionizes that idea.
 - [ ] Census report `docs/trace-census-2026-06.md` committed with
       distributions for: $ by category, turns per agent by role,
       cache_read vs turns scatter (table or numbers, figure optional)
-- [ ] Report ends with a "candidate hypotheses for phase 2" section
-      listing which of H1-H5 (see 0236) the census supports
+- [ ] Report ends with a "discovery feedstock" section (input to the
+      phase-2 hypothesis-discovery child, see 0236): (a) top-20 cost
+      outliers WITH residuals from a cost ~ f(turns) fit — agents far
+      off the curve, not just big ones; (b) any bimodal/heavy-tailed
+      distributions the census surfaced; (c) a stratified random sample
+      frame (project x entry-skill x cost-decile, including cheap
+      deciles) listing trace paths for the LLM open-coding pass; (d)
+      only then, which of the H1-H5 seeds the aggregates appear to
+      support — clearly labeled as seeds from N=1, not findings

--- a/tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
+++ b/tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
@@ -53,40 +53,62 @@ detection. This ticket productionizes that idea.
 3. Session-level rollup (second CSV or JSON section): entry skill if
    detectable from the first Skill call or prompt prefix, agent count,
    total $, wall-clock span.
-4. Schema tolerance: count and report skipped/unparseable lines per
+4. CRITICAL — dedupe usage by `message.id`: one assistant message spans
+   multiple JSONL rows (one per content block), each repeating the same
+   `usage` object. Summing per row overstates ~2.7x (measured: 248
+   usage rows vs 96 unique message ids in one main trace). Count one
+   usage per unique message id. Also skip `<synthetic>` model records
+   (harness-injected, no real API cost) but count them in a reported
+   `synthetic_messages` column.
+5. Schema tolerance: count and report skipped/unparseable lines per
    file — no silent truncation. Parser must not crash on records
    missing `message` or `usage`.
-5. Run the census over the live corpus; commit the summary report
+6. Run the census over the live corpus; commit the summary report
    (markdown, distributions + top-20 most expensive agents) under
    `docs/trace-census-2026-06.md`. Do NOT commit the raw CSV (it may
    embed prompt fragments; the report carries only aggregates).
-6. Pricing table: per-model $/Mtok constants for opus/sonnet/haiku/fable
+7. Pricing table: per-model $/Mtok constants for opus/sonnet/haiku/fable
    current generations, with an "unknown model" fallback that flags the
-   row rather than guessing.
+   row rather than guessing. Price each MESSAGE by its own `model`
+   field — sessions mix models (measured: 129 of 649 messages in the
+   reference session were Sonnet under an Opus orchestrator).
 
 ## Test
 
-- `tests/test_trace_stats.py` first (red): feed a fixture JSONL (3-4
-  hand-written records: one assistant+usage, one tool_use Bash repeated
-  twice, one malformed line) and assert: token sums, repeated-command
-  count = 2, malformed-line count = 1. Pure unit test, no markers.
+- `tests/test_trace_stats.py` first (red): feed a fixture JSONL with
+  hand-written records covering: one assistant message whose usage
+  object is REPEATED across 3 rows with the same `message.id` (must be
+  counted once — this is the bug that inflated the motivating analysis
+  2.7x), one `<synthetic>` model record (excluded from $, counted in
+  synthetic_messages), one tool_use Bash repeated twice, one malformed
+  line. Assert: token sums equal the single-counted values,
+  repeated-command count = 2, malformed-line count = 1. Pure unit
+  test, no markers.
 - CLI flag presence via source inspection, not subprocess --help.
 
 ## Verification
 
 - [ ] `uv run python scripts/trace-stats.py --days 28 --json` runs over
-      the live corpus without crashing and reports >2000 sessions parsed
+      the live corpus without crashing and reports >2000 trace FILES
+      parsed (the 28-day corpus had ~2,305 files on 2026-06-10; files
+      include subagent traces — sessions are far fewer; report both
+      counts separately)
 - [ ] Skipped-line count is reported and <5% of total lines
-- [ ] Spot-check: totals for session 96516ff3 (aedist) match the
-      2026-06-10 manual analysis (~399K output, ~77.5M cache_read
-      across main+14 subagents)
+- [ ] Spot-check on session 96516ff3 (aedist): the script's per-file
+      unique-message-id count must be well below its raw usage-row
+      count (248 rows -> 96 ids in the main trace at review time),
+      proving dedupe is active; deduped totals should be in the
+      neighborhood of the corrected 2026-06-10 review numbers (~264K
+      output, ~57.5M cache_read across main+15 subagents) — the
+      session was still LIVE when measured, so match approximately and
+      document the gap
 - [ ] `make check-fast` passes
 
 ## Invariants
 
 - Zero LLM/API calls in the script (pure I/O helper — see
   feedback_skill_architecture memory)
-- No hardcoded /home/user paths (check-agnostic)
+- No hardcoded absolute home paths — use `~/...` (check-agnostic)
 - Raw trace content (prompts, file contents) never lands in committed
   artifacts — aggregates only
 

--- a/tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
+++ b/tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
@@ -1,0 +1,100 @@
+%erg 0.1
+Title: trace-doctor phase 1: trace-stats census script + first report
+Created: 2026-06-10
+Author: claude
+
+--- log ---
+2026-06-10T11:18Z claude created
+
+--- body ---
+## Context
+
+Child of tracking ticket 0236 (session-trace economics audit). Phase 1:
+a deterministic, zero-LLM-token census of all Claude Code session traces
+from the last 28 days, to replace N=1 anecdotes about token waste with
+distributions. See 0236 for the full study design and the motivating
+spot analysis (~$234/raid-wave, cache_read dominant).
+
+A throwaway prototype exists from the spot analysis (written to /tmp,
+not preserved): it parsed one session JSONL + its subagents directory
+and emitted per-agent token totals, tool histograms, and repeated-Bash
+detection. This ticket productionizes that idea.
+
+## Relevant files
+
+- `~/.claude/projects/<project-dir>/*.jsonl` — main-session traces; one
+  JSON object per line; assistant messages carry
+  `message.usage.{input_tokens,output_tokens,cache_read_input_tokens,cache_creation_input_tokens}`
+- `~/.claude/projects/<project-dir>/<session-id>/subagents/agent-*.jsonl`
+  — subagent traces (note: under the WORKTREE-suffixed project dir when
+  the session ran in a worktree)
+- `scripts/skill-doctor-survey.py` — the sibling survey script; match
+  its CLI/JSON-output conventions
+- `scripts/trace-stats.py` — NEW, the deliverable
+- `rules/coding-python.md` — argparse on every entry point, logging not
+  print, no hardcoded paths, uv workflow
+
+## Actions
+
+1. Write `scripts/trace-stats.py` with argparse:
+   `--projects-dir` (default `~/.claude/projects`), `--days N`
+   (default 28), `--output CSV`, `--json` (summary to stdout).
+2. Per agent (main session or subagent file), emit one CSV row:
+   project (worktree suffix stripped), session id, agent id or "main",
+   date (from in-record timestamps, NOT file mtime), model id,
+   turn count, tokens by the 4 usage categories, $ via a per-model
+   pricing table, tool-use histogram (JSON column), total tool-result
+   bytes, plus waste-signature columns:
+   - max times the same file path was Read
+   - max times an identical Bash command ran
+   - read_only flag (no Edit/Write/NotebookEdit) combined with turns
+   - count of AskUserQuestion calls
+   - cache_read of the final turn (context-size proxy)
+3. Session-level rollup (second CSV or JSON section): entry skill if
+   detectable from the first Skill call or prompt prefix, agent count,
+   total $, wall-clock span.
+4. Schema tolerance: count and report skipped/unparseable lines per
+   file — no silent truncation. Parser must not crash on records
+   missing `message` or `usage`.
+5. Run the census over the live corpus; commit the summary report
+   (markdown, distributions + top-20 most expensive agents) under
+   `docs/trace-census-2026-06.md`. Do NOT commit the raw CSV (it may
+   embed prompt fragments; the report carries only aggregates).
+6. Pricing table: per-model $/Mtok constants for opus/sonnet/haiku/fable
+   current generations, with an "unknown model" fallback that flags the
+   row rather than guessing.
+
+## Test
+
+- `tests/test_trace_stats.py` first (red): feed a fixture JSONL (3-4
+  hand-written records: one assistant+usage, one tool_use Bash repeated
+  twice, one malformed line) and assert: token sums, repeated-command
+  count = 2, malformed-line count = 1. Pure unit test, no markers.
+- CLI flag presence via source inspection, not subprocess --help.
+
+## Verification
+
+- [ ] `uv run python scripts/trace-stats.py --days 28 --json` runs over
+      the live corpus without crashing and reports >2000 sessions parsed
+- [ ] Skipped-line count is reported and <5% of total lines
+- [ ] Spot-check: totals for session 96516ff3 (aedist) match the
+      2026-06-10 manual analysis (~399K output, ~77.5M cache_read
+      across main+14 subagents)
+- [ ] `make check-fast` passes
+
+## Invariants
+
+- Zero LLM/API calls in the script (pure I/O helper — see
+  feedback_skill_architecture memory)
+- No hardcoded /home/user paths (check-agnostic)
+- Raw trace content (prompts, file contents) never lands in committed
+  artifacts — aggregates only
+
+## Exit criteria
+
+- [ ] `scripts/trace-stats.py` committed with passing unit tests
+- [ ] Census report `docs/trace-census-2026-06.md` committed with
+      distributions for: $ by category, turns per agent by role,
+      cache_read vs turns scatter (table or numbers, figure optional)
+- [ ] Report ends with a "candidate hypotheses for phase 2" section
+      listing which of H1-H5 (see 0236) the census supports


### PR DESCRIPTION
## What

Files the systematic study the author directed after the 2026-06-10 raid spot analysis: replace N=1 token-waste anecdotes with a census of ~2,305 session traces (28 days, 5 projects), hypothesis **discovery**, empirical confirmation, and validated cost-saving measures. Modeled on skill-doctor (survey script + interpretation + tickets out, never auto-applies), but bigger.

- **0236** — tracking ticket: five-phase design (census → hypothesis discovery → hypothesis testing → counterfactual accounting → targeted A/B). Discovery has two instruments: mechanical anomaly mining (Pareto, fit residuals, shape clustering — zero tokens) and LLM open-coding of a stratified random sample including cheap deciles. The five N=1 findings (cache_read dominance ~$116 of $234, quadratic turn cost, recon drift, gaze⊥diff-size, preamble re-caching) are seeds, not the hypothesis universe; discovery happens on the sample, confirmation on the full census. Stays open until all children close.
- **0237** — phase-1 child, full cold-handoff body: deterministic `scripts/trace-stats.py` (zero LLM tokens), per-agent cost/shape/waste-signature rows, census report ending with a discovery-feedstock section (outliers with residuals, anomalous distributions, stratified sample frame). Ground-truth spot-check against the manually analyzed session.

Phases 2–5 are not filed yet — discovery (phase 2) gets filed first, before any confirmatory work, once the census lands.

Ticket: none
Ticket-ref: tickets/0236-trace-doctor-session-trace-economics-aud.erg
Ticket-ref: tickets/0237-trace-doctor-phase-1-trace-stats-census.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)