### PR TITLE
Capture R&R-intake sweep: ticket 0265 + harness memory

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [R&R intake is laborious](feedback_rr_intake_is_laborious.md) — Ingesting an editor decision + reviewer comments has no skill; done by hand it burns turns (Gmail re-search, comment recount, coverage verified 2-3×). Check `release/` not Gmail, archive to a known path, verify coverage once. Fix ticketed IDH 0265 (2026-06-18)
 - [No ruff ping-pong](feedback_no_ruff_ping_pong.md) — PostToolUse ruff hook fires after EVERY Edit; batch related edits so no intermediate state has unused imports; write new files complete in one Write
 - [Skills Just Work — no per-repo CONFIG blocks](feedback_skills_just_work_no_config_blocks.md) — Author directive: skills auto-discover repo specifics at run start (0184 adapter precedent); explicit inputs are optional overrides; also resolve missing args from authoritative state (branch→MR) and never fabricate example IDs in refusal messages (wrong-PR anchoring, 2026-06-10)
 - [Workflow agents are session-bound](feedback_workflow_agents_session_bound.md) — Workflow agent() runs in the SESSION checkout unless isolation:'worktree'; worktrees cut from the SESSION repo — cross-repo skills need a session in the target repo; probe before expensive fan-outs

--- a/projects/-home-haduong--claude/memory/feedback_rr_intake_is_laborious.md
+++ b/projects/-home-haduong--claude/memory/feedback_rr_intake_is_laborious.md
@@ -1,0 +1,33 @@
+---
+name: rr-intake-is-laborious
+description: Journal Revise-and-Resubmit intake (ingest editor decision + reviewer comments) has no harness skill, so it's done by hand and is laborious; don't re-search Gmail for moved files, archive comments to a known path, and verify remark↔ticket coverage once with a deterministic check, not 2-3× manually
+metadata:
+  type: feedback
+---
+
+A full day (2026-06-18, ~12 sessions on the Oeconomia — Climate finance
+manuscript) went into R&R *intake* entirely by hand because no skill exists:
+PDF extraction of the decision letter + reviewer comments, a **vain Gmail
+search** (the files had already been moved into `release/`), counting "60
+atomic comments" down to "56 remarks", creating ~10 thematic tickets, and
+**verifying coverage two or three times manually** because there is no
+remark↔ticket ledger. A track-changes PDF for the author to annotate was
+requested and never delivered (no skill). Every existing review skill produces
+reviews of *our* manuscript — the inverse of ingesting a journal's.
+
+**Why:** R&R intake is a recurring, project-agnostic workflow (every journal
+paper hits it) with a fixed shape — extract → archive → structure into remarks
+→ map to tickets → verify coverage → render revisions for annotation. Done ad
+hoc it burns turns on re-finding files and re-counting, and the
+highest-value step (a marked-up PDF) gets abandoned mid-feasibility.
+
+**How to apply:** when the author says "we got R&R comments" / "ingest the
+decision letter", expect this friction and front-load the cheap fixes — (1)
+don't hand-search Gmail: ask where the files were saved or check `release/`
+first (journal artifacts get moved there); (2) archive the comments to one
+documented path so the next session doesn't re-hunt; (3) build the remark↔ticket
+coverage check once and trust it — re-counting by hand 2-3× is the tell that a
+deterministic ledger is missing. The durable fix is the
+`ingest-decision-letter` + `track-changes-pdf` skill chain, ticketed in IDH
+0265. Author sweep request, 2026-06-18.
+Related: [[feedback_skills_just_work_no_config_blocks]], [[feedback_harness_is_the_deliverable]].

--- a/tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg
+++ b/tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg
@@ -1,0 +1,94 @@
+%erg 0.1
+Title: R&R intake skill chain: ingest-decision-letter + track-changes-pdf
+Created: 2026-06-18
+Author: minh
+
+--- log ---
+2026-06-18T13:46Z minh created
+
+--- body ---
+## Context
+A full day (2026-06-18, ~12 sessions on the Oeconomia — Climate finance
+manuscript) was spent doing journal Revise-and-Resubmit *intake* entirely by
+hand, with no harness tooling. A post-hoc sweep of those transcripts isolated
+the expensive steps:
+
+- PDF extraction of the editor decision + reviewer comments — manual.
+- A **vain Gmail search** for the comments — the files had already been moved
+  into `release/Oeconomia*`; nobody knew where they lived, so the search wasted
+  effort.
+- Comment counting reconciled "60 atomic comments" down to "56 remarks" over
+  several turns, with no parser.
+- ~10 thematic tickets created and organised by hand.
+- **Coverage verified two or three times manually** — re-confirming that the
+  tickets cover all 56 remarks each time, because there is no remark↔ticket
+  ledger.
+- A **track-changes PDF** was requested ("do 140 with track-change mode, open
+  it for me to annotate") and never delivered — ~14 tool calls spent assessing
+  feasibility, then abandoned because no skill exists.
+
+This is the gap flagged at the top of that day's harness session: asked "which
+skills/rules/memories ingest an Editor decision letter and Reviewer comments?",
+the answer was *none* — every existing review skill produces reviews of our
+manuscript, the inverse of ingesting a journal's. The day proved the need.
+
+Two skills, one workflow:
+
+1. **`ingest-decision-letter`** — take the decision letter + reviewer comments
+   (PDF / text / email thread; the Gmail MCP tools are available), extract and
+   archive them in a known location, parse into a structured remark ledger (id,
+   reviewer, category, verbatim text, source location), dedupe atomic-vs-remark,
+   and emit a coverage check (which remark maps to which ticket; flag orphans
+   and uncovered remarks) so verification is one deterministic pass, not a
+   manual re-count.
+2. **`track-changes-pdf`** — render a revision-marked PDF (insertions/deletions
+   highlighted, ideally grouped by ticket/remark) from the manuscript so the
+   author can read and annotate, closing the annotate→reply→apply loop.
+
+## Relevant files
+- `~/.claude/skills/external-peer-review/` — closest sibling (sends our PDF
+  out for review); the new intake skill is its inverse. Reuse its PDF/text
+  plumbing and persona-free structure.
+- `~/.claude/skills/related-work-note/`, `~/.claude/skills/zotero-import/` —
+  precedents for skills that extract structure from a document.
+- Gmail MCP tools (`mcp__claude_ai_Gmail__*`) — for the email-thread source so
+  the next intake does not repeat the vain manual search.
+- `~/.claude/README.md` — skills catalog, regenerated via `make skills-catalog`.
+
+## Actions
+1. Spec the remark-ledger schema (id, reviewer, category, verbatim, source loc,
+   mapped-ticket, status) — the contract both skills and the coverage check share.
+2. Build `ingest-decision-letter`: source adapters (PDF / pasted text / Gmail
+   thread) → archive to a known path → emit the ledger → coverage report
+   (remark↔ticket, orphans, gaps).
+3. Build `track-changes-pdf`: manuscript + applied changes → revision-marked PDF
+   grouped by ticket. Decide the toolchain (latexdiff / Quarto track-changes /
+   pandoc critic markup) in the spec.
+4. Regenerate the skills catalog (`make skills-catalog`); add description tests
+   per `tests/test_skill_descriptions.py` (discoverability-first opening
+   sentence).
+5. Land via the harness branch + PR flow (main is read-only).
+
+## Test
+- `ingest-decision-letter` on a fixture decision letter (the archived Oeconomia
+  one is a real corpus) yields the expected remark count and a coverage report
+  that flags a deliberately-removed ticket as an uncovered remark (RED first).
+- `make check-skills-drift` stays clean after catalog regeneration.
+
+## Verification
+- [ ] `ingest-decision-letter` extracts + archives + emits a structured ledger from PDF, text, and a Gmail thread.
+- [ ] Coverage check reports remark↔ticket mapping, orphan tickets, and uncovered remarks — one pass, no manual re-count.
+- [ ] `track-changes-pdf` renders a revision-marked PDF grouped by ticket from a manuscript.
+- [ ] Both skills listed in `README.md` catalog; `make check-skills-drift` clean.
+- [ ] Description tests pass (discoverability-first first sentence).
+
+## Invariants
+- Skills are SKILL.md + pure I/O helpers; no direct Anthropic API calls in helpers (subscription auth).
+- Forge-agnostic language in skill text (no hardcoded `gh`).
+- The intake skill writes archived comments to a known, documented location — never relies on the author re-searching Gmail.
+
+## Exit criteria
+- Both skills exist, are catalogued and tested, and a real decision-letter
+  intake (next Oeconomia resubmission, or a fixture) runs end-to-end: extract →
+  archive → ledger → coverage check → track-changes PDF, with no manual
+  re-counting and no Gmail hunt.


### PR DESCRIPTION
Outcome of sweeping the 2026-06-18 Oeconomia sessions (~12 conversations), at the author's request after a laborious day.

## What the sweep found
Journal Revise-and-Resubmit *intake* was done entirely by hand because no harness skill exists: PDF extraction of the editor decision + reviewer comments, a vain Gmail search (files had been moved into `release/`), counting "60 atomic comments" → "56 remarks", ~10 thematic tickets created and organised, phasing, and **coverage verified 2-3× manually** for want of a remark↔ticket ledger. A requested track-changes PDF for the author to annotate was never delivered (~14 tool calls spent on feasibility, then abandoned).

This is the gap flagged at the top of that day's harness session: asked which skills/rules/memories ingest an editor decision letter + reviewer comments, the answer was *none*.

## This PR
- **Ticket 0265** — build the `ingest-decision-letter` + `track-changes-pdf` skill chain (extract → archive → remark ledger → coverage check → revision-marked PDF).
- **Harness memory** `feedback_rr_intake_is_laborious` + MEMORY.md index pointer — so the next intake front-loads the cheap fixes (check `release/` not Gmail; archive to a known path; verify coverage once).

No code/skill is built here — this captures the finding and the work item. Oeconomia-project-specific items (deferred rename, re-anonymize gate, shared-venv `python -m` discipline) belong in that repo and are out of scope.

Ticket-ref: tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)