### PR TITLE
ticket(0267,0268): file harness cwd + refresh-STATE papercuts

### DIFF
--- a/tickets/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg
+++ b/tickets/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg
@@ -1,0 +1,62 @@
+%erg 0.1
+Title: EnterWorktree (and cwd-skills) resolve the wrong repo when the session base cwd is parked off-project
+Created: 2026-06-19
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-06-19T11:35Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`EnterWorktree` (and cwd-dependent skills like `/verify-adherence`, `/review-pr`)
+resolve the target git repo from the **session base cwd**, not from wherever the
+last `cd` landed. A plain `cd <project>` inside a Bash call does not move the
+base — it resets after every call. So if the base cwd is parked *outside* the
+intended project, these tools silently target the nearest enclosing repo.
+
+Observed 2026-06-19 during the ticket 0160 hunt in `climate-finance-het`: the
+session base cwd had been parked at `~/.claude/projects` (left there by a Claude-
+cache `cd` during an earlier reorg step, then restored there by `ExitWorktree`).
+`EnterWorktree t160` created the worktree at `~/.claude/.claude/worktrees/t160` —
+inside the **harness** repo, not the project. Nothing flagged it; the wrong-repo
+worktree was caught only by reading the returned path. Recovery was a manual
+`git worktree add` in the correct repo + driving everything by absolute path and
+`git -C`, and running the merge gate mechanically instead of via the skills.
+
+This is a silent-footgun class: a tool meant to *isolate* work created an
+isolated worktree in an unrelated repository.
+
+## Relevant files
+- The `EnterWorktree` tool implementation (harness) — repo resolution from cwd
+- `rules/workflow.md` — § Worktree paths / Session start (where the trap belongs)
+- Any PreToolUse guard that could assert worktree ownership
+- Project memory `feedback_enterworktree_stuck_cwd` (climate-finance-het) — the field note
+
+## Actions
+1. Cheap, certain win: document the failure mode in `rules/workflow.md` — the
+   base-cwd-vs-`cd` distinction, the ownership check
+   (`basename "$(git rev-parse --show-toplevel)"` must equal the worktree name),
+   and the manual `git worktree add` + `git -C` fallback.
+2. Stronger (design): make `EnterWorktree` warn/abort when the resolved repo is
+   not the expected project — e.g. when it resolves to the harness repo itself,
+   or differs from the repo the conversation has been operating in.
+
+## Test
+- For action 1: a doc/grep ratchet asserting `rules/workflow.md` documents the
+  ownership check.
+- For action 2: a unit test of the repo-resolution helper feeding a parked cwd
+  and asserting it refuses / warns rather than silently picking the harness repo.
+
+## Verification
+- [ ] `rules/workflow.md` documents the parked-cwd trap + ownership check + fallback
+- [ ] (if action 2) EnterWorktree warns/aborts on an unexpected resolved repo
+- [ ] A test guards whichever action lands
+
+## Invariants
+- Do not break the normal in-project EnterWorktree happy path.
+
+## Exit criteria
+- The wrong-repo footgun is either prevented (warn/abort) or clearly documented
+  with the ownership check + fallback, and guarded by a test.

--- a/tickets/0268-refresh-state-clobbers-custom-status-section.erg
+++ b/tickets/0268-refresh-state-clobbers-custom-status-section.erg
@@ -1,0 +1,68 @@
+%erg 0.1
+Title: refresh-STATE.py clobbers a hand-maintained custom "## Status:" section
+Created: 2026-06-19
+Author: HDMX-coding-agent
+Label: needs-human
+
+--- log ---
+2026-06-19T11:35Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+`scripts/refresh-STATE.py` (invoked by `/lair` step 10) replaces everything from
+the first `## Status` heading to the next `## ` heading with machine-generated
+ticket counts + recent commits. It assumes the machine STATE template where
+`## Status` is a generated section.
+
+Some projects deliberately use a **custom** STATE format where `## Status` is a
+hand-maintained, titled section. Example (`climate-finance-het`):
+
+    ## Status: TWO PAPERS SUBMITTED + ALL NULL DRIVERS WIRED
+    ### Oeconomia (Varia) — submitted 2026-03-18
+    ...rich hand-written submission detail...
+    ### RDJ4HSS (data paper) — submitted 2026-03-26
+    ...
+
+`split_at_status()` matches the first `## Status` (so it matches `## Status:
+TWO PAPERS…`), and since no `## ` heading follows, the whole tail — all the
+hand-written submission detail — would be replaced. Running the script there
+destroys curated content. That project's `state-roadmap.md` even defines custom
+`## Submissions` / `## Corpus` sections, signalling an intentional divergence
+from the machine template.
+
+Caught 2026-06-19 during `/lair` in climate-finance-het: step 10 was skipped by
+hand after inspecting the script; an unsuspecting run would have clobbered STATE.
+
+## Relevant files
+- `scripts/refresh-STATE.py` — `STATUS_HEADING`, `split_at_status`, `_next_section_idx`
+- `skills/lair/SKILL.md` — step 10 invokes the script unconditionally
+- `rules/state.md` — STATE format spec
+
+## Actions
+1. Make `refresh-STATE.py` detect a non-machine Status section and **abort with a
+   clear message** instead of clobbering. Heuristics: a titled heading
+   (`## Status:` with trailing text), the absence of the `<!-- generated -->`
+   marker the machine section carries, or `### ` subsections inside Status.
+2. Alternatively/additionally: support an explicit opt-out (e.g. a
+   `<!-- state:hand-maintained -->` marker or a per-project config flag) and have
+   `/lair` step 10 skip when present.
+3. Document in `rules/state.md` that custom-STATE projects opt out of step 10.
+
+## Test
+- Unit test: feed a fixture STATE with `## Status: <title>` + `### ` subsections;
+  assert the script aborts (non-zero / no write) and leaves the file byte-identical.
+- Unit test: the machine-format fixture still refreshes correctly (no regression).
+
+## Verification
+- [ ] refresh-STATE.py refuses to overwrite a custom/titled `## Status:` section
+- [ ] Machine-format STATE still refreshes (happy path intact)
+- [ ] `rules/state.md` notes the opt-out
+- [ ] Tests cover both the abort and the happy path
+
+## Invariants
+- The machine-STATE happy path (`## Status` + generated counts/commits) must keep working.
+
+## Exit criteria
+- A custom hand-maintained `## Status:` section is never silently clobbered;
+  the abort (or opt-out) is tested and documented.


### PR DESCRIPTION
## File two harness papercuts (from the climate-finance-het reorg)

Both surfaced while doing the 0159/0160 work in `climate-finance-het`. Each is a
`needs-human` design call — this PR just files the tickets, fixes come later.

- **0267 — EnterWorktree resolves the wrong repo on a parked cwd.** EnterWorktree
  and cwd-dependent skills read the *session base cwd*, not the last `cd`. With the
  base parked at `~/.claude/projects`, `EnterWorktree t160` created the worktree
  inside the **harness** repo, silently. Proposed: document the trap + ownership
  check in `rules/workflow.md`, and/or warn when the resolved repo is unexpected.
- **0268 — refresh-STATE.py clobbers a custom `## Status:` section.** The script
  (/lair step 10) replaces the whole first `## Status` block; a hand-maintained
  titled `## Status:` with `###` subsections (e.g. this project's submission
  status) would be destroyed. Proposed: abort on a non-machine Status section
  and/or support an opt-out marker.

Field note: `feedback_enterworktree_stuck_cwd` in the climate-finance-het memory.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
