### PR TITLE
tickets: file 0251 — consolidate ticket-execution entry points (imagine)

### DIFF
--- a/tickets/0251-consolidate-ticket-execution-entry-points.erg
+++ b/tickets/0251-consolidate-ticket-execution-entry-points.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: Consolidate ticket-execution entry points (imagine) — start-ticket / raid / hunt / headless raids
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T10:40Z orchestrator created from aedist orchestration-night retrospective (2026-06-11/12)
+
+--- body ---
+## Context
+
+An orchestrator session (aedist, night of 2026-06-11/12) spawned nine
+headless raid agents via the Agent tool with hand-typed execution
+contracts instead of any skill. It worked (8/9 delivered), but the
+contract drifted between waves — Wave A prompts lacked the
+PYTEST_ADDOPTS workaround that Wave B had, and every agent rediscovered
+it — demonstrating that the ticket-execution discipline currently
+lives in prompt-writing memory, not in a versioned artifact.
+
+The obvious patch — a new headless `raid-ticket` skill — would create a
+FOURTH entry point next to `/start-ticket` (interactive, this session),
+`/raid` (autonomous multi-ticket waves), and `/hunt` (single ticket).
+That is the wrong direction by default: three entry points is already
+too many. They share the same core contract (verify ticket open on
+fresh origin/main, isolated worktree + branch, test-first, disposition
+log before --- body ---, PR with **Ticket:** line) and differ only in
+wrapper concerns (interactive vs headless, one ticket vs waves, who
+merges).
+
+## Intent (imagine — NOT a handoff execution task)
+
+Rethink the entry-point architecture before adding anything. Questions
+the imagine step must answer:
+
+1. Can the shared execution contract be factored into ONE canonical
+   core (a skill the others invoke, or a contract document the wrappers
+   reference) so the wrappers shrink to their genuine differences?
+2. Should some existing entry points merge or die? (e.g. is /hunt a
+   degenerate /raid wave of size 1? Is /start-ticket just the
+   interactive wrapper of the same core?)
+3. How does a headless spawned agent get the contract — Skill
+   invocation from inside the agent, or prompt assembled by the spawner
+   from the canonical core?
+4. Worktree ownership: the core must NOT create a worktree when the
+   spawner already provided one (Agent isolation:"worktree") — the
+   aedist session hit nested-worktree/cwd confusion twice.
+
+Constraint: fewer or equal entry points after the redesign, never more.
+
+## Exit criteria
+- [ ] Imagine discussion held with the author; chosen architecture
+      recorded (ADR or ticket log) before any execution sub-tickets
+      are filed.


### PR DESCRIPTION
Ticket-ref: tickets/0251-consolidate-ticket-execution-entry-points.erg

Intent ticket from the aedist orchestration-night retrospective: the execution contract lives in prompt-writing memory; but the imagine step must weigh that start-ticket/raid/hunt is already too many entry points — consolidate, don't add a fourth.