### PR TITLE
roar(359): file ticket 0241 + merge-recipe memory

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_verify_agents_dirty_main_repo.md
+++ b/projects/-home-haduong--claude/memory/feedback_verify_agents_dirty_main_repo.md
@@ -35,4 +35,16 @@ close rogue PRs; (3) confirm the expected branch. Known benign tail
 (2026-06-05): a gaze fork may leave the session worktree detached or on the PR
 branch — re-switch, don't panic.
 
+**Merging while the primary holds the PR branch** (recipe validated on PR #359,
+2026-06-10): when the primary checkout sits on the PR branch (dirty, possibly
+owned by another live session), don't move its files. From a fresh worktree:
+(1) `git -C ~/.claude switch --detach` — frees the branch name in place, same
+commit, dirty files untouched; (2) `git switch --ignore-other-worktrees <branch>`
+in the worktree if the detach must be avoided (only safe when no commits will be
+added, e.g. `Ticket: none`); (3) after the mandatory pre-merge rebase, the old
+SHA the primary still sits on is no longer an ancestor of origin/main — verify
+merge equivalence with `git cherry origin/main <old-sha> <base>` (`-` prefix =
+patch already upstream), not `merge-base --is-ancestor`. The /roar pre-check
+hits the same false negative after any rebase-then-merge.
+
 See also: [[feedback_rogue_agent_pattern]], [[feedback_parallel_execute_branch_contamination]]

--- a/rules/git.md
+++ b/rules/git.md
@@ -19,8 +19,9 @@
   ```bash
   git fetch --prune
   for b in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
+    [ "$b" = main ] && continue   # main is always an ancestor; nothing protects it when HEAD is detached
     git merge-base --is-ancestor "$b" origin/main && git branch -d "$b"
   done
   ```
-  The old `git branch -vv | awk '/: gone]/'` pipeline silently no-ops under rtk output rewriting; the merge-probe loop keys on exit code, not parsed stdout, so it stays robust under any hook. The healthcheck's branch hygiene check flags stale locals; this is how to resolve them. Do not use `git branch -D` on a branch whose PR you have not verified is merged.
+  The old `git branch -vv | awk '/: gone]/'` pipeline silently no-ops under rtk output rewriting; the merge-probe loop keys on exit code, not parsed stdout, so it stays robust under any hook. The `main` guard is load-bearing: with the primary checkout detached, `git branch -d main` succeeds (2026-06-10: the unguarded loop deleted local main during a /roar hygiene pass; recovered via `git branch --track main origin/main`). Also expect spurious `-d` refusals from a stale detached HEAD — `-d` checks merged-into-HEAD, not into origin/main; when the is-ancestor probe passed, `-D` is safe. The healthcheck's branch hygiene check flags stale locals; this is how to resolve them. Do not use `git branch -D` on a branch whose PR you have not verified is merged.
 - **Don't gitignore handoff artifacts.** Generated files that a downstream workpackage consumes (figures, tables, macros `\input`ed by the manuscript) are durable state — commit them. Caches, LaTeX aux files, and the final rendered PDF are regenerable — gitignore.

--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -17,7 +17,15 @@ Verify the branch has been merged before proceeding:
 ```bash
 git fetch origin && git merge-base --is-ancestor HEAD origin/main
 ```
-If the current branch is not merged into origin/main, stop and tell the user. Do not continue with roar.
+If the ancestry check fails, do not stop yet: a rebase at the merge gate
+(mandatory per `rules/git.md`) rewrites the SHA, so a checkout still on the
+pre-rebase commit is patch-equivalent but not an ancestor. Fall back to:
+```bash
+git cherry origin/main HEAD <merge-base-or-branch-point>
+```
+A `-` prefix on every listed commit means the patches are already upstream —
+treat that as merged and proceed. Only if commits show `+` (genuinely absent
+from origin/main) stop and tell the user. Do not continue with roar in that case.
 
 ## Reflect and update
 

--- a/tickets/0241-dream-derive-the-consolidation-pr-body-f.erg
+++ b/tickets/0241-dream-derive-the-consolidation-pr-body-f.erg
@@ -1,0 +1,54 @@
+%erg 0.1
+Title: dream: derive the consolidation PR body from the decision table; clean provenance on DELETE
+Created: 2026-06-10
+Author: Integration Test
+
+--- log ---
+2026-06-10T14:10Z Integration Test created
+
+--- body ---
+## Context
+The /gaze review of PR #359 (dream consolidation of -home-haduong-padme)
+found the PR body claimed "8 entries, all NOOP / timestamps refreshed"
+while the diff actually contained 1 DELETE + 2 ADD + 1 UPDATE. The body
+had to be rewritten in-review via REST PATCH. Root cause: SKILL.md step 8
+says "push the branch and open a PR" but never specifies the body content,
+so the model improvises a summary instead of reusing the step-4 decision
+table it just produced.
+
+A second gap from the same review: step 7 records provenance for
+surviving entries but nothing removes the record when an entry is
+DELETEd, leaving stale slugs in the provenance store (harmless today —
+unpromoted entries are ignored by decay — but drift accumulates).
+
+Related non-blocking observation (no action here, housekeeping adopts
+orphans): `projects/-home-haduong-padme/memory/feedback_no_sudo.md` is
+absent from that project's MEMORY.md index on main.
+
+## Relevant files
+- `skills/dream/SKILL.md` — step 4 (decision table), step 7 (provenance record), step 8 (commit + PR)
+- `skills/dream/provenance.py` — needs a `remove <slug> <project>` (or equivalent) operation
+
+## Actions
+1. In SKILL.md step 8, require the PR body to be generated from the
+   step-4 decision table: per-decision counts (NOOP/ADD/UPDATE/DELETE)
+   plus the filename → decision list. No free-form "all NOOP" prose.
+2. In step 2/7, when an entry is classified DELETE, drop its provenance
+   record for that project (add the provenance.py operation if missing).
+
+## Test
+- Adherence-style check: SKILL.md step 8 mentions the decision table as
+  the PR-body source (string match on the skill file).
+- Unit test for the new provenance.py removal operation.
+
+## Verification
+- [ ] A dry-run dream on a fixture project produces a PR body matching the decision table
+- [ ] Deleting an entry removes its provenance record
+
+## Invariants
+- Existing provenance records for surviving entries unchanged
+- `make check` passes
+
+## Exit criteria
+- [ ] Dream PR bodies are mechanically derived from the decision table
+- [ ] DELETE cleans up provenance


### PR DESCRIPTION
Follow-ups from the /roar wrap-up of PR #359 (dream consolidation merge).

- **tickets/0241** — dream skill: derive the consolidation PR body from the step-4 decision table (gaze caught the improvised body misdescribing the diff on #359), and drop provenance records on DELETE.
- **memory** — append the validated merge recipe (detach-in-place, `--ignore-other-worktrees`, `git cherry` equivalence after a pre-merge rebase) to the existing `feedback_verify_agents_dirty_main_repo` entry. The entry file only — the MEMORY.md index is left untouched because a parallel session has uncommitted changes there.
- **rules/git.md** — the branch-hygiene merge-probe loop now skips `main`: with the primary checkout detached, nothing protects it and the unguarded loop deleted local main during this roar (recovered via `git branch --track main origin/main`). Also documents the spurious `-d` refusal from a stale detached HEAD.
- **skills/roar/SKILL.md** — pre-check gains a `git cherry` patch-equivalence fallback: the mandatory merge-gate rebase rewrites the SHA, so a checkout on the pre-rebase commit false-negatives the ancestry check.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)