### PR TITLE
tickets: 0261/0262 — lair STATE-via-PR + cross-PR ID-collision CI check

### DIFF
--- a/tickets/0261-lair-state-refresh-must-go-via-pr.erg
+++ b/tickets/0261-lair-state-refresh-must-go-via-pr.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: Lair step 10 must land STATE.md via a PR, not a local ff-merge + push to main
+Created: 2026-06-18
+Author: minh
+
+--- log ---
+2026-06-18T10:00Z minh created
+
+--- body ---
+## Context
+The `lair` skill step 10 says: refresh STATE.md on a throwaway branch, then
+"Commit, merge to main via fast-forward, delete branch." It implies local main
+carries the commit and gets pushed. But the GitHub gate is closed — `main` is
+branch-protected and direct pushes are rejected (`rules/git.md`: "no
+direct-push-to-main path"). During the 2026-06-18 lair run the local ff-merge
+succeeded, leaving local main one commit ahead of origin, and `git push origin
+main` was rejected by repository rules. Recovery required moving the commit to a
+branch, `git reset --mixed` back to origin/main, restoring STATE.md, and opening
+a PR by hand — the exact dance the gate is meant to prevent.
+
+## Relevant files
+- `skills/lair/SKILL.md` — step 10 (Refresh STATE.md)
+
+## Actions
+1. Rewrite step 10 to: create `housekeeping-state-YYYY-MM-DD` from main, run
+   `refresh-STATE.py`, hand-edit, commit, push the branch, open a PR
+   (`Ticket: none`), and let it merge through the normal gate (auto-merge).
+2. Drop the "merge to main via fast-forward, delete branch" local-merge wording.
+3. Keep the throwaway-branch naming and the prune step for after the PR merges.
+
+## Test
+- Source-inspection test: `skills/lair/SKILL.md` step 10 must not instruct a
+  local merge to main or a `git push origin main`; it must mention opening a PR.
+  (Add to `tests/` as a string-match adherence test.)
+
+## Verification
+- [ ] Step 10 text routes STATE.md through a branch + PR
+- [ ] No "merge to main via fast-forward" or push-to-main instruction remains
+- [ ] A dry lair run produces a STATE PR, not a rejected main push
+
+## Invariants
+- The gate stays closed; STATE.md is not special-cased.
+
+## Exit criteria
+- Lair step 10 lands STATE.md via PR with no direct-main-push step; adherence
+  test green.

--- a/tickets/0262-ci-detect-cross-pr-ticket-id-collision.erg
+++ b/tickets/0262-ci-detect-cross-pr-ticket-id-collision.erg
@@ -1,0 +1,49 @@
+%erg 0.1
+Title: CI check to detect ticket-ID collisions across open PRs
+Created: 2026-06-18
+Author: minh
+
+--- log ---
+2026-06-18T10:05Z minh created
+
+--- body ---
+## Context
+The optimistic ID allocation trap (git-erg#282, wontfix) bites across *open
+PRs*, and no current check catches it. `erg check` and the `validate-tickets` CI
+job run per-branch: each branch's IDs are unique within itself, so both pass. The
+duplicate only materializes on `main` after the second PR merges — by which point
+the first has landed. On 2026-06-18 this produced a three-way clash (a stranded
+0257 merged, then open PRs #408 and #410 both still claimed 0257/0258), and
+separately #385 and #387 both claim 0248 today. Each had to be renumbered by
+hand after the fact.
+
+## Relevant files
+- `tickets/erg-github` — the forge-side verify helper (per CLAUDE.md)
+- CI workflow that runs `validate-tickets`
+- `tickets/AGENTS.md` — documents the trap and the renumber remedy
+
+## Actions
+1. Add a CI check (or extend `erg-github verify`) that, for a PR, lists the
+   ticket IDs it ADDS and compares them against the ticket IDs added by every
+   other OPEN PR (and any already on the base branch). Fail with a clear message
+   naming the colliding PR and the next free ID.
+2. Make the check forge-agnostic where possible: the cross-PR enumeration is the
+   only forge-specific part; isolate it behind the existing erg-github boundary.
+3. Document the check in `tickets/AGENTS.md` next to the existing trap note.
+
+## Test
+- Fixture: two PR branches each adding `tickets/0300-*.erg`. The check must FAIL
+  naming both PRs. A control where the IDs differ must PASS. (Likely an
+  integration test that stubs the PR-enumeration call.)
+
+## Verification
+- [ ] Check fails when two open PRs add the same ticket ID
+- [ ] Check passes when IDs are distinct
+- [ ] Failure message names the colliding PR and suggests the next free ID
+
+## Invariants
+- Per-branch `erg check` behavior unchanged; this is an additive cross-PR gate.
+
+## Exit criteria
+- A PR adding a ticket ID already claimed by another open PR (or base) is blocked
+  in CI with an actionable message; tests green.


### PR DESCRIPTION
Files two harness-improvement tickets surfaced during the 2026-06-18 lair run (both handoff documents, no code change):

- **0261** — lair step 10 ff-merges STATE.md to main and pushes, but the gate is closed (main is protected). Route STATE.md through a branch + PR instead.
- **0262** — per-branch `erg check`/`validate-tickets` can't see a ticket-ID collision that lives across two open PRs; it only surfaces on main after the second merges. Add a cross-PR collision check.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)