### PR TITLE
memory: gaze forks still under-execute — verify-gate-direct fallback

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_verify_fork_under_execution.md
+++ b/projects/-home-haduong--claude/memory/feedback_verify_fork_under_execution.md
@@ -23,3 +23,11 @@ three completion markers before accepting the result: (1) a verdict line
 Deterministic fix ticketed as 0216 (Agent-spawn conversion with pinned cwd).
 Positive signal from the same cycle: the permission guard DENIED an
 out-of-role force-push from a verify fix loop — guard layers work.
+
+Re-confirmed 2026-06-12 (raid 0253, PR #393) — after 0216/0228 closed: two
+consecutive `/gaze` forks returned mid-run status text ("waiting for
+reviewers") instead of a verdict; retry-once did NOT cure it. Working
+fallback: the orchestrator collects the reviewer agents' results (they
+arrive as task notifications) and runs `/verify-gate` directly with the
+findings summarized in args — the gate completed and posted the verdict
+comment first try.


### PR DESCRIPTION
Re-confirmation appended to memory `feedback_verify_fork_under_execution`: two consecutive /gaze forks in raid 0253 (PR #393) returned mid-run status instead of a verdict, post-0216/0228; retry-once did not cure it. Documented working fallback: orchestrator collects reviewer results and runs /verify-gate directly.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)