### PR TITLE
trace-doctor(0237): trace-stats census script + first 28-day report

### DIFF
--- a/docs/trace-census-2026-06.md
+++ b/docs/trace-census-2026-06.md
@@ -1,0 +1,252 @@
+# Trace census — June 2026 (28-day window)
+
+First deterministic census of the Claude Code session-trace corpus, produced by
+`scripts/trace-stats.py` (ticket 0237, phase 1 of the trace-doctor study,
+tracking ticket 0236). Run date: 2026-06-10. Zero LLM tokens spent.
+
+## Method
+
+- Corpus: every `*.jsonl` under `~/.claude/projects/` — main-session traces
+  plus `*/subagents/agent-*.jsonl`. Worktree-suffixed project dirs are folded
+  into their parent project.
+- Window: in-record timestamps (never file mtime); a file counts when its
+  last record is within 28 days of the run.
+- **Dedupe rule**: one assistant message spans multiple JSONL rows (one per
+  content block), each repeating the same `usage` object. Usage is counted
+  once per unique `message.id`. Summing per row overstates ~2.7x — this bug
+  inflated the first spot analysis (see 0236) and is now a fixture case in
+  `tests/test_trace_stats.py`.
+- `<synthetic>` model records (harness-injected, no API cost) are excluded
+  from $ and token sums (52 in the window).
+- Pricing: each message priced by its own `model` field, $/MTok — Opus 4.x
+  5/25, Sonnet 4.x 3/15, Haiku 4.5 1/5, Fable 5 10/50; cache read 0.1×
+  input, 5m cache write 1.25×, 1h cache write 2× (the 5m/1h split is taken
+  from `usage.cache_creation` when present). Unknown models are flagged, not
+  guessed: 0 unknown-model messages in this window.
+- Schema tolerance: 0 unparseable lines out of 388,467 (<5% criterion met
+  trivially); 0 unreadable files.
+
+## Headline numbers
+
+| Metric | Value |
+|---|---|
+| Trace files parsed | 2,412 (1,747 in window; 665 older/undated) |
+| Sessions | 305 (main agents: 304 with rows) |
+| Agents (rows) | 1,747 (304 main + 1,442 subagents + 1 orphan) |
+| API turns (unique assistant messages) | 90,362 |
+| Total cost | **~$6,544 / 28 days** (~$234/day) |
+
+## $ by category
+
+Token totals are exact (deduped); the $ split uses each row's dominant model
+(close approximation — sessions are 90%+ single-family).
+
+| Category | Tokens | ~$ | Share |
+|---|---|---|---|
+| cache_read | 9.69 B | 4,152 | **63%** |
+| cache_write | 231 M | 1,258 | 19% |
+| output | 28.5 M | 607 | 9% |
+| fresh input | 4.4 M | 22 | <1% |
+
+Re-reading cached context is two-thirds of all spend. Anything that shortens
+context or shortens agent lifetimes attacks the dominant category.
+
+## Turns per agent, by role
+
+| Role | n | mean | median | p90 | p99 | max |
+|---|---|---|---|---|---|---|
+| main | 304 | 156 | 80 | 327 | 882 | 5,255 |
+| subagent | 1,442 | 30 | 20 | 63 | 155 | 649 |
+
+| Role | mean $ | median $ | p90 $ | p99 $ | max $ |
+|---|---|---|---|---|---|
+| main | 16.30 | 4.72 | 36.53 | 177.04 | 368.90 |
+| subagent | 1.10 | 0.57 | 2.11 | 7.57 | 75.07 |
+
+Main sessions are 17% of agents but ~76% of spend ($4,955 of $6,544). The
+N=1 intuition that subagent fan-outs drive cost is wrong at corpus scale:
+long-lived *main* conversations are the cost center.
+
+## cache_read vs turns
+
+Mean total cache_read and mean $ by turns-decile (agents with ≥1 turn):
+
+| Decile | Turns range | cache_read | $ |
+|---|---|---|---|
+| d1 | 1–5 | 0.1 M | 0.13 |
+| d2 | 5–10 | 0.2 M | 0.32 |
+| d3 | 10–15 | 0.4 M | 0.41 |
+| d4 | 15–18 | 0.6 M | 0.55 |
+| d5 | 18–23 | 0.7 M | 0.68 |
+| d6 | 23–29 | 1.0 M | 0.87 |
+| d7 | 29–38 | 1.4 M | 1.01 |
+| d8 | 38–56 | 2.3 M | 1.46 |
+| d9 | 56–106 | 5.6 M | 3.99 |
+| d10 | 106–5,255 | 42.7 M | 27.72 |
+
+Cost grows mildly superlinearly with turns: the log-log fit is
+log($) = −3.86 + **1.134**·log(turns), R² = 0.775. The exponent is ~1.1,
+not ~2 — see H2 below. The top decile is qualitatively different: 7.6× the
+cache_read of d9 for 1.9× the turns, i.e. *long agents also carry far more
+context per turn*.
+
+## Top-20 most expensive agents
+
+`resid` = log-residual from the cost~turns fit (+1.0 ≈ 2.7× the curve).
+
+| $ | resid | turns | agent | project | model |
+|---|---|---|---|---|---|
+| 368.90 | +1.39 | 1,624 | main | aedist-technical-report | opus |
+| 230.13 | +1.77 | 767 | main | git-erg | opus |
+| 178.21 | +1.69 | 654 | main | chemin-de-voix | opus |
+| 177.04 | −0.68 | 5,255 | main | chemin-de-voix | sonnet |
+| 168.98 | +1.61 | 669 | main | aedist-technical-report | opus |
+| 130.10 | +1.49 | 594 | main | aedist-technical-report | opus |
+| 116.69 | +1.35 | 610 | main | aedist-technical-report | sonnet |
+| 112.12 | +1.67 | 441 | main | aedist-technical-report | opus |
+| 107.18 | +1.44 | 521 | main | aedist-technical-report | opus |
+| 102.42 | +1.82 | 357 | main | aedist-technical-report | opus |
+| 97.78 | +1.69 | 384 | main | aedist-technical-report | opus |
+| 96.61 | +1.15 | 615 | main | aedist-technical-report | opus |
+| 76.53 | +1.23 | 465 | main | IDH | opus |
+| 75.76 | +1.46 | 378 | main | IDH | opus |
+| 75.07 | +1.29 | 436 | agent-abeb2c87… | aedist-technical-report | opus |
+| 68.13 | +0.01 | 1,233 | main | chemin-de-voix | sonnet |
+| 67.78 | +1.01 | 509 | main | aedist-technical-report | opus |
+| 63.45 | +0.98 | 491 | main | aedist-technical-report | opus |
+| 62.42 | +0.65 | 649 | agent-ad937f28… | aedist-technical-report | opus |
+| 62.37 | +1.44 | 323 | main | IDH | opus |
+
+18 of 20 are main sessions; 17 of 20 are Opus. The two Sonnet outliers
+(5,255 and 1,233 turns) sit *on or below* the curve — model choice moves an
+agent off the cost curve as much as turn count does.
+
+By session, the 5 most expensive: raid $404.75 (28 agents), raid $355.23
+(24 agents), git-erg "model" session $279.26 (48 agents), gaze-entry
+$253.58 (40 agents), chemin-de-voix interactive $181.30 (14 agents).
+
+## Distributions worth knowing
+
+- **Heavy tail, mild bimodality in per-agent cost**: log-histogram of agent
+  cost has modes at ~$0.1–1 (subagents, n=971) and ~$1–10 (mains, n=495),
+  with 121 agents above $10. Top 5% of agents = **66%** of spend; top 1% =
+  34%. The Pareto knife falls between "an agent" and "a long main session".
+- **Read-only drift exists but is modest**: 998 of 1,442 subagents are
+  read-only (no Edit/Write/NotebookEdit); 68 of them ran past 40 turns.
+- **Repeated work signatures**: 172 agents Read the same file ≥5 times;
+  20 agents ran the identical Bash command ≥5 times.
+- **Final-turn cache_read (context-size proxy)**: median 48K, p90 114K,
+  p99 395K, max 982K — a long tail of agents ending life near the 1M
+  context ceiling, where every subsequent turn re-reads ~1M tokens.
+
+## Validation (exit criteria of 0237)
+
+- 2,412 files parsed without crashing (>2,000 ✓); 1,747 in window — both
+  counts reported because the window filter uses in-record timestamps.
+- Skipped lines: 0 of 388,467 (<5% ✓).
+- Spot-check on session 96516ff3 (aedist raid wave): the main trace has 278
+  usage rows vs 107 unique message ids (review-time measurement was 248→96;
+  the session was live and grew) — dedupe demonstrably active. Deduped
+  session totals (main + 16 subagents): cache_read 65.2M vs ~57.5M at
+  review time (grew, consistent), output 157K vs ~264K claimed at review
+  time. The output gap runs the *wrong way* for growth: the review's
+  throwaway-prototype figure was itself residually inflated. The committed
+  script's numbers are fixture-tested; treat the 0236 spot figures as
+  upper bounds.
+
+## Discovery feedstock (input to phase 2, see 0236)
+
+### (a) Cost outliers by residual, not size
+
+Top residual outliers among agents costing >$1 (far *off* the cost~turns
+curve, not merely big):
+
+| resid | $ | turns | cache_read | agent | project |
+|---|---|---|---|---|---|
+| +3.09 | 54.70 | 67 | 12.0 M | main | git-erg |
+| +2.54 | 11.65 | 28 | 4.6 M | main | IDH |
+| +2.40 | 2.11 | 7 | 0.1 M | agent-aa495618… | git-erg |
+| +2.38 | 2.40 | 8 | 0.2 M | agent-aa1f62fc… | git-erg |
+| +2.14 | 1.89 | 8 | 0.1 M | agent-a7b1a23d… | git-erg |
+| +2.03 | 1.95 | 9 | 0.4 M | main | aedist-technical-report |
+| +1.82 | 102.42 | 357 | 127.7 M | main | aedist-technical-report |
+| +1.77 | 230.13 | 767 | 356.2 M | main | git-erg |
+| +1.69 | 97.78 | 384 | 143.6 M | main | aedist-technical-report |
+| +1.69 | 178.21 | 654 | 217.5 M | main | chemin-de-voix |
+
+Two distinct off-curve shapes: (i) short agents (<10 turns) paying $2+ —
+huge per-turn context, likely heavy preamble cache_writes; (ii) long mains
+whose cache_read per turn dwarfs the norm (300–500K/turn) — context that
+never shrinks. Both are open-coding targets.
+
+### (b) Bimodal / heavy-tailed distributions surfaced
+
+1. Per-agent cost (modes ≈ $0.3 and ≈ $3; tail to $369).
+2. Final-turn cache_read (median 48K vs p99 395K — most agents stay small,
+   a tail rides near the context ceiling).
+3. Spend concentration (top 5% of agents = 66% of $).
+
+### (c) Stratified random sample frame for LLM open-coding
+
+Sampled by project × entry-skill × session-cost-decile (decile 1 =
+cheapest; cheap deciles included deliberately — frugal sessions show what
+good looks like). Seed 237, ≤3 cells per decile. Paths relative to
+`~/.claude/projects/`.
+
+| Dec | Project | Entry skill | $ | Agents | Main trace path |
+|---|---|---|---|---|---|
+| 1 | aedist-technical-report | effort | 0.00 | 1 | `-home-haduong-aedist-technical-report/542e887b-a055-4672-a349-937b5b929ef5.jsonl` |
+| 1 | aedist-technical-report-docs | (none) | 0.00 | 1 | `-home-haduong-aedist-technical-report-docs/3274cf36-6a99-4518-b7b0-0f0274444fff.jsonl` |
+| 1 | padme | (none) | 0.00 | 1 | `-home-haduong-padme--claude-worktrees-t0028/839f8569-e584-44b8-991c-cc58353c37c4.jsonl` |
+| 2 | IDH (~/.claude) | celebrate | 0.51 | 1 | `-home-haduong--claude/a2f09575-dcbe-4eef-879e-d22edd2b88cf.jsonl` |
+| 2 | IDH (~/.claude) | verify | 0.19 | 1 | `-home-haduong--claude/6aec3371-ad10-41d2-a8e1-a653c155156c.jsonl` |
+| 2 | aedist-technical-report | celebrate | 0.34 | 1 | `-home-haduong-aedist-technical-report--claude-worktrees-explore-t289/65c82411-4937-438a-a742-bb2537397df1.jsonl` |
+| 3 | aedist-technical-report | loop | 1.03 | 1 | `-home-haduong-aedist-technical-report/eda10041-f6e3-4a55-89e5-d458235feff3.jsonl` |
+| 3 | chemin-de-voix | merge | 0.59 | 1 | `-home-haduong-chemin-de-voix--claude-worktrees-raid-overnight-sweep/63b8501c-7347-487b-9b44-e538085fc625.jsonl` |
+| 3 | chemin-de-voix | perch | 1.30 | 1 | `-home-haduong-chemin-de-voix/e4cc6990-d371-41a3-b661-3dc59c037ff7.jsonl` |
+| 4 | aedist-technical-report | housekeeping | 3.06 | 1 | `-home-haduong-aedist-technical-report/03c5e78e-c87c-49cd-8100-d561c8699cad.jsonl` |
+| 4 | aedist-technical-report | merge | 3.07 | 1 | `-home-haduong-aedist-technical-report/e23002cf-aa34-4dee-beda-f2985d7f7231.jsonl` |
+| 4 | chemin-de-voix | celebrate | 1.46 | 1 | `-home-haduong-chemin-de-voix/f58bf9dc-2a2d-4bf2-8f52-d1c99dbb3d89.jsonl` |
+| 5 | aedist-technical-report | merge | 5.08 | 1 | `-home-haduong-aedist-technical-report/e6212fb6-ee3d-4868-97f0-3ee0685b2b17.jsonl` |
+| 5 | chemin-de-voix | housekeeping | 3.16 | 1 | `-home-haduong-chemin-de-voix/467339b6-956c-4f7b-b351-cb4b5612bde6.jsonl` |
+| 5 | git-erg | end-session | 4.38 | 1 | `-home-haduong-git-erg--claude-worktrees-t0202/07745b70-f383-4683-9b2c-9fc0e08496ec.jsonl` |
+| 6 | chemin-de-voix | merge | 5.90 | 1 | `-home-haduong-chemin-de-voix/be60ade1-d9f6-4a05-a08e-1874e96670c5.jsonl` |
+| 6 | chemin-de-voix | ticket-new | 5.52 | 4 | `-home-haduong-chemin-de-voix/822c9c51-c25f-4231-9efb-cb69dd291453.jsonl` |
+| 6 | git-erg | ticket-new | 6.00 | 4 | `-home-haduong-git-erg--claude-worktrees-t0160-followup/d27c1566-c018-4f41-838e-05b153511a28.jsonl` |
+| 7 | aedist-technical-report | housekeeping | 13.76 | 3 | `-home-haduong-aedist-technical-report--claude-worktrees-housekeeping/e63dac2c-61c4-4aeb-a18b-37ac8a268c54.jsonl` |
+| 7 | chemin-de-voix | healthcheck | 10.78 | 2 | `-home-haduong-chemin-de-voix/e6535bce-fc93-4a50-a534-f5364fd023c4.jsonl` |
+| 7 | padme | raid | 10.04 | 4 | `-home-haduong-padme/3f1f90f2-faed-4288-b0cb-9f496e567323.jsonl` |
+| 8 | IDH (~) | raid | 22.85 | 1 | `-home-haduong/f72154b3-d66f-438d-a7d5-46b1d1a81931.jsonl` |
+| 8 | aedist-technical-report | ticket-new | 16.62 | 2 | `-home-haduong-aedist-technical-report/60ffdb7a-3472-4ce2-b965-eb2267d2e033.jsonl` |
+| 8 | git-erg | fang-audit | 23.23 | 2 | `-home-haduong-git-erg/ff83e53f-129c-436d-b421-d6c97d72674d.jsonl` |
+| 9 | aedist-technical-report | claude-api | 33.84 | 4 | `-home-haduong-aedist-technical-report--claude-worktrees-explore-anthropic-caching/4ce9fb20-3b79-41a4-90ba-e2b94004e133.jsonl` |
+| 9 | aedist-technical-report | perch | 29.21 | 2 | `-home-haduong-aedist-technical-report/a35a77ee-6d22-4e10-a1ba-db903464f65d.jsonl` |
+| 9 | aedist-technical-report | ticket-claim | 42.50 | 7 | `-home-haduong-aedist-technical-report/f2d5c6fe-e355-4bbd-a8e7-8cba453c7d7b.jsonl` |
+| 10 | IDH (~/.claude) | code-review | 60.76 | 30 | `-home-haduong--claude/ad59e972-efa3-40b6-9fe9-38345f0047ab.jsonl` |
+| 10 | IDH (~/.claude) | merge | 102.55 | 33 | `-home-haduong--claude/a78d6efc-7746-40ac-ad23-c854b1fd3641.jsonl` |
+| 10 | aedist-technical-report | gaze | 253.58 | 40 | `-home-haduong-aedist-technical-report/dd5fd1a6-54f6-4a9c-8dac-81a5fb68b497.jsonl` |
+
+Reproduce with seed 237 over the census CSV (regenerate via
+`uv run python scripts/trace-stats.py --days 28 --output <csv>`).
+
+### (d) H1–H5 seed assessment — seeds from N=1, NOT findings
+
+| Seed | Aggregate signal | Verdict for phase 3 |
+|---|---|---|
+| H1 cache_read dominates $ | 63% of spend ($4,152 of $6,544) | **Supported** — promote to confirmation |
+| H2 cost ~ turns² | log-log exponent **1.13** (R²=0.78), not ~2 | **Not supported** as stated — cost is mildly superlinear in turns; the quadratic intuition came from one extreme session. Reframe: "top-decile agents carry disproportionate context per turn" |
+| H3 read-only agents drift past budget | 68 read-only subagents >40 turns (4.7% of subagents) | **Weakly supported** — real but small; quantify $ share in phase 3 before acting |
+| H4 gaze cost independent of diff size | Not testable from census alone (needs forge join); only 3 gaze-entry sessions in window, but the single gaze-entry top-5 session cost $253.58 | **Open** — needs the PR-diff join instrument |
+| H5 duplicate preamble cache_writes across siblings | cache_write is 19% of spend ($1,258); multi-agent sessions (raid/code-review/merge) dominate the top rollup | **Plausible** — needs per-sibling cache_creation comparison in phase 3 |
+
+New candidate hypotheses the census surfaced (not in the seed list):
+
+- **H6 — main sessions, not subagents, are the cost center** (76% of spend
+  from 17% of agents). Interventions targeting subagent budgets address a
+  minority of spend.
+- **H7 — model mix off-curve**: Opus mains sit ~+1.4 log-residual above the
+  curve; comparable-length Sonnet mains sit on it. Model right-sizing of
+  long interactive sessions may be the single largest lever.
+- **H8 — context never shrinks**: top-decile agents average 43M cache_read
+  over their life; final-turn context p99 is 395K. Compaction/context-edit
+  timing is a measurable lever on the dominant cost category.

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Trace-stats census — deterministic, zero-LLM-token accounting of Claude Code session traces.
+
+Walks ~/.claude/projects/, parses every main-session and subagent JSONL trace
+in the window, and emits one CSV row per agent plus a session-level rollup.
+
+CRITICAL accounting rule (ticket 0237 / 0236): one assistant message spans
+multiple JSONL rows — one per content block — each repeating the same
+`message.usage` object. Usage is counted ONCE per unique `message.id`
+(summing per row overstates ~2.7x). `<synthetic>` model records are
+harness-injected and carry no API cost: excluded from $ and token sums,
+counted in `synthetic_messages`.
+
+Emits JSON summary: {window, files, sessions, totals, skipped_lines, rollup}
+"""
+
+import argparse
+import csv
+import json
+import logging
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+log = logging.getLogger("trace-stats")
+
+# $/MTok, per category. Source: claude-api skill pricing tables (2026-06).
+# Cache read = 0.1x input; 5m cache write = 1.25x; 1h cache write = 2x.
+PRICING = {
+    "fable": {
+        "input": 10.0,
+        "output": 50.0,
+        "cache_read": 1.0,
+        "cache_write_5m": 12.5,
+        "cache_write_1h": 20.0,
+    },
+    "opus": {
+        "input": 5.0,
+        "output": 25.0,
+        "cache_read": 0.5,
+        "cache_write_5m": 6.25,
+        "cache_write_1h": 10.0,
+    },
+    "sonnet": {
+        "input": 3.0,
+        "output": 15.0,
+        "cache_read": 0.3,
+        "cache_write_5m": 3.75,
+        "cache_write_1h": 6.0,
+    },
+    "haiku": {
+        "input": 1.0,
+        "output": 5.0,
+        "cache_read": 0.1,
+        "cache_write_5m": 1.25,
+        "cache_write_1h": 2.0,
+    },
+}
+
+WRITE_TOOLS = {"Edit", "Write", "NotebookEdit"}
+
+# Built-in CLI commands that appear as <command-name> but are not entry skills.
+BUILTIN_COMMANDS = {
+    "clear",
+    "compact",
+    "model",
+    "login",
+    "logout",
+    "resume",
+    "exit",
+    "help",
+    "config",
+    "cost",
+    "doctor",
+    "status",
+    "context",
+    "agents",
+    "mcp",
+    "memory",
+    "todos",
+    "rewind",
+}
+
+USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+)
+
+
+def resolve_pricing(model_id: str) -> dict | None:
+    """Map a model id to its pricing family; None for unknown models."""
+    for family in ("fable", "opus", "sonnet", "haiku"):
+        if family in model_id:
+            return PRICING[family]
+    return None
+
+
+def strip_worktree(project_dir_name: str) -> str:
+    """Strip the worktree suffix from an encoded project dir name."""
+    return re.sub(r"--claude-worktrees-.+$", "", project_dir_name)
+
+
+def _parse_ts(s: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _message_cost(model: str, usage: dict) -> float:
+    p = resolve_pricing(model)
+    if p is None:
+        return 0.0
+    cache_creation = usage.get("cache_creation") or {}
+    write_5m = cache_creation.get("ephemeral_5m_input_tokens")
+    write_1h = cache_creation.get("ephemeral_1h_input_tokens", 0)
+    if write_5m is None and write_1h == 0:
+        # No split available: treat the whole creation count as 5m.
+        write_5m = usage.get("cache_creation_input_tokens", 0) or 0
+        write_1h = 0
+    dollars = (
+        (usage.get("input_tokens", 0) or 0) * p["input"]
+        + (usage.get("output_tokens", 0) or 0) * p["output"]
+        + (usage.get("cache_read_input_tokens", 0) or 0) * p["cache_read"]
+        + (write_5m or 0) * p["cache_write_5m"]
+        + (write_1h or 0) * p["cache_write_1h"]
+    )
+    return dollars / 1_000_000
+
+
+def parse_trace_file(path: Path) -> dict:
+    """Parse one trace JSONL file into per-agent statistics.
+
+    Tolerant of malformed lines and records missing `message`/`usage`:
+    those are counted (`skipped_lines`) or silently passed over, never fatal.
+    """
+    seen_ids: set[str] = set()
+    seen_tool_use_ids: set[str] = set()
+    tokens = dict.fromkeys(USAGE_KEYS, 0)
+    cost = 0.0
+    synthetic = 0
+    unknown_model = 0
+    skipped = 0
+    total_lines = 0
+    models: Counter = Counter()
+    tool_counts: Counter = Counter()
+    read_paths: Counter = Counter()
+    bash_commands: Counter = Counter()
+    ask_user = 0
+    tool_result_bytes = 0
+    wrote_files = False
+    first_ts = last_ts = None
+    final_cache_read = 0
+    entry_skill = None
+
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            total_lines += 1
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                skipped += 1
+                continue
+            if not isinstance(rec, dict):
+                skipped += 1
+                continue
+
+            ts = _parse_ts(rec.get("timestamp", ""))
+            if ts is not None:
+                first_ts = first_ts or ts
+                last_ts = ts
+
+            msg = rec.get("message")
+            if not isinstance(msg, dict):
+                continue
+            rec_type = rec.get("type")
+            content = msg.get("content")
+
+            if rec_type == "assistant":
+                model = msg.get("model") or ""
+                msg_id = msg.get("id")
+                usage = msg.get("usage")
+                if msg_id and msg_id not in seen_ids and isinstance(usage, dict):
+                    seen_ids.add(msg_id)
+                    if model == "<synthetic>":
+                        synthetic += 1
+                    else:
+                        models[model] += 1
+                        for k in USAGE_KEYS:
+                            tokens[k] += usage.get(k, 0) or 0
+                        if resolve_pricing(model) is None:
+                            unknown_model += 1
+                        else:
+                            cost += _message_cost(model, usage)
+                        final_cache_read = usage.get("cache_read_input_tokens", 0) or 0
+                if isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict) or block.get("type") != "tool_use":
+                            continue
+                        block_id = block.get("id")
+                        if block_id and block_id in seen_tool_use_ids:
+                            continue
+                        if block_id:
+                            seen_tool_use_ids.add(block_id)
+                        name = block.get("name", "?")
+                        tool_counts[name] += 1
+                        tool_input = block.get("input") or {}
+                        if name in WRITE_TOOLS:
+                            wrote_files = True
+                        elif name == "Read" and tool_input.get("file_path"):
+                            read_paths[tool_input["file_path"]] += 1
+                        elif name == "Bash" and tool_input.get("command"):
+                            bash_commands[tool_input["command"]] += 1
+                        elif name == "AskUserQuestion":
+                            ask_user += 1
+                        elif name == "Skill" and entry_skill is None:
+                            entry_skill = tool_input.get("skill")
+            elif rec_type == "user":
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_result":
+                            try:
+                                tool_result_bytes += len(
+                                    json.dumps(block.get("content", ""))
+                                )
+                            except (TypeError, ValueError):
+                                pass
+                elif isinstance(content, str) and entry_skill is None:
+                    for m in re.finditer(r"<command-name>/?([\w-]+)</command-name>", content):
+                        if m.group(1) not in BUILTIN_COMMANDS:
+                            entry_skill = m.group(1)
+                            break
+
+    return {
+        **tokens,
+        "cost_usd": cost,
+        "turns": len(seen_ids) - synthetic,
+        "synthetic_messages": synthetic,
+        "unknown_model_messages": unknown_model,
+        "skipped_lines": skipped,
+        "total_lines": total_lines,
+        "models": models,
+        "tool_counts": tool_counts,
+        "tool_result_bytes": tool_result_bytes,
+        "max_read_repeat": max(read_paths.values(), default=0),
+        "max_bash_repeat": max(bash_commands.values(), default=0),
+        "read_only": not wrote_files,
+        "ask_user_questions": ask_user,
+        "final_cache_read": final_cache_read,
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+        "entry_skill": entry_skill,
+    }
+
+
+def iter_trace_files(projects_dir: Path):
+    """Yield (project, session_id, agent_id, path) for every trace file."""
+    for proj_dir in sorted(projects_dir.iterdir()):
+        if not proj_dir.is_dir():
+            continue
+        project = strip_worktree(proj_dir.name)
+        for main in sorted(proj_dir.glob("*.jsonl")):
+            yield project, main.stem, "main", main
+        for sub in sorted(proj_dir.glob("*/subagents/agent-*.jsonl")):
+            yield project, sub.parent.parent.name, sub.stem, sub
+
+
+CSV_COLUMNS = [
+    "project",
+    "session_id",
+    "agent_id",
+    "date",
+    "model",
+    "turns",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "cost_usd",
+    "synthetic_messages",
+    "unknown_model_messages",
+    "skipped_lines",
+    "total_lines",
+    "tool_histogram",
+    "tool_result_bytes",
+    "max_read_repeat",
+    "max_bash_repeat",
+    "read_only",
+    "ask_user_questions",
+    "final_cache_read",
+    "entry_skill",
+    "path",
+]
+
+
+def build_row(project: str, session_id: str, agent_id: str, path: Path, stats: dict) -> dict:
+    dominant_model = stats["models"].most_common(1)
+    return {
+        "project": project,
+        "session_id": session_id,
+        "agent_id": agent_id,
+        "date": stats["first_ts"].date().isoformat() if stats["first_ts"] else "",
+        "model": dominant_model[0][0] if dominant_model else "",
+        "turns": stats["turns"],
+        "input_tokens": stats["input_tokens"],
+        "output_tokens": stats["output_tokens"],
+        "cache_read_input_tokens": stats["cache_read_input_tokens"],
+        "cache_creation_input_tokens": stats["cache_creation_input_tokens"],
+        "cost_usd": round(stats["cost_usd"], 4),
+        "synthetic_messages": stats["synthetic_messages"],
+        "unknown_model_messages": stats["unknown_model_messages"],
+        "skipped_lines": stats["skipped_lines"],
+        "total_lines": stats["total_lines"],
+        "tool_histogram": json.dumps(dict(stats["tool_counts"]), sort_keys=True),
+        "tool_result_bytes": stats["tool_result_bytes"],
+        "max_read_repeat": stats["max_read_repeat"],
+        "max_bash_repeat": stats["max_bash_repeat"],
+        "read_only": stats["read_only"],
+        "ask_user_questions": stats["ask_user_questions"],
+        "final_cache_read": stats["final_cache_read"],
+        "entry_skill": stats["entry_skill"] or "",
+        "path": str(path),
+    }
+
+
+def session_rollup(rows: list[dict]) -> list[dict]:
+    """Aggregate per-agent rows into one record per (project, session)."""
+    sessions: dict[tuple, dict] = {}
+    for r in rows:
+        key = (r["project"], r["session_id"])
+        s = sessions.setdefault(
+            key,
+            {
+                "project": r["project"],
+                "session_id": r["session_id"],
+                "entry_skill": "",
+                "agents": 0,
+                "cost_usd": 0.0,
+                "turns": 0,
+                "first_date": r["date"],
+            },
+        )
+        s["agents"] += 1
+        s["cost_usd"] += r["cost_usd"]
+        s["turns"] += r["turns"]
+        if r["agent_id"] == "main" and r["entry_skill"]:
+            s["entry_skill"] = r["entry_skill"]
+    out = sorted(sessions.values(), key=lambda s: -s["cost_usd"])
+    for s in out:
+        s["cost_usd"] = round(s["cost_usd"], 4)
+    return out
+
+
+def run_census(projects_dir: Path, days: int) -> tuple[list[dict], dict]:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    rows = []
+    files_seen = 0
+    files_skipped_old = 0
+    files_unreadable = 0
+    for project, session_id, agent_id, path in iter_trace_files(projects_dir):
+        files_seen += 1
+        try:
+            stats = parse_trace_file(path)
+        except OSError as e:
+            log.warning("unreadable %s: %s", path, e)
+            files_unreadable += 1
+            continue
+        if stats["last_ts"] is None or stats["last_ts"] < cutoff:
+            files_skipped_old += 1
+            continue
+        rows.append(build_row(project, session_id, agent_id, path, stats))
+    meta = {
+        "files_seen": files_seen,
+        "files_in_window": len(rows),
+        "files_skipped_old_or_undated": files_skipped_old,
+        "files_unreadable": files_unreadable,
+    }
+    return rows, meta
+
+
+def summarize(rows: list[dict], meta: dict, days: int) -> dict:
+    totals = {k: sum(r[k] for r in rows) for k in USAGE_KEYS}
+    total_lines = sum(r["total_lines"] for r in rows)
+    skipped_lines = sum(r["skipped_lines"] for r in rows)
+    return {
+        "window_days": days,
+        **meta,
+        "sessions": len({(r["project"], r["session_id"]) for r in rows}),
+        "totals": {
+            **totals,
+            "cost_usd": round(sum(r["cost_usd"] for r in rows), 2),
+            "turns": sum(r["turns"] for r in rows),
+            "synthetic_messages": sum(r["synthetic_messages"] for r in rows),
+            "unknown_model_messages": sum(r["unknown_model_messages"] for r in rows),
+        },
+        "skipped_lines": skipped_lines,
+        "total_lines": total_lines,
+        "skipped_line_pct": round(100 * skipped_lines / total_lines, 3) if total_lines else 0.0,
+        "rollup": session_rollup(rows),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Census of Claude Code session traces: one CSV row per agent."
+    )
+    parser.add_argument(
+        "--projects-dir",
+        type=Path,
+        default=Path("~/.claude/projects").expanduser(),
+        help="Root of the trace corpus (default: ~/.claude/projects)",
+    )
+    parser.add_argument("--days", type=int, default=28, help="Window in days (default 28)")
+    parser.add_argument("--output", type=Path, help="Write per-agent rows to this CSV")
+    parser.add_argument(
+        "--json", action="store_true", help="Print the summary as JSON to stdout"
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    rows, meta = run_census(args.projects_dir, args.days)
+
+    if args.output:
+        with open(args.output, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+            writer.writeheader()
+            writer.writerows(rows)
+        log.info("wrote %d rows to %s", len(rows), args.output)
+
+    summary = summarize(rows, meta, args.days)
+    if args.json:
+        json.dump(summary, sys.stdout, indent=2, default=str)
+        print()
+    else:
+        log.info(
+            "files=%d sessions=%d cost=$%s skipped_lines=%s%%",
+            summary["files_in_window"],
+            summary["sessions"],
+            summary["totals"]["cost_usd"],
+            summary["skipped_line_pct"],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -116,12 +116,12 @@ def _message_cost(model: str, usage: dict) -> float:
     if p is None:
         return 0.0
     cache_creation = usage.get("cache_creation") or {}
+    total_write = usage.get("cache_creation_input_tokens", 0) or 0
+    write_1h = cache_creation.get("ephemeral_1h_input_tokens", 0) or 0
     write_5m = cache_creation.get("ephemeral_5m_input_tokens")
-    write_1h = cache_creation.get("ephemeral_1h_input_tokens", 0)
-    if write_5m is None and write_1h == 0:
-        # No split available: treat the whole creation count as 5m.
-        write_5m = usage.get("cache_creation_input_tokens", 0) or 0
-        write_1h = 0
+    if write_5m is None:
+        # No 5m key: whatever the 1h bucket doesn't account for was 5m.
+        write_5m = max(0, total_write - write_1h)
     dollars = (
         (usage.get("input_tokens", 0) or 0) * p["input"]
         + (usage.get("output_tokens", 0) or 0) * p["output"]
@@ -364,6 +364,8 @@ def run_census(projects_dir: Path, days: int) -> tuple[list[dict], dict]:
     files_seen = 0
     files_skipped_old = 0
     files_unreadable = 0
+    corpus_skipped_lines = 0
+    corpus_total_lines = 0
     for project, session_id, agent_id, path in iter_trace_files(projects_dir):
         files_seen += 1
         try:
@@ -372,6 +374,8 @@ def run_census(projects_dir: Path, days: int) -> tuple[list[dict], dict]:
             log.warning("unreadable %s: %s", path, e)
             files_unreadable += 1
             continue
+        corpus_skipped_lines += stats["skipped_lines"]
+        corpus_total_lines += stats["total_lines"]
         if stats["last_ts"] is None or stats["last_ts"] < cutoff:
             files_skipped_old += 1
             continue
@@ -381,6 +385,8 @@ def run_census(projects_dir: Path, days: int) -> tuple[list[dict], dict]:
         "files_in_window": len(rows),
         "files_skipped_old_or_undated": files_skipped_old,
         "files_unreadable": files_unreadable,
+        "corpus_skipped_lines": corpus_skipped_lines,
+        "corpus_total_lines": corpus_total_lines,
     }
     return rows, meta
 

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -1,0 +1,162 @@
+"""Tests for scripts/trace-stats.py — session-trace census (ticket 0237)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+spec = importlib.util.spec_from_file_location("trace_stats", SCRIPTS / "trace-stats.py")
+ts = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ts)
+
+
+def _assistant_row(msg_id, model, usage, block, ts_str="2026-06-09T10:00:00.000Z"):
+    return {
+        "type": "assistant",
+        "timestamp": ts_str,
+        "message": {
+            "id": msg_id,
+            "model": model,
+            "role": "assistant",
+            "usage": usage,
+            "content": [block],
+        },
+    }
+
+
+USAGE = {
+    "input_tokens": 100,
+    "output_tokens": 50,
+    "cache_read_input_tokens": 1000,
+    "cache_creation_input_tokens": 200,
+}
+
+
+def _fixture_lines():
+    """Hand-written records covering the mandatory ticket 0237 cases."""
+    bash_block = {
+        "type": "tool_use",
+        "id": "toolu_1",
+        "name": "Bash",
+        "input": {"command": "git status"},
+    }
+    bash_block2 = dict(bash_block, id="toolu_2")
+    text_block = {"type": "text", "text": "hello"}
+    rows = [
+        # One assistant message whose usage is REPEATED across 3 rows,
+        # same message.id — must be counted ONCE (the 2.7x bug).
+        _assistant_row("msg_A", "claude-opus-4-8", USAGE, text_block),
+        _assistant_row("msg_A", "claude-opus-4-8", USAGE, bash_block),
+        _assistant_row("msg_A", "claude-opus-4-8", USAGE, bash_block2),
+        # A <synthetic> record: excluded from $, counted in synthetic_messages.
+        _assistant_row(
+            "msg_synth",
+            "<synthetic>",
+            USAGE,
+            {"type": "text", "text": "synthetic"},
+            ts_str="2026-06-09T10:01:00.000Z",
+        ),
+    ]
+    lines = [json.dumps(r) for r in rows]
+    lines.append("{this is not json")  # one malformed line
+    return lines
+
+
+def _write_fixture(tmp_path):
+    f = tmp_path / "session.jsonl"
+    f.write_text("\n".join(_fixture_lines()) + "\n")
+    return f
+
+
+def test_usage_deduped_by_message_id(tmp_path):
+    stats = ts.parse_trace_file(_write_fixture(tmp_path))
+    # 3 rows share msg_A: counted once, synthetic excluded.
+    assert stats["input_tokens"] == 100
+    assert stats["output_tokens"] == 50
+    assert stats["cache_read_input_tokens"] == 1000
+    assert stats["cache_creation_input_tokens"] == 200
+    assert stats["turns"] == 1  # one unique non-synthetic message id
+
+
+def test_synthetic_excluded_from_cost_but_counted(tmp_path):
+    stats = ts.parse_trace_file(_write_fixture(tmp_path))
+    assert stats["synthetic_messages"] == 1
+    # Cost equals the single Opus message priced once.
+    p = ts.PRICING["opus"]
+    expected = (
+        100 * p["input"]
+        + 50 * p["output"]
+        + 1000 * p["cache_read"]
+        + 200 * p["cache_write_5m"]
+    ) / 1_000_000
+    assert abs(stats["cost_usd"] - expected) < 1e-12
+
+
+def test_repeated_bash_command_detected(tmp_path):
+    stats = ts.parse_trace_file(_write_fixture(tmp_path))
+    assert stats["max_bash_repeat"] == 2
+    assert stats["tool_counts"]["Bash"] == 2
+
+
+def test_malformed_line_counted_not_fatal(tmp_path):
+    stats = ts.parse_trace_file(_write_fixture(tmp_path))
+    assert stats["skipped_lines"] == 1
+
+
+def test_missing_message_or_usage_tolerated(tmp_path):
+    f = tmp_path / "odd.jsonl"
+    rows = [
+        {"type": "user", "timestamp": "2026-06-09T10:00:00.000Z"},
+        {"type": "assistant", "timestamp": "2026-06-09T10:00:01.000Z", "message": {}},
+        {"type": "file-history-snapshot"},
+    ]
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    stats = ts.parse_trace_file(f)
+    assert stats["skipped_lines"] == 0
+    assert stats["turns"] == 0
+
+
+def test_per_message_pricing_uses_each_models_rate(tmp_path):
+    f = tmp_path / "mixed.jsonl"
+    rows = [
+        _assistant_row("msg_O", "claude-opus-4-8", USAGE, {"type": "text", "text": "a"}),
+        _assistant_row("msg_S", "claude-sonnet-4-6", USAGE, {"type": "text", "text": "b"}),
+    ]
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    stats = ts.parse_trace_file(f)
+
+    def cost(p):
+        return (
+            100 * p["input"]
+            + 50 * p["output"]
+            + 1000 * p["cache_read"]
+            + 200 * p["cache_write_5m"]
+        ) / 1_000_000
+
+    expected = cost(ts.PRICING["opus"]) + cost(ts.PRICING["sonnet"])
+    assert abs(stats["cost_usd"] - expected) < 1e-12
+
+
+def test_unknown_model_flagged_not_priced(tmp_path):
+    f = tmp_path / "unk.jsonl"
+    row = _assistant_row("msg_U", "future-model-9", USAGE, {"type": "text", "text": "x"})
+    f.write_text(json.dumps(row) + "\n")
+    stats = ts.parse_trace_file(f)
+    assert stats["unknown_model_messages"] == 1
+    assert stats["cost_usd"] == 0
+
+
+def test_worktree_suffix_stripped():
+    assert (
+        ts.strip_worktree("-home-haduong--claude--claude-worktrees-explore-foo")
+        == "-home-haduong--claude"
+    )
+    assert ts.strip_worktree("-home-haduong--claude") == "-home-haduong--claude"
+
+
+def test_cli_flags_present():
+    src = (SCRIPTS / "trace-stats.py").read_text()
+    for flag in ("--projects-dir", "--days", "--output", "--json"):
+        assert flag in src, f"missing CLI flag {flag}"
+    assert "ArgumentParser" in src

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -138,6 +138,24 @@ def test_per_message_pricing_uses_each_models_rate(tmp_path):
     assert abs(stats["cost_usd"] - expected) < 1e-12
 
 
+def test_cache_write_split_with_only_1h_key(tmp_path):
+    usage = dict(USAGE, cache_creation_input_tokens=300)
+    usage["cache_creation"] = {"ephemeral_1h_input_tokens": 200}  # no 5m key
+    f = tmp_path / "split.jsonl"
+    row = _assistant_row("msg_H", "claude-opus-4-8", usage, {"type": "text", "text": "x"})
+    f.write_text(json.dumps(row) + "\n")
+    stats = ts.parse_trace_file(f)
+    p = ts.PRICING["opus"]
+    expected = (
+        100 * p["input"]
+        + 50 * p["output"]
+        + 1000 * p["cache_read"]
+        + 100 * p["cache_write_5m"]  # 300 total - 200 in the 1h bucket
+        + 200 * p["cache_write_1h"]
+    ) / 1_000_000
+    assert abs(stats["cost_usd"] - expected) < 1e-12
+
+
 def test_unknown_model_flagged_not_priced(tmp_path):
     f = tmp_path / "unk.jsonl"
     row = _assistant_row("msg_U", "future-model-9", USAGE, {"type": "text", "text": "x"})

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -109,6 +109,7 @@ verify the skill runs end-to-end on live traces).
 
 Children:
 - 0237 — phase 1 census script + first report
+- 0239 — phase 2a missed compact/clear opportunity detector
 - (phases 2-5 to be filed once the census shows what is real; the
   discovery phase 2 is filed FIRST, before any confirmatory work, so
   the hypothesis list is fixed before testing begins)

--- a/tickets/0238-make-check-runs-no-tests-contradicts-cod.erg
+++ b/tickets/0238-make-check-runs-no-tests-contradicts-cod.erg
@@ -1,0 +1,43 @@
+%erg 0.1
+Title: make check runs no tests — contradicts coding-python.md gate definition
+Created: 2026-06-10
+Author: Integration Test
+
+--- log ---
+2026-06-10T12:12Z Integration Test created
+
+--- body ---
+## Context
+
+`rules/coding-python.md` defines `make check` as "full suite including
+integration + slow tests — run before opening a PR". In this repo the
+`check` target runs only `check-skills-drift` + `check-agnostic-*` — zero
+pytest. Surfaced by the /review-pr run on PR #365 (pre-existing, untouched
+by that PR). Sessions relying on `make check` as the pre-PR gate silently
+skip 500 tests.
+
+Related environment trap found in the same review: padme's
+`/etc/profile.d/dev-cache.sh` exports
+`PYTEST_ADDOPTS="--cache-dir=/data/cache/pytest"`, an invalid pytest flag
+that aborts every bare pytest run. That fix belongs in the padme repo
+(file a ticket there); noted here because the broken env var masks itself
+when `make check` runs no pytest at all.
+
+## Relevant files
+
+- `Makefile` — `check:` target (currently no pytest)
+- `rules/coding-python.md` — gate definitions
+
+## Actions
+
+1. Add the full pytest run to `check`: `python3 -m pytest tests/`
+   (keep the existing drift + agnostic prerequisites).
+
+## Verification
+
+- [ ] `make check` runs the 500-test suite and the static checks
+
+## Exit criteria
+
+- [ ] `make check` matches the coding-python.md definition
+- [ ] CI (or a hygiene test) would catch a future regression of the target

--- a/tickets/0239-trace-doctor-phase-2a-missed-compact-cle.erg
+++ b/tickets/0239-trace-doctor-phase-2a-missed-compact-cle.erg
@@ -1,0 +1,56 @@
+%erg 0.1
+Title: trace-doctor phase 2a: missed compact/clear opportunity detector
+Created: 2026-06-10
+Author: Integration Test
+
+--- log ---
+2026-06-10T12:14Z Integration Test created
+
+--- body ---
+## Context
+
+Child of tracking ticket 0236 (session-trace economics audit), phase 2a —
+mechanical anomaly mining, zero LLM tokens. Author request (2026-06-10,
+during 0237 review): "check for missed compact and clear opportunities."
+
+The 0237 census showed cache_read is 63% of spend and main sessions are
+76% of it; H8 ("context never shrinks") is the matching hypothesis seed.
+Compactions are detectable in traces: `type: "system"` records with
+`subtype: "compact_boundary"` (e.g. 11 boundaries in the 5,255-turn
+chemin-de-voix session). `/clear` shows up as a `<command-name>clear`
+user record and resets context (next turn's cache_read drops).
+
+## Relevant files
+
+- `scripts/trace-stats.py` — extend, or add a sibling
+  `scripts/trace-compact-audit.py`; reuse its dedupe-by-message.id parser
+- `docs/trace-census-2026-06.md` — census baseline + H8
+- `tickets/0236-trace-doctor-session-trace-economics-aud.erg` — tracker
+
+## Actions
+
+1. Per agent, extract the per-turn cache_read trajectory (unique
+   message.id order) and the positions of compact_boundary / clear events.
+2. Define "missed opportunity" mechanically, e.g.: a run of >=N turns with
+   per-turn cache_read above a threshold T (start at N=30, T=300K) that
+   contains no compact_boundary and no clear; report the $ that the run
+   cost vs. the counterfactual where context drops to the post-compact
+   median observed in sessions that DID compact.
+3. Aggregate: count of missed-opportunity runs, $ upper bound, by project
+   and entry skill; top-20 sessions ranked by recoverable $.
+4. Report under docs/ (aggregates only, no prompt fragments).
+
+## Test
+
+- Fixture trace with a synthetic cache_read ramp and one compact_boundary:
+  assert the detector flags the un-compacted ramp and not the compacted one.
+
+## Invariants
+
+- Zero LLM/API calls; no raw trace content in committed artifacts.
+
+## Exit criteria
+
+- [ ] Detector script committed with passing unit tests
+- [ ] Missed-compact/clear report committed with the $ counterfactual,
+      clearly labeled as an upper bound

--- a/tickets/closed/0237-trace-doctor-phase-1-trace-stats-census.erg
+++ b/tickets/closed/0237-trace-doctor-phase-1-trace-stats-census.erg
@@ -2,10 +2,12 @@
 Title: trace-doctor phase 1: trace-stats census script + first report
 Created: 2026-06-10
 Author: claude
+Closed: autoclosed — PR #365
 
 --- log ---
 2026-06-10T11:18Z claude created
 
+2026-06-10T12:20Z Integration Test closed — autoclosed — PR #365
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0237-trace-doctor-phase-1-trace-stats-census.erg
Ticket-ref: tickets/0236-trace-doctor-session-trace-economics-aud.erg

Phase 1 of the session-trace economics audit: `scripts/trace-stats.py`, a pure-Python zero-LLM-token census of the 28-day trace corpus, plus the first report `docs/trace-census-2026-06.md`.

## What it does
- One CSV row per agent (main session or subagent): tokens by the 4 usage categories, $ via per-message pricing (each message priced by its own `model`), tool histogram, tool-result bytes, waste signatures (repeated Reads, identical Bash commands, read-only flag, AskUserQuestion count, final-turn cache_read), session-level rollup with entry-skill detection.
- **Dedupe by `message.id`** — the 2.7x row-repeat bug from the 0236 spot analysis is a mandatory red fixture in `tests/test_trace_stats.py` (9 unit tests, no markers needed).
- `<synthetic>` records excluded from $; unknown models flagged, never guessed; malformed lines counted, never fatal.

## Verification (ticket checkboxes)
- [x] Live run: 2,412 files parsed, 1,747 in window, no crash (>2000 ✓); both counts reported
- [x] Skipped lines 0/388,467 (<5% ✓)
- [x] Spot-check 96516ff3: 278 usage rows → 107 unique ids (dedupe active); cache_read 65.2M vs ~57.5M at review (session grew — consistent); output gap documented in the report (review figure was itself inflated)
- [x] `make check-fast` passes (481 tests); full suite 500 passed; `/verify-adherence` PASS (noted in line with hunt step 9 — gaze may skip the mechanical phase)

## Report highlights
$6.5k/28 days; cache_read = 63% of spend; **main sessions are 17% of agents but 76% of spend**; cost~turns exponent is 1.13 (not quadratic — H2 from N=1 does not survive the corpus). Discovery-feedstock section includes residual outliers, heavy-tail notes, a seed-237 stratified sample frame, and H1–H8 hypothesis assessment for phase 2.

## Follow-up flagged (out of scope here)
`/etc/profile.d/dev-cache.sh` on padme exports `PYTEST_ADDOPTS="--cache-dir=/data/cache/pytest"`, which is not a valid pytest flag and aborts every bare pytest run; valid spelling is `-o cache_dir=...`. Belongs to the padme repo — needs a ticket there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)