### PR TITLE
chore(config): land accumulated settings + AEDIST memory drift

### DIFF
--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/MEMORY.md
@@ -34,12 +34,15 @@
 - French-language report about Vietnamese thermal power plants as AI benchmark task
 
 ## Active
+- [Orphaned WIP = unlanded exit-criteria](feedback_orphaned_wip_is_unlanded_exit_criteria.md) — uncommitted WIP in a stale worktree may be a closed ticket's dropped deliverable; preserve, verify it runs, re-ticket (0609→0673)
+- [Side book — *Idées reçues* / finance climat](project_book_idees_recues_finance_climat.md) — separate repo; Le Cavalier Bleu dossier ready to send via Romain Blachier
+- [Editorial / trade-book working style](feedback_editorial_book_work.md) — multi-agent sims welcomed; grand-public legibility; no namedrop/family in pitch files
 - [Reference v1 defects & pipeline](project_reference_fix1.md) — v1 scores as-is, defects documented (PROVENANCE checklist); fix1 leapfrogged, never shipped; corrections via pipe 0420→0416→0419, adoption 0413 after 0412; fix the master + regenerate, never patch downstream
 - [No invented names](feedback_no_invented_names.md) — reference names must be source-attested; disambiguate structurally (status/units), never synthesize a name
 - [Verbatim by construction](feedback_verbatim_by_construction.md) — line-shaped edits via grep/sed/awk + count guards, not csv round-trips; diff-vs-source is the provenance evidence
 - [Three-quality argument](project_three_quality_argument.md) — paper's spine: data / answer / method, four limits split 2/2, method quality is perpendicular not a fifth limit (ticket chain 0145–0154)
 - [Coherence axis decomposition](project_coherence_axis_decomposition.md) — Coherence dimension → internal/external reference-free composites, per-row pass/fail; + `level` enum dimension (granularity, capacity plausibility is level-conditional); ticket chain 0201→0396→0397, 0401→0402
-- [Econom'IA 2026](project_economia_2026.md) — talk delivered & archived: tag economia-2026-cergy (bbc4a013), HAL hal-05644906, release with presented PDF
+- [Econom'IA 2026](project_economia_2026.md) — talk delivered & archived: tag economia-2026-cergy (bbc4a013), HAL hal-05644906, release with presented PDF; technical report diffused 2026-06-15: tag economia-2026-report (2da83d04), 65pp widow-free; deposited on HAL 2026-06-16 as working paper hal-05658462 (type UNDEFINED, CC-BY, seeAlso→talk; arXiv deferred to v2)
 - [Exp 1 module scheme](project_exp1_module_scheme.md) — modules renamed 1-6/A-D; Exp 1 baseline = 2_goal+5_table
 - [Exp 1 design decisions](project_exp1_design_decisions.md) — URL unguarded (intentional), >30MW in both files, Notes column; pending: harness.py + README + Annex A (ticket 0175)
 - [Reproducible pipeline](feedback_reproducible_pipeline.md) — test harness must be clear and reproducible
@@ -71,11 +74,19 @@
 - [No typo callouts](feedback_no_typo_callouts.md) — never reference user typos in tickets, commits, or any durable artefact
 - [No ps -ef](feedback_no_ps_ef_in_claude.md) — process listings with cmd-line args leak API keys via Claude Code's bash wrapper
 - [Check sister files first](feedback_check_sister_files_first.md) — before writing integration code, read an existing sibling that already solves the same problem
+- [Display-name sweep hits plot scripts](feedback_display_name_sweep_includes_plot_scripts.md) — stale model-name fix in prose must sweep `plot_*.py` label maps too (they render into manuscript figures); disambiguate vs genuinely-different registry entries before fixing
 - [Local 9B near ceiling](project_local_9b_near_ceiling.md) — qwen3.5:9b at F1=0.984 on direct (n=1); may collapse priority-3 scope if reproduces
 - [Pydantic unknown kwargs](feedback_pydantic_unknown_kwargs.md) — test schema *projection effects* (asymmetric values), not literal construction; BaseModel accepts unknown kwargs silently
 - [STRUCTURED_DIRS registry](project_structured_dirs_registry.md) — Makefile has hardcoded sweep-dir list; new outputs must be registered or extract skips them
 - [Ticket housekeeping via PR](feedback_ticket_housekeeping_on_main.md) — ALL main-targeted commits (tickets, STATE) go through branch+PR; GH006 branch protection rejects direct pushes; merge with `--merge --auto`, never squash
 - [gaze fork dies in bg jobs](feedback_gaze_fork_dies_in_background_jobs.md) — in background sessions run sonnet reviewers + /verify-gate directly; /gaze's forked reviewers evaporate
+- [Teams worklist purges completed](feedback_teams_worklist_purges_completed.md) — shared worklist is real but completed tasks vanish; collect results from agent return values, pre-tier model per batch, smoke-test one first
+- [Verify against synced main](feedback_verify_against_synced_main.md) — sync local checkout to origin before any verification/review fan-out; a stale tree yields false FAILs on already-merged fixes
+- [Shell timeout, no loops](feedback_shell_timeout_no_loops.md) — shells stall on gh/git/CI calls; wrap every network call in `timeout`, never write shell poll-loops; queue native auto-merge and check back later
+- [Teams raid region bundling](feedback_teams_raid_region_bundling.md) — large prose-edit wave via Teams: sweeps-first, bundle tickets by manuscript region (one PR/section), emitters merge free, invasive PR last, red-team at end
+- [Render & adjust tables](feedback_render_and_adjust_tables.md) — after ANY table change, always render the PDF and check/adjust column widths of ALL tables (overfull \hbox); never assume fit
+- [No caveats in captions](feedback_no_caveats_in_captions.md) — captions state plainly what the figure/table shows; caveats, hedges, method qualifications go in body/annex, never the caption
+- [Pagination widow verification](feedback_pagination_widow_verification.md) — fix widows by shaving signposts/roadmaps/recaps first; verify by rendering the exact page to PNG and Reading it (not pdftotext grep); cross-PR layouts interact
 - [haiku truncated final reports](feedback_haiku_truncated_final_reports.md) — haiku agents end turn on narration instead of long structured reports; run mechanical checks inline or demand one-line verdicts
 - [rtk git log stale](feedback_rtk_git_log_stale.md) — rtk-filtered `git log` hides/lags merge commits; use `rtk proxy git` for ground truth on git state
 - [Build from user worktree](feedback_build_from_user_worktree.md) — user edits main tree while you're in a worktree → same file diverges; build from their source, verify before `checkout --`
@@ -89,3 +100,4 @@
 - [~/.claude = IDH checkout](reference_claude_dir_is_idh.md) — the live harness dir is the ImperialDragonHarness clone on doudou; PR then `git -C ~/.claude pull`
 - [Stacked PR waves](feedback_stacked_pr_waves.md) — same-file raid waves go out stacked (base = previous wave's branch); rebase the stack at every gate, the author lands decisions mid-raid
 - [BG merge anchoring + auto-merge race](feedback_bg_merge_anchoring.md) — erg-pr-merge in bg sessions: anchor `cd <pr-worktree> && …` in one compound; check PR state before any retry (bounced run may have queued auto-merge)
+- [pgrep self-match watcher](feedback_pgrep_self_match_watcher.md) — watcher loops that `pgrep -f` their own pattern self-match and never exit; gate on a captured PID + timeout fallback

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/project_economia_2026.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/project_economia_2026.md
@@ -1,6 +1,6 @@
 ---
 name: econom-ia-2026-presentation
-description: "Econom'IA 2026 talk delivered 2026-05-27 and fully archived: tag economia-2026-cergy, release, HAL hal-05644906"
+description: "Econom'IA 2026 talk delivered 2026-05-27 (tag economia-2026-cergy, HAL hal-05644906); technical report diffused 2026-06-15 (tag economia-2026-report, 2da83d04) and deposited on HAL 2026-06-16 as working paper hal-05658462"
 metadata: 
   node_type: memory
   type: project
@@ -23,3 +23,24 @@ the exactly-presented state.
 **How to apply:** Any question about "what was shown at Econom'IA" resolves against the tag,
 not main. Paper writing follows; the EN deck (`slides-en.tex`) post-dates the talk.
 [[project-exp1-module-scheme]]
+
+**Follow-up — technical report diffused to participants (2026-06-15):** the full
+manuscript (`slides/manuscript/main.tex`, title *Can Frontier AI Build a Statistical
+Register? A Benchmark and Research Programme on Vietnam's Thermal Power Fleet*) was sent
+to the conference organizer for diffusion to Econom'IA 2026 participants. The diffused
+PDF is commit `2da83d04`, tagged **`economia-2026-report`** (65 pages, widow-free,
+peer-review-calibrated). **HAL deposit 2026-06-16 (ticket 0664):** a *separate* HAL
+record [hal-05658462](https://hal.science/hal-05658462) — type `UNDEFINED`
+(Preprint/Working paper bucket; HAL SWORD rejects the `WORKINGPAPER`/`UNDERTAKING`
+leaf codes, only the top-level is accepted), CC-BY 4.0, `seeAlso` cross-links to the
+talk record hal-05644906 + the GitHub release tag. Deposited via the `/update-publist`
+SWORD path (Content-Disposition filename must be the meta `*.xml`, not the zip). NOT
+merged into the talk record (no double counting: slides=COMM, report=working paper).
+Pending moderation at deposit time. arXiv transfer (0665) deliberately deferred to the
+planned v2 article (this version is a working paper, not the final preprint). Before
+that send the manuscript went through: a 4-reviewer
+external panel (OpenAI gpt-5.5 + Mistral large, grinchy + student personas, via the
+`/external-peer-review` IDH skill) → tracker ticket 0644 (9 prose findings fixed, 8
+experiments deferred post-arXiv, 0653 related-work expansion declined) → front-to-back
+pagination shaving (abstract/intro/§7/§9/§10 widows cleared, conclusion landing on
+page 26). Reviews archived under `slides/manuscript/attic/peer-reviews-2026-06-15/`.

--- a/settings.json
+++ b/settings.json
@@ -70,15 +70,32 @@
       "Bash(ssh -o ConnectTimeout=5 -o BatchMode=yes padme \"uname -n; df -h ~/chemin-de-voix 2>/dev/null | tail -1; df -h ~/data 2>/dev/null | tail -1\")",
       "Bash(pkill -f \"ssh -C padme\")",
       "Bash(pkill -f \"dd if=/dev/urandom bs=1M count=500\")",
-      "Bash(ssh padme ' *)"
+      "Bash(ssh padme ' *)",
+      "mcp__claude_ai_Gmail__search_threads",
+      "mcp__claude_ai_Gmail__get_thread",
+      "Bash(rtk ls *)",
+      "Read(//home/haduong/CNRS/papiers/actif/AEDIST-technical-report/slides/manuscript/**)",
+      "Bash(rtk read *)",
+      "WebSearch",
+      "Bash(python3 -c \"import fpdf2; print\\('fpdf2 ok'\\)\")",
+      "Bash(python3 -c \"import reportlab; print\\('reportlab ok'\\)\")",
+      "Bash(pandoc --version)",
+      "Bash(fc-list)",
+      "Bash(fc-list --format=\"%{family}\\\\n\")",
+      "Bash(grep -i \"free\\\\|dejavu\\\\|liberation\\\\|noto sans$\\\\|ubuntu\")",
+      "Read(//home/haduong/CNRS/papiers/actif/AEDIST-technical-report/**)",
+      "Bash(rtk git *)",
+      "Bash(rtk grep *)"
     ],
     "defaultMode": "auto",
     "additionalDirectories": [
       "/home/haduong/CNRS/projets/actifs/chemin-de-voix",
       "/home/haduong/data/projets/chemin-de-voix/corpus",
-      "/tmp"
+      "/tmp",
+      "/home/haduong/CNRS/papiers/actif/AEDIST-technical-report/tickets"
     ]
   },
+  "model": "opus",
   "hooks": {
     "SessionStart": [
       {
@@ -177,11 +194,12 @@
     ],
     "Stop": []
   },
-  "advisorModel": "opus",
+  "effortLevel": "high",
   "voice": {
     "enabled": true,
     "mode": "hold"
   },
   "skipDangerousModePermissionPrompt": true,
+  "teammateMode": "auto",
   "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
Commits the uncommitted working-tree state that had accumulated in the live `~/.claude` checkout (on the now-merged `skill-external-peer-review` label), so the checkout can return to a clean `main`.

## Changes
- **settings.json** — permission allowlist additions (MCP Gmail read, `rtk ls/read/git/grep`, WebSearch, font/import probes, AEDIST manuscript Read globs); AEDIST `tickets/` as an additional dir; `model: opus`, `effortLevel: high` (replacing `advisorModel`), `teammateMode: auto`.
- **AEDIST project memory** — `MEMORY.md` + `project_economia_2026.md` updates.

No code/skill/hook logic touched; disjoint from #401.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)