### PR TITLE
trace-doctor phase 2a: missed compact/clear opportunity detector (ticket 0239)

### DIFF
--- a/docs/trace-compact-audit-2026-06.md
+++ b/docs/trace-compact-audit-2026-06.md
@@ -1,0 +1,127 @@
+# Missed compact/clear audit — June 2026 (28-day window)
+
+Mechanical detector for missed compaction opportunities in Claude Code
+session traces, produced by `scripts/trace-compact-audit.py` (ticket 0239,
+trace-doctor phase 2a, tracking ticket 0236). Run date: 2026-06-10. Zero
+LLM tokens spent. Tests H8 from the census ("context never shrinks",
+`docs/trace-census-2026-06.md`).
+
+## Method
+
+- Per agent, the per-turn cache_read trajectory in unique `message.id`
+  order (same dedupe rule as the census), interleaved with compaction
+  boundaries (`type: "system"` / `subtype: "compact_boundary"`) and
+  `/clear` commands (`<command-name>/clear</command-name>` user records).
+- **Missed opportunity** = a run of ≥30 consecutive turns each reading
+  ≥300K cache tokens, uninterrupted by any compact or clear
+  (`--min-run 30 --threshold 300000`, the ticket's starting parameters).
+- **Counterfactual $** — an explicit **upper bound**: had the agent
+  compacted at the run's first turn, each later turn in the run would have
+  read the post-compact median context instead of its actual cache_read.
+  The median is observed from sessions that DID compact: 137 boundaries in
+  the window; the first turn after a boundary reads a median of **12,866
+  tokens** (boundary `postTokens` metadata gives a similar 12–14K). The
+  bound ignores context re-growth after the hypothetical compaction and
+  the compaction's own cost (~$0.10–0.30 of cache_write per event), and
+  assumes compacted context loses nothing the session later needs —
+  all three simplifications inflate it, none deflate it.
+- Pricing: per-turn model at the census rates (cache read = 0.1× input).
+
+Reproduce: `python3 scripts/trace-compact-audit.py --days 28 --json`.
+
+## Headline numbers
+
+| Metric | Value |
+|---|---|
+| Agents in window | 1,749 |
+| Compactions observed | 137 |
+| `/clear` observed | 124 |
+| Missed-opportunity runs | **63** (61 in main sessions, 2 in subagents) |
+| Recoverable $ (upper bound) | **≤ $1,035 / 28 days** |
+
+Against the census's $6,544 window total, the upper bound is ~16% of all
+spend — and ~25% of main-session spend ($4,955), since 61 of 63 runs are
+main sessions. H8 is supported: long main sessions routinely ride 300K+
+contexts for dozens of turns without ever compacting.
+
+Run shape: median flagged run is 58 turns at ~414K cache_read/turn; the
+worst (a git-erg main session) is 366 consecutive turns averaging 567K,
+worth ≤$101 on its own.
+
+## By project (encoded trace-dir names)
+
+| Project | Runs | Recoverable $ ≤ |
+|---|---|---|
+| aedist-technical-report | 38 | 659.83 |
+| git-erg | 7 | 169.92 |
+| IDH (~/.claude) | 9 | 118.84 |
+| chemin-de-voix | 8 | 78.24 |
+| padme | 1 | 8.00 |
+
+## By entry skill
+
+| Entry skill | Runs | Recoverable $ ≤ |
+|---|---|---|
+| raid | 26 | 419.05 |
+| effort | 4 | 173.71 |
+| celebrate | 7 | 85.25 |
+| perch | 5 | 77.15 |
+| (none) | 7 | 68.94 |
+| start-ticket | 6 | 64.77 |
+| healthcheck | 2 | 57.36 |
+| housekeeping | 3 | 33.61 |
+| roar | 1 | 29.96 |
+| hunt | 1 | 19.86 |
+| scry | 1 | 5.18 |
+
+Raid sessions — long-lived multi-wave orchestrators — account for 40% of
+the recoverable bound. They are exactly the sessions where the
+orchestrator's context accumulates wave after wave of agent reports.
+
+## Top-20 sessions by recoverable $
+
+| Recoverable $ ≤ | Runs | Entry skill | Project | Session |
+|---|---|---|---|---|
+| 157.57 | 8 | raid | aedist-technical-report | 21e99ac0… |
+| 125.14 | 2 | effort | git-erg | 211826a9… |
+| 103.83 | 6 | raid | aedist-technical-report | f4537f72… |
+| 64.77 | 6 | start-ticket | chemin-de-voix | 207f5efc… |
+| 60.15 | 4 | raid | aedist-technical-report | de20a516… |
+| 57.36 | 2 | healthcheck | aedist-technical-report | aa731a09… |
+| 48.57 | 2 | effort | aedist-technical-report | 1ef5880f… |
+| 42.32 | 3 | (none) | aedist-technical-report | 8fe4d2ee… |
+| 41.13 | 3 | perch | aedist-technical-report | f6f1d1a2… |
+| 38.29 | 2 | roar | aedist-technical-report | dd5fd1a6… |
+| 36.54 | 2 | celebrate | aedist-technical-report | eddfaf5e… |
+| 32.49 | 2 | raid | IDH | a78d6efc… |
+| 24.01 | 1 | raid | aedist-technical-report | e8c40ecf… |
+| 22.52 | 1 | perch | IDH | 2e3a435d… |
+| 21.44 | 2 | housekeeping | IDH | 617b4df5… |
+| 19.86 | 1 | hunt | IDH | dd0eb522… |
+| 19.08 | 2 | celebrate | git-erg | 28935cc7… |
+| 18.37 | 1 | celebrate | aedist-technical-report | 15b3b196… |
+| 14.09 | 1 | raid | git-erg | 01c6929f… |
+| 13.51 | 1 | perch | aedist-technical-report | 90650ce6… |
+
+## Caveats
+
+- The $ figure is a **counterfactual upper bound**, not a measured saving.
+  A compaction at 300K context drops the *next* turn to ~13K, but real
+  context re-grows; the realizable saving over a 58-turn run is smaller.
+- The detector measures *opportunity*, not *advisability*: some flagged
+  runs may genuinely need their full context (e.g. a manuscript review
+  holding a large document). The per-run CSV
+  (`--output`) is the open-coding sample frame for phase 3 to separate
+  load-bearing context from sediment.
+- Auto-compaction triggers near the model context ceiling, so 300K+ runs
+  on a 1M-context model sit *below* the auto trigger by design — these are
+  missed *manual/policy* opportunities, pointing at skill-level or
+  harness-level compaction policy, not at a Claude Code bug.
+
+## Parameter sensitivity
+
+The N=30/T=300K starting point is from the ticket. Re-running at
+N=20/T=200K flags 144 runs, ≤$1,668; at N=40/T=400K, 33 runs, ≤$631.
+The headline is robust in order of magnitude across a 2× parameter
+spread, and concentrated: the top-10 sessions alone carry $0.74K of the
+$1.03K baseline bound.

--- a/scripts/trace-compact-audit.py
+++ b/scripts/trace-compact-audit.py
@@ -36,10 +36,29 @@ _TS_SPEC = importlib.util.spec_from_file_location(
 ts = importlib.util.module_from_spec(_TS_SPEC)
 _TS_SPEC.loader.exec_module(ts)
 
-CLEAR_RE = re.compile(r"<command-name>/?clear</command-name>")
+# A real /clear record pairs the two tags across an actual newline; trace
+# text *quoted* inside a session (e.g. trace-doctor work) keeps the JSON
+# escape as literal backslash-n and so does not match.
+CLEAR_RE = re.compile(
+    r"<command-name>/?clear</command-name>\s*\n\s*<command-message>clear</command-message>"
+)
 
 # Used only if the corpus contains no compaction to take a median from.
 DEFAULT_POST_COMPACT_TOKENS = 20_000
+
+
+def _user_text_parts(content) -> list[str]:
+    """Text of a user record: plain string, or the text blocks of list-form
+    content (tool_result blocks carry no commands and are skipped)."""
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, list):
+        return [
+            b["text"]
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text" and isinstance(b.get("text"), str)
+        ]
+    return []
 
 
 def parse_trajectory(path: Path) -> dict:
@@ -109,12 +128,12 @@ def parse_trajectory(path: Path) -> dict:
                         post_compact_reads.append(cache_read)
                         awaiting_post_read = False
             elif rec_type == "user":
-                if isinstance(content, str):
-                    if CLEAR_RE.search(content):
+                for text in _user_text_parts(content):
+                    if CLEAR_RE.search(text):
                         events.append({"kind": "clear"})
                     elif entry_skill is None:
                         for m in re.finditer(
-                            r"<command-name>/?([\w-]+)</command-name>", content
+                            r"<command-name>/?([\w-]+)</command-name>", text
                         ):
                             if m.group(1) not in ts.BUILTIN_COMMANDS:
                                 entry_skill = m.group(1)

--- a/scripts/trace-compact-audit.py
+++ b/scripts/trace-compact-audit.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Missed compact/clear opportunity detector — ticket 0239, trace-doctor phase 2a.
+
+Walks the session-trace corpus and, per agent, extracts the per-turn
+cache_read trajectory (unique message.id order, same dedupe rule as
+scripts/trace-stats.py) plus the positions of compaction boundaries
+(`type: "system"` / `subtype: "compact_boundary"`) and `/clear` commands.
+
+A *missed opportunity* is a run of >= --min-run consecutive turns whose
+per-turn cache_read stays >= --threshold, uninterrupted by any compact or
+clear. The recoverable $ is an UPPER BOUND counterfactual: had the agent
+compacted at the start of the run, every later turn in the run would have
+read the post-compact median context (observed across sessions that DID
+compact) instead of its actual cache_read. Context re-growth after the
+hypothetical compaction is ignored — hence upper bound.
+
+Zero LLM/API calls; emits aggregates only, never trace content.
+"""
+
+import argparse
+import csv
+import importlib.util
+import json
+import logging
+import re
+import statistics
+import sys
+from pathlib import Path
+
+log = logging.getLogger("trace-compact-audit")
+
+# Reuse the census module (pricing, dedupe conventions, corpus walker).
+_TS_SPEC = importlib.util.spec_from_file_location(
+    "trace_stats", Path(__file__).resolve().parent / "trace-stats.py"
+)
+ts = importlib.util.module_from_spec(_TS_SPEC)
+_TS_SPEC.loader.exec_module(ts)
+
+CLEAR_RE = re.compile(r"<command-name>/?clear</command-name>")
+
+# Used only if the corpus contains no compaction to take a median from.
+DEFAULT_POST_COMPACT_TOKENS = 20_000
+
+
+def parse_trajectory(path: Path) -> dict:
+    """Parse one trace into an ordered event stream.
+
+    Events: {"kind": "turn", "cache_read": int, "model": str},
+    {"kind": "compact"}, {"kind": "clear"}. Turns are deduped by
+    message.id; <synthetic> records are not turns. Also collects the
+    cache_read of the first turn after each compaction
+    (post_compact_reads) and the boundary's own postTokens
+    (post_compact_tokens) — both feed the corpus-wide median.
+    """
+    events: list[dict] = []
+    seen_ids: set[str] = set()
+    post_compact_reads: list[int] = []
+    post_compact_tokens: list[int] = []
+    awaiting_post_read = False
+    entry_skill = None
+    last_ts = None
+
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+
+            tstamp = ts._parse_ts(rec.get("timestamp", ""))
+            if tstamp is not None:
+                last_ts = tstamp
+
+            rec_type = rec.get("type")
+            if rec_type == "system" and rec.get("subtype") == "compact_boundary":
+                events.append({"kind": "compact"})
+                meta = rec.get("compactMetadata") or {}
+                if isinstance(meta.get("postTokens"), int):
+                    post_compact_tokens.append(meta["postTokens"])
+                awaiting_post_read = True
+                continue
+
+            msg = rec.get("message")
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content")
+
+            if rec_type == "assistant":
+                msg_id = msg.get("id")
+                usage = msg.get("usage")
+                model = msg.get("model") or ""
+                if (
+                    msg_id
+                    and msg_id not in seen_ids
+                    and isinstance(usage, dict)
+                    and model != "<synthetic>"
+                ):
+                    seen_ids.add(msg_id)
+                    cache_read = usage.get("cache_read_input_tokens", 0) or 0
+                    events.append(
+                        {"kind": "turn", "cache_read": cache_read, "model": model}
+                    )
+                    if awaiting_post_read:
+                        post_compact_reads.append(cache_read)
+                        awaiting_post_read = False
+            elif rec_type == "user":
+                if isinstance(content, str):
+                    if CLEAR_RE.search(content):
+                        events.append({"kind": "clear"})
+                    elif entry_skill is None:
+                        for m in re.finditer(
+                            r"<command-name>/?([\w-]+)</command-name>", content
+                        ):
+                            if m.group(1) not in ts.BUILTIN_COMMANDS:
+                                entry_skill = m.group(1)
+                                break
+
+    return {
+        "events": events,
+        "post_compact_reads": post_compact_reads,
+        "post_compact_tokens": post_compact_tokens,
+        "entry_skill": entry_skill,
+        "last_ts": last_ts,
+    }
+
+
+def find_missed_runs(events: list[dict], min_run: int, threshold: int) -> list[dict]:
+    """Maximal runs of consecutive turns with cache_read >= threshold,
+    broken by any compact/clear event or below-threshold turn. Returns the
+    runs of length >= min_run."""
+    runs = []
+    current: list[dict] = []
+    start = 0
+    for i, ev in enumerate(events):
+        if ev["kind"] == "turn" and ev["cache_read"] >= threshold:
+            if not current:
+                start = i
+            current.append(ev)
+        else:
+            if len(current) >= min_run:
+                runs.append({"start": start, "length": len(current), "turns": current})
+            current = []
+    if len(current) >= min_run:
+        runs.append({"start": start, "length": len(current), "turns": current})
+    return runs
+
+
+def run_recoverable_usd(turns: list[dict], median_post: int) -> float:
+    """Counterfactual upper bound: compact at the run's first turn, then
+    every later turn reads median_post instead of its actual cache_read."""
+    usd = 0.0
+    for t in turns[1:]:
+        saved = max(0, t["cache_read"] - median_post)
+        pricing = ts.resolve_pricing(t["model"])
+        if pricing is None:
+            continue
+        usd += saved * pricing["cache_read"] / 1_000_000
+    return usd
+
+
+def audit_corpus(projects_dir: Path, days: int, min_run: int, threshold: int) -> dict:
+    from datetime import datetime, timedelta, timezone
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    trajectories = []
+    files_seen = 0
+    for project, session_id, agent_id, path in ts.iter_trace_files(projects_dir):
+        files_seen += 1
+        try:
+            traj = parse_trajectory(path)
+        except OSError as e:
+            log.warning("unreadable %s: %s", path, e)
+            continue
+        if traj["last_ts"] is None or traj["last_ts"] < cutoff:
+            continue
+        trajectories.append((project, session_id, agent_id, traj))
+
+    post_reads = [r for _, _, _, t in trajectories for r in t["post_compact_reads"]]
+    post_tokens = [r for _, _, _, t in trajectories for r in t["post_compact_tokens"]]
+    if post_reads:
+        median_post, median_source = int(statistics.median(post_reads)), "next-turn cache_read"
+    elif post_tokens:
+        median_post, median_source = int(statistics.median(post_tokens)), "boundary postTokens"
+    else:
+        median_post, median_source = DEFAULT_POST_COMPACT_TOKENS, "default (no compactions)"
+
+    run_rows = []
+    compactions = clears = 0
+    for project, session_id, agent_id, traj in trajectories:
+        compactions += sum(1 for e in traj["events"] if e["kind"] == "compact")
+        clears += sum(1 for e in traj["events"] if e["kind"] == "clear")
+        for run in find_missed_runs(traj["events"], min_run, threshold):
+            usd = run_recoverable_usd(run["turns"], median_post)
+            reads = [t["cache_read"] for t in run["turns"]]
+            run_rows.append(
+                {
+                    "project": project,
+                    "session_id": session_id,
+                    "agent_id": agent_id,
+                    "entry_skill": traj["entry_skill"] or "",
+                    "run_start_event": run["start"],
+                    "run_turns": run["length"],
+                    "mean_cache_read": sum(reads) // len(reads),
+                    "max_cache_read": max(reads),
+                    "recoverable_usd": round(usd, 4),
+                }
+            )
+
+    def _agg(key):
+        out = {}
+        for r in run_rows:
+            k = r[key] or "(none)"
+            a = out.setdefault(k, {"runs": 0, "recoverable_usd": 0.0})
+            a["runs"] += 1
+            a["recoverable_usd"] += r["recoverable_usd"]
+        return {
+            k: {"runs": v["runs"], "recoverable_usd": round(v["recoverable_usd"], 2)}
+            for k, v in sorted(out.items(), key=lambda kv: -kv[1]["recoverable_usd"])
+        }
+
+    sessions = {}
+    for r in run_rows:
+        key = (r["project"], r["session_id"])
+        s = sessions.setdefault(
+            key,
+            {
+                "project": r["project"],
+                "session_id": r["session_id"],
+                "entry_skill": r["entry_skill"],
+                "runs": 0,
+                "recoverable_usd": 0.0,
+            },
+        )
+        s["runs"] += 1
+        s["recoverable_usd"] += r["recoverable_usd"]
+    top_sessions = sorted(sessions.values(), key=lambda s: -s["recoverable_usd"])[:20]
+    for s in top_sessions:
+        s["recoverable_usd"] = round(s["recoverable_usd"], 2)
+
+    return {
+        "window_days": days,
+        "min_run": min_run,
+        "threshold_tokens": threshold,
+        "files_seen": files_seen,
+        "agents_in_window": len(trajectories),
+        "compactions_observed": compactions,
+        "clears_observed": clears,
+        "post_compact_median_tokens": median_post,
+        "post_compact_median_source": median_source,
+        "missed_runs": len(run_rows),
+        "recoverable_usd_upper_bound": round(sum(r["recoverable_usd"] for r in run_rows), 2),
+        "by_project": _agg("project"),
+        "by_entry_skill": _agg("entry_skill"),
+        "top_sessions": top_sessions,
+        "run_rows": run_rows,
+    }
+
+
+CSV_COLUMNS = [
+    "project",
+    "session_id",
+    "agent_id",
+    "entry_skill",
+    "run_start_event",
+    "run_turns",
+    "mean_cache_read",
+    "max_cache_read",
+    "recoverable_usd",
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Detect missed compact/clear opportunities in session traces."
+    )
+    parser.add_argument(
+        "--projects-dir",
+        type=Path,
+        default=Path("~/.claude/projects").expanduser(),
+        help="Root of the trace corpus (default: ~/.claude/projects)",
+    )
+    parser.add_argument("--days", type=int, default=28, help="Window in days (default 28)")
+    parser.add_argument(
+        "--min-run",
+        type=int,
+        default=30,
+        help="Minimum consecutive high-context turns to flag (default 30)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=300_000,
+        help="Per-turn cache_read floor in tokens (default 300000)",
+    )
+    parser.add_argument("--output", type=Path, help="Write per-run rows to this CSV")
+    parser.add_argument(
+        "--json", action="store_true", help="Print the summary as JSON to stdout"
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    summary = audit_corpus(args.projects_dir, args.days, args.min_run, args.threshold)
+    run_rows = summary.pop("run_rows")
+
+    if args.output:
+        with open(args.output, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+            writer.writeheader()
+            writer.writerows(run_rows)
+        log.info("wrote %d runs to %s", len(run_rows), args.output)
+
+    if args.json:
+        json.dump(summary, sys.stdout, indent=2, default=str)
+        print()
+    else:
+        log.info(
+            "agents=%d missed_runs=%d recoverable<=$%s (median_post=%d from %s)",
+            summary["agents_in_window"],
+            summary["missed_runs"],
+            summary["recoverable_usd_upper_bound"],
+            summary["post_compact_median_tokens"],
+            summary["post_compact_median_source"],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trace_compact_audit.py
+++ b/tests/test_trace_compact_audit.py
@@ -130,6 +130,38 @@ def test_recoverable_usd_never_negative():
     assert tca.run_recoverable_usd(turns, median_post=20_000) == 0.0
 
 
+def test_quoted_clear_does_not_break_run(tmp_path):
+    """Trace text quoted in a user message keeps the JSON-escaped newline as
+    a literal backslash-n: not a real /clear, must not break the run."""
+    quoted = {
+        "type": "user",
+        "timestamp": "2026-06-09T10:30:00.000Z",
+        "message": {
+            "role": "user",
+            "content": "look: <command-name>/clear</command-name>\\n<command-message>clear</command-message>",
+        },
+    }
+    rows = _ramp(17, prefix="a") + [quoted] + _ramp(17, prefix="b")
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    runs = tca.find_missed_runs(traj["events"], min_run=30, threshold=300_000)
+    assert len(runs) == 1
+    assert runs[0]["length"] == 34
+
+
+def test_clear_detected_in_list_form_content(tmp_path):
+    listy = {
+        "type": "user",
+        "timestamp": "2026-06-09T10:30:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": _clear_row()["message"]["content"]}],
+        },
+    }
+    rows = _ramp(17, prefix="a") + [listy] + _ramp(17, prefix="b")
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    assert tca.find_missed_runs(traj["events"], min_run=30, threshold=300_000) == []
+
+
 def test_malformed_lines_tolerated(tmp_path):
     f = tmp_path / "bad.jsonl"
     f.write_text("{not json\n" + json.dumps(_assistant_row("ok", 400_000)) + "\n")

--- a/tests/test_trace_compact_audit.py
+++ b/tests/test_trace_compact_audit.py
@@ -1,0 +1,144 @@
+"""Tests for scripts/trace-compact-audit.py — missed compact/clear detector (ticket 0239)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+spec = importlib.util.spec_from_file_location(
+    "trace_compact_audit", SCRIPTS / "trace-compact-audit.py"
+)
+tca = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tca)
+
+
+def _assistant_row(msg_id, cache_read, model="claude-opus-4-8", ts_str="2026-06-09T10:00:00.000Z"):
+    return {
+        "type": "assistant",
+        "timestamp": ts_str,
+        "message": {
+            "id": msg_id,
+            "model": model,
+            "role": "assistant",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 10,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": 0,
+            },
+            "content": [{"type": "text", "text": "x"}],
+        },
+    }
+
+
+def _compact_row(post_tokens=12_000):
+    return {
+        "type": "system",
+        "subtype": "compact_boundary",
+        "timestamp": "2026-06-09T10:30:00.000Z",
+        "compactMetadata": {"trigger": "auto", "preTokens": 170_000, "postTokens": post_tokens},
+    }
+
+
+def _clear_row():
+    return {
+        "type": "user",
+        "timestamp": "2026-06-09T10:30:00.000Z",
+        "message": {
+            "role": "user",
+            "content": "<command-name>/clear</command-name>\n<command-message>clear</command-message>",
+        },
+    }
+
+
+def _write(tmp_path, rows, name="session.jsonl"):
+    f = tmp_path / name
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return f
+
+
+def _ramp(n, cache_read=400_000, prefix="msg"):
+    return [_assistant_row(f"{prefix}_{i}", cache_read) for i in range(n)]
+
+
+def test_flags_uncompacted_ramp(tmp_path):
+    """The ticket's mandated fixture: a >=30-turn high-cache_read run with no
+    compact_boundary is flagged."""
+    traj = tca.parse_trajectory(_write(tmp_path, _ramp(35)))
+    runs = tca.find_missed_runs(traj["events"], min_run=30, threshold=300_000)
+    assert len(runs) == 1
+    assert runs[0]["length"] == 35
+
+
+def test_compacted_ramp_not_flagged(tmp_path):
+    """Same ramp with a compact_boundary mid-run: both segments are under
+    min_run, so nothing is flagged."""
+    rows = _ramp(17, prefix="a") + [_compact_row()] + _ramp(17, prefix="b")
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    runs = tca.find_missed_runs(traj["events"], min_run=30, threshold=300_000)
+    assert runs == []
+
+
+def test_clear_breaks_run(tmp_path):
+    rows = _ramp(17, prefix="a") + [_clear_row()] + _ramp(17, prefix="b")
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    runs = tca.find_missed_runs(traj["events"], min_run=30, threshold=300_000)
+    assert runs == []
+
+
+def test_below_threshold_turn_breaks_run(tmp_path):
+    rows = _ramp(17, prefix="a") + [_assistant_row("low", 50_000)] + _ramp(17, prefix="b")
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    runs = tca.find_missed_runs(traj["events"], min_run=30, threshold=300_000)
+    assert runs == []
+
+
+def test_turns_deduped_by_message_id(tmp_path):
+    """One message spans multiple JSONL rows: one turn event, not three."""
+    rows = [_assistant_row("dup", 400_000)] * 3 + [_assistant_row("other", 400_000)]
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    turns = [e for e in traj["events"] if e["kind"] == "turn"]
+    assert len(turns) == 2
+
+
+def test_synthetic_records_not_turns(tmp_path):
+    rows = [_assistant_row("s1", 400_000, model="<synthetic>")]
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    assert [e for e in traj["events"] if e["kind"] == "turn"] == []
+
+
+def test_post_compact_reads_collected(tmp_path):
+    """The first turn after each compact_boundary feeds the corpus median."""
+    rows = _ramp(2, prefix="a") + [_compact_row()] + [_assistant_row("after", 15_000)]
+    traj = tca.parse_trajectory(_write(tmp_path, rows))
+    assert traj["post_compact_reads"] == [15_000]
+    assert traj["post_compact_tokens"] == [12_000]
+
+
+def test_recoverable_usd_upper_bound():
+    """31 Opus turns at 400K vs a 20K post-compact counterfactual: the first
+    turn pays for the compaction, the remaining 30 each save 380K cache_read."""
+    turns = [{"kind": "turn", "cache_read": 400_000, "model": "claude-opus-4-8"}] * 31
+    usd = tca.run_recoverable_usd(turns, median_post=20_000)
+    expected = 30 * 380_000 * tca.ts.PRICING["opus"]["cache_read"] / 1_000_000
+    assert abs(usd - expected) < 1e-9
+
+
+def test_recoverable_usd_never_negative():
+    turns = [{"kind": "turn", "cache_read": 10_000, "model": "claude-opus-4-8"}] * 5
+    assert tca.run_recoverable_usd(turns, median_post=20_000) == 0.0
+
+
+def test_malformed_lines_tolerated(tmp_path):
+    f = tmp_path / "bad.jsonl"
+    f.write_text("{not json\n" + json.dumps(_assistant_row("ok", 400_000)) + "\n")
+    traj = tca.parse_trajectory(f)
+    assert len([e for e in traj["events"] if e["kind"] == "turn"]) == 1
+
+
+def test_cli_flags_present():
+    src = (SCRIPTS / "trace-compact-audit.py").read_text()
+    for flag in ("--projects-dir", "--days", "--threshold", "--min-run", "--output", "--json"):
+        assert flag in src, f"missing CLI flag {flag}"
+    assert "ArgumentParser" in src

--- a/tickets/closed/0239-trace-doctor-phase-2a-missed-compact-cle.erg
+++ b/tickets/closed/0239-trace-doctor-phase-2a-missed-compact-cle.erg
@@ -2,10 +2,12 @@
 Title: trace-doctor phase 2a: missed compact/clear opportunity detector
 Created: 2026-06-10
 Author: Integration Test
+Closed: autoclosed — PR #367
 
 --- log ---
 2026-06-10T12:14Z Integration Test created
 
+2026-06-10T13:56Z Integration Test closed — autoclosed — PR #367
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0239-trace-doctor-phase-2a-missed-compact-cle.erg
Ticket-ref: tickets/0236-trace-doctor-session-trace-economics-aud.erg

## What

Mechanical (zero-LLM) detector for missed compaction/clear opportunities in session traces, plus its report on the 28-day window:

- `scripts/trace-compact-audit.py` — per agent, extracts the per-turn cache_read trajectory (unique message.id order, census dedupe rule) interleaved with `compact_boundary` and `/clear` events; flags runs of ≥30 turns at ≥300K cache_read/turn with no boundary; prices the counterfactual where context drops to the observed post-compact median (12,866 tokens, n=137 real compactions).
- `tests/test_trace_compact_audit.py` — 11 unit tests, including the ticket's mandated fixture (synthetic ramp flagged; same ramp with a mid-run compact_boundary not flagged).
- `docs/trace-compact-audit-2026-06.md` — report: **63 missed runs, recoverable ≤$1,035 / 28 days** (~16% of all spend), 61/63 in main sessions, raid entry skill = 40% of the bound. Clearly labeled an upper bound, with parameter-sensitivity runs (N=20/T=200K and N=40/T=400K).

## Exit criteria

- [x] Detector script committed with passing unit tests (`make check`: 515 passed)
- [x] Missed-compact/clear report committed with the $ counterfactual, clearly labeled as an upper bound

## Verification

`/verify-adherence` passed clean (PASS, no mechanical failures, no semantic findings) — gaze can skip the mechanical phase. Full `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)