### PR TITLE
docs(roar): degrade gracefully on non-git projects

### DIFF
--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -11,6 +11,15 @@ user-invocable: true
 
 Run after the branch has been merged. Do not skip steps.
 
+## Non-git projects
+
+When the working directory is not a git repository (manuscripts, data
+folders): skip the pre-check and steps 7-11; run steps 1-6 and 12.
+Telemetry: use `"branch":"none-non-git-project"`. The step-3 sweep
+records findings in the project's notes instead of erg tickets. State
+explicitly which steps were skipped and why.
+(Precedent: Œconomia manuscript wrap-up, 2026-07-07.)
+
 ## Pre-check
 
 Verify the branch has been merged before proceeding:


### PR DESCRIPTION
Codify the non-git degradation path for /roar: skip pre-check and steps 7-11, run 1-6 and 12, telemetry with a none-branch marker, sweep findings to project notes instead of erg tickets.

Surfaced by running /roar on the Œconomia manuscript folder (2026-07-07), which is not a git repository — the skill degraded correctly but only by improvisation; this makes the mapping explicit for the next agent.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)