### PR TITLE
hunt: require the ticket's own worktree, not just any worktree

### DIFF
--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -30,8 +30,9 @@ argument-hint: <ticket-id>
    rebase, branch, or leave uncommitted files in a worktree it does not own
    (2026-06-11: a hunt inherited an orchestration session's worktree, rebased its
    branch, and stranded in-progress test edits there). Before the first
-   branch-mutating command, confirm ownership: `git rev-parse --show-toplevel`
-   must end in `t$ARGUMENTS`.
+   branch-mutating command, confirm ownership:
+   `basename "$(git rev-parse --show-toplevel)"` must be exactly `t$ARGUMENTS`
+   (rules/git.md § anchor branch-mutating git across a forked-skill boundary).
 4. Create or checkout the ticket branch:
    ```bash
    git switch -c t$ARGUMENTS-short-description

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -23,7 +23,15 @@ argument-hint: <ticket-id>
      stray file in the shared `tickets/`), and open the
      merge request (step 10). Skip the test/implement steps (5–9); the merge request lands the close
      via review like any other change. Do not stop with an uncommitted-to-`main` or unpushed close.
-3. If not already in a worktree, enter one: call `EnterWorktree` with name `t$ARGUMENTS`.
+3. Enter the ticket's **own** worktree: unless the current worktree is already named
+   `t$ARGUMENTS`, call `EnterWorktree` with name `t$ARGUMENTS` — even if the session
+   already sits inside some other worktree. "Already in a worktree" is NOT isolation:
+   a shared or `explore-*` worktree may host a live session, and a hunt must never
+   rebase, branch, or leave uncommitted files in a worktree it does not own
+   (2026-06-11: a hunt inherited an orchestration session's worktree, rebased its
+   branch, and stranded in-progress test edits there). Before the first
+   branch-mutating command, confirm ownership: `git rev-parse --show-toplevel`
+   must end in `t$ARGUMENTS`.
 4. Create or checkout the ticket branch:
    ```bash
    git switch -c t$ARGUMENTS-short-description


### PR DESCRIPTION
The hunt skill's step 3 ("If not already in a worktree, enter one") treats *any* inherited worktree as satisfying isolation. A hunt launched from a session already sitting in a worktree squats in that tree: on 2026-06-11 the ticket-0525 hunt inherited an orchestration session's `explore-tickets-review` worktree, rebased its branch, created its ticket branch there, and stranded 90 lines of uncommitted test edits in the host's working tree.

Fix: step 3 now requires the ticket's **own** worktree (`t<ID>`), entering one even when already inside some other worktree, and adds the same ownership check the raid skill uses (`git rev-parse --show-toplevel` before the first branch-mutating command).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)