### PR TITLE
memory(climate-finance-het): persist this session's lessons

### DIFF
--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
@@ -149,3 +149,5 @@
 - [feedback_no_tool_for_single_use.md](feedback_no_tool_for_single_use.md) — single-use op → run the command, don't build a tested reusable tool (scrapped #804)
 - [feedback_file_decisions_with_submission.md](feedback_file_decisions_with_submission.md) — file journal decisions/referee reports as tracked text beside their submission folder; verify extraction before deleting source
 - [feedback_manuscript_number_provenance.md](feedback_manuscript_number_provenance.md) — cite only pipeline numbers that trace to an archived output; v1-pinned manuscript can silently drift from live-pipeline stats (the 0.68 case)
+- [feedback_read_before_cite.md](feedback_read_before_cite.md) — a reference enters the manuscript only after it is read and its core-relevance argued; no referee-checkbox padding (Mitchell/Deaton/Escobar case)
+- [feedback_fetch_before_sibling_merge.md](feedback_fetch_before_sibling_merge.md) — multi-PR wave on one file: fetch before each sibling merge + grep-verify the union (stale origin/main silently drops siblings' additions)

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_fetch_before_sibling_merge.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_fetch_before_sibling_merge.md
@@ -1,0 +1,38 @@
+---
+name: feedback_fetch_before_sibling_merge
+description: "In a multi-PR wave editing the same file, fetch immediately before each sibling merge and grep-verify the content union after — a stale origin/main ref silently drops just-merged siblings' additions"
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 2f6c6c7e-67d0-4265-a5f7-bfdc0a1ccdd1
+---
+
+When merging several PRs of a wave that all touch one file (e.g. three
+manuscript PRs each editing `content/manuscript.qmd` + `main.bib` +
+`test_manuscript_prose.py`), integrate them one at a time and **`git fetch origin`
+right before each `git merge origin/main`**. If you merged sibling #N with `gh pr
+merge` but did not fetch before merging origin/main into sibling #N+1, your local
+`origin/main` ref is stale — it lacks #N's merge commit — so the merge silently
+produces a result missing #N's non-conflicting additions (looks like a clean
+auto-merge, no conflict reported for that file).
+
+**Why:** the drop is invisible. `git merge` reports "Auto-merging <file>" and
+exits 0; only the *content* is wrong. Caught 2026-07-08 (raid on 0141 children,
+PRs #909/#910/#911) only because I grepped the merged `main.bib` for the three
+new `@key`s and found 1 of 3, then found the manuscript had lost #910's
+`@unfccc2010cancun`/`@aosis2024ncqg`/`@unfccc2009copenhagen` in-text cites too.
+
+**How to apply:**
+1. Before every sibling merge: `git fetch origin` (cheap; the git.md "rebase at
+   every gate" rule, applied to merges).
+2. After resolving conflicts, **grep-verify the union before committing** — every
+   sibling's citations/keys/tests present exactly once, plus prior siblings'
+   landmarks (e.g. `grep -c '@unfccc2010cancun' manuscript.qmd`). Do not trust a
+   clean auto-merge.
+3. If a drop is found, don't hand-patch the merge — `git checkout origin/main --
+   <file>` (known-good, carries the merged siblings) and re-layer only *this*
+   PR's small change on top. Then re-verify.
+
+Force-push is denied in this repo, so integrate with `git merge origin/main` into
+the branch (merge commit), not rebase. Extends [[feedback_no_rebase_dvc]];
+merge-side analogue of the rebase drop-cascade.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_het_register.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_het_register.md
@@ -24,3 +24,19 @@ money than a procedure for counting it". Keep concreteness and vivid coinages
 (e.g. "electrons have no colour") but frame them as idiom/evidence, not slogans.
 Complements the [[feedback_ghost_mode]] Economist-style rule and the project
 `writing.md` Ghost-mode guidance — this is the HET-specific layer.
+
+**Concrete anchor artifact (added 2026-07-08):** `docs/style-anchor-v205.md`
+holds the author's own pre-AI English voice — validated passages from his
+1997–2011 first-authored articles (ticket 0173). Draft manuscript prose against
+it *from the first draft*, not as a fix-up. The author's actual voice: short
+declarative sentences that LAND a point (not recap), one concrete analogy for an
+abstract idea (leaky CO2 storage = a bank loan), one measured hedge at a time,
+occasional question-close and light irony, grammatically correct British English.
+
+Two failure poles, both rejected, both fixed by rewriting against the anchor:
+(1) American punchy/business-book beats (the 2026-06-18 §3.1 case above);
+(2) ornate AI-academic long subordinate chains (2026-07-08, PR #894 loss & damage
+draft — author: "I don't recognise my voice"). The author's short declaratives
+are the cure for pole (2), but keep them plain and concrete — do not tip into the
+slogan-y hammer-beats of pole (1). When a draft is rejected on voice, the
+procedure is: read `docs/style-anchor-v205.md`, rewrite, re-run the prose ratchet.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_read_before_cite.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_read_before_cite.md
@@ -1,0 +1,32 @@
+---
+name: feedback_read_before_cite
+description: "A reference enters the Œconomia manuscript only after it is actually read and its relevance to the paper's CORE is argued — no referee-appeasing citation padding"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 2f6c6c7e-67d0-4265-a5f7-bfdc0a1ccdd1
+---
+
+When a referee names works to engage (e.g. R2.30: "engage Escobar, Tim
+Mitchell"), do NOT add the citation on reputation. The author's bar (2026-07-08):
+**"find and read the book, and convince me of its relevance for the core of the
+paper"** — else keep the existing refs / institutional framing.
+
+**Why:** the paper's value is scholarly integrity over referee-checkbox
+completeness; a name-dropped citation the author has not read is padding and
+erodes credibility. This is stronger than the generic scholarly-integrity rule
+(cite only what you have read + store the PDF locally): here you must also *argue
+core relevance* before recommending, and be willing to report "does not fit here."
+
+**How to apply:** read the actual text (PDFs live in `docs/articles/`), then give
+a differentiated verdict — where it earns its place and where it does NOT. Worked
+example (2026-07-08, PR #901): read Mitchell 1998 ("Fixing the Economy") and 2002
+(*Rule of Experts* ch. 7). Verdict: 1998 anchors the intro "birth of an aggregate"
+lineage; 2002 (the USAID/aid-apparatus chapter) is the on-point R2.30 cite at the
+DAC/Desrosières passage, COMPLEMENTING not replacing Desrosières/Porter; Escobar
+deferred, unread, so no claim made. Also: reject a referee's mis-attribution
+early — e.g. "Deaton, *Trade Development and Aid*" does not exist and Deaton does
+not fit; the author's answer was "keep institutional framing, I do not see the
+need for another guy". The read-and-decide outcome is logged in the owning ticket
+(0143 was the sole home of the Escobar/Mitchell selection). Related:
+[[feedback_manuscript_number_provenance]], [[reference_cited_works_local_docs_articles]].


### PR DESCRIPTION
Surgical persist of **only this session's** memory files, branched off a clean `origin/main`.

**Why not `/dream`:** the primary `~/.claude` checkout is parked mid-consolidation on `dream-consolidate-…20260707` with uncommitted work from other sessions/projects (settings.json, AEDIST zotero, other climate memory). A full `/dream` commit would bundle that unreviewed work. This PR touches only the four files this session authored.

**Contents (4 files):**
- `feedback_fetch_before_sibling_merge` *(new)* — multi-PR same-file merge waves: fetch before each sibling merge + grep-verify the union.
- `feedback_read_before_cite` *(new)* — a reference enters the manuscript only after it's read and its core-relevance argued; no referee-checkbox padding.
- `feedback_het_register` *(+16)* — the `style-anchor-v205` artifact + the two voice-failure poles.
- `MEMORY.md` — two index pointers (added to the clean origin/main index, **not** the Jul-7 restructuring).

`projects/` is gitignored by design; new files force-added to match `/dream`'s tracking.

Note: the parked `dream-consolidate-…20260707` branch still needs its owner to finish or discard it before a clean `/dream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)