### PR TITLE
dream: consolidate archiveCIRED memory (4→4)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -1688,6 +1688,38 @@
       "first_seen": "2026-06-16T10:22:31Z",
       "last_confirmed": "2026-06-16T10:22:31Z",
       "promoted": false
+    },
+    "project_zotero_pivot": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-archiveCIRED"
+      ],
+      "first_seen": "2026-06-23T10:01:53Z",
+      "last_confirmed": "2026-06-23T10:01:53Z",
+      "promoted": false
+    },
+    "feedback_merge_workflow": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-archiveCIRED"
+      ],
+      "first_seen": "2026-06-23T10:01:53Z",
+      "last_confirmed": "2026-06-23T10:01:53Z",
+      "promoted": false
+    },
+    "project_index_architecture": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-archiveCIRED"
+      ],
+      "first_seen": "2026-06-23T10:01:53Z",
+      "last_confirmed": "2026-06-23T10:01:53Z",
+      "promoted": false
+    },
+    "project_recueil_merge": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-archiveCIRED"
+      ],
+      "first_seen": "2026-06-23T10:01:53Z",
+      "last_confirmed": "2026-06-23T10:01:53Z",
+      "promoted": false
     }
   }
 }

--- a/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/MEMORY.md
@@ -1,0 +1,16 @@
+# Memory index — archiveCIRED
+
+## Key insights
+
+- The project pivoted from HAL mass-deposit to a **private Zotero group** to sidestep rights triage; a mature catalogue (inari/Bordignon) already existed, so the work is reconciliation/dedup/enrichment, not bulk import.
+- **Match Zotero records by identifier, never by title** — the Sachs fonds reuses titles across distinct works. The same rule in matching code: Jaccard + author/year corroboration, never bare title-containment.
+- The data backbone is a **two-layer index**: physical `file_index.json` (1991 files) → logical `doc_index.json` (1112 docs); the old `index.json` is superseded.
+- Antonin's "recueil 50 ans" was **mirrored into a My-Library collection** (VPDB49CK, 131 items) instead of joined by a (nonexistent) mapping table; deleting the source group is gated on a zero-information-loss audit (ticket 0025).
+- Tooling discipline: every Zotero-writing script needs `--backup` with `--apply`; the **committed `tickets/erg` bootstrap can drift** behind the installed binary (caused a `Label:`/`refresh-STATE.py` failure) — keep it current.
+
+## Entries
+
+- [Zotero pivot (2026-05-16)](project_zotero_pivot.md) — HAL deferred; private Zotero group; catalogue deduplicated 1378→686 (PR #7); match by id never title; 0015 unblocked (mirrored)
+- [Merge workflow lessons (2026-05-16)](feedback_merge_workflow.md) — squash-merge divergence; guard hook blocks reset --hard on clean tree (ask via `!`); a missing erg subcommand/header usually means a stale committed bootstrap binary (0027)
+- [Index architecture (2026-05-16)](project_index_architecture.md) — file_index.json (1991 files) + doc_index.json (1112 docs); replaces index.json
+- [Recueil merge (2026-06-23)](project_recueil_merge.md) — Antonin's group mirrored into collection VPDB49CK (131 items); group deletion FROZEN until ticket 0025 audit confirms zero info loss

--- a/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/feedback_merge_workflow.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/feedback_merge_workflow.md
@@ -1,0 +1,20 @@
+---
+name: feedback-merge-workflow
+description: "Lessons from squash-merge + worktree workflow — branch divergence, guard hook, erg-pr-merge sequence"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: be1e835b-17e0-441d-84ec-bcb75c0f8549
+---
+
+After a squash merge, local main diverges (6 ahead, 1 behind). `git reset --hard origin/main` is blocked by the guard hook even with a clean working tree. The fix is to ask the user to run `! git -C <project> reset --hard origin/main` in the terminal.
+
+**Why:** The guard-destructive-bash.sh hook pattern-matches on `git reset --hard` without checking git status first.
+
+**How to apply:** When local main diverges after a squash merge and the tree is clean, proactively tell the user to run the reset via `!` prefix rather than trying multiple workarounds.
+
+Also: `erg-pr-merge` runs in the agent's worktree on the PR branch. If the verify agent pushed commits to the branch after the execution agent finished, a `git pull --rebase` in the agent worktree is needed before `erg-pr-merge` can push the ticket-close commit.
+
+**erg-pr-merge corrupts dependent tickets (2026-06-19, PR #7).** When a PR closes a ticket that is a `Blocked-by:` of still-open tickets, `erg-pr-merge` edits those dependents to drop the `Blocked-by:` header — but it produced a malformed ticket *missing the `--- log ---` separator* (the created log line was left bare between headers and `--- body ---`). That broke the *next* close in the same run (`close: missing '--- log ---' separator`), and the script is not idempotent past its committed closes. Recovery: re-insert `--- log ---` before the orphaned log line in each touched dependent, `erg check` until PASS, then `erg close <id> "<reason>"` the missed ticket + `git mv` it into `closed/`, commit, and `gh pr merge` directly (do NOT re-run erg-pr-merge). Separately, the *committed* `tickets/erg` bootstrap binary rejected the `Label:` header (`unknown header 'Label'`) and lacked `list` — it was simply **stale vs the installed `~/.local/bin/erg`**. **Resolved 2026-06-23 (ticket 0027):** `tickets/erg update` (→ build 2026-06-18) restored `Label:`/`list`; `erg migrate` then converted the whole store `Tag:`→`Label:`. Lesson: when an erg subcommand/header "doesn't exist," suspect a stale *committed* bootstrap binary before assuming a real erg bug — diff `./tickets/erg version` against `~/.local/bin/erg`, and keep the committed one current (it also feeds `refresh-STATE.py`). The dependent-ticket-corruption bug above was not reproduced this session.
+
+See also: [[feedback-worktree-isolation]]

--- a/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/project_index_architecture.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/project_index_architecture.md
@@ -1,0 +1,18 @@
+---
+name: project-index-architecture
+description: Two-layer index architecture — file_index.json (physical) and doc_index.json (logical documents)
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: be1e835b-17e0-441d-84ec-bcb75c0f8549
+---
+
+**Two-layer indexing pipeline** (complete as of 2026-05-16):
+
+- `outputs/file_index.json` — 1991 physical files, all archive dirs. Fields: fichier, taille, hash, ext. No id field (fichier is natural key). Built by `src/build_file_index.py` (ticket 0010).
+
+- `outputs/doc_index.json` — 1112 logical documents, full archive. 3-pass grouping: (1) hash identity → doublon, (2) canonical_key(filename) → variante/ocr, (3) post-enrichment Titre+Auteur+Année fallback → groupe_incertain. Built by `src/build_doc_index.py` (ticket 0011). Replaces `outputs/index.json` (ticket 0002).
+
+**Why:** Coverage dropped from 741 docs (docs/ only) to 1112 (full archive) but metadata % fell (annee=57.8%, auteurs=72.8%) because attente/ and TDM/ files lack rich metadata. Cleanup deferred to future tickets.
+
+**How to apply:** When tickets reference index.json or ask about the document index, point to doc_index.json. file_index.json is the physical-layer input.

--- a/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/project_recueil_merge.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/project_recueil_merge.md
@@ -1,0 +1,36 @@
+---
+name: project_recueil_merge
+description: "Antonin's Recueil_CIRED group mirrored into a My-Library collection (131 items); group deletion FROZEN until ticket 0025 audit returns zero information loss"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 9ab720bf-5060-4796-8455-6c9e7417e171
+---
+
+Antonin's separate Zotero group `Recueil_CIRED` (id 2511149, 131 notices) was the
+"recueil 50 ans CIRED" selection. Decision (not a separate group): **mirror it into
+My Library** (userID 2114597) as collection **"Recueil 50 ans CIRED" key VPDB49CK**
+plus tag `recueil-50ans`. This replaces [[project_zotero_pivot]]'s blocked 0015.
+
+State as of 2026-06-23 (PRs #9–#15 merged to main):
+- Collection VPDB49CK holds **131 items**: 53 title-strong matches reconciled (tag links
+  existing notices), 78 group notices injected as fresh copies, 69 PDF/URL links attached
+  (tag `à-dédoublonner`). 4 bad author+year reconciliations were reverted → 5 notices.
+- Tooling on main: `select_new_recueil.py`, `build_recueil_ris.py`, `diff_recueil.py`
+  (+`report_to_ledger`), `apply_corrections.py`, `add_new_docs.py`, `match_untyped.py`.
+- 12 corrections applied to live My Library (4 manual PDF/HAL-verified + 8 "sûr").
+
+**GATE — do not delete the group** `Recueil_CIRED` until ticket **0025** (read-only
+independent audit) returns *zero information loss*: every field + PDF/URL of each of the
+131 group notices must be covered by some My-Library notice. Dedup of the ~48+ injected
+duplicates is explicitly OUT of 0025's scope (deferred, `src/zotero_dedup.py` exists).
+
+Tracker **0015** stays open (children 0018 ingest, 0019 propagate — both still open).
+0018's 13 non-recueil new-content docs: injection paused. Enrichment swarms: 0021
+(author normalization), 0022 HAL, 0023 OpenAlex, 0024 Google.
+
+Matching rule learned: use **Jaccard + author/year corroboration**, never bare
+title-containment — containment inflated a Godard/Hourcade pair to 0.75 (Jaccard 0.25).
+`diff_recueil.py` fixed; `match_untyped.py` still uses `max(jaccard, containment)` but
+guarded by `smaller>=4` for legitimately-truncated filenames — latent containment-without-
+corroboration path in `score()` tracked by **ticket 0026** (not yet a confirmed defect).

--- a/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/project_zotero_pivot.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-archiveCIRED/memory/project_zotero_pivot.md
@@ -1,0 +1,24 @@
+---
+name: project-zotero-pivot
+description: archiveCIRED — pivot from HAL deposit to private Zotero group; HAL deferred
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: be1e835b-17e0-441d-84ec-bcb75c0f8549
+---
+
+As of 2026-05-16, the project goal shifted from HAL mass deposit to a private Zotero group library shared with CIRED and ENPC researchers.
+
+The private Zotero group **"archive CIRED" already exists** (confirmed 2026-06-19). Credentials live outside the repo in `~/.config/keys/zotero-archive-cired.env`: `ZOTERO_API_KEY`, `ZOTERO_USER_ID`, `ZOTERO_USER_PASSWORD`, `ZOTERO_API_KEY_NAME` (the variable names had a `ZOERO_`→`ZOTERO_` typo, fixed). Open question for ticket 0008: confirm the **group ID** (distinct from userID; needed for `/groups/<groupID>/items`) — may need `GET /users/<userID>/groups` and adding `ZOTERO_GROUP_ID` to the env file.
+
+**Why:** HAL requires rights triage (all 741 records had `statut_droits: "inconnu"`) which blocks progress. Zotero private group sidesteps this — no public deposit, no rights barrier.
+
+**Reconciliation finding (2026-06-19):** a *mature* Zotero catalogue already exists — 1378 personal notices + group `Recueil_CIRED` (id 2511149) — almost certainly the inari/CIRED_numerisation work (F. Bordignon). Notices link PDFs by URL `inari.centre-cired.fr/.../docs/<name>.pdf` whose basename is the archive filename (the join key with our doc_index). `src/reconcile_zotero.py` (PR #7) crosses the two: **829/1112 docs already catalogued, 0 orphan keys, structured fonds ~100% covered**, only `CIR_GOD_0017` missing, 282 docs without an archive key (type=null/non-classifié) still to match by title/author. So bulk import is dead; remaining 0008 work is the 282 title-match + gap-filling + metadata audit. Note: env var `ZOTERO_USER_LOGIN` holds the login "Base R2DS" (renamed from the misleading `ZOTERO_USER_ID`), not the numeric id — get the numeric id via `GET /keys/current`.
+
+**Dedup done (2026-06-19, PR #7, tickets 0013/0014/0016/0017 closed):** My Library **1378 → 686 notices**, zero data loss. Removed: 2015/2020 import generations (merged fields + re-parented PDFs), inari↔numenpc cross-server duplicates, 5 residual + a 2-volume work split into 2 notices. 26 multi-version groups (preprint/article, translations) linked as Zotero *Related* (53 notices). Collections `CIRED`/`LEESU` converted to **tags** and deleted; only `!! Documents à consulter` (686) remains. Scripts in `src/`: `reconcile_zotero`, `zotero_dedup`, `zotero_relate`, `zotero_tag_collections`. Backups in `outputs/zotero_backup_*.json` (gitignored).
+
+**0015 (Antonin's recueil) — was blocked, now resolved:** group `Recueil_CIRED` = the "recueil 50 ans CIRED" curated by **Antonin** (separate inari tree `Wehurei6-recueil_50ans_CIRED/`, own `YYYY-NN` numbering). It does NOT cleanly join My Library — only 50/131 matchable (id+hash+title/author/year union), 81 unjoinable (files outside local archive; Antonin's title corrections break title matching). Antonin has no mapping table (confirmed). The original "import his corrections" plan was stuck without that table. **Unblocked 2026-06-23:** 0015 became a tracker split into 0018 (ingest genuinely-new docs, keyed on the file's `YYYY-NNN`) + 0019 (propagate corrections via fuzzy match + human review), and the group was **mirrored into collection VPDB49CK** rather than joined by table. Full live state and the deletion gate: see [[project_recueil_merge]].
+
+**How to apply:** Don't plan HAL-related work unless reintroduced. Don't plan a bulk RIS import — the catalogue exists and is now deduplicated. Match Zotero records by **identifier (CIR_/ENPC/docid), never by title** — the Sachs fonds reuses titles across distinct works. Dedup invariant: re-parent the PDF onto the master BEFORE deleting a twin. `--apply` on every Zotero-writing script requires `--backup`. Zotero auto-creates the reciprocal `Related` link.
+
+Related closed tickets: 0003 (HAL check), 0005 (HAL batch) — superseded/deferred. 0013/0014/0016/0017 — dedup/tags/relate, done. **0008 (reconciliation) closed (PR #9, 2026-06-23)** — its keyless-doc matcher is `src/match_untyped.py`. Tracker 0015 stays open (children 0018/0019); enrichment swarms 0021–0024 spun off.


### PR DESCRIPTION
Memory consolidation for archiveCIRED (`/dream`). 4 entries → 4 (no deletions).

## Classifications
- **UPDATE** `project_zotero_pivot` — corrected stale "0015 BLOCKED" (now mirrored, split into 0018/0019) and "0008 open" (closed PR #9); kept the durable HAL→Zotero pivot, dedup 1378→686, and match-by-id-never-title invariant.
- **UPDATE** `feedback_merge_workflow` — the `Label:`-header rejection was a *stale committed `tickets/erg`*, not an erg bug; resolved via binary upgrade (ticket 0027). Added the lesson: suspect a stale bootstrap binary before assuming a real erg bug.
- **NOOP** `project_index_architecture`, `project_recueil_merge` — current.

## Reflected insights
Regenerated MEMORY.md with 5 cross-cutting insights (Zotero pivot, match-by-id, two-layer index, recueil mirror + 0025 gate, erg-bootstrap drift).

## Promotion / decay
- Candidate `reference_zotero` (AEDIST) **not promoted**: its two "projects" are the same AEDIST report under an old + current path encoding — a rename artifact, not genuine cross-project frequency. Belongs to AEDIST's own dream run.
- Decay: none.