### PR TITLE
feat(healthcheck): flag working-tree hooks that drift from origin default

### DIFF
--- a/scripts/project-state.py
+++ b/scripts/project-state.py
@@ -291,6 +291,58 @@ def test_state(project):
     return {"runner": "none", "status": "skip", "detail": "no test runner detected"}
 
 
+def hooks_state(project):
+    """Stale-hook-in-worktree trap (ticket 0260). A ``core.hooksPath`` inside
+    the working tree resolves to an absolute path under the MAIN checkout, so
+    every worktree runs the main checkout's hooks — a merged hook fix takes
+    effect only once the main checkout's working tree carries it. Report drift
+    between the working-tree hooks and the tracked default branch. Advisory
+    only; silent when hooksPath is unset or lives under the git dir."""
+    silent = {"hooks_path": None, "in_worktree": False, "stale_files": []}
+    r = run(["git", "config", "core.hooksPath"], project)
+    hooks_path = r.stdout.strip() if r.returncode == 0 else ""
+    if not hooks_path:
+        return silent
+
+    top_r = run(["git", "rev-parse", "--show-toplevel"], project)
+    if top_r.returncode != 0:
+        return silent
+    top = Path(top_r.stdout.strip())
+    git_r = run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], project
+    )
+    git_dir = Path(git_r.stdout.strip()) if git_r.returncode == 0 else top / ".git"
+    abs_hooks = Path(hooks_path)
+    if not abs_hooks.is_absolute():
+        abs_hooks = top / hooks_path
+
+    def _under(child, parent):
+        try:
+            child.relative_to(parent)
+            return True
+        except ValueError:
+            return False
+
+    if _under(abs_hooks, git_dir) or not _under(abs_hooks, top):
+        return {**silent, "hooks_path": hooks_path}
+
+    rel = abs_hooks.relative_to(top).as_posix()
+    default = _default_branch(project)
+    diff = run(["git", "diff", "--name-only", f"origin/{default}", "--", rel], project)
+    if diff.returncode != 0:
+        return {
+            "hooks_path": rel,
+            "in_worktree": True,
+            "stale_files": [],
+            "error": f"cannot diff against origin/{default}: {diff.stderr.strip()[:80]}",
+        }
+    return {
+        "hooks_path": rel,
+        "in_worktree": True,
+        "stale_files": [ln.strip() for ln in diff.stdout.splitlines() if ln.strip()],
+    }
+
+
 def pr_state(project):
     r = run(
         ["gh", "pr", "list", "--json", "number,title,headRefName", "--limit", "50"],
@@ -335,6 +387,7 @@ def main():
         "tickets": ticket_state,
         "branches": branch_state,
         "worktrees": worktree_state,
+        "hooks": hooks_state,
         "prs": pr_state,
     }
 

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -22,7 +22,7 @@ First, run the mechanical probe to collect structured state:
 python3 ~/.claude/scripts/project-state.py "$(git rev-parse --show-toplevel)" --tests
 ```
 
-Parse the JSON output. Use its fields to populate checks 1–10 below without re-running git commands — the probe covers everything through check 9; only check 10 requires additional file reads. If the script is missing or fails, fall back to ad-hoc commands per check.
+Parse the JSON output. Use its fields to populate checks 1–11 below without re-running git commands — the probe covers everything through check 10; only check 11 requires additional file reads. If the script is missing or fails, fall back to ad-hoc commands per check.
 
 ## Checks
 
@@ -53,7 +53,8 @@ Parse the JSON output. Use its fields to populate checks 1–10 below without re
 7. **Tests green** — from `tests.status` / `tests.detail`. Skip if `tests.runner == "none"`.
 8. **Housekeeping** — from `housekeeping.state` / `housekeeping.age_hours` / `housekeeping.branch`. Report `ok` if `state == "clean"` (age ≤ 12 h), `warn` if `state == "needed"` (overdue) or `state == "tidying"` (a `claude/housekeeping-*` branch is in flight). Skip if probe missing.
 9. **Ticket archival** — from `tickets.closed_unarchived` (list of ticket IDs sitting in `tickets/*.erg` with a `Closed:` header, never moved to `tickets/closed/`). `ok` if empty; `warn` listing the IDs otherwise. This is the close-without-archive escape: a PR merged outside `erg-pr-merge` skips the `erg archive` step. Classify the fix as **fix-now** — `tickets/erg archive` (moves all closed tickets to `tickets/closed/`; commit the move). Skip if `tickets.error` is set or no `tickets/` directory.
-10. **Docs freshness (deep verification)** — cross-check status/directive docs (`STATE.md`, `README.md`, etc.):
+10. **Hook freshness** — from `hooks`. Skip (silent) if `hooks.hooks_path` is null or `hooks.in_worktree` is false — no working-tree `core.hooksPath`, so the stale-hook-in-worktree trap does not exist. `skip` with the reason if `hooks.error` is set (no remote, detached HEAD). `warn` if `hooks.stale_files` is non-empty, naming the files: "working-tree hooks differ from origin/<default> — worktrees will run the main checkout's stale hooks until it is updated". `ok` if in-worktree hooks match the default branch. Advisory only, never a hard gate.
+11. **Docs freshness (deep verification)** — cross-check status/directive docs (`STATE.md`, `README.md`, etc.):
    - **Staleness** — flag docs whose content predates recent repo activity
    - **Ticket cross-check** — references to tickets whose status contradicts
      the doc (todo but closed, done but open, broken ref). Skip if no `.erg` tickets.
@@ -79,6 +80,7 @@ Parse the JSON output. Use its fields to populate checks 1–10 below without re
 | Tests green      | ...    | N passed / K failed          |
 | Housekeeping     | ...    | clean / needed / tidying     |
 | Ticket archival  | ...    | N closed-but-unarchived      |
+| Hook freshness   | ...    | in sync / N stale / skip     |
 | Docs freshness   | ...    | N docs scanned, K stale refs |
 ```
 

--- a/tests/test_project_state.py
+++ b/tests/test_project_state.py
@@ -196,3 +196,81 @@ def test_ticket_state_ready_ids_populated(tmp_path, monkeypatch):
     out = ps.ticket_state(tmp_path)
     assert out["ready"] == 2, "ready_ids should include all erg-ready tickets"
     assert out["ready_ids"] == ["0042", "0043"]
+
+
+# ── hooks_state (ticket 0260: stale-hook-in-worktree trap) ───────────────────
+
+
+def _hooks_responder(config_out, config_rc=0, toplevel="/proj",
+                     common_dir="/proj/.git", diff_out="", diff_rc=0):
+    def responder(args):
+        if args[:3] == ["git", "config", "core.hooksPath"]:
+            return _cp(config_out, config_rc)
+        if "--show-toplevel" in args:
+            return _cp(toplevel + "\n")
+        if "--git-common-dir" in args:
+            return _cp(common_dir + "\n")
+        if args[:2] == ["git", "diff"]:
+            return _cp(diff_out, diff_rc)
+        return _cp("", 1)
+
+    return responder
+
+
+def test_hooks_state_silent_when_hookspath_unset(monkeypatch):
+    _patch_run(monkeypatch, _hooks_responder("", config_rc=1))
+    out = ps.hooks_state(Path("/proj"))
+    assert out["in_worktree"] is False
+    assert out["stale_files"] == []
+
+
+def test_hooks_state_silent_when_hookspath_under_git_dir(monkeypatch):
+    _patch_run(monkeypatch, _hooks_responder(".git/hooks\n"))
+    out = ps.hooks_state(Path("/proj"))
+    assert out["in_worktree"] is False
+    assert out["stale_files"] == []
+
+
+def test_hooks_state_reports_drift(monkeypatch):
+    _patch_run(
+        monkeypatch,
+        _hooks_responder("hooks\n", diff_out="hooks/pre-commit\nhooks/pre-push\n"),
+    )
+    monkeypatch.setattr(ps, "_default_branch", lambda _p: "main")
+    out = ps.hooks_state(Path("/proj"))
+    assert out["in_worktree"] is True
+    assert out["stale_files"] == ["hooks/pre-commit", "hooks/pre-push"]
+
+
+def test_hooks_state_silent_when_hooks_match_default_branch(monkeypatch):
+    _patch_run(monkeypatch, _hooks_responder("hooks\n", diff_out=""))
+    monkeypatch.setattr(ps, "_default_branch", lambda _p: "main")
+    out = ps.hooks_state(Path("/proj"))
+    assert out["in_worktree"] is True
+    assert out["stale_files"] == []
+    assert "error" not in out
+
+
+def test_hooks_state_degrades_without_remote(monkeypatch):
+    _patch_run(
+        monkeypatch,
+        _hooks_responder(
+            "hooks\n",
+            diff_out="",
+            diff_rc=128,
+        ),
+    )
+    monkeypatch.setattr(ps, "_default_branch", lambda _p: "main")
+    out = ps.hooks_state(Path("/proj"))
+    assert out["in_worktree"] is True
+    assert out["stale_files"] == []
+    assert "error" in out
+
+
+def test_hooks_state_wired_into_collectors():
+    import inspect
+
+    source = inspect.getsource(ps.main)
+    assert '"hooks": hooks_state' in source, (
+        "hooks_state must be a collector so the healthcheck skill sees it"
+    )

--- a/tickets/closed/0260-flag-stale-worktree-hooks-vs-origin.erg
+++ b/tickets/closed/0260-flag-stale-worktree-hooks-vs-origin.erg
@@ -2,10 +2,12 @@
 Title: healthcheck: flag when working-tree hooks differ from origin/main (stale-hook-in-worktree trap)
 Created: 2026-06-18
 Author: HDMX-coding-agent
+Closed: hooks_state collector in scripts/project-state.py (silent when hooksPath unset or under .git/, advisory drift report vs origin/<default>) + Hook freshness check 10 in skills/healthcheck/SKILL.md; unit tests + synthetic-repo end-to-end verified
 
 --- log ---
 2026-06-18T00:00Z HDMX-coding-agent created
 
+2026-07-07T11:53Z Claude closed — hooks_state collector in scripts/project-state.py (silent when hooksPath unset or under .git/, advisory drift report vs origin/<default>) + Hook freshness check 10 in skills/healthcheck/SKILL.md; unit tests + synthetic-repo end-to-end verified
 --- body ---
 ## Context
 When a repo sets `core.hooksPath` to a directory inside the working tree (e.g.


### PR DESCRIPTION
**Ticket:** 0260 (closed in this PR via `erg close` + `erg archive`)

## What

Catches the stale-hook-in-worktree trap: a `core.hooksPath` inside the working tree resolves to an absolute path under the main checkout, so every worktree runs the main checkout's hooks — a merged hook fix does not take effect until that checkout carries it. This bit a real session (2026-06-18, Oeconomia #797/#801) and cost a full confused round.

- **`scripts/project-state.py`** — new `hooks_state` collector, wired into the probe: silent when `core.hooksPath` is unset or resolves under the git dir (the normal case, no trap); otherwise diffs the hooks directory against `origin/<default>` and lists stale files; degrades gracefully with an `error` field when there is no remote or a detached HEAD.
- **`skills/healthcheck/SKILL.md`** — new check 10 "Hook freshness" (advisory, never a hard gate; warns naming the stale files) + output-table row; Docs freshness renumbered to 11.

## Tests

Six `hooks_state` tests in `tests/test_project_state.py` (canned-`run()` style, red-first): hooksPath unset, hooksPath under `.git/`, drift reported, in-sync silent, no-remote degradation, collector wiring. The drift path was also exercised end-to-end on a synthetic clone (drift detected and named; silent after restore).

## Verification

- `make check` green: 630 passed (624 baseline + 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtySzQJN1jNmwfpLXPVH11

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtySzQJN1jNmwfpLXPVH11)_