### PR TITLE
trace-doctor phase 3: hypothesis testing on the full census

### DIFF
--- a/docs/trace-hypotheses-2026-06.md
+++ b/docs/trace-hypotheses-2026-06.md
@@ -1,0 +1,69 @@
+# Trace hypothesis-testing report — 2026-06 (ticket 0243, trace-doctor phase 3)
+
+Confirmation pass: the thirteen hypotheses fixed by phase 2b
+(`docs/trace-open-coding-2026-06.md`) computed over the FULL 28-day
+census — 1,790 agents, 309 sessions, $6,705 total (≈ $1,676/week). The
+30-trace discovery sample played no part in any number below.
+
+## Method
+
+- Census regenerated with the new 0243 detector columns:
+  `uv run python scripts/trace-stats.py --days 28 --output <csv>`
+  (nav/idle turn classification, merge-success marker, verify/gaze count).
+- Statistics: `uv run python scripts/trace-hypotheses.py --census <csv>
+  --compact-audit-json <json>`; H8 input from
+  `scripts/trace-compact-audit.py --days 28 --json`.
+- $ attributions for H10/H11 are linear per-turn approximations
+  (cost × turns-in-class / turns). Late turns read more context than
+  early ones, so H10 is a LOWER bound; H11's idle-turn component counts
+  legitimate reasoning/communication turns too and is an UPPER bound.
+  Both are screening numbers — phase 4 settles them counterfactually.
+- Zero LLM tokens; aggregates only.
+
+## Verdicts
+
+| ID | Hypothesis | Statistic (28-day census) | Verdict |
+|----|-----------|---------------------------|---------|
+| H1 | cache_read dominates $ | 68.7% of categorized $ ($4,252 of $6,189) | **Supported** |
+| H2 | top-decile context concentration | cr/turn by cost decile: 24K (d1) → 161K (d10), 6.8×; log-log exponent 1.18 | **Supported** (as reframed; the quadratic form stays rejected) |
+| H3 | read-only agents drift past budget | 68 agents, $96, 1.4% of spend | **Confirmed-but-small** — deprioritize |
+| H4 | gaze cost independent of diff size | needs forge join (`--pr-stats`) | **Needs-data** → phase 4 |
+| H5 | spawn-boundary redundancy | subagent cache_write ≤ $572 upper; per-message overlap needs phase-4 extraction | **Plausible, needs-data** |
+| H6 | mains are the cost center | 75.4% of $ from main agents | **Supported** |
+| H7 | Opus mains sit off the cost curve | mean log-residual, mains: opus **+1.04** (≈2.8× over curve), sonnet +0.00, haiku −0.55 | **Supported** |
+| H8 | compaction late or absent | 64 missed runs, **$1,044** recoverable (upper bound), 135 compactions observed | **Supported** |
+| H10 | post-delivery tail is material | 60 sessions carry a merge marker; tail = **$968**, 14.4% of all spend (lower bound) | **Supported** — largest surprise |
+| H11 | micro-turn churn | nav+idle turns ≈ **$2,169**, 32.4% (upper bound; idle includes legitimate reasoning turns); p99 nav-run length 32 | **Supported as screening** — needs phase-4 tightening |
+| H12 | same-file re-reads | 384 agents re-read one file ≥3×; they hold $4,679 (total agent $, NOT the waste itself) | **Weakly supported** — statistic too blunt, refine in phase 4 |
+| H13 | verification re-entry | 43 sessions invoked verify/gaze ≥2×; they hold $2,080 (31% of spend; incremental cost not yet isolated) | **Supported as signal** — incremental $ in phase 4 |
+| D1 | zero-turn traces | 29 flagged, excluded from all $ statistics | **Done** (chore) |
+
+## Ranked recommendations (by $/week at stake)
+
+Window total ≈ $1,676/week. "At stake" is the screening bound above, not
+a promised saving; the Route column says which phase settles it.
+
+| # | Recommendation | $/week at stake | Bound | Route |
+|---|----------------|-----------------|-------|-------|
+| 1 | Micro-turn discipline: batch navigational commands, cap nav runs (p99 run = 32 turns) | ≤ $542 | upper | Phase 4: re-estimate excluding final/communication turns, then prompt-rule A/B |
+| 2 | Verification re-entry: make gaze/verify converge in one pass | ≤ $520 (total in affected sessions) | upper | Phase 4: isolate incremental $ of 2nd+ invocations |
+| 3 | Compaction policy: compact/clear when cr/turn stays ≥300K over 30+ turns | ≤ $261 | upper | Adopt cheaply: the phase-2a detector IS the counterfactual; wire as advisory check |
+| 4 | Post-delivery tail: move wrap-up (memory, housekeeping, roar) to a fresh cheap session instead of the peak-context session | ≥ $242 | lower | Phase 5 A/B: roar-in-fresh-session flag |
+| 5 | Model right-sizing: long interactive mains on Opus run ≈2.8× over the cost curve | (subset of H6's 75%) | — | Phase 5 A/B: default long autonomous mains to Sonnet, measure quality via gaze verdicts |
+| 6 | Read-only drift caps (H3) | ~$24 | exact | **Reject**: measured small; close the seed |
+
+Quality baseline (trace → PR outcome join) and H4 remain open pending the
+forge join; phase 4 should land `--pr-stats` first so recommendations 1–5
+can each carry a quality-risk column before any A/B ships.
+
+## Phase-4 feedstock
+
+- Tighten H11: classify idle turns into reasoning-before-action vs
+  trailing communication; exclude the final turn.
+- H13 incremental cost: per-invocation $ delta within re-entry sessions.
+- H12 refine: re-read cost = (repeats−1) × file size × cache_read rate,
+  not total agent $.
+- H5 extraction: per-message cache_creation overlap across siblings
+  (needs trace-level pass, still zero-LLM).
+- H4 + quality: forge CLI join (PR number from trace → diff size,
+  verdict, REROLL count) cached to a committed CSV.

--- a/docs/trace-hypotheses-2026-06.md
+++ b/docs/trace-hypotheses-2026-06.md
@@ -28,7 +28,7 @@ census — 1,790 agents, 309 sessions, $6,705 total (≈ $1,676/week). The
 | H2 | top-decile context concentration | cr/turn by cost decile: 24K (d1) → 161K (d10), 6.8×; log-log exponent 1.18 | **Supported** (as reframed; the quadratic form stays rejected) |
 | H3 | read-only agents drift past budget | 68 agents, $96, 1.4% of spend | **Confirmed-but-small** — deprioritize |
 | H4 | gaze cost independent of diff size | needs forge join (`--pr-stats`) | **Needs-data** → phase 4 |
-| H5 | spawn-boundary redundancy | subagent cache_write ≤ $572 upper; per-message overlap needs phase-4 extraction | **Plausible, needs-data** |
+| H5 | spawn-boundary redundancy | subagent cache_write ≤ $498 upper (each row at its family's 5m write rate — the census has fable subagents at 2× the opus rate, so flat opus pricing is not a bound); per-message overlap needs phase-4 extraction | **Plausible, needs-data** |
 | H6 | mains are the cost center | 75.4% of $ from main agents | **Supported** |
 | H7 | Opus mains sit off the cost curve | mean log-residual, mains: opus **+1.04** (≈2.8× over curve), sonnet +0.00, haiku −0.55 | **Supported** |
 | H8 | compaction late or absent | 64 missed runs, **$1,044** recoverable (upper bound), 135 compactions observed | **Supported** |

--- a/scripts/trace-hypotheses.py
+++ b/scripts/trace-hypotheses.py
@@ -221,8 +221,9 @@ def merge_optional_inputs(results: dict, compact_json: Path | None, pr_stats: Pa
         data = json.loads(compact_json.read_text())
         results["H8"] = {
             "verdict": "computed",
-            "recoverable_usd_upper": data.get("recoverable_usd_upper")
-            or data.get("total_recoverable_usd"),
+            "recoverable_usd_upper": data.get("recoverable_usd_upper_bound")
+            or data.get("recoverable_usd_upper"),
+            "missed_runs": data.get("missed_runs"),
             "source": str(compact_json),
         }
     if pr_stats and pr_stats.exists():

--- a/scripts/trace-hypotheses.py
+++ b/scripts/trace-hypotheses.py
@@ -97,6 +97,7 @@ def compute_all(all_rows: list[dict]) -> dict:
     )
     ts = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(ts)
+    max_5m_pricing = max(ts.PRICING.values(), key=lambda p: p["cache_write_5m"])
     for r in rows:
         p = ts.resolve_pricing(r.get("model") or "")
         if p is None:
@@ -177,9 +178,18 @@ def compute_all(all_rows: list[dict]) -> dict:
         "H5": {
             "verdict": "needs-data",
             "note": "spawn-boundary redundancy needs per-message cache_creation; phase-4 extraction",
+            # Per-row family 5m write rate; unknown models priced at the
+            # fleet-max rate so the figure stays a true upper bound (the
+            # census has fable subagents, which bill 2x the opus rate).
             "subagent_cache_write_usd_upper": round(
                 sum(
-                    r["cache_creation_input_tokens"] * 6.25 / 1e6  # opus 5m upper
+                    r["cache_creation_input_tokens"]
+                    * (
+                        (ts.resolve_pricing(r.get("model") or "") or max_5m_pricing)[
+                            "cache_write_5m"
+                        ]
+                    )
+                    / 1e6
                     for r in subs
                 ),
                 2,

--- a/scripts/trace-hypotheses.py
+++ b/scripts/trace-hypotheses.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Phase-3 hypothesis statistics over the trace census — ticket 0243.
+
+Reads the per-agent census CSV (scripts/trace-stats.py with the 0243
+detector columns) and computes one statistic per hypothesis H1-H13 from
+docs/trace-open-coding-2026-06.md, plus the D1 data-quality flag. Emits a
+JSON summary and an optional markdown section ready for the report.
+
+Honest-accounting notes:
+- Zero-turn agents (D1) are flagged and EXCLUDED from every $ statistic.
+- Per-turn $ attributions (H10 tail, H11 micro-turns) are linear
+  approximations: cost x (turns-in-class / turns). Late turns read more
+  context than early ones, so H10 is a LOWER bound and H11 mixes both
+  directions; both are screening statistics, settled in phase 4.
+- H4 and the quality baseline need a forge join (--pr-stats CSV); H5 and
+  H8 need per-message data (--compact-audit-json for H8). Absent inputs
+  yield verdict "needs-data", never a silent drop.
+
+Zero LLM/API calls.
+"""
+
+import argparse
+import csv
+import json
+import logging
+import math
+import statistics
+import sys
+from pathlib import Path
+
+log = logging.getLogger("trace-hypotheses")
+
+INT_COLS = (
+    "turns",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "max_read_repeat",
+    "nav_turns",
+    "idle_turns",
+    "max_nav_run",
+    "verify_gaze_skills",
+)
+
+
+def load_census(path: Path) -> list[dict]:
+    rows = []
+    with open(path, newline="", encoding="utf-8") as fh:
+        for raw in csv.DictReader(fh):
+            r = dict(raw)
+            for k in INT_COLS:
+                r[k] = int(float(r.get(k) or 0))
+            r["cost_usd"] = float(r.get("cost_usd") or 0)
+            mm = r.get("merge_marker_turn")
+            r["merge_marker_turn"] = int(float(mm)) if mm not in (None, "") else None
+            r["read_only"] = str(r.get("read_only")) == "True"
+            rows.append(r)
+    return rows
+
+
+def fit_loglog(rows: list[dict]) -> float:
+    """Least-squares slope of log(cost) ~ log(turns) over positive rows."""
+    pts = [
+        (math.log(r["turns"]), math.log(r["cost_usd"]))
+        for r in rows
+        if r["turns"] > 0 and r["cost_usd"] > 0
+    ]
+    n = len(pts)
+    if n < 2:
+        return float("nan")
+    mx = sum(x for x, _ in pts) / n
+    my = sum(y for _, y in pts) / n
+    sxx = sum((x - mx) ** 2 for x, _ in pts)
+    sxy = sum((x - mx) * (y - my) for x, y in pts)
+    return sxy / sxx if sxx else float("nan")
+
+
+def _share(part: float, whole: float) -> float:
+    return part / whole if whole else 0.0
+
+
+def compute_all(all_rows: list[dict]) -> dict:
+    zero = [r for r in all_rows if r["turns"] == 0]
+    rows = [r for r in all_rows if r["turns"] > 0]
+    total = sum(r["cost_usd"] for r in rows)
+    mains = [r for r in rows if r["agent_id"] == "main"]
+    subs = [r for r in rows if r["agent_id"] != "main"]
+
+    # H1: $ share by token category, priced per row's dominant model.
+    # Approximation: the dominant model prices ALL of a row's tokens.
+    cat_usd = dict.fromkeys(("input", "output", "cache_read", "cache_write"), 0.0)
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "trace_stats", Path(__file__).resolve().parent / "trace-stats.py"
+    )
+    ts = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ts)
+    for r in rows:
+        p = ts.resolve_pricing(r.get("model") or "")
+        if p is None:
+            continue
+        cat_usd["input"] += r["input_tokens"] * p["input"] / 1e6
+        cat_usd["output"] += r["output_tokens"] * p["output"] / 1e6
+        cat_usd["cache_read"] += r["cache_read_input_tokens"] * p["cache_read"] / 1e6
+        cat_usd["cache_write"] += r["cache_creation_input_tokens"] * p["cache_write_5m"] / 1e6
+    cat_total = sum(cat_usd.values())
+
+    # H2: context concentration by cost decile + global exponent.
+    by_cost = sorted(rows, key=lambda r: r["cost_usd"])
+    cr_per_turn_decile = []
+    if by_cost:
+        size = max(1, len(by_cost) // 10)
+        for d in range(10):
+            chunk = by_cost[d * size : (d + 1) * size] if d < 9 else by_cost[9 * size :]
+            turns = sum(r["turns"] for r in chunk)
+            cr = sum(r["cache_read_input_tokens"] for r in chunk)
+            cr_per_turn_decile.append(round(cr / turns) if turns else 0)
+
+    # H3: read-only subagents drifting past 40 turns.
+    drift = [r for r in subs if r["read_only"] and r["turns"] > 40]
+
+    # H7: mean log-residual by model family, mains only.
+    slope = fit_loglog(rows)
+    resid_by_family: dict[str, list[float]] = {}
+    if not math.isnan(slope):
+        pts = [r for r in rows if r["turns"] > 0 and r["cost_usd"] > 0]
+        mx = statistics.mean(math.log(r["turns"]) for r in pts)
+        my = statistics.mean(math.log(r["cost_usd"]) for r in pts)
+        intercept = my - slope * mx
+        for r in mains:
+            if r["cost_usd"] <= 0 or r["turns"] <= 0:
+                continue
+            fam = next(
+                (f for f in ("fable", "opus", "sonnet", "haiku") if f in (r.get("model") or "")),
+                "unknown",
+            )
+            pred = intercept + slope * math.log(r["turns"])
+            resid_by_family.setdefault(fam, []).append(math.log(r["cost_usd"]) - pred)
+    h7 = {f: round(statistics.mean(v), 3) for f, v in resid_by_family.items() if v}
+
+    # H10: post-delivery tail (linear approximation, lower bound).
+    marked = [r for r in mains if r["merge_marker_turn"] is not None]
+    tail_usd = sum(
+        r["cost_usd"] * (r["turns"] - r["merge_marker_turn"]) / r["turns"]
+        for r in marked
+        if r["turns"] > 0 and r["merge_marker_turn"] < r["turns"]
+    )
+
+    # H11: micro-turn (navigational + idle) $ estimate, linear approximation.
+    micro_usd = sum(
+        r["cost_usd"] * (r["nav_turns"] + r["idle_turns"]) / r["turns"]
+        for r in rows
+        if r["turns"] > 0
+    )
+
+    # H12: $ sitting in agents that re-read one file 3+ times.
+    reread = [r for r in rows if r["max_read_repeat"] >= 3]
+
+    # H13: sessions whose MAIN invoked verify/gaze 2+ times.
+    reentry = [r for r in mains if r["verify_gaze_skills"] >= 2]
+
+    return {
+        "D1": {"zero_turn_agents": len(zero)},
+        "H1": {
+            "category_usd": {k: round(v, 2) for k, v in cat_usd.items()},
+            "cache_read_share": round(_share(cat_usd["cache_read"], cat_total), 3),
+        },
+        "H2": {"loglog_exponent": round(slope, 3), "cr_per_turn_by_decile": cr_per_turn_decile},
+        "H3": {
+            "drift_agents": len(drift),
+            "drift_usd": round(sum(r["cost_usd"] for r in drift), 2),
+            "drift_share": round(_share(sum(r["cost_usd"] for r in drift), total), 4),
+        },
+        "H4": {"verdict": "needs-data", "note": "requires --pr-stats forge join"},
+        "H5": {
+            "verdict": "needs-data",
+            "note": "spawn-boundary redundancy needs per-message cache_creation; phase-4 extraction",
+            "subagent_cache_write_usd_upper": round(
+                sum(
+                    r["cache_creation_input_tokens"] * 6.25 / 1e6  # opus 5m upper
+                    for r in subs
+                ),
+                2,
+            ),
+        },
+        "H6": {
+            "total_usd": round(total, 2),
+            "main_share": round(_share(sum(r["cost_usd"] for r in mains), total), 3),
+        },
+        "H7": {"mean_log_residual_by_family_mains": h7},
+        "H8": {"verdict": "needs-data", "note": "run scripts/trace-compact-audit.py --json"},
+        "H10": {
+            "sessions_with_marker": len(marked),
+            "tail_usd": round(tail_usd, 2),
+            "tail_share_of_total": round(_share(tail_usd, total), 4),
+        },
+        "H11": {
+            "micro_usd": round(micro_usd, 2),
+            "micro_share": round(_share(micro_usd, total), 4),
+            "max_nav_run_p99": (
+                sorted(r["max_nav_run"] for r in rows)[int(0.99 * (len(rows) - 1))]
+                if rows
+                else 0
+            ),
+        },
+        "H12": {
+            "reread_agents": len(reread),
+            "reread_usd": round(sum(r["cost_usd"] for r in reread), 2),
+        },
+        "H13": {
+            "reentry_sessions": len(reentry),
+            "reentry_usd": round(sum(r["cost_usd"] for r in reentry), 2),
+        },
+    }
+
+
+def merge_optional_inputs(results: dict, compact_json: Path | None, pr_stats: Path | None) -> dict:
+    if compact_json and compact_json.exists():
+        data = json.loads(compact_json.read_text())
+        results["H8"] = {
+            "verdict": "computed",
+            "recoverable_usd_upper": data.get("recoverable_usd_upper")
+            or data.get("total_recoverable_usd"),
+            "source": str(compact_json),
+        }
+    if pr_stats and pr_stats.exists():
+        results["H4"]["verdict"] = "computed-externally"
+        results["H4"]["source"] = str(pr_stats)
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute H1-H13 statistics over the trace census CSV."
+    )
+    parser.add_argument("--census", type=Path, required=True, help="Per-agent census CSV")
+    parser.add_argument("--output", type=Path, help="Write JSON results here (default stdout)")
+    parser.add_argument(
+        "--compact-audit-json", type=Path, help="trace-compact-audit.py --json output (H8)"
+    )
+    parser.add_argument("--pr-stats", type=Path, help="Forge-join CSV for H4/quality baseline")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    rows = load_census(args.census)
+    results = merge_optional_inputs(compute_all(rows), args.compact_audit_json, args.pr_stats)
+    text = json.dumps(results, indent=2)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+        log.info("wrote %s", args.output)
+    else:
+        sys.stdout.write(text + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -90,6 +90,23 @@ USAGE_KEYS = (
     "cache_creation_input_tokens",
 )
 
+# Ticket 0243 (H11): a turn is "navigational" when every tool call on it
+# matches this — pure orientation, no mutation, no new information source.
+NAV_COMMAND_RE = re.compile(
+    r"^\s*(?:cd|ls|pwd)\b|^\s*git\s+(?:status|log|branch|show-current)\b"
+)
+
+# Ticket 0243 (H10): delivery completed inside the session. Matched against
+# JSON-encoded tool_result content; upper bound (quoted text also matches).
+MERGE_MARKER_RE = re.compile(r"Merge queued|Pull Request successfully merged|state=MERGED")
+
+# Ticket 0243 (H13): verification machinery re-entry.
+VERIFY_SKILLS = {"verify", "gaze", "verify-gate"}
+
+
+def _is_nav_tool(name: str, tool_input: dict) -> bool:
+    return name == "Bash" and bool(NAV_COMMAND_RE.search(str(tool_input.get("command", ""))))
+
 
 def resolve_pricing(model_id: str) -> dict | None:
     """Map a model id to its pricing family; None for unknown models."""
@@ -156,6 +173,10 @@ def parse_trace_file(path: Path) -> dict:
     first_ts = last_ts = None
     final_cache_read = 0
     entry_skill = None
+    turn_tool_kinds: list[list[str]] = []  # per non-synthetic turn: "nav"/"work" per tool
+    msg_turn_index: dict[str, int] = {}
+    merge_marker_turn: int | None = None
+    verify_gaze = 0
 
     with open(path, encoding="utf-8", errors="replace") as fh:
         for line in fh:
@@ -192,6 +213,8 @@ def parse_trace_file(path: Path) -> dict:
                     if model == "<synthetic>":
                         synthetic += 1
                     else:
+                        msg_turn_index[msg_id] = len(turn_tool_kinds)
+                        turn_tool_kinds.append([])
                         models[model] += 1
                         for k in USAGE_KEYS:
                             tokens[k] += usage.get(k, 0) or 0
@@ -212,6 +235,13 @@ def parse_trace_file(path: Path) -> dict:
                         name = block.get("name", "?")
                         tool_counts[name] += 1
                         tool_input = block.get("input") or {}
+                        turn_idx = msg_turn_index.get(msg.get("id") or "")
+                        if turn_idx is not None:
+                            turn_tool_kinds[turn_idx].append(
+                                "nav" if _is_nav_tool(name, tool_input) else "work"
+                            )
+                        if name == "Skill" and tool_input.get("skill") in VERIFY_SKILLS:
+                            verify_gaze += 1
                         if name in WRITE_TOOLS:
                             wrote_files = True
                         elif name == "Read" and tool_input.get("file_path"):
@@ -227,21 +257,35 @@ def parse_trace_file(path: Path) -> dict:
                     for block in content:
                         if isinstance(block, dict) and block.get("type") == "tool_result":
                             try:
-                                tool_result_bytes += len(
-                                    json.dumps(block.get("content", ""))
-                                )
+                                result_text = json.dumps(block.get("content", ""))
                             except (TypeError, ValueError):
-                                pass
+                                continue
+                            tool_result_bytes += len(result_text)
+                            if merge_marker_turn is None and MERGE_MARKER_RE.search(
+                                result_text
+                            ):
+                                merge_marker_turn = len(turn_tool_kinds)
                 elif isinstance(content, str) and entry_skill is None:
                     for m in re.finditer(r"<command-name>/?([\w-]+)</command-name>", content):
                         if m.group(1) not in BUILTIN_COMMANDS:
                             entry_skill = m.group(1)
                             break
 
+    nav_flags = [bool(kinds) and all(k == "nav" for k in kinds) for kinds in turn_tool_kinds]
+    max_nav_run = run = 0
+    for flag in nav_flags:
+        run = run + 1 if flag else 0
+        max_nav_run = max(max_nav_run, run)
+
     return {
         **tokens,
         "cost_usd": cost,
         "turns": len(seen_ids) - synthetic,
+        "nav_turns": sum(nav_flags),
+        "idle_turns": sum(1 for kinds in turn_tool_kinds if not kinds),
+        "max_nav_run": max_nav_run,
+        "merge_marker_turn": merge_marker_turn,
+        "verify_gaze_skills": verify_gaze,
         "synthetic_messages": synthetic,
         "unknown_model_messages": unknown_model,
         "skipped_lines": skipped,
@@ -295,6 +339,11 @@ CSV_COLUMNS = [
     "read_only",
     "ask_user_questions",
     "final_cache_read",
+    "nav_turns",
+    "idle_turns",
+    "max_nav_run",
+    "merge_marker_turn",
+    "verify_gaze_skills",
     "entry_skill",
     "path",
 ]
@@ -325,6 +374,13 @@ def build_row(project: str, session_id: str, agent_id: str, path: Path, stats: d
         "read_only": stats["read_only"],
         "ask_user_questions": stats["ask_user_questions"],
         "final_cache_read": stats["final_cache_read"],
+        "nav_turns": stats["nav_turns"],
+        "idle_turns": stats["idle_turns"],
+        "max_nav_run": stats["max_nav_run"],
+        "merge_marker_turn": (
+            "" if stats["merge_marker_turn"] is None else stats["merge_marker_turn"]
+        ),
+        "verify_gaze_skills": stats["verify_gaze_skills"],
         "entry_skill": stats["entry_skill"] or "",
         "path": str(path),
     }

--- a/tests/test_trace_hypotheses.py
+++ b/tests/test_trace_hypotheses.py
@@ -99,6 +99,22 @@ def test_h12_reread_cost():
     assert abs(res["H12"]["reread_usd"] - 6.0) < 1e-9
 
 
+def test_h5_subagent_cache_write_priced_per_family():
+    # Upper bound must price each subagent row at ITS family's 5m write rate:
+    # fable bills 12.5/MTok — flat opus pricing (6.25) would understate it 2x.
+    rows = [
+        _row(agent_id="agent-f", model="claude-fable-5", cache_creation_input_tokens=1_000_000),
+        _row(
+            session_id="s2",
+            agent_id="agent-o",
+            model="claude-opus-4-8",
+            cache_creation_input_tokens=1_000_000,
+        ),
+    ]
+    res = th.compute_all(rows)
+    assert abs(res["H5"]["subagent_cache_write_usd_upper"] - (12.5 + 6.25)) < 1e-6
+
+
 def test_h2_loglog_exponent_recovers_power_law():
     rows = [_row(session_id=f"s{n}", turns=n, cost_usd=float(n**1.5)) for n in (2, 4, 8, 16, 32)]
     exp = th.fit_loglog(rows)

--- a/tests/test_trace_hypotheses.py
+++ b/tests/test_trace_hypotheses.py
@@ -121,6 +121,14 @@ def test_load_census_types(tmp_path):
     assert rows[0]["read_only"] is False
 
 
+def test_h8_reads_compact_audit_key(tmp_path):
+    j = tmp_path / "compact.json"
+    j.write_text('{"missed_runs": 64, "recoverable_usd_upper_bound": 1044.29}')
+    res = th.merge_optional_inputs({"H4": {"verdict": "needs-data"}, "H8": {}}, j, None)
+    assert res["H8"]["recoverable_usd_upper"] == 1044.29
+    assert res["H8"]["missed_runs"] == 64
+
+
 def test_cli_flags_present():
     src = (SCRIPTS / "trace-hypotheses.py").read_text()
     for flag in ("--census", "--output", "--compact-audit-json", "--pr-stats"):

--- a/tests/test_trace_hypotheses.py
+++ b/tests/test_trace_hypotheses.py
@@ -1,0 +1,128 @@
+"""Tests for scripts/trace-hypotheses.py — phase-3 hypothesis statistics (ticket 0243)."""
+
+import importlib.util
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+spec = importlib.util.spec_from_file_location(
+    "trace_hypotheses", SCRIPTS / "trace-hypotheses.py"
+)
+th = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(th)
+
+
+def _row(**kw):
+    base = {
+        "project": "p",
+        "session_id": "s1",
+        "agent_id": "main",
+        "model": "claude-opus-4-8",
+        "turns": 10,
+        "input_tokens": 100,
+        "output_tokens": 100,
+        "cache_read_input_tokens": 10_000,
+        "cache_creation_input_tokens": 1_000,
+        "cost_usd": 1.0,
+        "read_only": False,
+        "max_read_repeat": 1,
+        "nav_turns": 0,
+        "idle_turns": 0,
+        "max_nav_run": 0,
+        "merge_marker_turn": None,
+        "verify_gaze_skills": 0,
+        "entry_skill": "",
+    }
+    base.update(kw)
+    return base
+
+
+def test_zero_turn_rows_flagged_and_excluded():
+    rows = [_row(), _row(session_id="s2", turns=0, cost_usd=0.0)]
+    res = th.compute_all(rows)
+    assert res["D1"]["zero_turn_agents"] == 1
+    assert res["H6"]["total_usd"] == 1.0  # zero-turn row excluded
+
+
+def test_h6_main_cost_share():
+    rows = [
+        _row(cost_usd=75.0),
+        _row(session_id="s1", agent_id="agent-x", cost_usd=25.0),
+    ]
+    res = th.compute_all(rows)
+    assert abs(res["H6"]["main_share"] - 0.75) < 1e-9
+
+
+def test_h11_micro_turn_estimate():
+    rows = [_row(turns=10, nav_turns=4, idle_turns=1, cost_usd=10.0)]
+    res = th.compute_all(rows)
+    assert abs(res["H11"]["micro_usd"] - 5.0) < 1e-9
+    assert abs(res["H11"]["micro_share"] - 0.5) < 1e-9
+
+
+def test_h10_post_delivery_tail():
+    rows = [
+        _row(turns=10, merge_marker_turn=8, cost_usd=10.0),
+        _row(session_id="s2", cost_usd=5.0),  # no marker: not in tail stats
+    ]
+    res = th.compute_all(rows)
+    assert abs(res["H10"]["tail_usd"] - 2.0) < 1e-9
+    assert res["H10"]["sessions_with_marker"] == 1
+
+
+def test_h13_verification_reentry():
+    rows = [
+        _row(verify_gaze_skills=3, cost_usd=50.0),
+        _row(session_id="s2", verify_gaze_skills=1, cost_usd=7.0),
+    ]
+    res = th.compute_all(rows)
+    assert res["H13"]["reentry_sessions"] == 1
+    assert abs(res["H13"]["reentry_usd"] - 50.0) < 1e-9
+
+
+def test_h3_readonly_drift():
+    rows = [
+        _row(agent_id="agent-a", read_only=True, turns=50, cost_usd=4.0),
+        _row(agent_id="agent-b", read_only=True, turns=10, cost_usd=1.0),
+        _row(agent_id="main", read_only=True, turns=99, cost_usd=9.0),  # mains excluded
+    ]
+    res = th.compute_all(rows)
+    assert abs(res["H3"]["drift_usd"] - 4.0) < 1e-9
+
+
+def test_h12_reread_cost():
+    rows = [
+        _row(max_read_repeat=4, cost_usd=6.0),
+        _row(session_id="s2", max_read_repeat=1, cost_usd=3.0),
+    ]
+    res = th.compute_all(rows)
+    assert abs(res["H12"]["reread_usd"] - 6.0) < 1e-9
+
+
+def test_h2_loglog_exponent_recovers_power_law():
+    rows = [_row(session_id=f"s{n}", turns=n, cost_usd=float(n**1.5)) for n in (2, 4, 8, 16, 32)]
+    exp = th.fit_loglog(rows)
+    assert abs(exp - 1.5) < 0.01
+
+
+def test_load_census_types(tmp_path):
+    import csv
+
+    f = tmp_path / "census.csv"
+    row = {k: ("" if v is None else v) for k, v in _row().items()}
+    with open(f, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(row))
+        w.writeheader()
+        w.writerow(row)
+    rows = th.load_census(f)
+    assert rows[0]["turns"] == 10
+    assert rows[0]["cost_usd"] == 1.0
+    assert rows[0]["merge_marker_turn"] is None
+    assert rows[0]["read_only"] is False
+
+
+def test_cli_flags_present():
+    src = (SCRIPTS / "trace-hypotheses.py").read_text()
+    for flag in ("--census", "--output", "--compact-audit-json", "--pr-stats"):
+        assert flag in src, f"missing CLI flag {flag}"
+    assert "ArgumentParser" in src

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -178,3 +178,78 @@ def test_cli_flags_present():
     for flag in ("--projects-dir", "--days", "--output", "--json"):
         assert flag in src, f"missing CLI flag {flag}"
     assert "ArgumentParser" in src
+
+
+# --- ticket 0243 detector columns (H10/H11/H13) ---
+
+
+def _tool_row(msg_id, name, tool_input, ts_str="2026-06-09T10:00:00.000Z"):
+    block = {"type": "tool_use", "id": f"{msg_id}_tu", "name": name, "input": tool_input}
+    return _assistant_row(msg_id, "claude-opus-4-8", USAGE, block, ts_str=ts_str)
+
+
+def _result_row(text):
+    return {
+        "type": "user",
+        "timestamp": "2026-06-09T10:02:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "x", "content": text}],
+        },
+    }
+
+
+def test_nav_and_idle_turns_classified(tmp_path):
+    rows = [
+        _tool_row("m1", "Bash", {"command": "cd /tmp"}),
+        _tool_row("m2", "Bash", {"command": "git status"}),
+        _tool_row("m3", "Bash", {"command": "uv run pytest -q"}),
+        _assistant_row("m4", "claude-opus-4-8", USAGE, {"type": "text", "text": "thinking"}),
+    ]
+    f = tmp_path / "nav.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    stats = ts.parse_trace_file(f)
+    assert stats["nav_turns"] == 2  # cd + git status
+    assert stats["idle_turns"] == 1  # m4 has no tool_use
+    assert stats["max_nav_run"] == 2  # m1,m2 consecutive
+
+
+def test_merge_marker_turn_recorded(tmp_path):
+    rows = [
+        _tool_row("m1", "Bash", {"command": "gh pr view"}),
+        _result_row("Merge queued; lands when required checks pass."),
+        _tool_row("m2", "Bash", {"command": "git log"}),
+    ]
+    f = tmp_path / "merged.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    stats = ts.parse_trace_file(f)
+    assert stats["merge_marker_turn"] == 1  # marker arrived after turn 1
+    assert stats["turns"] == 2
+
+
+def test_no_merge_marker_is_none(tmp_path):
+    stats = ts.parse_trace_file(_write_fixture(tmp_path))
+    assert stats["merge_marker_turn"] is None
+
+
+def test_verify_gaze_skill_count(tmp_path):
+    rows = [
+        _tool_row("m1", "Skill", {"skill": "verify"}),
+        _tool_row("m2", "Skill", {"skill": "gaze"}),
+        _tool_row("m3", "Skill", {"skill": "celebrate"}),
+    ]
+    f = tmp_path / "vg.jsonl"
+    f.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    stats = ts.parse_trace_file(f)
+    assert stats["verify_gaze_skills"] == 2
+
+
+def test_new_csv_columns_declared():
+    for col in (
+        "nav_turns",
+        "idle_turns",
+        "max_nav_run",
+        "merge_marker_turn",
+        "verify_gaze_skills",
+    ):
+        assert col in ts.CSV_COLUMNS, f"missing CSV column {col}"

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -7,7 +7,7 @@ Author: claude
 2026-06-10T11:18Z claude created
 2026-06-10T14:05Z claude note children updated: 0237/0239 closed, 0240 filed (phase 2b)
 2026-06-10T15:08Z claude note 0240 closed (PR #370); 0243 filed (phase 3, H1-H13 fixed)
-
+2026-06-10T15:23Z claude note phase 3 complete (0243, PR #374) — report docs/trace-hypotheses-2026-06.md: 13/13 hypotheses resolved, ranked $/week list; H4/H5/quality routed to phase 4; phase 4-5 filing unblocked
 --- body ---
 ## Context
 

--- a/tickets/0243-trace-doctor-phase-3-hypothesis-testing.erg
+++ b/tickets/0243-trace-doctor-phase-3-hypothesis-testing.erg
@@ -5,7 +5,7 @@ Author: Integration Test
 
 --- log ---
 2026-06-10T15:05Z Integration Test created
-
+2026-06-10T15:20Z claude note bump verify-reroll — round 1: tracker 0236 update missing (exit criterion 3); H5 subagent cache-write bound priced at opus rate despite fable subagents
 --- body ---
 ## Context
 

--- a/tickets/closed/0243-trace-doctor-phase-3-hypothesis-testing.erg
+++ b/tickets/closed/0243-trace-doctor-phase-3-hypothesis-testing.erg
@@ -2,10 +2,12 @@
 Title: trace-doctor phase 3: hypothesis testing on the full census
 Created: 2026-06-10
 Author: Integration Test
+Closed: autoclosed — PR #374
 
 --- log ---
 2026-06-10T15:05Z Integration Test created
 2026-06-10T15:20Z claude note bump verify-reroll — round 1: tracker 0236 update missing (exit criterion 3); H5 subagent cache-write bound priced at opus rate despite fable subagents
+2026-06-10T15:28Z Integration Test closed — autoclosed — PR #374
 --- body ---
 ## Context
 


### PR DESCRIPTION
Executes ticket 0243 (child of tracker 0236, phase 3 — confirmation).

**What's in it** (2 commits):
1. `trace-stats.py` detector columns (H10 merge marker, H11 nav/idle turn classification + max run, H13 verify/gaze count) — column additions only, accounting untouched; `trace-hypotheses.py` computing all thirteen statistics with honest bound labeling and needs-data verdicts instead of silent drops; 13 new/extended tests.
2. `docs/trace-hypotheses-2026-06.md` — verdict table + ranked $/week recommendation list over the full 28-day census (1,790 agents, $6,705).

**Headlines**: post-delivery tail = 14.4% of all spend (lower bound, 60 sessions); micro-turn churn ≤32% (upper bound, p99 nav-run 32 turns); Opus mains ≈2.8× over the cost curve while Sonnet mains sit on it; $1,044 upper recoverable via compaction policy (H8, 64 missed runs); H3 (read-only drift) measured at 1.4% and rejected. H4/H5 + quality baseline routed to phase 4 (forge join).

`make check` exit 0.

**Ticket:** tickets/0243-trace-doctor-phase-3-hypothesis-testing.erg
Ticket-ref: tickets/0236-trace-doctor-session-trace-economics-aud.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)