### PR TITLE
rules(python): co-locate uv cache and env on one filesystem

### DIFF
--- a/rules/coding-python.md
+++ b/rules/coding-python.md
@@ -1,4 +1,4 @@
-<!-- last-reviewed: 2026-06-16 -->
+<!-- last-reviewed: 2026-06-18 -->
 # Coding Rules
 
 ## Python (3.10+)
@@ -19,6 +19,8 @@ Script structure:
 - **Logging, not print.** Use `logging` module.
 
 Dependencies: **always `uv sync`** (never pip). `uv run python scripts/...` to execute.
+
+**Keep the uv cache and the project env on one filesystem.** uv hardlinks wheels from its cache (`UV_CACHE_DIR`) into `.venv`. Hardlinks cannot cross filesystems, so when cache and env sit on different ones uv silently copies the whole dependency closure (≈1.8 GB with torch) into every env — slow enough to make worktree creation time out and fail. If big regenerable things live on a separate disk, put the env there too, beside the cache, and symlink `.venv` to it (symlinks cross filesystems; hardlinks do not). Pre-create the target first: a dangling `.venv` symlink makes `uv run` error.
 
 ## Testing
 


### PR DESCRIPTION
## What

Adds a rule to `rules/coding-python.md`: keep `UV_CACHE_DIR` and the project `.venv` on the same filesystem.

## Why

uv hardlinks wheels from its cache into `.venv`. Hardlinks cannot cross filesystems, so when cache and env sit on different ones uv silently copies the whole dependency closure (≈1.8 GB with torch) into every env. In Oeconomia (cache on `/data`, repos on `/home`) this made worktree creation slow enough to **time out and fail** (fixed in Oeconomia PR #797 by symlinking `.venv` to a shared env beside the cache).

The rule states the fix: co-locate the env with the cache, symlink `.venv` to it (symlinks cross filesystems; hardlinks do not), and pre-create the target since a dangling `.venv` symlink makes `uv run` error.

`make check-fast` green (587 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ticket: none