### PR TITLE
config: enable frontend-design plugin

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -211,5 +211,8 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "teammateMode": "auto",
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
 }


### PR DESCRIPTION
Enables the `frontend-design@claude-plugins-official` plugin in settings.json. Stranded uncommitted in the checkout; preserved here.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)