### PR TITLE
feat(hooks): per-file global rule injection (format/doctype/lang/prose axes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ memory/.provenance.lock
 !tickets/
 !tickets/**
 tickets/tools/go/*.test
+!rules/
+!rules/**
 
 # Makefile for harness targets (skills catalog, checks, etc.)
 !Makefile

--- a/rules/README.md
+++ b/rules/README.md
@@ -9,8 +9,39 @@ files on demand when their scope signal applies to your task.
 | [git.md](./git.md) | always | Branch discipline, commit-message standards, worktree lifecycle, merge-request workflow. |
 | [state.md](./state.md) | skill-list: `/lair` | STATE.md format spec — sections, length cap, pruning rules. |
 | `tickets/AGENTS.md` (project-level) | skill-list: `ticket-*`, `hunt` | Ticket format rules injected via `@tickets/AGENTS.md` in project CLAUDE.md — no global rules file needed. |
-| [coding-python.md](./coding-python.md) | condition: project contains `*.py` (or `pyproject.toml` / `setup.py`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
-| [coding-bash.md](./coding-bash.md) | condition: project contains `*.sh` | Bash `set -euo pipefail` discipline: arithmetic-zero abort, unbound associative-array key. |
+| [coding-python.md](./coding-python.md) | edit of `*.py` (alias: `format/python`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
+| [coding-bash.md](./coding-bash.md) | edit of `*.sh` (alias: `format/bash`) | Bash `set -euo pipefail` discipline: arithmetic-zero abort, unbound associative-array key. |
+| [prose/_all.md](./prose/_all.md) | edit of any prose file (`*.tex` `*.qmd` `*.md` `*.txt`) | Universal prose rules: LLMism guards, Elements of Style. |
 
 Compliance is verified ex post by the `verify-adherence` skill — this
 index is the single source of truth on when each rule file applies.
+
+## Per-file rule injection (axis model)
+
+`scripts/inject_rule_on_edit.py` (PreToolUse `Edit|Write` hook) injects the full
+body of every matching **global** rule the first time you edit a file along each
+axis in a session — then stays silent (deduped per `session_id` + rule). Rules
+stay global and shared; only the *mapping* can be project-local. A file resolves
+along four orthogonal axes, and the injected set is their union:
+
+| Axis | Resolved from | Rule path |
+|------|---------------|-----------|
+| **format** | filename extension (project-agnostic) | `format/<value>.md` (legacy alias: `coding-<value>.md`) |
+| **doctype** | `\documentclass` sniff for `.tex`; else project manifest | `doctype/<value>.md` |
+| **lang** | project manifest (`lang` per glob, else `default_lang`) | `lang/<value>.md` |
+| **prose** | implied for prose formats | `prose/_all.md` |
+
+Missing rule files are skipped silently, so content grows by adding files — no
+code change. Doc-type and language (not derivable from the filename) come from an
+optional per-project manifest `<repo>/.claude/rules-map.toml`:
+
+```toml
+default_lang = "fr"
+[[map]]
+glob = "slides/manuscript/**/*.tex"
+doctype = "techreport"
+lang = "fr"
+```
+
+The manifest holds path→axis *mappings* only, never rule text — the rulebook
+itself stays here, shared across every project.

--- a/rules/prose/_all.md
+++ b/rules/prose/_all.md
@@ -1,0 +1,36 @@
+<!-- last-reviewed: 2026-06-16 -->
+# Prose rules — every prose file
+
+Applies to all prose formats (tex, qmd, md, txt) regardless of document type or
+language. Injected on the first prose edit of a session by the
+`inject_rule_on_edit.py` PreToolUse hook. This is the universal layer; doctype-
+and language-specific rules compose on top of it.
+
+## LLMism guards — phrasings to avoid
+
+These are the tics that mark text as machine-written. Cut them.
+
+- **No "It's not just X, it's Y"** and its cousins ("not only… but…", "isn't merely… but rather…"). The antithesis-reversal cadence is the single strongest LLM tell.
+- **No empty intensifier openers**: "It's important to note that", "It's worth noting", "Needless to say", "In today's fast-paced world".
+- **No "delve", "tapestry", "landscape", "realm", "navigate the complexities", "testament to", "boasts", "underscores", "leverage" (as a verb), "robust", "seamless", "game-changer".**
+- **No tricolon padding**: avoid reflexive three-item lists ("fast, reliable, and scalable") where two items, or one, carry the meaning.
+- **No summary that restates the body** ("In conclusion, as we have seen…"). End on a point, not a recap.
+- **No hedging stacks**: "may potentially", "could possibly", "it seems likely that perhaps". One hedge maximum.
+- **No second-person life-coaching** ("Let's dive in", "You've got this") in formal prose.
+
+## Elements of Style — the load-bearing few
+
+- **Omit needless words.** Every word must earn its place. Cut "the fact that", "in order to" → "to", "due to the fact that" → "because".
+- **Use the active voice.** "We measured X" not "X was measured", unless the actor is genuinely irrelevant.
+- **Put statements in positive form.** Assert what is, not what is not.
+- **Use definite, specific, concrete language.** A number beats "several"; a name beats "various stakeholders".
+- **Keep related words together.** Subject next to verb; modifier next to what it modifies.
+- **One paragraph, one idea.** If a paragraph turns, it is two paragraphs.
+- **Prefer the standard word to the fancy one.** "use" over "utilize", "before" over "prior to".
+
+## Scope note
+
+This is a seed. Grow it deliberately — add a guard only when you have seen the
+defect in real drafts, and keep each entry one line so the injected body stays
+small. Document-type conventions (techreport, slides, book) and language norms
+(fr, en) live in `rules/doctype/` and `rules/lang/`, not here.

--- a/scripts/inject_rule_on_edit.py
+++ b/scripts/inject_rule_on_edit.py
@@ -59,6 +59,9 @@ EXT_FORMAT = {
 }
 PROSE_FORMATS = {"tex", "qmd", "md", "txt"}
 
+# Keep injected context under the platform's 10,000-char additionalContext cap.
+MAX_CONTEXT = 9500
+
 # \documentclass{X} -> doctype axis value.
 DOCUMENTCLASS_DOCTYPE = {
     "report": "techreport",
@@ -99,10 +102,18 @@ def _glob_to_regex(glob: str) -> str:
 
 def glob_match(rel: str, glob: str) -> bool:
     """Match a repo-relative path against a glob. A slash-less glob also matches
-    on the basename alone (so `*.qmd` means "any .qmd anywhere")."""
-    if re.match(_glob_to_regex(glob), rel):
+    on the basename alone (so `*.qmd` means "any .qmd anywhere").
+
+    Manifest globs are author-controlled, but guard anyway: collapse runs of 3+
+    stars (typos like ``***/``) to ``**`` and reject absurd globs, so a many-``**``
+    pattern can't drive catastrophic regex backtracking past the hook timeout."""
+    glob = re.sub(r"\*{3,}", "**", glob)
+    if len(glob) > 200 or glob.count("*") > 8:
+        return False
+    pattern = _glob_to_regex(glob)
+    if re.match(pattern, rel):
         return True
-    return "/" not in glob and re.match(_glob_to_regex(glob), rel.rsplit("/", 1)[-1]) is not None
+    return "/" not in glob and re.match(pattern, rel.rsplit("/", 1)[-1]) is not None
 
 
 def format_for(path: str) -> str | None:
@@ -138,7 +149,7 @@ def find_manifest(path: str) -> Path | None:
     return None
 
 
-def manifest_axes(path: str, manifest: Path) -> dict:
+def manifest_axes(path: str, manifest: Path) -> dict[str, str]:
     """Resolve doctype/lang overrides + default_lang from the project manifest.
 
     The first ``[[map]]`` whose glob matches the file (relative to the dir that
@@ -154,11 +165,13 @@ def manifest_axes(path: str, manifest: Path) -> dict:
         rel = str(Path(path).resolve().relative_to(repo_root))
     except ValueError:
         rel = Path(path).name
-    out: dict = {}
+    out: dict[str, str] = {}
     default_lang = data.get("default_lang")
     if isinstance(default_lang, str):
         out["lang"] = default_lang
     for entry in data.get("map", []):
+        if not isinstance(entry, dict):
+            continue  # malformed [[map]] entry — skip it, not the whole file
         glob = entry.get("glob")
         if not isinstance(glob, str):
             continue
@@ -170,7 +183,7 @@ def manifest_axes(path: str, manifest: Path) -> dict:
     return out
 
 
-def resolve_axes(path: str) -> dict:
+def resolve_axes(path: str) -> dict[str, str]:
     """Compose all axis values for the edited file.
 
     format from extension; doctype from markup sniff then manifest override;
@@ -179,7 +192,7 @@ def resolve_axes(path: str) -> dict:
     fmt = format_for(path)
     if fmt is None:
         return {}
-    axes: dict = {"format": fmt}
+    axes: dict[str, str] = {"format": fmt}
     if fmt in PROSE_FORMATS:
         axes["prose"] = "_all"
 
@@ -196,7 +209,7 @@ def resolve_axes(path: str) -> dict:
     return axes
 
 
-def candidate_rule_files(axes: dict, rules_dir: Path) -> list[Path]:
+def candidate_rule_files(axes: dict[str, str], rules_dir: Path) -> list[Path]:
     """Existing rule files for the resolved axes, in injection order.
 
     Convention: ``rules/<axis>/<value>.md``. Format has a legacy-alias fallback
@@ -219,11 +232,12 @@ def candidate_rule_files(axes: dict, rules_dir: Path) -> list[Path]:
 
 def marker_path(session_id: str, rule: Path) -> Path:
     base = Path(os.environ.get("TMPDIR", "/tmp")) / "claude-rule-inject"
-    sid = session_id or "nosession"
+    # session_id is untrusted stdin — sanitize so it cannot escape the dir.
+    sid = re.sub(r"[^A-Za-z0-9_-]", "_", session_id or "nosession")[:64]
     return base / f"{sid}.{rule.parent.name}.{rule.name}"
 
 
-def build_context(path: str, axes: dict, files: list[Path]) -> str:
+def build_context(path: str, axes: dict[str, str], files: list[Path]) -> str:
     fmt = axes.get("format", "")
     desc = ", ".join(f"{k}={v}" for k, v in axes.items())
     parts = [
@@ -276,6 +290,8 @@ def main() -> int:
         return 0
 
     context = build_context(file_path, axes, fresh)
+    if len(context) > MAX_CONTEXT:
+        context = context[:MAX_CONTEXT] + "\n\n[... truncated at the additionalContext size limit ...]"
     json.dump(
         {"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": context}},
         sys.stdout,
@@ -284,7 +300,11 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Advisory hook: never block the edit. Catch SystemExit too (argparse on a
+    # bad invocation raises it) so the hook can never exit non-zero, which a
+    # PreToolUse hook signals as "block the tool".
     try:
-        sys.exit(main())
-    except Exception:  # advisory hook: any failure must not block the edit
-        sys.exit(0)
+        main()
+    except (Exception, SystemExit):
+        pass
+    sys.exit(0)

--- a/scripts/inject_rule_on_edit.py
+++ b/scripts/inject_rule_on_edit.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""PreToolUse(Edit|Write) hook: inject matching GLOBAL rule bodies on the first
+edit of a file along each axis, once per session.
+
+The rulebook in ``rules/`` is shared across every project. The session-start
+hook injects only the rules INDEX (pointers); bodies are read on demand. This
+hook tightens that for files with style rules: it resolves the edited file along
+four orthogonal axes and injects the body of every matching global rule that
+exists, then stays silent for the rest of the session (deduped per
+``session_id`` + rule file).
+
+Axes (composed per file):
+  format  — from the filename extension (project-agnostic). py/sh/tex/qmd/md/txt.
+  doctype — sniffed from markup where reliable (\\documentclass for .tex);
+            overridable by a project manifest. e.g. techreport/article/slides.
+  lang    — not mechanically detectable; from the project manifest, else the
+            manifest's default_lang. e.g. fr/en.
+  prose   — implied for prose formats (tex/qmd/md/txt); injects prose/_all.md
+            (LLMism guards, Elements of Style) regardless of doctype/lang.
+
+Rule files live by convention ``rules/<axis>/<value>.md`` (e.g.
+``rules/format/python.md``, ``rules/doctype/techreport.md``, ``rules/lang/fr.md``,
+``rules/prose/_all.md``). Legacy flat code rules (``rules/coding-python.md``,
+``rules/coding-bash.md``) are reached via a fallback alias so no rename is
+needed; missing files are silently skipped, so content grows by adding files.
+
+Project manifest (optional): ``<repo>/.claude/rules-map.toml`` ::
+
+    default_lang = "fr"
+    [[map]]
+    glob = "slides/manuscript/**/*.tex"
+    doctype = "techreport"
+    lang = "fr"
+
+Output: JSON on stdout with ``hookSpecificOutput.additionalContext`` (exit 0).
+Claude surfaces it in a system reminder before the edit runs. Framing is
+declarative (a fact about the file), never imperative, per the harness
+hook-output convention. The hook is advisory: any error exits 0 silently so it
+can never block an edit.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Extension -> format axis value. Project-agnostic by design: keyed on the
+# filename suffix, never on a directory like src/ or scripts/.
+EXT_FORMAT = {
+    ".py": "python",
+    ".sh": "bash",
+    ".tex": "tex",
+    ".qmd": "qmd",
+    ".md": "md",
+    ".txt": "txt",
+}
+PROSE_FORMATS = {"tex", "qmd", "md", "txt"}
+
+# \documentclass{X} -> doctype axis value.
+DOCUMENTCLASS_DOCTYPE = {
+    "report": "techreport",
+    "article": "article",
+    "beamer": "slides",
+    "book": "book",
+}
+_DOCUMENTCLASS_RE = re.compile(r"\\documentclass(?:\[[^\]]*\])?\{([^}]+)\}")
+
+
+def _glob_to_regex(glob: str) -> str:
+    """Translate a path glob to an anchored regex. `**` matches zero or more
+    directory segments; `*`/`?` stay within a single segment. Works on 3.11+
+    (pathlib.PurePath.full_match is 3.13-only, so we cannot use it)."""
+    out = ["(?s:"]
+    i, n = 0, len(glob)
+    while i < n:
+        c = glob[i]
+        if glob[i : i + 2] == "**":
+            if glob[i + 2 : i + 3] == "/":
+                out.append("(?:.*/)?")  # **/  -> zero or more dirs
+                i += 3
+            else:
+                out.append(".*")
+                i += 2
+        elif c == "*":
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    out.append(r")\Z")
+    return "".join(out)
+
+
+def glob_match(rel: str, glob: str) -> bool:
+    """Match a repo-relative path against a glob. A slash-less glob also matches
+    on the basename alone (so `*.qmd` means "any .qmd anywhere")."""
+    if re.match(_glob_to_regex(glob), rel):
+        return True
+    return "/" not in glob and re.match(_glob_to_regex(glob), rel.rsplit("/", 1)[-1]) is not None
+
+
+def format_for(path: str) -> str | None:
+    """Format axis value from the file extension, or None if unstyled."""
+    return EXT_FORMAT.get(Path(path).suffix.lower())
+
+
+def sniff_doctype(path: str, fmt: str | None) -> str | None:
+    """Doctype from markup where reliable. Only .tex \\documentclass today."""
+    if fmt != "tex":
+        return None
+    try:
+        head = Path(path).read_text(encoding="utf-8", errors="replace")[:4000]
+    except OSError:
+        return None
+    m = _DOCUMENTCLASS_RE.search(head)
+    if not m:
+        return None
+    cls = m.group(1).strip()
+    return DOCUMENTCLASS_DOCTYPE.get(cls, cls)
+
+
+def find_manifest(path: str) -> Path | None:
+    """Walk up from the edited file for ``.claude/rules-map.toml``."""
+    try:
+        start = Path(path).resolve().parent
+    except OSError:
+        return None
+    for d in (start, *start.parents):
+        candidate = d / ".claude" / "rules-map.toml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def manifest_axes(path: str, manifest: Path) -> dict:
+    """Resolve doctype/lang overrides + default_lang from the project manifest.
+
+    The first ``[[map]]`` whose glob matches the file (relative to the dir that
+    holds ``.claude/``) supplies its doctype/lang. ``default_lang`` is the
+    fallback when no entry sets lang.
+    """
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    repo_root = manifest.parent.parent  # <repo>/.claude/rules-map.toml -> <repo>
+    try:
+        rel = str(Path(path).resolve().relative_to(repo_root))
+    except ValueError:
+        rel = Path(path).name
+    out: dict = {}
+    default_lang = data.get("default_lang")
+    if isinstance(default_lang, str):
+        out["lang"] = default_lang
+    for entry in data.get("map", []):
+        glob = entry.get("glob")
+        if not isinstance(glob, str):
+            continue
+        if glob_match(rel, glob):
+            for axis in ("doctype", "lang"):
+                if isinstance(entry.get(axis), str):
+                    out[axis] = entry[axis]
+            break  # first match wins
+    return out
+
+
+def resolve_axes(path: str) -> dict:
+    """Compose all axis values for the edited file.
+
+    format from extension; doctype from markup sniff then manifest override;
+    lang from manifest (per-glob, else default_lang); prose implied by format.
+    """
+    fmt = format_for(path)
+    if fmt is None:
+        return {}
+    axes: dict = {"format": fmt}
+    if fmt in PROSE_FORMATS:
+        axes["prose"] = "_all"
+
+    doctype = sniff_doctype(path, fmt)
+
+    manifest = find_manifest(path)
+    overrides = manifest_axes(path, manifest) if manifest else {}
+    # Manifest overrides the sniffed doctype; supplies lang (not sniffable).
+    doctype = overrides.get("doctype", doctype)
+    if doctype:
+        axes["doctype"] = doctype
+    if overrides.get("lang"):
+        axes["lang"] = overrides["lang"]
+    return axes
+
+
+def candidate_rule_files(axes: dict, rules_dir: Path) -> list[Path]:
+    """Existing rule files for the resolved axes, in injection order.
+
+    Convention: ``rules/<axis>/<value>.md``. Format has a legacy-alias fallback
+    (``rules/coding-<value>.md``) so the flat code rules need no rename.
+    """
+    files: list[Path] = []
+    for axis in ("format", "doctype", "lang", "prose"):
+        value = axes.get(axis)
+        if not value:
+            continue
+        candidates = [rules_dir / axis / f"{value}.md"]
+        if axis == "format":
+            candidates.append(rules_dir / f"coding-{value}.md")
+        for c in candidates:
+            if c.is_file():
+                files.append(c)
+                break
+    return files
+
+
+def marker_path(session_id: str, rule: Path) -> Path:
+    base = Path(os.environ.get("TMPDIR", "/tmp")) / "claude-rule-inject"
+    sid = session_id or "nosession"
+    return base / f"{sid}.{rule.parent.name}.{rule.name}"
+
+
+def build_context(path: str, axes: dict, files: list[Path]) -> str:
+    fmt = axes.get("format", "")
+    desc = ", ".join(f"{k}={v}" for k, v in axes.items())
+    parts = [
+        f"You are editing a {fmt} file ({path}). Its global style rules "
+        f"({desc}) apply to such files in this session. They are reproduced "
+        f"once below for reference:"
+    ]
+    for f in files:
+        parts.append(f"\n----- {f.parent.name}/{f.name} -----\n{f.read_text(encoding='utf-8').rstrip()}")
+    return "\n".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rules-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "rules",
+        help="Directory holding the global rule tree (default: ../rules).",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # advisory: never block on bad input
+
+    file_path = (payload.get("tool_input") or {}).get("file_path")
+    if not file_path:
+        return 0
+
+    axes = resolve_axes(file_path)
+    files = candidate_rule_files(axes, args.rules_dir)
+    if not files:
+        return 0
+
+    session_id = payload.get("session_id") or ""
+    fresh: list[Path] = []
+    for f in files:
+        marker = marker_path(session_id, f)
+        if marker.exists():
+            continue  # already injected this rule this session
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch()
+        except OSError:
+            pass  # dedup best-effort; still inject
+        fresh.append(f)
+    if not fresh:
+        return 0
+
+    context = build_context(file_path, axes, fresh)
+    json.dump(
+        {"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": context}},
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # advisory hook: any failure must not block the edit
+        sys.exit(0)

--- a/settings.json
+++ b/settings.json
@@ -178,6 +178,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/scripts/inject_rule_on_edit.py",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/tests/test_harness_rules_injection.sh
+++ b/tests/test_harness_rules_injection.sh
@@ -16,7 +16,7 @@ fail=0
 out=$(bash scripts/on-start.sh 2>&1 || true)
 
 # 1. Index headers/scope signals must appear in the hook output.
-for needle in "workflow.md" "git.md" "always" "condition"; do
+for needle in "workflow.md" "git.md" "always" "edit of"; do
   if ! grep -qF "$needle" <<<"$out"; then
     echo "FAIL: hook output missing index marker '$needle'"
     fail=1

--- a/tests/test_inject_rule_on_edit.py
+++ b/tests/test_inject_rule_on_edit.py
@@ -179,3 +179,68 @@ def test_hook_silent_for_unstyled_file(tmp_path):
     )
     assert res.returncode == 0
     assert res.stdout.strip() == ""
+
+
+# --- glob matcher (direct) ---------------------------------------------------
+
+@pytest.mark.parametrize(
+    "rel,glob,expected",
+    [
+        ("slides/manuscript/main.tex", "slides/manuscript/**/*.tex", True),
+        ("slides/manuscript/sub/main.tex", "slides/manuscript/**/*.tex", True),
+        ("slides/x.qmd", "**/*.qmd", True),
+        ("book/index.qmd", "*.qmd", True),  # slash-less -> basename fallback
+        ("a/main.tex", "slides/**/*.tex", False),
+        ("src/foo.py", "*.py", True),  # basename fallback
+        ("src/foo.py", "src/*.py", True),
+        ("src/deep/foo.py", "src/*.py", False),  # * does not cross /
+    ],
+)
+def test_glob_match(rel, glob, expected):
+    assert inj.glob_match(rel, glob) is expected
+
+
+def test_glob_match_rejects_pathological_glob():
+    # Many '*' would drive catastrophic backtracking; the complexity cap returns
+    # False fast instead of hanging past the hook timeout.
+    assert inj.glob_match("a/b/c/d/e/f.tex", "**a**b**c**d**e**f**g") is False
+
+
+def test_manifest_non_match_leaves_sniffed_doctype(tmp_path):
+    repo = _manifest_repo(
+        tmp_path,
+        '[[map]]\nglob = "other/**/*.tex"\ndoctype = "slides"\n',  # does NOT match
+    )
+    f = repo / "slides" / "manuscript" / "main.tex"
+    f.write_text("\\documentclass{report}\n")
+    axes = inj.resolve_axes(str(f))
+    assert axes["doctype"] == "techreport"  # sniff survives when no glob matches
+
+
+def test_candidate_prefers_convention_over_alias(tmp_path):
+    rules = tmp_path
+    (rules / "format").mkdir()
+    (rules / "format" / "python.md").write_text("canonical")
+    (rules / "coding-python.md").write_text("legacy alias")  # both exist
+    files = inj.candidate_rule_files({"format": "python"}, rules)
+    assert [f.name for f in files] == ["python.md"]  # canonical wins, alias skipped
+
+
+@pytest.mark.integration
+def test_hook_truncates_oversized_context(tmp_path):
+    rules = tmp_path / "rules"
+    (rules / "format").mkdir(parents=True)
+    (rules / "format" / "python.md").write_text("X" * 20000)  # > MAX_CONTEXT
+    tmpdir = tmp_path / "tmp"
+    tmpdir.mkdir()
+    payload = json.dumps(
+        {"session_id": "big", "tool_input": {"file_path": str(tmp_path / "x.py")}}
+    )
+    res = subprocess.run(
+        ["python3", str(_HOOK), "--rules-dir", str(rules)],
+        input=payload, capture_output=True, text=True,
+        env={"TMPDIR": str(tmpdir), "PATH": "/usr/bin:/bin"},
+    )
+    ctx = json.loads(res.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert len(ctx) < 10000
+    assert "truncated" in ctx

--- a/tests/test_inject_rule_on_edit.py
+++ b/tests/test_inject_rule_on_edit.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/inject_rule_on_edit.py — the PreToolUse hook that injects
+matching global rule bodies on the first edit of a file per session."""
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HOOK = Path(__file__).resolve().parent.parent / "scripts" / "inject_rule_on_edit.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("inject_rule_on_edit", _HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+inj = _load()
+
+
+# --- format axis (extension, project-agnostic) -------------------------------
+
+def test_format_for_known_extensions():
+    assert inj.format_for("/a/b/foo.py") == "python"
+    assert inj.format_for("x.sh") == "bash"
+    assert inj.format_for("paper.tex") == "tex"
+    assert inj.format_for("book.qmd") == "qmd"
+
+
+def test_format_for_unstyled_is_none():
+    assert inj.format_for("data.json") is None
+    assert inj.format_for("table.csv") is None
+    assert inj.format_for("ticket.erg") is None
+
+
+# --- doctype sniff (markup, .tex only today) ---------------------------------
+
+@pytest.mark.parametrize(
+    "cls,expected",
+    [("report", "techreport"), ("article", "article"), ("beamer", "slides"), ("memoir", "memoir")],
+)
+def test_sniff_doctype_from_documentclass(tmp_path, cls, expected):
+    f = tmp_path / "main.tex"
+    f.write_text(f"\\documentclass[a4paper,11pt]{{{cls}}}\n\\begin{{document}}\n")
+    assert inj.sniff_doctype(str(f), "tex") == expected
+
+
+def test_sniff_doctype_none_without_class(tmp_path):
+    f = tmp_path / "frag.tex"
+    f.write_text("just some \\section{x} text\n")
+    assert inj.sniff_doctype(str(f), "tex") is None
+
+
+def test_sniff_doctype_skips_non_tex(tmp_path):
+    f = tmp_path / "x.md"
+    f.write_text("\\documentclass{report}\n")  # not parsed for .md
+    assert inj.sniff_doctype(str(f), "md") is None
+
+
+# --- manifest (project-local mapping) ----------------------------------------
+
+def _manifest_repo(tmp_path, toml_body):
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "rules-map.toml").write_text(toml_body)
+    (tmp_path / "slides" / "manuscript").mkdir(parents=True)
+    return tmp_path
+
+
+def test_manifest_default_lang_applies(tmp_path):
+    repo = _manifest_repo(tmp_path, 'default_lang = "fr"\n')
+    f = repo / "slides" / "manuscript" / "main.tex"
+    f.write_text("x")
+    axes = inj.manifest_axes(str(f), repo / ".claude" / "rules-map.toml")
+    assert axes["lang"] == "fr"
+
+
+def test_manifest_glob_sets_doctype_and_overrides_lang(tmp_path):
+    repo = _manifest_repo(
+        tmp_path,
+        'default_lang = "en"\n\n[[map]]\nglob = "slides/manuscript/**/*.tex"\n'
+        'doctype = "techreport"\nlang = "fr"\n',
+    )
+    f = repo / "slides" / "manuscript" / "main.tex"
+    f.write_text("x")
+    axes = inj.manifest_axes(str(f), repo / ".claude" / "rules-map.toml")
+    assert axes["doctype"] == "techreport"
+    assert axes["lang"] == "fr"  # per-glob lang beats default_lang
+
+
+# --- composition -------------------------------------------------------------
+
+def test_resolve_axes_composes_format_prose_doctype(tmp_path):
+    repo = _manifest_repo(tmp_path, 'default_lang = "fr"\n')
+    f = repo / "slides" / "manuscript" / "main.tex"
+    f.write_text("\\documentclass{report}\n")
+    axes = inj.resolve_axes(str(f))
+    assert axes["format"] == "tex"
+    assert axes["prose"] == "_all"
+    assert axes["doctype"] == "techreport"  # sniffed
+    assert axes["lang"] == "fr"  # manifest default
+
+
+def test_resolve_axes_empty_for_data_file():
+    assert inj.resolve_axes("/x/data.json") == {}
+
+
+def test_manifest_doctype_overrides_sniff(tmp_path):
+    repo = _manifest_repo(
+        tmp_path,
+        '[[map]]\nglob = "slides/manuscript/**/*.tex"\ndoctype = "slides"\n',
+    )
+    f = repo / "slides" / "manuscript" / "main.tex"
+    f.write_text("\\documentclass{report}\n")  # would sniff techreport
+    axes = inj.resolve_axes(str(f))
+    assert axes["doctype"] == "slides"  # manifest wins
+
+
+# --- rule-file resolution (convention + legacy alias) ------------------------
+
+def test_candidate_rule_files_convention_and_alias(tmp_path):
+    rules = tmp_path
+    (rules / "format").mkdir()
+    (rules / "prose").mkdir()
+    (rules / "format" / "tex.md").write_text("tex rules")
+    (rules / "coding-bash.md").write_text("legacy bash rules")  # alias target
+    (rules / "prose" / "_all.md").write_text("prose rules")
+
+    # tex prose file -> format/tex.md + prose/_all.md (doctype/lang absent)
+    files = inj.candidate_rule_files(
+        {"format": "tex", "prose": "_all", "doctype": "techreport"}, rules
+    )
+    names = [f.name for f in files]
+    assert names == ["tex.md", "_all.md"]  # techreport.md does not exist -> skipped
+
+    # bash resolves via the legacy coding-bash.md alias
+    bash_files = inj.candidate_rule_files({"format": "bash"}, rules)
+    assert [f.name for f in bash_files] == ["coding-bash.md"]
+
+
+# --- end-to-end: injection + per-session dedup -------------------------------
+
+@pytest.mark.integration
+def test_hook_injects_then_dedups(tmp_path):
+    rules = tmp_path / "rules"
+    (rules / "format").mkdir(parents=True)
+    (rules / "format" / "python.md").write_text("PYRULE-MARKER body")
+    tmpdir = tmp_path / "tmp"
+    tmpdir.mkdir()
+    payload = json.dumps(
+        {"session_id": "sess1", "tool_input": {"file_path": str(tmp_path / "x.py")}}
+    )
+    env = {"TMPDIR": str(tmpdir), "PATH": "/usr/bin:/bin"}
+
+    def run():
+        return subprocess.run(
+            ["python3", str(_HOOK), "--rules-dir", str(rules)],
+            input=payload, capture_output=True, text=True, env=env,
+        )
+
+    first = run()
+    assert first.returncode == 0
+    out = json.loads(first.stdout)
+    assert "PYRULE-MARKER" in out["hookSpecificOutput"]["additionalContext"]
+    assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+
+    second = run()  # same session -> deduped -> no output
+    assert second.returncode == 0
+    assert second.stdout.strip() == ""
+
+
+@pytest.mark.integration
+def test_hook_silent_for_unstyled_file(tmp_path):
+    payload = json.dumps({"session_id": "s", "tool_input": {"file_path": "/x/data.json"}})
+    res = subprocess.run(
+        ["python3", str(_HOOK)], input=payload, capture_output=True, text=True
+    )
+    assert res.returncode == 0
+    assert res.stdout.strip() == ""


### PR DESCRIPTION
Builds the multi-axis rule-injection engine discussed in design: keep the rulebook **global and shared**, but inject the right rules **only when you touch a file they govern**, scoped by file *type* (universal) rather than directory (project-dependent).

## What it does

A new PreToolUse(`Edit|Write`) hook (`scripts/inject_rule_on_edit.py`) resolves the edited file along four orthogonal axes and injects the full body of every matching global rule **once per session** (deduped on `session_id` + rule):

| Axis | Resolved from | Rule path |
|------|---------------|-----------|
| **format** | filename extension (project-agnostic) | `rules/format/<v>.md` (legacy alias `rules/coding-<v>.md`) |
| **doctype** | `\documentclass` sniff for `.tex`; else project manifest | `rules/doctype/<v>.md` |
| **lang** | project manifest (`lang` per glob, else `default_lang`) | `rules/lang/<v>.md` |
| **prose** | implied for prose formats | `rules/prose/_all.md` |

The injected set is the **union** — editing `main.tex` pulls format + prose + doctype + lang together. Doc-type and language (not derivable from a filename) come from an optional per-project manifest `<repo>/.claude/rules-map.toml` that holds path→axis **mappings only, never rule text** — so global sharing is preserved.

## Phasing (engine only)

This ships the **engine** + seeds, not a full rule library:
- `rules/prose/_all.md` — LLMism guards + Elements of Style starter (injected on every prose edit).
- Existing `coding-python.md` / `coding-bash.md` reused via the format alias — **no rename** (blast radius was 7 files + the flat-glob staleness checker).
- `doctype/` and `lang/` resolve but have no bodies yet — added incrementally; missing files skip silently.

## Notes
- **Python, not bash**: tomllib + glob + JSON are clean and the resolver helpers are unit-tested. `**` globbing uses a 3.11+-safe translator (`pathlib.full_match` is 3.13-only; the uv env is 3.12).
- **Advisory**: any error exits 0 — the hook can never block an edit.
- **`.gitignore`**: added `!rules/` + `!rules/**` to the allowlist — the ignore-all `*` was silently dropping new files under `rules/` (existing ones were force-added historically). Latent bug, fixed.
- `rules/README.md` documents the axis model; full suite **597 passed** (16 new), ruff clean, end-to-end smoke verified (`.py`→coding-python, `.tex`→prose + sniffed doctype=techreport).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)