### PR TITLE
skills: add external-peer-review (real OpenAI/Mistral PDF reviews)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/check-readiness` | Alias of /scry — multi-repo pre-flight readiness check and interactive triage. |
 | `/dream` | Autonomous nightly memory consolidation for one project. |
 | `/end-session` | Deprecated — renamed to /lair. Warns, then delegates to the new name. |
+| `/external-peer-review` | Get external peer reviews of a manuscript PDF from real OpenAI and Mistral models via OpenRouter, then synthesize them into one verdict. Each model adopts a reviewer persona (a grinchy senior nitpicker, a bright doctoral student) and returns a full review; the skill weighs convergent findings across reviewers. Complements the simulated /review-pr-prose panel by sending the paper to genuinely external frontier models. |
 | `/gaze` | Run the full per-PR verification loop (adherence + review + review-pr + simplify), then gate through /verify-gate. Bounces the PR for at most one retry. Never merges. |
 | `/healthcheck` | Repo healthcheck — git hygiene, test status, and deep freshness verification of status/directive docs. Gracefully degrades when project-specific conventions (git-erg tickets, STATE.md, etc.) are absent. |
 | `/housekeeping` | Alias of /molt — repo housekeeping with git sync, healthcheck, and eager fix-now repairs. |

--- a/skills/external-peer-review/SKILL.md
+++ b/skills/external-peer-review/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: external-peer-review
+description: Get external peer reviews of a manuscript PDF from real OpenAI and Mistral models via OpenRouter, then synthesize them into one verdict. Each model adopts a reviewer persona (a grinchy senior nitpicker, a bright doctoral student) and returns a full review; the skill weighs convergent findings across reviewers. Complements the simulated /review-pr-prose panel by sending the paper to genuinely external frontier models.
+user-invocable: true
+disable-model-invocation: false
+argument-hint: <pdf-path> [--models openai/gpt-5.5,mistralai/mistral-large-2512] [--personas grinchy,student] [--text]
+---
+
+# External peer review $ARGUMENTS
+
+Send a manuscript PDF to real external models (OpenAI + Mistral, via one
+OpenRouter key) under reviewer personas, then read the reviews back and present
+a cross-reviewer synthesis. This is **complementary** to `/review-pr-prose`:
+that skill runs a *simulated* in-harness panel; this one solicits *real
+external* frontier-model reviews.
+
+The bundled script is `~/.claude/skills/external-peer-review/peer_review.py`.
+
+## Steps
+
+1. **Locate the PDF.** Resolve the path argument. If it does not exist and the
+   project has a Makefile target that builds the manuscript PDF (e.g. the rule
+   whose output is that `.pdf`), offer to build it. Degrade gracefully if there
+   is no such target — just ask the user for a path.
+
+2. **Check the key.** Confirm `OPENROUTER_API_KEY` is available (in the
+   environment or a `.env` walking up from the project root). The script reads
+   it the same way; never echo the value. If it is missing, stop and tell the
+   user.
+
+3. **Pick models and personas.** Defaults: models
+   `openai/gpt-5.5,mistralai/mistral-large-2512`, personas `grinchy,student`
+   (four combos). Any OpenRouter model id is accepted. Personas are an
+   extensible dict in the script — adding one is a single entry.
+
+4. **Smoke-test ONE combo first** (project rule: test one before blasting).
+   Run a single model×persona to confirm prompt assembly, that a review comes
+   back non-empty, and that the input mode works:
+   ```
+   python ~/.claude/skills/external-peer-review/peer_review.py <pdf> \
+       --models openai/gpt-5.5 --personas grinchy --out-dir <out>
+   ```
+   Inspect the written `review_*.md` for quality before launching the rest.
+   - **Balance gate:** PDF-file mode (the default, via the `file-parser`
+     plugin) needs the OpenRouter "files" balance minimum of **$0.50**. On
+     HTTP 402 the script automatically falls back to local text extraction
+     (`pdftotext`); you can also force this with `--text`. Text mode needs
+     `pdftotext` (poppler-utils) installed.
+
+5. **Run the rest in the background.** Launch the full set in the background so
+   the long calls do not block:
+   ```
+   python ~/.claude/skills/external-peer-review/peer_review.py <pdf> \
+       --models openai/gpt-5.5,mistralai/mistral-large-2512 \
+       --personas grinchy,student --out-dir <out>
+   ```
+   Combos run concurrently; one failing combo is reported and the others
+   continue. One `review_<model>_<persona>.md` is written per combo.
+
+6. **Synthesize.** Read every written review and present a single cross-reviewer
+   synthesis:
+   - **Consensus verdict** (reject / major / minor / accept) — where reviewers
+     agree, and where they split (preserve dissent).
+   - **Convergent themes**, weighted by how many reviewers raised each one (a
+     concern flagged by 3 of 4 reviewers outranks a solo gripe).
+   - **Sharp individual catches** — incisive points a single reviewer made that
+     the others missed.
+   Reference the specific reviewer (model + persona) behind each point so the
+   author can judge its source.
+
+## Notes
+
+- Forge-agnostic: this skill produces review artifacts; it does not open or
+  touch any merge request itself.
+- The reviews are advisory input for the author, never a CI gate.
+- Output filenames are derived from the model id and persona, so re-running
+  with the same combos overwrites in place.

--- a/skills/external-peer-review/peer_review.py
+++ b/skills/external-peer-review/peer_review.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""External peer review of a manuscript PDF via OpenRouter.
+
+Sends a PDF to OpenAI and Mistral models (one ``OPENROUTER_API_KEY``, OpenAI
+SDK against the OpenRouter base URL), each model adopting a reviewer persona,
+and writes one markdown review per (model, persona) combo.
+
+Portable across projects: no project-specific hardcoding. Models, personas,
+and the task prompt are all configurable from the command line.
+
+Two input modes:
+  - PDF file mode (default): the PDF is uploaded and parsed by the
+    ``file-parser`` plugin (engine configurable, default ``mistral-ocr``).
+    Requires at least the OpenRouter "files" balance minimum ($0.50).
+  - Text mode (``--text`` or automatic fallback on HTTP 402): the PDF text is
+    extracted locally with ``pdftotext`` and sent as plain text.
+
+Example:
+    python peer_review.py paper.pdf \\
+        --models openai/gpt-5.5,mistralai/mistral-large-2512 \\
+        --personas grinchy,student --out-dir reviews/
+"""
+
+import argparse
+import base64
+import concurrent.futures as cf
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from openai import APIStatusError, OpenAI
+
+log = logging.getLogger(__name__)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+DEFAULT_MODELS = ["openai/gpt-5.5", "mistralai/mistral-large-2512"]
+
+# Add a persona by adding one entry here: name -> system prompt.
+PERSONAS: dict[str, str] = {
+    "grinchy": (
+        "You are a grinchy, senior, nitpicking peer reviewer for a top-tier "
+        "venue. You have refereed hundreds of papers and are very hard to "
+        "impress. Be skeptical, demanding, and specific. Hunt relentlessly for: "
+        "overclaims and unsupported generalizations; methodological holes; "
+        "missing or shallow related work; statistical weaknesses and confounds; "
+        "figures/tables that do not earn their space; vague or hand-wavy "
+        "passages; and any gap between what is claimed and what is shown. Do "
+        "NOT pad with praise. Give a clear recommendation (reject / major "
+        "revision / minor revision / accept) and a prioritized, numbered list of "
+        "concrete objections, each with a section/figure reference and what "
+        "would fix it. End with the 3 things that most threaten the paper's "
+        "central claim."
+    ),
+    "student": (
+        "You are a bright, curious, well-read doctoral student giving a careful "
+        "peer review. You are genuinely engaged: say briefly what is genuinely "
+        "novel or useful, but spend most of your effort on sharp, incisive "
+        "questions — where the argument does not follow, where you got confused, "
+        "which experiments or ablations you would want, what related work is "
+        "missing, and the naive-but-pointed questions a smart student asks in a "
+        "reading group. Be constructive and specific, with section/figure "
+        "references. End with a numbered list of the questions you would ask the "
+        "authors, and one experiment you would run next."
+    ),
+}
+
+DEFAULT_TASK = (
+    "Below is a research paper. Write a full, rigorous peer review. Focus on "
+    "the main body (Introduction through Conclusion); annexes are supporting "
+    "material. Be concrete and reference specific sections, figures, and tables."
+)
+
+
+def slug(model: str) -> str:
+    """A filesystem-safe stem for a model id (e.g. ``openai/gpt-5.5``)."""
+    return model.replace("/", "_").replace(":", "_")
+
+
+def load_api_key(repo_root: Path) -> str:
+    """Read OPENROUTER_API_KEY from the environment, else the nearest .env.
+
+    Walks up from ``repo_root`` looking for a ``.env`` containing the key.
+    """
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        return key
+    for parent in [repo_root, *repo_root.parents]:
+        env = parent / ".env"
+        if env.exists():
+            for line in env.read_text().splitlines():
+                if line.startswith("OPENROUTER_API_KEY="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    raise SystemExit(
+        "OPENROUTER_API_KEY not found in environment or any .env walking up "
+        f"from {repo_root}"
+    )
+
+
+def extract_text(pdf_path: Path) -> str:
+    """Extract PDF text locally via pdftotext (clear error if absent)."""
+    if shutil.which("pdftotext") is None:
+        raise SystemExit(
+            "pdftotext not found — install poppler-utils to use text mode, or "
+            "ensure the OpenRouter balance is above $0.50 for PDF-file mode."
+        )
+    result = subprocess.run(
+        ["pdftotext", "-layout", str(pdf_path), "-"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def build_messages(persona: str, task: str, pdf_path: Path,
+                   data_url: str | None, text: str | None) -> tuple[list, dict]:
+    """Assemble chat messages and extra_body for one combo."""
+    system = {"role": "system", "content": PERSONAS[persona]}
+    if text is not None:
+        user = {
+            "role": "user",
+            "content": task + "\n\n=== PAPER (extracted text) ===\n\n" + text,
+        }
+        return [system, user], {}
+    assert data_url is not None, "file mode requires a data_url"
+    user = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": task},
+            {"type": "file",
+             "file": {"filename": pdf_path.name, "file_data": data_url}},
+        ],
+    }
+    extra = {"plugins": [{"id": "file-parser", "pdf": {"engine": "mistral-ocr"}}]}
+    return [system, user], extra
+
+
+def review_one(model: str, persona: str, pdf_path: Path, api_key: str,
+               task: str, engine: str, max_tokens: int, out_dir: Path,
+               data_url: str | None, text: str | None) -> Path:
+    """Run one (model, persona) review and write its markdown file."""
+    client = OpenAI(base_url=OPENROUTER_BASE_URL, api_key=api_key, timeout=600)
+    mode = "text" if text is not None else "file"
+    log.info("START model=%s persona=%s mode=%s", model, persona, mode)
+    messages, extra = build_messages(persona, task, pdf_path, data_url, text)
+    if extra:
+        extra["plugins"][0]["pdf"]["engine"] = engine
+    resp = client.chat.completions.create(
+        model=model, messages=messages, max_tokens=max_tokens, extra_body=extra,
+    )
+    content = resp.choices[0].message.content or ""
+    out = out_dir / f"review_{slug(model)}_{persona}.md"
+    out.write_text(
+        f"# Peer review — {model}, persona: {persona}\n\n{content}\n",
+        encoding="utf-8",
+    )
+    log.info("DONE  model=%s persona=%s -> %s (%d chars)",
+             model, persona, out, len(content))
+    return out
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="External peer review of a PDF via OpenRouter.")
+    p.add_argument("pdf", type=Path, help="Path to the manuscript PDF.")
+    p.add_argument(
+        "--models", default=",".join(DEFAULT_MODELS),
+        help="Comma-separated OpenRouter model ids "
+             f"(default: {','.join(DEFAULT_MODELS)}).")
+    p.add_argument(
+        "--personas", default="grinchy,student",
+        help=f"Comma-separated persona names. Available: "
+             f"{','.join(sorted(PERSONAS))}.")
+    p.add_argument(
+        "--task", default=None,
+        help="Override the full task prompt sent to every reviewer.")
+    p.add_argument(
+        "--topic", default=None,
+        help="One-line description of the paper, appended to the task prompt.")
+    p.add_argument("--engine", default="mistral-ocr",
+                   help="file-parser PDF engine (default: mistral-ocr).")
+    p.add_argument("--max-tokens", type=int, default=6000)
+    p.add_argument("--out-dir", type=Path, default=Path("reviews"))
+    p.add_argument("--repo-root", type=Path, default=Path.cwd(),
+                   help="Where to start the .env search (default: cwd).")
+    p.add_argument("--text", action="store_true",
+                   help="Send locally-extracted text instead of the PDF file "
+                        "(also the automatic fallback on HTTP 402).")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+    if not args.pdf.exists():
+        raise SystemExit(f"PDF not found: {args.pdf}")
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    personas = [p.strip() for p in args.personas.split(",") if p.strip()]
+    unknown = [p for p in personas if p not in PERSONAS]
+    if unknown:
+        raise SystemExit(
+            f"unknown persona(s): {unknown}. Available: {sorted(PERSONAS)}")
+
+    task = args.task or DEFAULT_TASK
+    if args.topic:
+        task = f"{task}\n\nPaper topic: {args.topic}"
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    api_key = load_api_key(args.repo_root)
+
+    text: str | None = None
+    data_url: str | None = None
+    if args.text:
+        text = extract_text(args.pdf)
+    else:
+        data_url = ("data:application/pdf;base64,"
+                    + base64.b64encode(args.pdf.read_bytes()).decode("utf-8"))
+
+    combos = [(m, p) for m in models for p in personas]
+    log.info("Running %d combo(s): %s", len(combos),
+             ", ".join(f"{m}:{p}" for m, p in combos))
+
+    written: list[Path] = []
+    failed: list[str] = []
+    with cf.ThreadPoolExecutor(max_workers=max(1, len(combos))) as ex:
+        futs = {
+            ex.submit(review_one, m, p, args.pdf, api_key, task, args.engine,
+                      args.max_tokens, args.out_dir, data_url, text): (m, p)
+            for m, p in combos
+        }
+        for fut in cf.as_completed(futs):
+            m, p = futs[fut]
+            try:
+                written.append(fut.result())
+            except APIStatusError as e:
+                if e.status_code == 402 and not args.text and data_url is not None:
+                    log.warning(
+                        "402 (OpenRouter files balance < $0.50) for %s:%s — "
+                        "retrying in text mode", m, p)
+                    try:
+                        local_text = extract_text(args.pdf)
+                        written.append(review_one(
+                            m, p, args.pdf, api_key, task, args.engine,
+                            args.max_tokens, args.out_dir, None, local_text))
+                    except Exception as e2:  # noqa: BLE001 - report and continue
+                        log.error("FAILED (text retry) %s:%s: %s", m, p, e2)
+                        failed.append(f"{m}:{p}")
+                else:
+                    log.error("FAILED %s:%s: %s", m, p, e)
+                    failed.append(f"{m}:{p}")
+            except Exception as e:  # noqa: BLE001 - report and continue
+                log.error("FAILED %s:%s: %s", m, p, e)
+                failed.append(f"{m}:{p}")
+
+    log.info("Summary: %d written, %d failed", len(written), len(failed))
+    for path in written:
+        log.info("  wrote %s", path)
+    if failed:
+        log.warning("  failed combos: %s", ", ".join(failed))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_external_peer_review_skill.py
+++ b/tests/test_external_peer_review_skill.py
@@ -1,0 +1,64 @@
+"""external-peer-review bundles a portable script and documents its contract.
+
+The skill solicits real external model reviews of a PDF and synthesizes them.
+These ratchets pin the documented contract in the skill text and the portability
+invariants in the bundled script (no project-specific hardcoding).
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO / "skills" / "external-peer-review"
+SKILL = SKILL_DIR / "SKILL.md"
+SCRIPT = SKILL_DIR / "peer_review.py"
+
+
+def skill_text() -> str:
+    return SKILL.read_text()
+
+
+def script_text() -> str:
+    return SCRIPT.read_text()
+
+
+def test_bundled_script_exists():
+    assert SCRIPT.exists(), "external-peer-review must bundle peer_review.py"
+
+
+def test_documents_balance_gate_and_text_fallback():
+    text = skill_text().lower()
+    assert "$0.50" in skill_text(), "must document the OpenRouter $0.50 files gate"
+    assert "--text" in skill_text(), "must document the text-mode fallback flag"
+    assert "402" in skill_text(), "must document the HTTP 402 automatic fallback"
+
+
+def test_documents_smoke_test_one_before_blasting():
+    text = skill_text().lower()
+    assert "smoke" in text or "test one" in text, (
+        "must document smoke-testing one combo before launching the rest "
+        "(project rule: test one before blasting)"
+    )
+
+
+def test_documents_complementary_to_simulated_panel():
+    assert "review-pr-prose" in skill_text(), (
+        "must state it is complementary to the simulated /review-pr-prose panel"
+    )
+
+
+def test_first_sentence_names_real_external_models():
+    """Discoverability: plain searchable keywords in the opening sentence."""
+    first = skill_text().split("description:", 1)[1].split("\n", 1)[0].lower()
+    for kw in ("peer review", "openai", "mistral"):
+        assert kw in first, f"first sentence should mention {kw!r}"
+
+
+def test_script_is_portable_no_project_hardcoding():
+    src = script_text()
+    # The reference implementation baked in the AEDIST topic; the portable
+    # version must not. Topic is supplied via --topic, not hardcoded.
+    assert "thermal" not in src.lower(), "script must not hardcode a paper topic"
+    assert "--models" in src and "--personas" in src, (
+        "models and personas must be CLI-configurable"
+    )
+    assert "OPENROUTER_API_KEY" in src, "must read the OpenRouter key from env/.env"


### PR DESCRIPTION
## What

Adds a new portable IDH skill `external-peer-review` that sends a manuscript
PDF to real external models (OpenAI + Mistral) via one OpenRouter key, each
under a reviewer persona, and synthesizes the returned reviews into one
cross-reviewer verdict.

This **complements** `/review-pr-prose`: that skill runs a *simulated*
in-harness panel; this one solicits *real external* frontier-model reviews.

## Files

- `skills/external-peer-review/SKILL.md` — frontmatter (searchable first
  sentence, themed flavor after), numbered steps: locate PDF, check
  `OPENROUTER_API_KEY`, smoke-test ONE combo before blasting, run the rest in
  background, then synthesize (consensus verdict + convergent themes weighted
  by reviewer count + sharp individual catches). Documents the $0.50 OpenRouter
  files gate and the `--text` / HTTP-402 fallback.
- `skills/external-peer-review/peer_review.py` — portable rewrite of a working
  throwaway script. No project hardcoding: comma-separated `--models` /
  `--personas` CLI flags with defaults (`openai/gpt-5.5`,
  `mistralai/mistral-large-2512`), one-entry-each persona dict, `--topic`
  override, key from env or nearest `.env`. PDF-file mode (file-parser plugin)
  with automatic `pdftotext` text fallback on HTTP 402 or `--text`; clear error
  if `pdftotext` absent. Concurrent combos; one failure does not kill the rest.
- `tests/test_external_peer_review_skill.py` — ratchet on the documented
  contract and the script's portability invariants.
- `README.md` — regenerated skills catalog (`make skills-catalog`).

## Checks

- `make skills-catalog` regenerated; `make check-skills-drift` OK.
- `pytest tests/test_skill_descriptions.py tests/test_external_peer_review_skill.py` — 8 passed.
- `check-agnostic.sh skills/external-peer-review` — clean.
- ruff clean on the script.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)