### PR TITLE
fix(hooks): disarm ruff autofix swordfight (--unfixable F401,I001,UP)

### DIFF
--- a/scripts/lint-on-edit.sh
+++ b/scripts/lint-on-edit.sh
@@ -19,10 +19,27 @@ file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
 # every time an agent touched a .py file via Edit/Write. Lint stays (advisory,
 # self-correcting); formatting is a no-op until a formatter is adopted
 # repo-wide. See ticket 0212.
+#
+# `--unfixable F401,I001,UP` disarms a whole class of "swordfight" trap: an
+# autofix that MUTATES the file between two of the agent's Edits, leaving the
+# agent's pending `old_string`s stale. The three confirmed members (empirically
+# reproduced, ticket-evidenced across 19 historical sessions):
+#   F401 — agent adds `import X` in Edit 1, its first usage in Edit 2; the hook
+#          fires in between and DELETES the still-unused import → Edit 2 NameErrors.
+#   I001 — the hook REORDERS the import block; a later Edit whose `old_string`
+#          spans import lines no longer matches → Edit fails.
+#   UP   — pyupgrade rewrites in-body (`List[str]`→`list[str]`, `Optional[x]`→
+#          `x | None`, `.format`→f-string); a later Edit targeting that text
+#          finds it already changed → Edit fails.
+# All three are still REPORTED (the agent sorts imports / modernizes annotations /
+# drops dead imports itself — matching the project's own style rules), so nothing
+# is lost except the silent mid-sequence mutation. F841 (unused var) is NOT in the
+# list: its fix is unsafe and never fires without `--unsafe-fixes`. Genuinely safe
+# fixes (whitespace W291/W293, blank lines, E-class) stay on — they never desync.
 if command -v uv &>/dev/null; then
-    output=$(uv run ruff check --fix --quiet "$file_path" 2>&1 || true)
+    output=$(uv run ruff check --fix --unfixable F401,I001,UP --quiet "$file_path" 2>&1 || true)
 elif command -v ruff &>/dev/null; then
-    output=$(ruff check --fix --quiet "$file_path" 2>&1 || true)
+    output=$(ruff check --fix --unfixable F401,I001,UP --quiet "$file_path" 2>&1 || true)
 else
     exit 0  # no linter available
 fi

--- a/tests/test_lint_on_edit.sh
+++ b/tests/test_lint_on_edit.sh
@@ -53,6 +53,45 @@ else
     echo "SKIP: ruff not installed — behavioral reformat check not run"
 fi
 
+# --- static ratchet: the swordfight class stays unfixable ---------------------
+# F401/I001/UP autofixes MUTATE a file between two of the agent's Edits, leaving
+# pending `old_string`s stale (NameError or failed Edit). They must be reported,
+# never auto-applied. Guard each rule code independently so a future edit can't
+# silently drop one from the `--unfixable` list.
+for code in F401 I001 UP; do
+    if grep -qE "unfixable[^|]*\b${code}\b" "$HOOK"; then
+        echo "PASS: hook exempts ${code} from autofix (swordfight trap disarmed)"
+    else
+        echo "FAIL: hook no longer exempts ${code} from autofix — re-arms the"
+        echo "      between-edits mutation swordfight (see ticket / lint-on-edit comment)."
+        fail=1
+    fi
+done
+
+# --- behavioral: a temporary-bad-state file must not be mutated by the hook ----
+# An unused import is the canonical swordfight setup: the agent has added the
+# import but not yet its usage. With F401 exempt the hook must REPORT it but
+# leave the bytes untouched, so the next Edit's old_string still matches.
+if command -v uv &>/dev/null || command -v ruff &>/dev/null; then
+    probe=$(mktemp --suffix=.py)
+    printf 'import os\nprint("hi")\n' > "$probe"
+    before=$(cat "$probe")
+    printf '{"tool_name":"Edit","tool_input":{"file_path":%s}}' \
+        "$(printf '%s' "$probe" | jq -Rs .)" \
+        | bash "$HOOK" >/dev/null 2>&1 || true
+    after=$(cat "$probe")
+    rm -f "$probe"
+    if [[ "$before" == "$after" ]]; then
+        echo "PASS: hook leaves an unused import in place (does not delete it)"
+    else
+        echo "FAIL: hook deleted the unused import (before: [$before] after: [$after])"
+        echo "      — the F401 swordfight is re-armed."
+        fail=1
+    fi
+else
+    echo "SKIP: ruff not installed — unused-import behavioral check not run"
+fi
+
 if (( fail )); then
     exit 1
 fi


### PR DESCRIPTION
## What

The PostToolUse lint hook (`scripts/lint-on-edit.sh`) ran `ruff check --fix` after every Python Edit/Write. `--fix` auto-applies a class of rules that **mutate the file between two of the agent's Edits**, leaving the agent's pending `old_string`s stale and triggering an agent↔ruff "swordfight" (re-add → re-run → repeat → token waste).

Three confirmed members, all empirically reproduced against the live ruff:

| Rule | Desync shape |
|------|-------------|
| **F401** unused import | add import (Edit 1) then usage (Edit 2) → import deleted in between → Edit 2 `NameError` |
| **I001** import sort | hook reorders the import block → later Edit spanning imports fails to match |
| **UP** pyupgrade | rewrites `List[str]`→`list[str]`, `Optional`→`\| None`, `.format`→f-string in-body → later Edit targeting that text fails |

## Evidence

- A sweep of **621 historical transcripts** found the swordfight in **19 sessions** (worst ~6–10 wasted edit cycles). `--unfixable` would have prevented 100% of them.
- Verified empirically: a temporary-bad-state file (unused + unsorted + old-annotation) is now **byte-identical** after the hook, while plain `--fix` deleted/rewrote it.

## Fix

`ruff check --fix --unfixable F401,I001,UP`. The three are still **reported** — the agent sorts imports / modernizes annotations / drops dead imports itself (matching the repo's own Python style rules). Only the silent mid-sequence mutation is removed.

- **F841** (unused var) deliberately *not* exempted: its fix is unsafe and never fires without `--unsafe-fixes`.
- Whitespace (W291/W293), blank-line, and E-class fixes stay on — they never desync.

## Tests

Two new checks in `tests/test_lint_on_edit.sh`: a static ratchet (each of F401/I001/UP must stay in `--unfixable`) and a behavioral check (the hook must leave an unused import in place). Full suite: **581 passed**.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)