### PR TITLE
config: effort→medium, fullscreen TUI, erg-pr-merge permission

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,5 @@
 {
+  "cleanupPeriodDays": 180,
   "env": {
     "UV_ENV_FILE": "/home/haduong/.claude/.env",
     "BASH_ENV": "/home/haduong/.claude/scripts/bash-env.sh"
@@ -85,7 +86,8 @@
       "Bash(grep -i \"free\\\\|dejavu\\\\|liberation\\\\|noto sans$\\\\|ubuntu\")",
       "Read(//home/haduong/CNRS/papiers/actif/AEDIST-technical-report/**)",
       "Bash(rtk git *)",
-      "Bash(rtk grep *)"
+      "Bash(rtk grep *)",
+      "Bash(~/.claude/skills/merge/erg-pr-merge:*)"
     ],
     "defaultMode": "auto",
     "additionalDirectories": [
@@ -204,15 +206,14 @@
     ],
     "Stop": []
   },
-  "effortLevel": "high",
+  "enabledPlugins": {},
+  "effortLevel": "medium",
+  "tui": "fullscreen",
   "voice": {
     "enabled": true,
     "mode": "hold"
   },
   "skipDangerousModePermissionPrompt": true,
   "teammateMode": "auto",
-  "skipAutoPermissionPrompt": true,
-  "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
-  }
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
Personal harness config that was sitting uncommitted in the primary working tree, separated out of the stalled dream branch #441 so it lands on its own.

- `effortLevel` `high` → `medium`
- add `tui: "fullscreen"`, `cleanupPeriodDays: 180`
- allowlist `Bash(~/.claude/skills/merge/erg-pr-merge:*)`
- drop the `frontend-design` plugin

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)