### PR TITLE
dream: consolidate AEDIST memory (persist 16 untracked entries)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -1010,10 +1010,11 @@
     },
     "reference_zotero": {
       "projects": [
-        "-home-haduong-aedist-technical-report"
+        "-home-haduong-aedist-technical-report",
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
       ],
       "first_seen": "2026-06-05T19:26:10Z",
-      "last_confirmed": "2026-06-06T12:24:11Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
       "promoted": false
     },
     "feedback_skills_just_work_no_config_blocks": {
@@ -1142,6 +1143,550 @@
       ],
       "first_seen": "2026-06-08T22:31:11Z",
       "last_confirmed": "2026-06-08T22:31:11Z",
+      "promoted": false
+    },
+    "user_platform": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:17Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "project_release_needs_codedata_doi": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_durable_reminder_is_blocked_open_ticket": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_no_article_for_working_paper": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_ruff_hook_reports_not_deletes": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_orphaned_wip_is_unlanded_exit_criteria": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "project_book_idees_recues_finance_climat": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_editorial_book_work": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "project_reference_fix1": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_no_invented_names": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:24Z",
+      "last_confirmed": "2026-06-16T10:22:24Z",
+      "promoted": false
+    },
+    "feedback_verbatim_by_construction": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "project_three_quality_argument": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "project_coherence_axis_decomposition": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "project_economia_2026": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "project_exp1_module_scheme": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "project_exp1_design_decisions": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "feedback_reproducible_pipeline": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "feedback_make_not_loops": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "feedback_local_vs_cloud": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "feedback_pipeline_ux": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:25Z",
+      "last_confirmed": "2026-06-16T10:22:25Z",
+      "promoted": false
+    },
+    "feedback_fast_pipelines": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "feedback_review_before_merge": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "feedback_gh_merge_worktree": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "feedback_nohup_path": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "project_pdf_converters": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "reference_emmy": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "feedback_evaluate_all_overwrite": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "project_sweep2_results": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "reference_autonomous_padme": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "reference_tmux_padme": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:26Z",
+      "last_confirmed": "2026-06-16T10:22:26Z",
+      "promoted": false
+    },
+    "feedback_worktree_not_stash": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_evaluate_all_quality": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_ollama_num_ctx": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "project_model_registry_consolidation": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_shared_utils": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_pipe_table_splitting": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_multiturn_all_turns": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_autonomous_means_execute": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:27Z",
+      "last_confirmed": "2026-06-16T10:22:27Z",
+      "promoted": false
+    },
+    "feedback_no_typo_callouts": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_no_ps_ef_in_claude": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_check_sister_files_first": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_display_name_sweep_includes_plot_scripts": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "project_local_9b_near_ceiling": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_pydantic_unknown_kwargs": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "project_structured_dirs_registry": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_ticket_housekeeping_on_main": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_gaze_fork_dies_in_background_jobs": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:28Z",
+      "last_confirmed": "2026-06-16T10:22:28Z",
+      "promoted": false
+    },
+    "feedback_teams_worklist_purges_completed": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_verify_against_synced_main": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_shell_timeout_no_loops": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_teams_raid_region_bundling": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_render_and_adjust_tables": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_no_caveats_in_captions": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_pagination_widow_verification": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_haiku_truncated_final_reports": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_rtk_git_log_stale": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_build_from_user_worktree": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:29Z",
+      "last_confirmed": "2026-06-16T10:22:29Z",
+      "promoted": false
+    },
+    "feedback_live_edit_build_watcher": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_cleanroom_force_rebuild_test": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_stale_line_numbers_across_waves": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_use_quickpr_for_chores": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_erg_id_collision": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_merge_review_merge_cadence": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_handoff_in_state_not_tickets": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "reference_claude_dir_is_idh": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_stacked_pr_waves": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:30Z",
+      "last_confirmed": "2026-06-16T10:22:30Z",
+      "promoted": false
+    },
+    "feedback_bg_merge_anchoring": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:31Z",
+      "last_confirmed": "2026-06-16T10:22:31Z",
+      "promoted": false
+    },
+    "feedback_pgrep_self_match_watcher": {
+      "projects": [
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+      ],
+      "first_seen": "2026-06-16T10:22:31Z",
+      "last_confirmed": "2026-06-16T10:22:31Z",
       "promoted": false
     }
   }

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/MEMORY.md
@@ -1,13 +1,13 @@
 # AEDIST Technical Report - Project Memory
 
 ## Key insights
-<!-- /dream consolidation 2026-06-12 -->
+<!-- /dream consolidation 2026-06-16 -->
 
 - Anchor on stable identifiers, never on position: label-keyed test extraction, grep-relocation over line hints, slug-keyed memories — every positional anchor (line numbers, section titles, annex letters) broke at least once during the 2026-06 manuscript waves.
-- In multi-session and background work, cwd and branch state are not yours: parallel sessions legitimately move a worktree's branch; anchor every mutating command in one compound (`cd X && …` / `git -C`) and verify with `rev-parse` before branch-mutating git.
+- In multi-session and background work, cwd and branch state are not yours: parallel sessions legitimately move a worktree's branch; sync to origin before any fan-out, anchor every mutating command in one compound (`cd X && …` / `git -C`), and verify with `rev-parse`. Forge automation is also not idempotent — check forge state before retrying a merge.
 - Agent-surveyed numbers are hypotheses; committed artifacts are the source of truth — re-derive before writing prose, and guard quoted literals with re-derivation tests.
-- Close-then-merge automation is not idempotent: check forge state (`gh pr view --json state`) before retrying any merge step — a bounced-looking run may already have queued the merge.
-- Negative guards + label contracts let prose restructure freely; positive wording pins force test-chasing — editorial intent lives in the brief, not in CI (polarity rule).
+- The ticket/state dependency graph is the only durable "remember later" primitive: reminders → an OPEN ticket `Blocked-by` the trigger (auto-fires in `erg ready` when it closes); handoffs → STATE + edges; closed tickets and orphaned worktree WIP silently lose their unlanded content (re-ticket it, never leave it in a closed ticket's notes).
+- Dissemination is not the paper — code+data need their own persistent citable DOI (a mutable forge URL is not one), and register precision matters ("article" = peer-reviewed only; negative prose guards beat positive wording pins — the polarity rule).
 
 ## Project Structure
 - **Monorepo**: code absorbed into report repo (2026-04-02). aedist GitHub archived.
@@ -34,6 +34,10 @@
 - French-language report about Vietnamese thermal power plants as AI benchmark task
 
 ## Active
+- [Release needs code+data DOI](project_release_needs_codedata_doi.md) — disseminating the paper isn't disseminating the work; persistent DOI for code+data (Zenodo concept 10.5281/zenodo.20715179) is a release exit criterion, not a GitHub URL
+- [Durable reminder = blocked open ticket](feedback_durable_reminder_is_blocked_open_ticket.md) — "remember in N months" goes in an OPEN ticket Blocked-by the trigger (auto-surfaces in erg ready), never a closed-ticket note
+- ["Article" = peer-reviewed only](feedback_no_article_for_working_paper.md) — never call a working paper/preprint an "article" (EN or FR); use working paper/preprint/report/étude/document de travail
+- [Ruff hook reports, not deletes](feedback_ruff_hook_reports_not_deletes.md) — global lint-on-edit hook now exempts F401/I001/UP from autofix; import-in-same-Edit rule is hygiene not trap-avoidance; AEDIST workflow.md § ruff is stale
 - [Orphaned WIP = unlanded exit-criteria](feedback_orphaned_wip_is_unlanded_exit_criteria.md) — uncommitted WIP in a stale worktree may be a closed ticket's dropped deliverable; preserve, verify it runs, re-ticket (0609→0673)
 - [Side book — *Idées reçues* / finance climat](project_book_idees_recues_finance_climat.md) — separate repo; Le Cavalier Bleu dossier ready to send via Romain Blachier
 - [Editorial / trade-book working style](feedback_editorial_book_work.md) — multi-agent sims welcomed; grand-public legibility; no namedrop/family in pitch files

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_display_name_sweep_includes_plot_scripts.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_display_name_sweep_includes_plot_scripts.md
@@ -1,0 +1,28 @@
+---
+name: feedback_display_name_sweep_includes_plot_scripts
+description: "Stale model/display-name fixes in prose must sweep figure-generating label maps too, and disambiguate vs genuinely-different registry entries"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e6272c1e-8db3-4722-a5d7-ca195f81cf04
+---
+
+When fixing a stale model display name in manuscript/report prose (e.g.
+`Qwen3-Max` → `Qwen3.7 Max`, tickets 0584/0594), the defect class extends
+beyond `.tex`/`.md` to **figure-generating scripts** — `src/aedist/plot_*.py`
+carry label dicts like `{"qwen": "Qwen3-Max"}` that render the stale name into
+a manuscript figure via `\includegraphics`. The 0594 `/roar` sweep caught one
+(`plot_exp2_coverage_certainty.py:55`) live in a `main.tex` figure → ticket 0596.
+
+**Why:** prose-only sweeps miss the rendered-figure surface; a label map is just
+as much a display-name source as a sentence, and figures are first-class artifacts.
+
+**How to apply:**
+- Sweep target for any display-name rename: `*.tex *.md *.yaml *.toml` AND
+  `src/aedist/plot_*.py` label/legend maps.
+- Disambiguate before fixing: the same token may legitimately name a *different*
+  registry entry. `Qwen3-Max-Thinking` (`qwen3-max-thinking`) and OpenRouter
+  `qwen3-max` are genuinely different `models.yaml` entries — leave them. Confirm
+  the arm's slug from a run-record, never assume (see [[feedback_no_invented_names]]).
+- Never edit archived run-records (`experiments/archive/outputs/`) or protocol
+  specs (`experiments/sota/`) — immutable experimental record.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_durable_reminder_is_blocked_open_ticket.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_durable_reminder_is_blocked_open_ticket.md
@@ -1,0 +1,33 @@
+---
+name: feedback_durable_reminder_is_blocked_open_ticket
+description: A future reminder goes in an OPEN ticket Blocked-by the triggering ticket — never a note in a closed ticket.
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7b53f61c-a20c-44df-a541-3fc6bab72c28
+---
+
+To leave a reminder that must fire at a future event, create an **open**
+ticket with `Blocked-by: <trigger-ticket>`. When the trigger closes, the
+reminder auto-unblocks and surfaces in `erg ready` at exactly the right
+moment — the dependency graph does the remembering. A note in the
+"Follow-ups" of a **closed/archived** ticket is a *false* reminder: closed
+tickets never surface in `erg ready` and nobody re-reads them.
+
+2026-06-16: the "manuscript v2 must cite the Zenodo concept DOI" reminder was
+first parked in closed ticket 0676 — useless. Refiled as open ticket 0677
+`Blocked-by: 0665` (the arXiv push, ~2 months out); when 0665 closes, 0677
+becomes ready automatically. Author had to ask "did you note it to remember
+in 2 months?" to catch the dead reminder.
+
+**Why:** the ticket store has no time-based alarms; the only durable
+"remember later" primitive is a blocker edge that resolves on the triggering
+event. `deferred`-labelled tickets are also suppressed from `erg ready`, so
+a deferred ticket is NOT a reminder either — pair the reminder with a
+`Blocked-by` on the event that should wake it.
+
+**How to apply:** reminder for "do X when Y happens" → open ticket, body =
+the concrete X, `Blocked-by: <Y's ticket>`. Cross-link from the relevant
+planning/tracker ticket for a second discovery path. Related:
+[[feedback_orphaned_wip_is_unlanded_exit_criteria]] (closed tickets lose
+their unlanded content).

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_editorial_book_work.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_editorial_book_work.md
@@ -1,0 +1,22 @@
+---
+name: feedback_editorial_book_work
+description: "How to work with the user on trade-book / editorial / prose projects (pitch dossiers, titles, démontage chapters)"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ca2b78dc-59b4-4ce7-9ac0-b7b65483a84b
+---
+
+Standing preferences for the user's grand-public / trade-book work (surfaced over a long 2026-06-15 session building a Le Cavalier Bleu "Idées reçues" dossier).
+
+**Why:** these choices recurred and were explicitly corrected or confirmed across the session.
+
+**How to apply:**
+- **Multi-agent simulations are welcomed and effective.** A simulated editorial committee (divergent personas debate → chair's verdict) and a title *tournoi* (jury scores N candidates → arbiter picks top 3) both drove real decisions. Reach for Workflow orchestration on editorial judgement calls; the user explicitly enjoys and trusts it.
+- **Grand-public legibility beats technical precision.** An "idée reçue" must be a belief a lay reader actually holds ("Il existe un grand fonds mondial pour le climat"), not an insider thesis ("Le Fonds vert est le cœur du dispositif"). For the donor object, "les pays riches" beat "le Nord" / "l'OCDE" (too narrow) / "internationale" / "entre nations" (implies a false symmetry).
+- **Rigour: source pivotal empirical claims to a third party, never the author alone.** Re-derive numbers; verify every URL (HTTP 200); prefer date-cible-to-date-cible comparisons at an observed (not hypothetical) rate. Example: discount the 300 Md\$ (2035) over 15 yrs to 2020 at observed inflation → ~200, i.e. a doubling not a tripling.
+- **Register: offensive but good-faith** (directeur-de-recherche posture, not pamphlet). Steelman the idée reçue, then demolish by facts; cool the polemical flourishes ("le plus froid des monstres froids").
+- **No name-dropping prospective contacts in a pitch dossier** — you cannot promise unsecured interviews; keep the method generic. The recommender (warm-intro giver) and the author's own credentials are fine. **Never write family / personal-network names into committed project files** (corrected sharply when a brother's name was added to a notes file).
+- The user iterates titles intensively and decisively — offer options with one clear recommendation and help them converge; don't endlessly enumerate.
+
+Related: [[feedback_no_invented_names]], [[feedback_no_typo_callouts]], [[project_book_idees_recues_finance_climat]]

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_no_article_for_working_paper.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_no_article_for_working_paper.md
@@ -1,0 +1,26 @@
+---
+name: feedback_no_article_for_working_paper
+description: "Never call a working paper / preprint an \"article\" — in scientific communication \"article\" means peer-reviewed."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7b53f61c-a20c-44df-a541-3fc6bab72c28
+---
+
+Do not use the word "article" (English) or «article» (French) for a working
+paper, preprint, technical report, or any non-peer-reviewed output. In
+scientific communication "article" denotes a **peer-reviewed** publication;
+calling a working paper an article misrepresents its status and overclaims.
+
+**Why:** Author-imperative (2026-06-16), given while drafting the CIRED
+dissemination email — the report is a working paper, not yet peer-reviewed.
+The distinction is load-bearing for a researcher's publication record.
+
+**How to apply:** For not-yet-peer-reviewed work use "working paper",
+"preprint", "report", "study", "paper", or FR «document de travail»,
+«preprint», «étude», «travail», «texte». Reserve "article" / «article» for
+peer-reviewed publications only. Applies everywhere outward-facing — emails,
+prose, tickets, bib `type`, captions. (The bib already uses
+`type = {Working paper}` correctly.)
+
+Related: [[feedback_no_invented_names]] — precision in scientific claims.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_no_caveats_in_captions.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_no_caveats_in_captions.md
@@ -1,0 +1,19 @@
+---
+name: feedback_no_caveats_in_captions
+description: "Figure/table captions state plainly what the figure shows — no caveats, hedging, or method qualifications (those go in body/annex)"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+**Standing author instruction (2026-06-15): no caveat and hedging in captions.**
+
+A figure or table caption states plainly *what the figure/table shows and how to read it* — the axes, the bars, the message. It does NOT carry caveats, hedges, limitations, or methodological qualifications. Those belong in the body or the annex.
+
+**Examples of what to MOVE OUT of a caption:** "OSM matching relies on name-only fuzzy search, so its sparser coverage reflects both genuine mapping gaps and the weaker matcher" (a method caveat — removed from the `fig:longtail` caption); "an existence proof rather than a validated detector" style hedges; "we did not measure …" disclaimers; "details/provenance are in Annex …" pointers when they are just hedge-padding.
+
+**How to apply:**
+- When writing or reviewing a caption, strip any caveat/hedge/limitation sentence and relocate it to the relevant body paragraph or annex.
+- Pairs with the standalone-caption policy (text + captions standalone at the maths/ideas level, code only in annexes — ticket 0633) and the render-and-adjust rule ([[feedback_render_and_adjust_tables]]).
+- A caption can still carry a plain `\ref` to the annex for *detail*, but not a sentence whose job is to hedge or qualify the result.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_orphaned_wip_is_unlanded_exit_criteria.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_orphaned_wip_is_unlanded_exit_criteria.md
@@ -1,0 +1,41 @@
+---
+name: feedback_orphaned_wip_is_unlanded_exit_criteria
+description: "Uncommitted WIP in a stale worktree may be a closed ticket's unlanded exit-criteria deliverable; inspect before discarding and verify it actually runs."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 7b53f61c-a20c-44df-a541-3fc6bab72c28
+---
+
+When a `/lair` or `/roar` worktree sweep finds **uncommitted** changes in a
+stale agent worktree, do not treat them as disposable build noise. They may
+be a *closed* ticket's exit-criteria deliverable that never landed:
+`erg-pr-merge` autocloses every ticket named in a PR's `**Ticket:**` line
+**unconditionally**, regardless of whether the exit-criteria checkboxes are
+ticked — so a PR can close a ticket having committed only part of the work.
+
+2026-06-16: ticket 0609's Test section mandated a `\NumRefPlants` adherence
+guard. PR #1111 autoclosed 0609 having committed only the data fix
+(`macros_slides.tex` 173→177); the finished test sat uncommitted in an agent
+worktree for weeks. The data half had *also* already landed via a later
+commit, so only the test was novel.
+
+**Why:** the close claim is the `**Ticket:**` line, not the work. Orphaned
+WIP is the only trace that a deliverable was specified but dropped.
+
+**How to apply:**
+1. On any stale worktree with uncommitted changes, diff it and ask "is this
+   a deliverable some closed ticket promised?" before `git worktree remove`.
+2. Preserve first (commit `wip(NNNN):` on a branch, push), then adjudicate.
+3. **Uncommitted WIP may never have been run** — the 0609 test had a latent
+   `NameError` (a `@pytest.mark` decorator using `pytest` before its
+   in-function `import pytest`). Always run it and prove RED-on-regression
+   before trusting it; hoist in-function `import pytest` to module level
+   (ruff's F821 guards this class for *committed* code, never for WIP).
+4. Re-enter the work as a fresh ticket (renumber if the branch's old ID
+   collided on main — see [[feedback_erg_id_collision]]), then execute.
+
+Related: [[feedback_check_sister_files_first]], the close-then-merge
+non-idempotence note in MEMORY.md, and the worktree-paths rule (tool
+Read/Write paths must be worktree-rooted; a shared-checkout path silently
+operates on main, not the worktree).

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_pagination_widow_verification.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_pagination_widow_verification.md
@@ -1,0 +1,32 @@
+---
+name: feedback_pagination_widow_verification
+description: "Fix manuscript widows/pagination by shaving signposts first and verifying by rendering the specific page to PNG and Reading it"
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+**When the author reports a widow / "N lines too long" on a specific page**, the
+reliable loop is:
+
+1. **Shave the lowest-value lines first**: section roadmaps, recap lead-ins,
+   forward-reference closers, signpost sentences, and descriptors already in a
+   figure caption. These carry no argument and ~2 lines of them clear most
+   widows. Prefer compressing a standalone paragraph into a `see Figure~\ref{…}`
+   pointer over deleting substance.
+2. **Verify by rendering the exact page**, never by guessing: `tectonic -r 2`,
+   then `pdftoppm -f N -l N -r 120 -png main.pdf out` and **Read the PNG**.
+   Confirm the orphan line is gone and the target (e.g. §heading, conclusion
+   end) lands on the intended page. `pdftotext | grep` is unreliable for this —
+   line-wrapping hides the phrase.
+3. **Cross-PR pagination interacts**: a widow on page K often depends on an
+   earlier shave (e.g. the abstract shave pulls everything up). Render with ALL
+   the relevant PRs merged before the final verdict; a build off a branch that
+   lacks the prior shave shows a stale layout.
+
+**Why:** the 2026-06-15 widow pass (abstract, intro, §7, §9/§10) cleared every
+widow this way; each fix was a 2-3 line shave of signpost prose, verified by
+reading the rendered page. Guards held (em-dash cap, §fusion primacy markers,
+0588 fig:cost-quality anchor) — see [[feedback_no_caveats_in_captions]] and the
+CI-polarity rule.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_pgrep_self_match_watcher.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_pgrep_self_match_watcher.md
@@ -1,0 +1,32 @@
+---
+name: feedback_pgrep_self_match_watcher
+description: Background watcher loops that pgrep their own pattern self-match and never exit
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ff935929-6d74-4b27-a396-830f64808637
+---
+
+A background-shell watcher that polls `pgrep -f "make check"` (or any `pgrep -f
+PATTERN` where PATTERN appears in the watcher's own command line) **self-matches
+and loops forever**. The watcher's command text literally contains the string,
+so `! pgrep -f "make check"` is never true and `kill -0 $(pgrep ... | head -1)`
+targets a live sibling watcher. Two such shells survived 9h+ on this project,
+matching each other and themselves; the `make check` they watched had died at
+~17% and never wrote its `passed|failed|EXIT=` sentinel, so the log-sentinel
+condition was also permanently false.
+
+**Why:** A watcher that never exits is worse than no watcher — it never
+re-invokes the agent, leaks a process across sessions, and `/clear` orphans it.
+
+**How to apply:**
+- Never gate a loop on `pgrep -f PATTERN` where PATTERN is a substring of the
+  loop's own command. Match a PID you captured (`pgrep` the target *before*
+  starting the watcher, then `kill -0 $PID`), or `pgrep -f` a pattern unique to
+  the target (full path / a flag the watcher line doesn't carry).
+- Pair the process check with a **timeout fallback** so a watched process that
+  dies without writing its sentinel still releases the loop (`SECONDS`-based cap
+  or a max-iteration counter).
+- Prefer the harness Monitor tool / `run_in_background` task tracking over a
+  hand-rolled `until … sleep` shell when the harness can notify on completion —
+  see the memory index note on harness-tracked background work.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_render_and_adjust_tables.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_render_and_adjust_tables.md
@@ -1,0 +1,18 @@
+---
+name: feedback_render_and_adjust_tables
+description: "After ANY table modification, always render the PDF and check/adjust every table's column widths"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+**Standing author instruction (2026-06-15):** for any LaTeX document with tables (manuscript `main.tex`, the report, the slides), after ANY change that touches a table — new column, changed content, new caption, edited colspec, or even a global edit that could reflow — **always render the PDF and check/adjust the column widths of ALL tables** before treating the change as done. Do not assume a table that fit before still fits.
+
+**Why:** a table that was fine can overflow (overfull `\hbox`, text spilling into the margin or colliding) the moment a column is added or content lengthens. Reading-3 added a 5th column to `tbl:status-difficulty` ("Avg. detection prob. (Exp 2, 1D)") and converted the Annex B agents table to `tabularx` — column fit must be verified by rendering, never assumed.
+
+**How to apply:**
+- Build with logs: `cd slides/manuscript && tectonic -r 2 --keep-logs main.tex`, then `grep -n 'Overfull \\hbox' main.log` and map each to its table.
+- Fix the colspec until clean: prefer `tabularx{\linewidth}{… >{\raggedright\arraybackslash}X}` for the wide text column; otherwise tune `p{…}` widths, abbreviate headers, or drop to `\small`/`\footnotesize`. Keep numeric columns `r`, short labels `l`.
+- This is a manual QA step (judgment on which column to shrink), so it lives as a working rule here — not a hook. Consider mirroring it into `.claude/rules/writing.md` as a project convention checked at `/review-pr-prose`.
+- Applies to every table in the document, not only the one just edited.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_ruff_hook_reports_not_deletes.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_ruff_hook_reports_not_deletes.md
@@ -1,0 +1,32 @@
+---
+name: feedback_ruff_hook_reports_not_deletes
+description: "The global ruff post-edit hook now reports (not deletes/rewrites) F401/I001/UP — the import-in-same-Edit workaround is hygiene, no longer trap-avoidance"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d9b81d4e-10df-4c13-976b-36187baec21d
+---
+
+The global PostToolUse hook `~/.claude/scripts/lint-on-edit.sh` runs
+`ruff check --fix --unfixable F401,I001,UP` (ImperialDragonHarness PR #401,
+2026-06-16). F401 (unused import), I001 (import sort), and UP (pyupgrade
+body rewrites: `List[str]`→`list[str]`, `Optional`→`| None`, `.format`→
+f-string) are still **reported** but never auto-applied — so the hook no
+longer mutates a `.py` file between two of an agent's Edits.
+
+**Why:** Those three autofixes were a "swordfight" trap: the agent adds an
+`import X` in Edit 1 and its usage in Edit 2; the hook fired in between and
+deleted/reordered/rewrote the code, leaving the next Edit's `old_string`
+stale → NameError or failed Edit → re-add → repeat (token waste). A sweep of
+621 transcripts found the pattern in 19 sessions. F841 stays fixable (its fix
+is unsafe, never fires without `--unsafe-fixes`); whitespace/E-class fixes
+stay on (they never desync).
+
+**How to apply:** The AEDIST rule "import + first usage go in the same Edit,
+always" (`.claude/rules/workflow.md` § *Ruff post-edit hook strips unused
+imports*) is now **good hygiene, not trap-avoidance** — a split import/usage
+across Edits will no longer be silently broken by the hook; ruff just reports
+it and the agent finishes the usage. That rule doc is stale and worth
+relaxing/updating. Guard: `tests/test_lint_on_edit.sh` in IDH ratchets the
+three codes into `--unfixable`. See [[feedback_no_typo_callouts]] for the
+broader "fix the tool, not the workaround" instinct.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_shell_timeout_no_loops.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_shell_timeout_no_loops.md
@@ -1,0 +1,20 @@
+---
+name: feedback_shell_timeout_no_loops
+description: "Shells stall on network/CI calls — wrap every gh/git call in timeout, never write shell poll-loops"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+In this environment (background sessions on doudou), shell commands **tend to stall** on network/CI calls — `gh pr view/checks/merge`, `git fetch/push`, `erg-pr-merge`. Two rules:
+
+1. **`timeout N` on every network call** (`timeout 30 git fetch`, `timeout 25 gh pr checks`, `timeout 90 ~/.claude/skills/merge/erg-pr-merge`). An unwrapped call can hang the whole shell.
+2. **No long-running shell poll-loops.** A `for attempt in $(seq 1 15); do … sleep 25; gh pr checks …; done` loop hangs the moment one CI check stays `pending` or one `gh` call wedges, and then must be killed with TaskStop.
+
+**Instead of polling loops:**
+- Queue **native GitHub auto-merge** (`gh pr merge --merge --auto`, or `erg-pr-merge` which queues) — it returns immediately and lands when CI passes; check back in a later turn.
+- For a genuine wait, use a **background `Bash` with an `until` condition that EXITS** (one notification), or the **Monitor** tool — not a foreground loop.
+- Do merges as **bounded discrete attempts across turns**, not one mega-loop.
+
+**Why:** 2026-06-15 reading-3 raid — a background merge loop (`seq 1 15` + `sleep 25` polling CI) stalled on a pending `build` check; had to TaskStop it and finish the merge with bounded `timeout`-wrapped commands. The author flagged: "shells have a tendency to stall … timeout, no shell loop." Relates to [[feedback_bg_merge_anchoring]] (anchor + check state before retry).

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_teams_raid_region_bundling.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_teams_raid_region_bundling.md
@@ -1,0 +1,19 @@
+---
+name: feedback_teams_raid_region_bundling
+description: "Large prose-edit wave via Teams — sweeps-first, bundle tickets by manuscript region (one PR per section), red-team at end"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+Executing a large manuscript-edit wave (many tickets) via the Teams worker pool works well with this structure:
+
+1. **Sweeps first.** Whole-file renames/policies (terminology, a caption/code policy) land BEFORE region edits, so later prose uses the final vocabulary. Encode as worklist `blockedBy` (or just merge them first). Run the sweeps as their own workers; they edit the whole file so merge them sequentially with rebase (low textual overlap → clean).
+2. **Bundle tickets BY MANUSCRIPT REGION, not one-ticket-one-worker.** One worker / one PR per section or figure-group (e.g. "§5 bundle: 0612+0613+0614", "FIGCAPS: 0616+0617+0623+0625"), with multiple `**Ticket:**` lines. Each worker owns DISJOINT lines, so parallel worktrees rebase cleanly and you stay under the 8-agent cap. One-ticket-one-worker on the same section causes needless intra-region rebase conflicts.
+3. **Emitter/.py and slides tickets merge freely** (different files from main.tex) — run them in the same wave as prose with no conflict.
+4. **Gate-merge in dependency/region order**, rebasing each (see [[feedback_shell_timeout_no_loops]] for the bounded-merge discipline). Hold the most invasive PR (e.g. an appendix restructure) for LAST so smaller edits rebase onto stable text, not the monster.
+5. **Interactive/decision tickets** (engineering, editorial calls) are held out of the autonomous waves; run their investigations via read-only workers, bring the author decisions, then execute.
+6. **Red-team integration pass at the end** — tiered verifiers (haiku mechanical / sonnet structural / opus judgment), refute-by-default, against post-merge main. This caught nothing this time precisely because each ticket shipped a negative guard + green CI; it is still the gate that closes the tracker.
+
+**Why:** 2026-06-15 reading-3 wave — 36 tickets via Teams across sweeps + 3 waves; region-bundling collapsed ~22 prose edits into ~10 PRs with near-zero merge conflicts; red-team found zero defects. Watch-outs: workers inconsistently close their ticket in-branch (handle both — erg-pr-merge for still-open, plain merge for closed-in-diff); and branch-allocated erg IDs collide when a prior ID is still in an unmerged PR ([[feedback_erg_id_collision]]).

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_teams_worklist_purges_completed.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_teams_worklist_purges_completed.md
@@ -1,0 +1,20 @@
+---
+name: feedback_teams_worklist_purges_completed
+description: "Teams shared worklist purges completed tasks — collect results from agent return values, not the worklist"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+The experimental Agent Teams shared worklist (`TaskCreate`/`TaskList`/`TaskUpdate`/`TaskGet`, enabled via `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) **is genuinely shared** between the lead and `Agent`-tool–spawned teammates (a sentinel task round-tripped: a read-only teammate echoed the lead's task back verbatim). Per-agent model tiering via the `Agent` `model` param works (haiku/sonnet/opus per task).
+
+**But completed tasks are purged from the store** — once a teammate marks a task `completed`, `TaskGet` returns "not found" and `TaskList` omits it. So the worklist is good for *distribution* and a *live board*, NOT for durable result storage.
+
+**Why:** 2026-06-14, verifier-team run on ticket 0578 (verify 42 reading-2 findings against `main.tex`). Lead-created task #1 vanished after a teammate completed it; only a second sentinel probe distinguished "completed-tasks-purged" from "worklist-not-shared".
+
+**How to apply:**
+- Have each teammate return its result as its **final message** (the lead collects from return values); never write a verdict into a task expecting to read it back.
+- **Smoke-test one task** before fanning out — this is what surfaced the purge before it bit all 42 ([[feedback_autonomous_means_execute]]-style: test one before blasting).
+- If model-sizing per item matters, **pre-assign batches by tier** rather than relying on dynamic claiming (claiming is first-come, so a haiku teammate could grab a judgment task).
+- Respect the 8-concurrent-agent cap: batch N findings into ≤8 tier-pinned teammates.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_verify_against_synced_main.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_verify_against_synced_main.md
@@ -1,0 +1,17 @@
+---
+name: feedback_verify_against_synced_main
+description: Sync local main before any verification/review fan-out — a stale checkout yields false FAILs
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a0bed5cd-c7ef-4c4b-bb4c-87b251470dcd
+---
+
+Before spawning a verification or review team that reads the working tree, **sync the checkout to origin first** (`git fetch origin && git checkout main && git pull --ff-only`, or have agents read a freshly-fetched ref). Agents read files from the primary checkout's working tree — if local `main` is behind `origin/main`, they audit stale content and report fixes-already-merged as FAIL.
+
+**Why:** 2026-06-14, the first 8-agent verification of ticket 0578's 42 findings ran against local main at `4ebe1a83` (pre-0591/0592). Findings 8 (Doc-07 codename) and 22 (code refs) came back FAIL — but those were already fixed in PR #1064/#1065, merged to origin and simply not pulled locally. The false FAILs had to be reconciled by reading the child tickets; a second red-team pass against synced main (`e5f782cc`) confirmed all clean. A whole multi-agent pass was partly wasted on a stale tree.
+
+**How to apply:**
+- `git fetch origin` + fast-forward local main (or branch) immediately before launching any read-only verification/review fan-out.
+- When a verification FAIL contradicts a ticket/PR that claims the fix merged, suspect a stale checkout before suspecting a regression ([[feedback_rtk_git_log_stale]]).
+- Background/parallel sessions especially: cwd and branch state are not yours (see Key insights — stale branch state).

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/project_book_idees_recues_finance_climat.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/project_book_idees_recues_finance_climat.md
@@ -1,0 +1,17 @@
+---
+name: project_book_idees_recues_finance_climat
+description: "Side book project — \"Idées reçues sur la générosité climatique des pays riches\" (Le Cavalier Bleu), separate from AEDIST"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: ca2b78dc-59b4-4ce7-9ac0-b7b65483a84b
+---
+
+A grand-public book the user is reviving, in its **own git repo** (not AEDIST) at
+`~/CNRS/papiers/actif/Comment dépenser plus de 100 milliards de dollars - Projet Livre/`.
+
+- **Concept:** a *démontage* of 16 idées reçues on North–South climate finance, for Le Cavalier Bleu's flagship "Idées reçues" collection. Title settled 2026-06-15: *Idées reçues sur la générosité climatique des pays riches* — sous-titre *Cent, trois cents milliards : à qui profite le compte ?*. Offensive but good-faith, no plaidoyer. Reframe of a stalled 2024 project ("Comment dépenser 100 milliards") whose COP30-anticipation premise had burned (NCQG was set at Bakou/COP29, Nov 2024: 300 Md\$/yr by 2035).
+- **Build:** markdown parts → pandoc + tectonic. `dossier/build-dossier.sh` assembles `dossier/dossier-proposition.pdf` — the pitch (bordereau + lettre à A.-L. Marsaleix + projet + sommaire commenté + 2 sample chapters: ch.3 Bakou, ch.12 JETP/Vietnam). The book itself is a Quarto project (`_quarto.yml`). Generated PDFs are gitignored; markdown parts are tracked.
+- **State at 2026-06-15:** dossier finalised (13 p.), claims hardened + URLs verified, démontages retitled grand-public, préface dropped (decided with author), interview plan in `notes/entretiens.md`. **Next step:** author sends the dossier to Romain Blachier (the recommender) to request a warm intro to Anne-Laure Marsaleix at Le Cavalier Bleu.
+
+Living state lives in the book repo's own `README.md`, `notes/synopsis.md`, `TODO.md`. Working style: [[feedback_editorial_book_work]].

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/project_release_needs_codedata_doi.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/project_release_needs_codedata_doi.md
@@ -1,0 +1,32 @@
+---
+name: project_release_needs_codedata_doi
+description: "Disseminating the paper is not disseminating the work — a release sequence must give code+data a persistent DOI, not just a GitHub URL."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 7b53f61c-a20c-44df-a541-3fc6bab72c28
+---
+
+Before closing any dissemination/release sequence, check that the **code and
+data** have a persistent, citable identifier — not only the paper. The
+mission (MASTERPLAN North star) is data whose errors are *locatable*, which
+requires a citable deposit; a GitHub URL is mutable and not a persistent
+identifier. A paper-channel tracker (HAL, arXiv, homepage, lab announcement)
+disseminates the manuscript and silently omits the artifact that the mission
+is actually about.
+
+2026-06-16: the dissemination tracker [[0663]] had no code+data DOI child.
+A pre-close reflection against the mission + the author's *Research Excellence
+à la Française* (REALF) caught it; deposited a Zenodo snapshot of tag
+`economia-2026-report` → **concept DOI 10.5281/zenodo.20715179** (all
+versions) + version DOI .20715180. Recorded in `Ha-Duong.bib`
+(`Ha-Duong2026:AEDISTcode`).
+
+**How to apply:**
+- Cite the Zenodo **concept** DOI (not the version DOI) in the manuscript so
+  the line survives every new snapshot; the preprint snapshot versions in
+  under the same concept DOI ([[0677]] tracks the manuscript citation).
+- The reconciled reference dataset gets its own citable home in the **data
+  paper** [[0517]]; the Zenodo snapshot is the interim reproducibility
+  artifact, complementary not redundant.
+- Treat "is the code+data citable?" as a release-sequence exit criterion.


### PR DESCRIPTION
/dream consolidation for AEDIST-technical-report.

- **69 entries, all NOOP** — set is deliberate and well-curated; no contradictions, no true duplicates, no stale entries.
- **Persists 16 previously-untracked memory files** (the `.gitignore '*'` deny-all meant they lived only in the working tree): 4 from the 2026-06-16 session + 12 prior strays. This is the main outcome.
- Refreshed the 5 Key insights (folded in: ticket-graph-as-only-durable-reminder, dissemination≠paper). Hand-curated sections (Project Structure / Pipeline / Design) preserved.
- Provenance recorded for all 69.
- Promotion: 1 candidate (`reference_zotero`) **rejected** — its two "projects" are the same project under old/new paths (spurious frequency), and it's project-specific IDs (fails context-independence).
- Decay: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)