### PR TITLE
raid: EnterWorktree --path fallback for worktree-bound PR branches

### DIFF
--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -210,7 +210,15 @@ confirm the tree: `git rev-parse --show-toplevel` must equal the session worktre
 
 For each eligible PR, sequentially within the wave:
 1. `git fetch origin` to pick up any prior merges.
-2. `gh pr checkout <pr-number>` — `/merge` requires being on the PR head branch. <!-- harness-extension-point -->
+2. `gh pr checkout <pr-number>` — `/merge` requires being on the PR head branch.
+   **If the PR branch is already bound to an Execute agent's worktree**,
+   `gh pr checkout` fails (`fatal: '<branch>' is already used by worktree at …`)
+   and the shell cwd self-resets so a plain `cd` into that worktree does not
+   persist for the `/merge` skill. Switch the *session* into the existing
+   worktree instead: `EnterWorktree` with `path:
+   .claude/worktrees/agent-<id>` (the path from the Execute agent's completion
+   notification), then run `/merge` there. Do not delete and re-checkout the
+   branch. <!-- harness-extension-point -->
 3. Check PR is still mergeable (no conflicts from earlier merges in this wave).
 4. Run `/merge <pr-number>`. This atomically closes the ticket and merges via GitHub API.
 5. If merge fails (conflict, CI regression), ESCALATE — leave a PR comment and move to the next PR.

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -210,9 +210,9 @@ confirm the tree: `git rev-parse --show-toplevel` must equal the session worktre
 
 For each eligible PR, sequentially within the wave:
 1. `git fetch origin` to pick up any prior merges.
-2. `gh pr checkout <pr-number>` — `/merge` requires being on the PR head branch.
+2. Check out the PR head branch — `/merge` requires being on it.
    **If the PR branch is already bound to an Execute agent's worktree**,
-   `gh pr checkout` fails (`fatal: '<branch>' is already used by worktree at …`)
+   checking out the branch fails (`fatal: '<branch>' is already used by worktree at …`)
    and the shell cwd self-resets so a plain `cd` into that worktree does not
    persist for the `/merge` skill. Switch the *session* into the existing
    worktree instead: `EnterWorktree` with `path:


### PR DESCRIPTION
Phase 7 step 2 of the raid skill instructed `gh pr checkout <pr-number>`, which **fails when the PR branch is already bound to an Execute agent's worktree** — the common case, since the coder that produced the PR still holds the branch:

```
fatal: '<branch>' is already used by worktree at '.claude/worktrees/agent-<id>'
```

The shell cwd also self-resets between Bash calls, so a plain `cd` into that worktree does not persist for the `/merge` skill invocation.

This documents the fix used in the 594/595 raid: switch the *session* into the existing worktree via `EnterWorktree` with `path: .claude/worktrees/agent-<id>` (the path comes from the Execute agent's completion notification), then run `/merge` there — never delete and re-checkout the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ticket: none