### PR TITLE
make check runs the full pytest suite (ticket 0238)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check check-fast
+.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check check-fast check-tests
 
 skills-catalog:
 	./scripts/update-skills-catalog.py
@@ -18,4 +18,8 @@ check-agnostic-tickets:
 check-agnostic-skills:
 	./scripts/check-agnostic.sh skills
 
-check: check-skills-drift check-agnostic-tickets check-agnostic-skills
+# Full gate (coding-python.md): the whole suite, integration + slow included.
+check-tests:
+	python3 -m pytest tests/
+
+check: check-skills-drift check-agnostic-tickets check-agnostic-skills check-tests

--- a/tests/test_makefile_gates.py
+++ b/tests/test_makefile_gates.py
@@ -1,0 +1,45 @@
+"""Hygiene: Makefile gate targets match the coding-python.md definitions.
+
+`check` is the pre-PR gate: full pytest suite (integration + slow included)
+plus the static checks. `check-fast` is the development gate: unit tests only.
+Source inspection, not subprocess (ticket 0238).
+"""
+
+import re
+from pathlib import Path
+
+MAKEFILE = Path(__file__).parent.parent / "Makefile"
+
+
+def target_recipe(name: str) -> str:
+    """Return the full rule (deps line + recipe) for a Makefile target."""
+    text = MAKEFILE.read_text()
+    match = re.search(rf"^{re.escape(name)}:.*(?:\n\t.*)*", text, re.MULTILINE)
+    assert match, f"target '{name}' not found in {MAKEFILE}"
+    return match.group(0)
+
+
+def test_check_runs_full_pytest_suite():
+    rule = target_recipe("check")
+    runs_pytest_directly = "pytest tests/" in rule and "-m" not in rule
+    deps = rule.splitlines()[0]
+    delegates = any(
+        dep in deps for dep in ("check-tests", "test")
+    ) and "pytest tests/" in target_recipe("check-tests" if "check-tests" in deps else "test")
+    assert runs_pytest_directly or delegates, (
+        "coding-python.md defines 'make check' as the full test suite "
+        f"(integration + slow included); current rule:\n{rule}"
+    )
+
+
+def test_check_keeps_static_checks():
+    deps = target_recipe("check").splitlines()[0]
+    for dep in ("check-skills-drift", "check-agnostic-tickets", "check-agnostic-skills"):
+        assert dep in deps, f"'check' lost its static prerequisite {dep}"
+
+
+def test_check_fast_excludes_integration_and_slow():
+    rule = target_recipe("check-fast")
+    assert "not integration" in rule and "not slow" in rule, (
+        f"'check-fast' must exclude integration and slow tiers; current rule:\n{rule}"
+    )

--- a/tests/test_makefile_gates.py
+++ b/tests/test_makefile_gates.py
@@ -21,14 +21,12 @@ def target_recipe(name: str) -> str:
 
 def test_check_runs_full_pytest_suite():
     rule = target_recipe("check")
-    runs_pytest_directly = "pytest tests/" in rule and "-m" not in rule
-    deps = rule.splitlines()[0]
-    delegates = any(
-        dep in deps for dep in ("check-tests", "test")
-    ) and "pytest tests/" in target_recipe("check-tests" if "check-tests" in deps else "test")
-    assert runs_pytest_directly or delegates, (
-        "coding-python.md defines 'make check' as the full test suite "
-        f"(integration + slow included); current rule:\n{rule}"
+    if "check-tests" in rule.splitlines()[0]:
+        rule = target_recipe("check-tests")
+    assert re.search(r"pytest tests/\s*$", rule, re.MULTILINE), (
+        "coding-python.md defines 'make check' as the full test suite — "
+        "pytest over tests/ with no marker filter or other trailing args; "
+        f"current rule:\n{rule}"
     )
 
 

--- a/tickets/closed/0238-make-check-runs-no-tests-contradicts-cod.erg
+++ b/tickets/closed/0238-make-check-runs-no-tests-contradicts-cod.erg
@@ -2,10 +2,12 @@
 Title: make check runs no tests — contradicts coding-python.md gate definition
 Created: 2026-06-10
 Author: Integration Test
+Closed: autoclosed — PR #366
 
 --- log ---
 2026-06-10T12:12Z Integration Test created
 
+2026-06-10T12:42Z Integration Test closed — autoclosed — PR #366
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary
`rules/coding-python.md` defines `make check` as the full suite (integration + slow included), but the target ran only the static drift/agnostic checks — zero pytest. Sessions using it as the pre-PR gate silently skipped ~500 tests.

- Add a `check-tests` prerequisite running bare `python3 -m pytest tests/`; `check` keeps its three static prerequisites.
- Add `tests/test_makefile_gates.py` (source inspection, unmarked → runs in `check-fast` too) so a future regression of either gate definition turns the suite red. Written red-first against the old Makefile.

## Verification
- `make check`: static checks + 504 passed.
- `make check-fast`: 485 passed, 19 deselected.
- `/verify-adherence t238-make-check-pytest`: PASS (one nit on the test heuristic, fixed in the second commit; gate re-run green).

**Ticket:** tickets/0238-make-check-runs-no-tests-contradicts-cod.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)