### PR TITLE
tickets: file 0252 — audit isolation: 'a worktree' vs 'YOUR worktree'

### DIFF
--- a/tickets/0252-audit-worktree-ownership-vs-isolation.erg
+++ b/tickets/0252-audit-worktree-ownership-vs-isolation.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: Audit harness isolation practices: "be in a worktree" vs "be in YOUR worktree"
+Created: 2026-06-12
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-12T10:55Z orchestrator created from aedist orchestration-night incidents (2026-06-11/12)
+
+--- body ---
+## Context
+
+The harness's isolation rules and skills verify the WEAK predicate
+("cwd is some worktree", "not on main") where the MATERIAL predicate is
+ownership ("this worktree is MINE, registered, and nobody else mutates
+it"). Two fresh incidents (aedist, night of 2026-06-11/12), echoing the
+2026-06-10 concurrent-pipelines root cause:
+
+1. An orchestrator session's worktree was deregistered mid-session
+   (likely a sibling's cleanup); its directory remained, so bare git
+   commands silently fell through to the PRIMARY repo — a `git
+   checkout -B` switched the primary checkout off main before the
+   session noticed via `rev-parse --show-toplevel`.
+2. A raid session checked out ITS branch (raid-544) in the
+   orchestrator's worktree path; the orchestrator later found itself on
+   a foreign branch with a foreign stash list, and only convention
+   ("clean tree, leave the branch alone") prevented a mutation on
+   someone else's WIP.
+
+Both passed every existing guard: the sessions WERE "in a worktree".
+
+## Intent (audit + imagine — not a handoff execution task)
+
+Audit every isolation touchpoint for the weak-predicate assumption and
+propose the ownership model. Surfaces to sweep:
+
+- SessionStart hook + EnterWorktree flow: what binds a session to its
+  worktree identity? What detects deregistration/eviction mid-session?
+- rules/workflow.md + rules/git.md "Worktree paths" sections: they warn
+  about absolute paths to the primary, not about the worktree dying
+  under you or being entered by a sibling.
+- Skills that create/enter/clean worktrees (raid, gaze, merge, roar
+  hygiene, healthcheck, beat): which ones `git worktree
+  remove/prune` paths they did not create? Which check `git worktree
+  list` registration before bare git?
+- Guard scripts (guard-cd-primary-repo.sh): extend to detect "cwd
+  claims worktree but rev-parse --show-toplevel resolves to primary"?
+  That single check would have caught incident 1 before damage.
+- Multi-session etiquette: a registered claim marker (lock file,
+  branch↔session binding, or worktree-name convention) so a sibling
+  entering or removing a foreign worktree is detectable, not just
+  impolite.
+
+Constraint: cheap per-command checks only — anchoring discipline
+(`git -C`, rev-parse preflight) must stay ergonomic or it will be
+skipped under load.
+
+## Exit criteria
+- [ ] Audit findings recorded (which skills/rules/hooks assume the weak
+      predicate, with file:line inventory).
+- [ ] Ownership model proposed and discussed with the author; execution
+      sub-tickets filed only after that discussion.


### PR DESCRIPTION
Ticket-ref: tickets/0252-audit-worktree-ownership-vs-isolation.erg

Two incidents in one night passed every guard because the guards test the weak predicate (in *a* worktree) not the material one (in *your registered* worktree): deregistration→bare-git fell through to primary; sibling checked out its branch in a foreign worktree path. Audit + imagine, execution sub-tickets only after author discussion.