### PR TITLE
chore(tickets): 0255/0256 — grow rule content for the injection hook

### DIFF
--- a/tickets/0255-grow-prose-all-md-llmism-guards-elements.erg
+++ b/tickets/0255-grow-prose-all-md-llmism-guards-elements.erg
@@ -1,0 +1,47 @@
+%erg 0.1
+Title: Grow prose/_all.md: LLMism guards + Elements of Style
+Created: 2026-06-16
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-16T09:57Z HDMX-coding-agent created
+
+--- body ---
+## Context
+PR #404 shipped the per-file rule-injection hook and seeded
+`rules/prose/_all.md` with a starter set of universal-prose rules (LLMism
+guards + a few Elements of Style entries). The hook injects this file's full
+body on the first prose edit (`.tex` `.qmd` `.md` `.txt`) of every session, in
+every project. The seed is deliberately small; this ticket grows it into the
+durable universal-prose layer.
+
+## Relevant files
+- `rules/prose/_all.md` — the file to grow (currently a marked seed).
+- `scripts/inject_rule_on_edit.py` — injects it (no change needed).
+- The injected body counts against a 10k-char `additionalContext` cap
+  (`MAX_CONTEXT` in the hook), so keep entries terse — one line each.
+
+## Actions
+1. Expand the LLMism-guard list from real observed tics (add a guard only when
+   it has been seen in actual drafts — see the seed's own scope note).
+2. Round out the Elements of Style load-bearing rules.
+3. Keep each entry one line; the whole file must stay well under ~6k chars so
+   it composes with doctype/lang bodies without tripping truncation.
+
+## Test
+- First write a guard test in `tests/` that fails if `rules/prose/_all.md`
+  exceeds a size budget (e.g. 6000 chars) — pins the "stays terse" invariant
+  before adding content.
+
+## Verification
+- [ ] `rules/prose/_all.md` size under budget; guard test green.
+- [ ] Every new guard is one line, declarative (not imperative — hook-output
+      convention), and corresponds to a real observed defect.
+
+## Invariants
+- Do not bloat: the file is injected verbatim every prose session.
+- Declarative framing only (imperative text reads as prompt injection).
+
+## Exit criteria
+- prose/_all.md expanded with vetted LLMism + style entries, size-guarded by a
+  test, `make check-tests` green.

--- a/tickets/0256-author-doctype-and-lang-rule-bodies-for.erg
+++ b/tickets/0256-author-doctype-and-lang-rule-bodies-for.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: Author doctype/ and lang/ rule bodies for the injection hook
+Created: 2026-06-16
+Author: HDMX-coding-agent
+
+--- log ---
+2026-06-16T09:57Z HDMX-coding-agent created
+
+--- body ---
+## Context
+PR #404 shipped the per-file rule-injection hook with four axes:
+format / doctype / lang / prose. The hook RESOLVES doctype (sniffed from
+`\documentclass` for `.tex`, or a project manifest) and lang (project
+manifest), but `rules/doctype/` and `rules/lang/` have NO rule bodies yet, so
+those two axes currently inject nothing. This ticket authors the content.
+The engine is already live; this is pure content.
+
+## Relevant files
+- `rules/doctype/<value>.md` — to create (e.g. techreport, slides, book,
+  article, blogpost). Values come from `\documentclass` sniff
+  (`DOCUMENTCLASS_DOCTYPE` map in the hook: report→techreport, beamer→slides,
+  book→book, article→article) or a manifest `doctype`.
+- `rules/lang/<value>.md` — to create (e.g. `fr.md`, `en.md`).
+- `scripts/inject_rule_on_edit.py` — `candidate_rule_files()` already probes
+  `rules/<axis>/<value>.md`; missing files skip silently. No code change needed
+  to light these up — just add the files.
+- `rules/README.md` — already documents the axis model; add index rows for the
+  new files.
+
+## Actions
+1. Decide the initial doctype set worth rules (start with what is actually
+   used: techreport, slides, book — see the surveyed `\documentclass` values).
+2. Write each `rules/doctype/<v>.md` with conventions specific to that document
+   type (not format, not language — those are separate axes).
+3. Write `rules/lang/fr.md` and `rules/lang/en.md` with language-specific prose
+   norms (e.g. FR typographic spacing, quotation marks).
+4. Keep each terse (composes with format + prose bodies under the 10k cap).
+5. Add a row per new file to `rules/README.md`.
+
+## Test
+- Guard test: for each `rules/doctype/*.md` and `rules/lang/*.md`, assert it is
+  reachable — i.e. its `<value>` is a possible output of the hook's resolver
+  (in `DOCUMENTCLASS_DOCTYPE` values, or a documented lang). Catches orphan
+  rule files that can never be injected.
+
+## Verification
+- [ ] At least techreport/slides/book doctype bodies + fr/en lang bodies exist.
+- [ ] Each is reachable by the resolver (guard test green).
+- [ ] README index lists them; declarative framing; terse.
+
+## Invariants
+- Axis separation: doctype files carry ONLY document-type conventions; language
+  rules go in lang/, format rules in format/, universal prose in prose/_all.md.
+
+## Exit criteria
+- doctype/ and lang/ populated for the in-use types, reachable, indexed,
+  `make check-tests` green.


### PR DESCRIPTION
Follow-up tickets to #404 (per-file rule-injection engine). The engine is live; these track the deferred content authoring:

- **0255** — grow `rules/prose/_all.md` (LLMism guards + Elements of Style), with a size-budget guard test.
- **0256** — author `rules/doctype/` + `rules/lang/` bodies (techreport/slides/book, fr/en), with a reachability guard test.

Filing only; neither closed here.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)