### PR TITLE
tickets: 0248 + 0249 — harness findings from the aedist 0537 background raid

### DIFF
--- a/tickets/0248-background-job-env-injects-invalid-pytes.erg
+++ b/tickets/0248-background-job-env-injects-invalid-pytes.erg
@@ -1,0 +1,38 @@
+%erg 0.1
+Title: Background-job env injects invalid PYTEST_ADDOPTS --cache-dir flag
+Created: 2026-06-11
+Author: Integration Test
+
+--- log ---
+2026-06-11T20:54Z Integration Test created
+
+--- body ---
+## Context
+Background-job sessions carry `PYTEST_ADDOPTS=--cache-dir=/data/cache/pytest`
+in the environment. `--cache-dir` is not a pytest flag (it is a `-o cache_dir=`
+ini override), so every bare `pytest` / `uv run pytest` invocation — including
+the pre-commit adherence hook — dies with a usage error.
+
+Observed 2026-06-11 in the aedist 0537 raid: the execute agent's first commit
+got mis-sliced because the pre-commit hook failed on this, and a /gaze reviewer
+independently hit the same wall. Both worked around it. Project memory
+feedback_pytest_addopts_env_breaks_uv_pytest documents the workaround
+(`env -u PYTEST_ADDOPTS` or `PYTEST_ADDOPTS="-o cache_dir=..."`), but the
+injection itself is the defect: every agent pays a debugging round-trip, and
+hooks fail in confusing ways far from the cause.
+
+## Relevant files
+- Wherever the bg-job env is composed (RTK hook or job-launcher env setup) —
+  grep the harness for `PYTEST_ADDOPTS` / `--cache-dir=/data/cache/pytest`.
+
+## Actions
+1. Locate the injector and either fix the value to the valid form
+   `-o cache_dir=/data/cache/pytest` or drop the variable entirely.
+2. Sweep for other env vars injected with invalid syntax in the same place.
+
+## Verification
+- [ ] In a fresh background job, `uv run pytest --version` and a pre-commit
+      hook run succeed with no PYTEST_ADDOPTS workaround.
+
+## Exit criteria
+- [ ] No agent needs `env -u PYTEST_ADDOPTS`; retire the memory entry.

--- a/tickets/0249-autonomous-raid-merge-step-classifier-re.erg
+++ b/tickets/0249-autonomous-raid-merge-step-classifier-re.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: Autonomous raid merge step: classifier rejects STATE standing authorization
+Created: 2026-06-11
+Author: Integration Test
+
+--- log ---
+2026-06-11T20:54Z Integration Test created
+
+--- body ---
+## Context
+Raid Phase 7 stalls in unattended sessions: the auto-mode permission
+classifier denied `erg-pr-merge` (aedist PR #979, 2026-06-11), citing the
+project rule "never close merge requests without explicit user confirmation".
+The author HAD granted a durable authorization — STATE.md (2026-06-11):
+"merge-review-merge cadence — merge each PR on APPROVED + green CI" — but the
+classifier only weighs the transcript, so file-recorded standing authorizations
+never count. Net effect: autonomous raids deliver APPROVED PRs but cannot land
+them; nightbeat/raid throughput drops to one human round-trip per PR.
+
+Side casualty discovered in the same incident: a killed `erg-pr-merge` run
+(non-zero exit after its rebase) leaves the PR-branch worktree with a stale
+pre-rebase INDEX — staged diffs that appear to re-open closed tickets and
+revert prose. Salvage tooling must not mistake that for WIP (worktree-gc
+correctly skipped it; a `git reset --hard HEAD` was required first).
+
+## Options to evaluate
+1. Settings permission rule: `Bash(~/.claude/skills/merge/erg-pr-merge *)`
+   in user or project settings — simplest, but unconditional.
+2. Make the authorization transcript-visible: raid skill quotes the STATE.md
+   standing-authorization line verbatim before Phase 7 so the classifier can
+   see it (cheap, no settings change; effectiveness unproven).
+3. Scoped grant: a project settings rule enabled only while a standing
+   authorization block exists in STATE.md (hook-checked).
+
+## Actions
+1. Pick a mechanism (1 is the pragmatic default; document the trade-off).
+2. Update the raid skill Phase 7 prose: on classifier denial, end with a
+   `needs input:` merge handoff (PR number + exact /merge command) instead of
+   retrying — already captured in aedist project memory
+   feedback_merge_classifier_blocks_autonomous_raid; lift it into the skill.
+3. Add the stale-index note to the merge/raid circuit-breaker docs:
+   after a failed erg-pr-merge, `git reset --hard HEAD` the PR worktree
+   before salvage/gc decisions.
+
+## Exit criteria
+- [ ] An autonomous raid can land an APPROVED+green PR without a mid-session
+      human round-trip, OR the raid skill formally specifies the merge
+      handoff as the designed terminal state.
+- [ ] Raid/merge docs cover the stale pre-rebase index pitfall.


### PR DESCRIPTION
Files two descriptive IDH tickets surfaced by the aedist-technical-report 0537 raid (PR MinhHaDuong/aedist-technical-report#979, 2026-06-11):

- **0248** — background-job env injects `PYTEST_ADDOPTS=--cache-dir=/data/cache/pytest`, an invalid pytest flag; broke bare pytest and the pre-commit adherence hook for two independent agents (execute + reviewer). Fix the injector (`-o cache_dir=…`) or drop the var.
- **0249** — autonomous raid Phase 7 stalls: the auto-mode permission classifier denied `erg-pr-merge` despite the author's standing merge-on-APPROVED authorization in STATE.md (classifier only weighs the transcript). Evaluate permission-rule / transcript-visible-authorization options; also documents the stale pre-rebase index a killed erg-pr-merge leaves in the PR worktree.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)