### PR TITLE
review-pr-prose: editorial-brief auditor checks manuscript diffs against standing decisions

### DIFF
--- a/skills/review-pr-prose/SKILL.md
+++ b/skills/review-pr-prose/SKILL.md
@@ -49,6 +49,25 @@ Agents with relevant expertise should use available tools (web search for litera
 
 One agent is always the **AI-tells auditor**. It reads `config/ai-tells.yml` for blacklisted words, phrases, conditional words, density limits, and patterns to flag. It scans the full text (not just the diff) and reports every violation with line number, context, and severity. This agent has no other role — it is a specialized lint pass.
 
+## Editorial-brief auditor (when present)
+
+If the project defines an editorial brief at `docs/editorial-brief.md`, one agent is the **editorial-brief auditor** (pinned `model: sonnet` like the rest of the panel). Skip silently when the file is absent — this check is project-specific and optional (skills degrade gracefully).
+
+The skill owns the schema, projects own the content. Expected brief format — one standing decision per entry, each entry carrying:
+
+- a decision title;
+- **Decision:** one sentence;
+- **Rationale:** one or two sentences;
+- **Ticket:** originating ticket reference.
+
+The auditor reads the brief plus the manuscript diff and reports a per-entry verdict table:
+
+| Entry | Verdict | Evidence |
+|---|---|---|
+| decision title | upheld / violated / not touched by this diff | line ref, or "not in diff" |
+
+Violations must cite the line. This agent has no other role — its table goes verbatim into the Synthesis step.
+
 ## Synthesis
 
 1. Preserve dissent verbatim.

--- a/tests/test_review_pr_prose_skill.py
+++ b/tests/test_review_pr_prose_skill.py
@@ -1,0 +1,43 @@
+"""review-pr-prose documents the editorial-brief auditor (ticket 0253).
+
+The skill must check manuscript diffs against an optional per-project
+editorial-brief file: default location ``docs/editorial-brief.md``,
+graceful skip when the file is absent, and per-entry verdicts
+(upheld / violated / not touched by this diff). This ratchet pins the
+documented contract in the skill text — companion to AEDIST 0557, which
+moves positive prose literals out of CI and into review-time judgment.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SKILL = REPO / "skills" / "review-pr-prose" / "SKILL.md"
+
+
+def skill_text() -> str:
+    with open(SKILL) as f:
+        return f.read()
+
+
+def test_documents_default_brief_location():
+    assert "docs/editorial-brief.md" in skill_text(), (
+        "review-pr-prose must document the default editorial-brief location "
+        "docs/editorial-brief.md (ticket 0253)"
+    )
+
+
+def test_documents_graceful_degradation_when_brief_absent():
+    text = skill_text().lower()
+    assert "absent" in text or "skip" in text, (
+        "review-pr-prose must document that the editorial-brief check is "
+        "skipped when the file is absent (skills-degrade-gracefully rule)"
+    )
+
+
+def test_documents_per_entry_verdicts():
+    text = skill_text().lower()
+    for verdict in ("upheld", "violated", "not touched"):
+        assert verdict in text, (
+            f"review-pr-prose must document the per-entry verdict {verdict!r} "
+            "(upheld / violated / not touched by this diff)"
+        )

--- a/tickets/0253-review-pr-prose-check-manuscript-diffs-a.erg
+++ b/tickets/0253-review-pr-prose-check-manuscript-diffs-a.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-06-12T09:30Z HDMX-coding-agent created
+2026-06-12T12:00Z claude note raid plan: insert Editorial-brief auditor section between AI-tells auditor and Synthesis; ratchet test tests/test_review_pr_prose_skill.py (RED first, then GREEN)
 
 --- body ---
 ## Context
@@ -55,6 +56,6 @@ standing hook for a per-project editorial-brief file.
 
 ## Exit criteria
 
-- [ ] Skill loads and applies `docs/editorial-brief.md` when present
-- [ ] Brief format documented in the skill
+- [x] Skill loads and applies `docs/editorial-brief.md` when present
+- [x] Brief format documented in the skill
 - [ ] AEDIST 0557 can reference this as done

--- a/tickets/closed/0253-review-pr-prose-check-manuscript-diffs-a.erg
+++ b/tickets/closed/0253-review-pr-prose-check-manuscript-diffs-a.erg
@@ -2,11 +2,13 @@
 Title: review-pr-prose: check manuscript diffs against a project editorial-brief file
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #393
 
 --- log ---
 2026-06-12T09:30Z HDMX-coding-agent created
 2026-06-12T12:00Z claude note raid plan: insert Editorial-brief auditor section between AI-tells auditor and Synthesis; ratchet test tests/test_review_pr_prose_skill.py (RED first, then GREEN)
 
+2026-06-12T10:15Z Minh Ha-Duong closed — autoclosed — PR #393
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Adds an **Editorial-brief auditor (when present)** section to `skills/review-pr-prose/SKILL.md`, between the AI-tells auditor and Synthesis. When a project defines `docs/editorial-brief.md`, a dedicated sonnet-pinned panel agent checks the manuscript diff against each standing editorial decision and reports a per-entry verdict table (upheld / violated / not touched by this diff, violations citing the line), which flows verbatim into Synthesis. The check is skipped silently when the brief is absent (skills degrade gracefully). The skill documents the brief schema (decision title, **Decision:**, **Rationale:**, **Ticket:**); projects own the content.

Companion to AEDIST ticket 0557: positive prose literals move out of CI adherence tests into review-time semantic judgment; grep-able negative guards stay in CI.

Purely additive — frontmatter `description:` and existing panel perspectives unchanged; no forge commands or project-specific paths in the skill text. Ratcheted by `tests/test_review_pr_prose_skill.py` (source-inspection unit test, confirmed RED before the edit).

**Ticket:** tickets/0253-review-pr-prose-check-manuscript-diffs-a.erg

## Verification

- New ratchet test RED on pre-edit skill text, GREEN after: 3 passed
- `make check-fast`: 556 passed, 19 deselected
- `uv run ruff check` clean on all touched files (pre-existing failures in `tests/test_beat.py` / `tests/test_worktree_tools.py` reproduce on the origin/main baseline — out of scope)
- Live-run Verification checkboxes in the ticket left unticked (require runs on AEDIST and a brief-less project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)