### PR TITLE
rules(0269): cost-based test tiers + make lint gate

### DIFF
--- a/rules/coding-python.md
+++ b/rules/coding-python.md
@@ -25,8 +25,9 @@ Dependencies: **always `uv sync`** (never pip). `uv run python scripts/...` to e
 ## Testing
 
 - Tests live in `tests/test_<module>.py`. A new script or changed behavior starts with a test.
-- `make check-fast`: unit tests + lint, < 30 s — run during development.
-- `make check`: full suite including integration + slow tests — run before opening a PR.
+- `make check-fast`: fast tier only (`-m "not slow and not integration and not adherence"`), < 30 s — run during development.
+- `make lint`: adherence tier only (`-m adherence`) — ruff / mypy / hygiene / contracts.
+- `make check`: everything — run before opening a PR. No coverage is lost by tiering a test slower; `make check` still runs it.
 
 Every Python project must have a ruff adherence test so lint failures are caught locally before CI:
 
@@ -37,16 +38,25 @@ def test_ruff():
     assert result.returncode == 0, result.stdout.decode()
 ```
 
-| Marker | Meaning | Excluded from |
-|--------|---------|---------------|
-| *(none)* | Unit test — pure logic, no subprocess, no sleep | — |
-| `@pytest.mark.integration` | Spawns subprocesses or uses sleep-based timing | `check-fast` |
-| `@pytest.mark.slow` | Requires network access or real data | `check-fast` |
+Classify each test by **cost**, not by the mechanism it happens to use:
+
+| Tier | Marker | Belongs here | Gate |
+|------|--------|--------------|------|
+| fast | *(none)* | pure-Python logic; no heavy numerical dependency (dcor / torch / ot / sentence_transformers / matplotlib), no subprocess, no lint | `make check-fast` |
+| integration | `@pytest.mark.integration` | spawns a subprocess / drives a script / sleep-based timing | `make check` |
+| slow | `@pytest.mark.slow` | network, real data, a heavy numerical dependency, or heavy compute | `make check` |
+| adherence | `@pytest.mark.adherence` | ruff / mypy / hygiene / contracts | `make lint` |
+
+Adherence is a gate, not a unit tier: `make lint` (`-m adherence`) runs it apart from the logic loop, so `make check-fast` stays pure and quick. The named dependencies are examples of the *heavy numerical dependency* category, not a fixed list.
 
 When writing new tests:
 - CLI flag presence: check via source inspection (`open().read()` + string match), not subprocess `--help`.
 - Tests using `subprocess.run()` or `time.sleep()`: mark `@pytest.mark.integration`.
 - Tests needing heavy modules only for `inspect.getsource()`: read the file directly instead.
+
+Two patterns keep the fast tier honest — generalizable, adopt per project (reference implementations live in the climate-finance-het repo, ticket 0216):
+- **Collection-time auto-mark** — a conftest hook marks any test whose module imports a heavy dependency `slow`, so the per-worker import tax never lands in the fast loop.
+- **Duration ratchet** — an `adherence` test fails when a fast-path test exceeds a recorded budget, catching heavy *compute* that no heavy *import* reveals.
 
 ## Build (Make)
 

--- a/tickets/closed/0269-marker-table-cost-based-tiers-make-lint.erg
+++ b/tickets/closed/0269-marker-table-cost-based-tiers-make-lint.erg
@@ -2,10 +2,12 @@
 Title: Marker table: cost-based tiers + make lint (was CFH 0220)
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: marker table migrated to cost-based tiers + make lint gate
 
 --- log ---
 2026-07-10T09:56Z HDMX-coding-agent created
 
+2026-07-10T09:59Z Minh Ha-Duong closed — marker table migrated to cost-based tiers + make lint gate
 --- body ---
 ## Context
 Migrated from climate-finance-het ticket 0220 (filed in the wrong repo — the


### PR DESCRIPTION
## What
Updates the global `## Testing` guidance in `rules/coding-python.md` from the old **mechanism-based** 3-row marker table to the **cost-based** four-tier scheme (fast / integration / slow / adherence) already used in climate-finance-het, and documents `make lint` (`-m adherence`) as a separate gate so `make check-fast` stays pure logic.

## Why
A new project inheriting the shared rulebook was getting stale tiering guidance: the old table classified by mechanism (subprocess/sleep → integration, network/data → slow) and never mentioned `make lint` or adherence-as-gate. Fixed the `make check-fast`/`make check` descriptions too (they claimed check-fast included lint, which the new scheme separates out).

## Scope discipline
Rule mechanics stay project-agnostic: the "heavy numerical dependency" category is named with deps (dcor/torch/ot/…) as examples only. The auto-mark and duration-ratchet enforcement patterns are cited as adoptable references (CFH ticket 0216), not mandates.

Exit criteria (0269):
- [x] Global table lists fast / integration / slow / adherence by cost
- [x] `make lint` / adherence-as-gate documented globally
- [x] No project-specific names hardcoded (examples only)

**Ticket:** tickets/0269-marker-table-cost-based-tiers-make-lint.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)