### PR TITLE
fix(0242): branch-cleanup recipe and roar 9b no longer destroy live branches

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -18,10 +18,12 @@
 - **Delete branches after merge.** All repos use `deleteBranchOnMerge: true` on GitHub, so the remote branch disappears automatically when a PR merges. Clean up stale local branches with:
   ```bash
   git fetch --prune
+  cur=$(git branch --show-current)
   for b in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
-    [ "$b" = main ] && continue   # main is always an ancestor; nothing protects it when HEAD is detached
-    git merge-base --is-ancestor "$b" origin/main && git branch -d "$b"
+    [ "$b" = main ] && continue     # main is always an ancestor; nothing protects it when HEAD is detached
+    [ "$b" = "$cur" ] && continue   # never delete the branch you are standing on
+    git merge-base --is-ancestor "$b" origin/main && git branch -D "$b"
   done
   ```
-  The old `git branch -vv | awk '/: gone]/'` pipeline silently no-ops under rtk output rewriting; the merge-probe loop keys on exit code, not parsed stdout, so it stays robust under any hook. The `main` guard is load-bearing: with the primary checkout detached, `git branch -d main` succeeds (2026-06-10: the unguarded loop deleted local main during a /roar hygiene pass; recovered via `git branch --track main origin/main`). Also expect spurious `-d` refusals from a stale detached HEAD — `-d` checks merged-into-HEAD, not into origin/main; when the is-ancestor probe passed, `-D` is safe. The healthcheck's branch hygiene check flags stale locals; this is how to resolve them. Do not use `git branch -D` on a branch whose PR you have not verified is merged.
+  The old `git branch -vv | awk '/: gone]/'` pipeline silently no-ops under rtk output rewriting; the merge-probe loop keys on exit code, not parsed stdout, so it stays robust under any hook. The `main` and current-branch guards are load-bearing: with the primary checkout detached, `git branch -d main` succeeds (2026-06-10: the unguarded loop deleted local main during a /roar hygiene pass; recovered via `git branch --track main origin/main`). The loop uses `-D` deliberately: `-d` checks merged-into-HEAD, not merged-into-origin/main, so it spuriously refuses — and silently leaves behind — merged branches whose upstream is gone (deleteBranchOnMerge) or when HEAD is a stale detached commit; the `merge-base --is-ancestor` probe has just proven the branch is contained in origin/main, which is exactly the safety `-d` is meant to provide. The healthcheck's branch hygiene check flags stale locals; this is how to resolve them. Outside this probe-guarded loop, do not use `git branch -D` on a branch whose PR you have not verified is merged.
 - **Don't gitignore handoff artifacts.** Generated files that a downstream workpackage consumes (figures, tables, macros `\input`ed by the manuscript) are durable state — commit them. Caches, LaTeX aux files, and the final rendered PDF are regenerable — gitignore.

--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -59,7 +59,20 @@ from origin/main) stop and tell the user. Do not continue with roar in that case
        (`git merge-base --is-ancestor HEAD origin/main`) has already
        passed, the worktree branch is fully merged — ExitWorktree's
        "N commits would be discarded" warning is a false alarm from a
-       stale local main. Authorize `discard_changes` in that case.
+       stale local main. But `discard_changes` does more than remove the
+       worktree: ExitWorktree restores the session to the ORIGINAL
+       checkout, and with `discard_changes: true` it also deletes the
+       original branch — the one the primary checkout returns to. So
+       BEFORE authorizing `discard_changes`, verify that ORIGINAL branch
+       is pushed or merged (`git -C <primary> merge-base --is-ancestor
+       <original-branch> origin/main`, or check it has an up-to-date
+       upstream). If it carries unmerged commits, use `action: "keep"`
+       instead (2026-06-10: discard_changes deleted
+       `dream-consolidate-2026-06-09` and orphaned another session's
+       unmerged commit at a detached HEAD). Recovery if the branch was
+       deleted anyway: find the commit in `git reflog` (or the deletion
+       message prints its sha) and re-create the branch with
+       `git switch -c <branch> <sha>`.
     Skip if not in a worktree.
 10. **GC stale worktrees** (from the main repo): prune any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
     ```bash

--- a/tests/test_branch_cleanup_recipes.py
+++ b/tests/test_branch_cleanup_recipes.py
@@ -1,0 +1,83 @@
+"""Branch-cleanup recipes must not destroy live branches (ticket 0242).
+
+Two documented recipes lost branches on 2026-06-10:
+
+1. The stale-branch cleanup loop in ``rules/git.md`` ("Delete branches
+   after merge") deletes any local branch that is an ancestor of
+   origin/main — local ``main`` always is, and so is the branch you are
+   standing on right after a merge. The recipe must skip ``main`` and the
+   current branch explicitly, and use ``git branch -D`` (safe: the
+   merge-base probe has just proven the branch is an ancestor of
+   origin/main; ``-d`` checks merged-into-HEAD and spuriously refuses).
+
+2. ``skills/roar/SKILL.md`` step 9b blanket-authorized ExitWorktree's
+   ``discard_changes``, which also deletes the ORIGINAL branch the
+   primary checkout returns to — orphaning unmerged commits at a
+   detached HEAD. The step must require verifying the original branch is
+   pushed or merged first, offer ``action: "keep"`` otherwise, and
+   document the reflog recovery path.
+
+These are string-match ratchets on the rule/skill text.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+GIT_RULES = (REPO / "rules" / "git.md").read_text()
+ROAR_SKILL = (REPO / "skills" / "roar" / "SKILL.md").read_text()
+
+
+def cleanup_recipe() -> str:
+    """The fenced bash block of the 'Delete branches after merge' bullet."""
+    bullet = GIT_RULES.split("**Delete branches after merge.**", 1)[1]
+    return bullet.split("```bash", 1)[1].split("```", 1)[0]
+
+
+def test_git_md_recipe_skips_main():
+    recipe = cleanup_recipe()
+    assert '[ "$b" = main ] && continue' in recipe, (
+        "rules/git.md cleanup loop must skip local main — it is always an "
+        "ancestor of origin/main and the loop would delete it"
+    )
+
+
+def test_git_md_recipe_skips_current_branch():
+    recipe = cleanup_recipe()
+    assert "--show-current" in recipe, (
+        "rules/git.md cleanup loop must skip the current branch "
+        "(guard via git branch --show-current)"
+    )
+
+
+def test_git_md_recipe_uses_force_delete_after_ancestor_probe():
+    recipe = cleanup_recipe()
+    assert 'git branch -D "$b"' in recipe, (
+        "rules/git.md cleanup loop must use -D: -d checks merged-into-HEAD "
+        "and silently skips branches whose upstream is gone; the "
+        "merge-base --is-ancestor probe already proved the branch merged"
+    )
+    assert 'git branch -d "$b"' not in recipe
+
+
+def test_roar_9b_checks_original_branch_before_discard():
+    assert "ORIGINAL branch" in ROAR_SKILL, (
+        "roar step 9b must require verifying the ORIGINAL branch (the one "
+        "the primary checkout returns to) is pushed or merged before "
+        "authorizing discard_changes"
+    )
+    assert "pushed or merged" in ROAR_SKILL
+
+
+def test_roar_9b_offers_keep_for_unmerged_original():
+    assert '`action: "keep"`' in ROAR_SKILL, (
+        "roar step 9b must direct the agent to use action: \"keep\" when "
+        "the original branch carries unmerged commits"
+    )
+
+
+def test_roar_9b_documents_reflog_recovery():
+    assert "reflog" in ROAR_SKILL and "git switch -c" in ROAR_SKILL, (
+        "roar step 9b must document the recovery path (reflog + "
+        "git switch -c) for a branch deleted by discard_changes"
+    )

--- a/tickets/closed/0242-branch-cleanup-recipe-deletes-local-main.erg
+++ b/tickets/closed/0242-branch-cleanup-recipe-deletes-local-main.erg
@@ -2,10 +2,12 @@
 Title: branch-cleanup recipe deletes local main; ExitWorktree discard nukes original branch
 Created: 2026-06-10
 Author: Integration Test
+Closed: autoclosed — PR #373
 
 --- log ---
 2026-06-10T14:33Z Integration Test created
 
+2026-06-10T15:10Z Integration Test closed — autoclosed — PR #373
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0242-branch-cleanup-recipe-deletes-local-main.erg

## What

Two documentation footguns from the 2026-06-10 incident (PR #370 session), plus a ratchet test:

- **rules/git.md** "Delete branches after merge" recipe: adds a current-branch guard next to the existing `main` guard, and switches the loop's deletion to `git branch -D`. `-d` checks merged-into-HEAD rather than merged-into-origin/main, so it spuriously refuses from a stale detached HEAD and silently skips merged branches whose upstream is gone; the `merge-base --is-ancestor` probe right before the delete already proves the branch is contained in origin/main. Prose updated to explain why `-D` is safe *inside* this probe-guarded loop and still forbidden outside it.

- **skills/roar/SKILL.md** step 9b: before authorizing ExitWorktree's `discard_changes`, the agent must verify the ORIGINAL branch (the one the primary checkout returns to) is pushed or merged; if it carries unmerged commits, use `action: "keep"` instead. Documents the reflog + `git switch -c` recovery path. Incident: `discard_changes` deleted `dream-consolidate-2026-06-09` and orphaned an unmerged commit at detached HEAD.

- **tests/test_branch_cleanup_recipes.py**: 6 string-match ratchet tests, proven RED against the pre-fix files (5 failed; the `main` guard itself had already landed via the incident hotfix), GREEN after.

## Verification

- `uv run ruff check tests/test_branch_cleanup_recipes.py` clean (7 pre-existing findings in untouched test files are out of scope; repo CI does not run repo-wide ruff)
- Full suite: 532 passed
- `make check`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)