### PR TITLE
docs(rules): import hygiene in coding-python (hook reports, not deletes)

### DIFF
--- a/rules/coding-python.md
+++ b/rules/coding-python.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-05-29 -->
+<!-- last-reviewed: 2026-06-16 -->
 # Coding Rules
 
 ## Python (3.10+)
@@ -6,6 +6,7 @@
 Style:
 - Built-in generics: `list[str]`, `dict[str, int]`, `str | None`. Never `from typing import List, Dict, Tuple, Optional`.
 - `X | Y` union syntax, not `Union[X, Y]`. No `from __future__ import annotations`.
+- Imports grouped at the top of the file; keep only imports that are used. Ruff flags unused imports (F401) and unsorted blocks (I001) via the post-edit hook, but it only *reports* — it does not auto-delete or reorder (`--unfixable F401,I001,UP`), so an import that is briefly unused while you wire up its first use is safe; finish the usage and the report clears.
 - No ABC classes. Use Protocol for structural subtyping if needed.
 - Type hints where they clarify intent. Skip where they add noise.
 - Assertions at system boundaries. Trust internal code.


### PR DESCRIPTION
Follow-up to #401 (which made the post-edit ruff hook `--unfixable F401,I001,UP`).

Adds one bullet to `rules/coding-python.md` Style: imports grouped at the top, keep only used imports — with an accurate note that ruff now only **reports** F401/I001, so a briefly-unused import mid-edit is safe.

This is the rightful home for guidance that had drifted into AEDIST's `.claude/rules/workflow.md` as an alarming "DANGER: ruff strips your imports" workaround (removed in a separate AEDIST PR). Living in the global coding rules means every Python project inherits it — no per-repo duplication.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)