### PR TITLE
scripts(shell-init): simplify cl repo-name derivation

### DIFF
--- a/scripts/shell-init.sh
+++ b/scripts/shell-init.sh
@@ -3,8 +3,8 @@
 # Wraps the claude CLI to: skip permission prompts, name the session after the project.
 
 claude() {
-  local name
-  name=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null | xargs -r basename)
-  name=${name:-$(basename "$PWD")}
+  local name top
+  top=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null)
+  name=$(basename "${top:-$PWD}")
   command claude --dangerously-skip-permissions --name "$name" "$@"
 }


### PR DESCRIPTION
Refactors the `cl` function's repo-name derivation to a single basename call over the toplevel (PWD fallback). Stranded uncommitted in the checkout; preserved here.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)