### PR TITLE
feat(rules): author doctype/ and lang/ bodies for the injection hook

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -12,6 +12,11 @@ files on demand when their scope signal applies to your task.
 | [coding-python.md](./coding-python.md) | edit of `*.py` (alias: `format/python`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
 | [coding-bash.md](./coding-bash.md) | edit of `*.sh` (alias: `format/bash`) | Bash `set -euo pipefail` discipline: arithmetic-zero abort, unbound associative-array key. |
 | [prose/_all.md](./prose/_all.md) | edit of any prose file (`*.tex` `*.qmd` `*.md` `*.txt`) | Universal prose rules: LLMism guards, Elements of Style. |
+| [doctype/techreport.md](./doctype/techreport.md) | edit of a `techreport` file (`\documentclass{report}` or manifest) | Report conventions: standalone abstract, numbered floats with takeaway captions, label cross-references. |
+| [doctype/slides.md](./doctype/slides.md) | edit of a `slides` file (`\documentclass{beamer}` or manifest) | Slide conventions: one idea per slide, takeaway titles, fragments not paragraphs. |
+| [doctype/book.md](./doctype/book.md) | edit of a `book` file (`\documentclass{book}` or manifest) | Book conventions: book-wide terminology, chapter openings/closings, label cross-references. |
+| [lang/fr.md](./lang/fr.md) | edit of a `lang = "fr"` file (manifest) | French norms: espaces insécables, guillemets « », virgule décimale, casse de phrase. |
+| [lang/en.md](./lang/en.md) | edit of a `lang = "en"` file (manifest) | English norms: one spelling variety, serial comma, sentence-case headings. |
 
 Compliance is verified ex post by the `verify-adherence` skill — this
 index is the single source of truth on when each rule file applies.

--- a/rules/doctype/book.md
+++ b/rules/doctype/book.md
@@ -1,0 +1,12 @@
+<!-- last-reviewed: 2026-07-07 -->
+# Book
+
+Document-type conventions only — language norms live in `lang/`, universal
+prose in `prose/_all.md`.
+
+- **Terminology is consistent across chapters**: one concept, one term, book-wide — no local synonyms per chapter.
+- **Chapters open with what the reader gets and close on the point**, not on a summary of what was said.
+- **Cross-reference by label** (`\ref`/`@ref`), never by hard-coded chapter/page number; page-relative wording ("as seen above") breaks under reflow.
+- **Notation is introduced once, in one place**, and reused; a notation table beats re-explaining symbols per chapter.
+- **Each chapter's dependencies are explicit**: say early which prior chapters it builds on, so selective readers can route.
+- **Front matter promises only what the body delivers** — keep the preface's roadmap in sync with the actual chapters.

--- a/rules/doctype/slides.md
+++ b/rules/doctype/slides.md
@@ -1,0 +1,13 @@
+<!-- last-reviewed: 2026-07-07 -->
+# Slides (beamer)
+
+Document-type conventions only — language norms live in `lang/`, universal
+prose in `prose/_all.md`.
+
+- **One idea per slide.** A slide that turns is two slides.
+- **The title states the takeaway**, not the topic: "Warming doubles retrofit cost" beats "Results".
+- **Fragments, not paragraphs.** Full sentences belong in the talk, not on the wall; keep bullets to one line.
+- **A figure beats a bullet list; a bullet list beats a table.** Dense tables are for the paper — show the one row that matters.
+- **No slide-by-slide outline recaps** ("Where are we?"); the structure should be audible without them.
+- **Every element is legible from the back row**: no fine print, no footnote-sized legends, no more than ~8 lines of content.
+- **Overlays reveal, they do not animate.** Use `\pause` to stage an argument, never for decoration.

--- a/rules/doctype/techreport.md
+++ b/rules/doctype/techreport.md
@@ -1,0 +1,13 @@
+<!-- last-reviewed: 2026-07-07 -->
+# Technical report / working paper
+
+Document-type conventions only — language norms live in `lang/`, universal
+prose in `prose/_all.md`.
+
+- **The abstract stands alone.** No citations, no undefined acronyms, no "in this paper we" padding — problem, method, result, in that order.
+- **Every figure and table is numbered, captioned, and referenced from the text.** A float nothing points to is dead weight.
+- **Captions carry the takeaway**, not just the topic: "X rises with Y (slope 0.4)" beats "X versus Y".
+- **Define each acronym at first use**, once; thereafter use the acronym.
+- **Numbered sections; cross-reference by label** (`\ref`/`@ref`), never by hard-coded number or "above/below".
+- **State assumptions and data provenance where they are used**, not only in an appendix.
+- **Results are reproducible from the text**: units, sample sizes, and parameter values appear with the numbers they qualify.

--- a/rules/lang/en.md
+++ b/rules/lang/en.md
@@ -1,0 +1,13 @@
+<!-- last-reviewed: 2026-07-07 -->
+# English
+
+Language norms only — document-type conventions live in `doctype/`, universal
+prose in `prose/_all.md`.
+
+- **Pick one spelling variety (US or UK) per document and hold it** — no "analyse" and "analyze" in the same text.
+- **Serial (Oxford) comma** in lists of three or more: "models, data, and code".
+- **Straight logic over typographic habit**: punctuation goes inside quotes in US style, outside in UK style — follow the chosen variety consistently.
+- **Sentence case for headings** unless the venue mandates Title Case.
+- **Hyphenate compound modifiers before a noun** ("long-run cost", "carbon-tax revenue"), not after ("the cost is long run").
+- **"Data" takes a plural verb in formal academic prose**; if the venue prefers singular, be consistent.
+- **Numbers**: decimal point (3.14), thin space or comma for thousands (10,000) per venue style — never the French comma.

--- a/rules/lang/fr.md
+++ b/rules/lang/fr.md
@@ -1,0 +1,13 @@
+<!-- last-reviewed: 2026-07-07 -->
+# Français
+
+Normes de langue uniquement — les conventions de type de document vivent dans
+`doctype/`, la prose universelle dans `prose/_all.md`.
+
+- **Espace insécable avant `: ; ? !`** et à l'intérieur des guillemets « comme ceci » (en LaTeX, `babel`/`polyglossia` française la gère — ne pas la taper à la main ; en Markdown, utiliser l'espace insécable).
+- **Guillemets français « »**, jamais "droits" ni "anglais", pour les citations de premier niveau.
+- **Virgule décimale** (3,14) et espace insécable comme séparateur de milliers (10 000) — jamais le point ni la virgule anglaise.
+- **Titres en casse de phrase** : seule la première lettre porte la majuscule, pas Chaque Mot.
+- **Majuscules accentuées obligatoires** : État, Énergie — l'accent ne tombe pas avec la capitale.
+- **Abréviations : M., Mme, Dr, 1ᵉʳ, 2ᵉ** — pas « Mr », pas « 2ème ».
+- **Pas d'anglicismes de confort** : « supporter » n'est pas *to support*, « digital » se dit numérique, « impacter » s'écrit affecter.

--- a/tests/test_rules_axis_bodies.py
+++ b/tests/test_rules_axis_bodies.py
@@ -1,0 +1,109 @@
+"""doctype/ and lang/ rule bodies for the injection hook (ticket 0256).
+
+The axis engine (PR #404) resolves doctype and lang, but until these bodies
+exist those axes inject nothing. Two ratchets:
+
+1. Coverage — the in-use doctype values (techreport, slides, book) and the
+   documented langs (fr, en) each have a rule body, indexed in rules/README.md.
+2. Reachability — every rules/doctype/*.md and rules/lang/*.md file corresponds
+   to a value the hook's resolver can actually emit; an orphan file that can
+   never be injected is dead content.
+
+Each body is injected verbatim and composes with format + prose bodies under
+the hook's MAX_CONTEXT cap, so every file also gets a size budget.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+RULES = REPO / "rules"
+_HOOK = REPO / "scripts" / "inject_rule_on_edit.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("inject_rule_on_edit", _HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+inj = _load()
+
+# Langs are manifest-supplied (free-form), so reachability can't be derived
+# from the hook; this documented set is the allowlist. Extend it when a
+# project's manifest introduces a new lang.
+DOCUMENTED_LANGS = {"fr", "en"}
+
+REQUIRED_DOCTYPES = {"techreport", "slides", "book"}
+
+# Composability budget: format (~3k) + doctype + lang + prose/_all (~3k) must
+# fit under MAX_CONTEXT (9500), so each axis body stays small.
+SIZE_BUDGET = 2000
+
+
+def doctype_files() -> list[Path]:
+    return sorted((RULES / "doctype").glob("*.md"))
+
+
+def lang_files() -> list[Path]:
+    return sorted((RULES / "lang").glob("*.md"))
+
+
+def test_required_doctype_bodies_exist():
+    stems = {f.stem for f in doctype_files()}
+    missing = REQUIRED_DOCTYPES - stems
+    assert not missing, (
+        f"rules/doctype/ lacks bodies for in-use doctypes: {sorted(missing)}"
+    )
+
+
+def test_documented_lang_bodies_exist():
+    stems = {f.stem for f in lang_files()}
+    missing = DOCUMENTED_LANGS - stems
+    assert not missing, (
+        f"rules/lang/ lacks bodies for documented langs: {sorted(missing)}"
+    )
+
+
+def test_doctype_files_are_reachable():
+    reachable = set(inj.DOCUMENTCLASS_DOCTYPE.values())
+    for f in doctype_files():
+        assert f.stem in reachable, (
+            f"rules/doctype/{f.name} is unreachable: '{f.stem}' is not a "
+            "DOCUMENTCLASS_DOCTYPE value, so the hook can never inject it "
+            "(manifest-only doctypes must be added to the map or documented)"
+        )
+
+
+def test_lang_files_are_reachable():
+    for f in lang_files():
+        assert f.stem in DOCUMENTED_LANGS, (
+            f"rules/lang/{f.name} is unreachable: '{f.stem}' is not a "
+            "documented lang value (extend DOCUMENTED_LANGS when a project "
+            "manifest introduces it)"
+        )
+
+
+@pytest.mark.parametrize(
+    "file", doctype_files() + lang_files(), ids=lambda f: f"{f.parent.name}/{f.name}"
+)
+def test_axis_body_stays_terse(file):
+    size = len(file.read_text(encoding="utf-8"))
+    assert size <= SIZE_BUDGET, (
+        f"{file.relative_to(REPO)} is {size} chars (> {SIZE_BUDGET}): axis "
+        "bodies are injected verbatim and must compose with format + prose "
+        "bodies under the hook's MAX_CONTEXT cap"
+    )
+
+
+def test_readme_indexes_every_axis_body():
+    readme = (RULES / "README.md").read_text(encoding="utf-8")
+    for f in doctype_files() + lang_files():
+        rel = f"{f.parent.name}/{f.name}"
+        assert rel in readme, (
+            f"rules/README.md must index {rel} — the index is the single "
+            "source of truth on when each rule file applies"
+        )

--- a/tickets/closed/0256-author-doctype-and-lang-rule-bodies-for.erg
+++ b/tickets/closed/0256-author-doctype-and-lang-rule-bodies-for.erg
@@ -2,10 +2,12 @@
 Title: Author doctype/ and lang/ rule bodies for the injection hook
 Created: 2026-06-16
 Author: HDMX-coding-agent
+Closed: authored rules/doctype/{techreport,slides,book}.md and rules/lang/{fr,en}.md, indexed in rules/README.md, reachability + size guard test tests/test_rules_axis_bodies.py
 
 --- log ---
 2026-06-16T09:57Z HDMX-coding-agent created
 
+2026-07-07T11:37Z Claude closed — authored rules/doctype/{techreport,slides,book}.md and rules/lang/{fr,en}.md, indexed in rules/README.md, reachability + size guard test tests/test_rules_axis_bodies.py
 --- body ---
 ## Context
 PR #404 shipped the per-file rule-injection hook with four axes:


### PR DESCRIPTION
**Ticket:** 0256 (closed in this PR via `erg close` + `erg archive`)

## What

The per-file rule-injection hook (PR #404) resolves the doctype and lang axes, but `rules/doctype/` and `rules/lang/` had no bodies — those axes injected nothing. This PR is pure content, no engine change:

- `rules/doctype/techreport.md`, `slides.md`, `book.md` — the in-use `\documentclass` values (report/beamer/book); `article` deliberately skipped until it is actually used (YAGNI).
- `rules/lang/fr.md`, `en.md` — typographic and usage norms per language.
- Index rows in `rules/README.md` for all five.

Each body keeps axis separation (doctype ≠ lang ≠ prose) and stays terse.

## Guard test (red-first)

`tests/test_rules_axis_bodies.py`:
- required doctype (techreport/slides/book) and documented lang (fr/en) bodies exist;
- every `rules/doctype/*.md` stem is a `DOCUMENTCLASS_DOCTYPE` value and every `rules/lang/*.md` stem is a documented lang — catches orphan files the hook can never inject;
- each body ≤ 2000 chars, so format + doctype + lang + prose compose under the hook's `MAX_CONTEXT` (9500);
- `rules/README.md` indexes every axis body.

## Verification

- `make check` green: 622 passed (612 baseline + 10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtySzQJN1jNmwfpLXPVH11

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtySzQJN1jNmwfpLXPVH11)_