### PR TITLE
rules(git): scope deleteBranchOnMerge as per-repo

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -15,7 +15,7 @@
 - **Merge-bounce recovery.** `erg-pr-merge` legitimately bounces in sequence; each bounce has a specific retry — do not blanket-fall back to `gh pr merge`:
   - *"close: no ticket found" on a retry* — the FIRST run already `erg close`d + archived + pushed the close commit (the script is **not** idempotent past that step). Do NOT re-run it and do NOT hand-close the ticket; the close commit is already on the branch, so finish with `gh pr merge <N> --merge` directly once CI is green.
   - *"must run from PR branch" after a fast-forward* — HEAD detached after `merge --ff-only`; `git checkout <branch>`, then retry.
-- **Delete branches after merge.** All repos use `deleteBranchOnMerge: true` on GitHub, so the remote branch disappears automatically when a PR merges. Clean up stale local branches with:
+- **Delete branches after merge.** `deleteBranchOnMerge` is per-repo — check it, don't assume. Where it is `true` (e.g. the harness repo) the remote branch disappears automatically when a PR merges; where it is `false` (e.g. `CIRED/cired.digital`, confirmed 2026-06-23 — and `gh pr merge --delete-branch` does *not* override it, plus its client-side checkout step can abort from a worktree, leaving the remote branch alive) you must delete the remote branch manually: `git push origin --delete <branch>`. Verify with `gh api repos/<owner>/<repo> --jq .delete_branch_on_merge`. Either way, clean up stale local branches with:
   ```bash
   git fetch --prune
   cur=$(git branch --show-current)


### PR DESCRIPTION
The **Delete branches after merge** bullet in `rules/git.md` claimed "All repos use `deleteBranchOnMerge: true`," but the rule is injected globally and the claim is false for `CIRED/cired.digital` (`delete_branch_on_merge=false`, confirmed via `gh api` 2026-06-23). There a merged PR leaves the remote branch alive, and `gh pr merge --delete-branch` does not override the repo setting — so an agent trusting the rule leaves stale remote branches (observed merging the consolidated Dependabot floor-bump PR #271).

Reworded to instruct checking the per-repo setting, with cired.digital as the `false` counter-example and the manual `git push origin --delete <branch>` remedy. Neither maintainer holds admin on the CIRED org repo to flip the flag, so documenting the exception is the available fix.

Same shape as #426 (squash-merge per-repo scoping).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)