### PR TITLE
lair/molt: inspect stale-worktree WIP for dropped exit-criteria before discard

### DIFF
--- a/skills/lair/SKILL.md
+++ b/skills/lair/SKILL.md
@@ -23,7 +23,7 @@ Run when the user ends a work session ("done for today", "let's stop", "wrap up"
     a. Preflight from inside the worktree: `~/.claude/scripts/worktree-exit-preflight.sh` (refuses on any uncommitted/untracked state; closes the ExitWorktree gap, ticket 0174). If it blocks, finish step 5/6 (commit WIP, handoff notes) and re-run.
     b. Call `ExitWorktree` to return to the main working tree. All remaining steps run on main.
 8. **Hygiene sweep**:
-   - `git worktree list` → remove any stale worktrees (`git worktree prune`)
+   - `git worktree list` → remove any stale worktrees (`git worktree prune`). **Before removing a worktree that has uncommitted/untracked changes, diff it and ask "is this a closed ticket's dropped deliverable?"** — `erg-pr-merge` autocloses on the `**Ticket:**` line unconditionally, so a PR can close a ticket having landed only part of the work, leaving the rest as orphaned WIP (2026-06-16: ticket 0609's mandated adherence test sat uncommitted for weeks after PR #1111 autoclosed 0609 with only the data fix). Preserve it (`wip(NNNN):` commit + push), then re-ticket and execute; never silently discard. Verify any recovered test actually runs — uncommitted WIP may never have been linted/executed.
    - `git branch -a` → delete stale remote branches
    - Check for orphan tickets and stale merge requests
 9. **Full test suite** — `make check` on main. New failures → open ticket. Known failures → confirm ticket still open.

--- a/skills/molt/SKILL.md
+++ b/skills/molt/SKILL.md
@@ -72,7 +72,7 @@ Run full repo housekeeping and act on every finding.
    ```bash
    ~/.claude/scripts/worktree-gc.sh
    ```
-   Skips any worktree with uncommitted changes (and the one it runs from), never `rm -rf`s, silent when there is nothing to clean. Safe here because step 0 already confirmed no other live session, and the git phase above ran `git fetch --prune` so gone branches are detectable. See tickets 0169, 0195.
+   Skips any worktree with uncommitted changes (and the one it runs from), never `rm -rf`s, silent when there is nothing to clean. Safe here because step 0 already confirmed no other live session, and the git phase above ran `git fetch --prune` so gone branches are detectable. See tickets 0169, 0195. **A worktree the GC skips for uncommitted changes is a signal, not just an obstacle:** diff it before moving on — orphaned WIP may be a closed ticket's dropped exit-criteria deliverable (`erg-pr-merge` autocloses on the `**Ticket:**` line unconditionally; 2026-06-16 ticket 0609's mandated test sat uncommitted after PR #1111 closed it with only the data fix). If so, preserve (`wip(NNNN):` commit + push) and open a follow-up ticket.
 
 2. **Healthcheck.** Invoke /healthcheck. The probe (`project-state.py`)
    runs once inside healthcheck and covers all checks — do not re-run git


### PR DESCRIPTION
Makes explicit a safety net that caught a real defect: when a sweep finds a stale worktree with uncommitted changes, **diff it before discarding** — it may be a closed ticket's dropped exit-criteria deliverable.

`erg-pr-merge` autocloses a ticket on its `**Ticket:**` line unconditionally, so a PR can close a ticket having landed only part of the work. The GC/hygiene sweeps already *skip* worktrees with uncommitted changes, but nothing told the operator to *inspect* that WIP.

**Real case (2026-06-16):** ticket 0609's mandated `\NumRefPlants` adherence test sat uncommitted in an agent worktree for weeks after PR #1111 autoclosed 0609 with only the data fix. The `/lair` sweep recovered it → re-ticketed 0673 → executed → merged. Also fixed a latent NameError the WIP carried (never run before).

Two-line change: one in `/lair` step 8 (hygiene sweep), one in `/molt` step 1.5 (GC note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)