### PR TITLE
fix(gaze): foreground reviewer/gate launches so the fork blocks (0250)

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -37,6 +37,27 @@ Merge is always the human's or the raid's call.
   invoking `/gaze`. The skill and its sub-skills (`/verify-gate`, `/simplify`, etc.)
   use `gh` and `git` commands that resolve against cwd.
 
+## Fork execution contract
+
+`/gaze` runs as a `context: fork` (see frontmatter). A fork's turn ends the
+instant it stops calling tools. Every agent this skill spawns — the phase 2–4
+reviewers, the phase 6 gate, the REROLL fix agent — must therefore be launched
+**foreground** (`run_in_background: false`), so the fork blocks on the result
+and continues to the next phase when the agent returns. Launching them
+`run_in_background: true` and then "waiting" does not wait: the fork stops
+calling tools, its turn ends, and the background completions re-invoke the
+**MAIN loop**, not the fork. The fork's last message is then a fan-out
+narration ("reviewers are running in parallel…") instead of a verdict, and
+phases 5–6 never run. This orphaned two real gate runs (aedist `/gaze 977`
+and `/gaze 978`, 2026-06-11), each forcing the caller to relaunch a duplicate
+reviewer battery.
+
+**Caller-side recovery.** If `/gaze <pr>` ever returns a bare fan-out
+narration with no `## /verify-gate verdict` block (APPROVED/REROLL/ESCALATE),
+treat it as a non-result: do **not** relaunch the reviewer battery. Wait for
+the background reviewer notifications, then run `/verify-gate <pr>
+worktree=/tmp/review-<pr>` directly to produce the verdict from their outputs.
+
 ## Phases
 
 ### 1. Setup
@@ -80,9 +101,12 @@ invocations** (ticket 0216). A fork does not inherit this skill's cwd or
 conversation, so it lands in the session worktree on whatever branch is
 checked out there — that is how a drifted fork pushed a stray branch and
 opened rogue PR #243 (ticket 0193). Spawning an Agent fixes this
-deterministically: each reviewer is a **read-only** background Agent whose
+deterministically: each reviewer is a **read-only, foreground** Agent whose
 cwd is **pinned to the existing review worktree** `/tmp/review-<pr-number>`
-(created in phase 1). Do **not** give these agents `isolation: "worktree"` —
+(created in phase 1). Foreground (`run_in_background: false`) is
+load-bearing, not incidental — see **Fork execution contract** below: this
+skill runs as a `context: fork`, and a fork cannot wait on background
+agents. Do **not** give these agents `isolation: "worktree"` —
 that cuts a *fresh* tree from the session repo on main/HEAD, which is exactly
 the wrong-branch failure this conversion eliminates; only the REROLL fix
 agent (a mutator) gets `isolation: "worktree"`.
@@ -98,9 +122,15 @@ Every reviewer agent's prompt:
 - ends by **returning a single structured block as its final message**, which
   the orchestrator parses to branch.
 
-Spawn the applicable agents **in a single message, as parallel background
-agents** (so the fan-out runs concurrently), then wait for all to return and
-collect their structured outputs. Pin every read-only reviewer to
+Spawn the applicable agents **in a single message, as parallel foreground
+Agent calls** (`run_in_background: false`) — the single message runs them
+concurrently, and foreground makes the fork block until every one returns
+before it proceeds. Do **not** launch them as background agents: a fork's
+turn ends the moment it stops calling tools, and a background completion
+re-invokes the MAIN loop, not the fork, so a background fan-out returns at
+launch and orphans its reviewers (ticket 0250; see **Fork execution
+contract**). Once all return, collect their structured outputs. Pin every
+read-only reviewer to
 **`model: sonnet`** — reviewers stay below the coder tier (rules/workflow.md
 § "Sonnet reviews Opus's work"), and an unpinned Agent inherits the session
 model, so on a top-tier session this fan-out is silently a top-model wave.
@@ -168,8 +198,9 @@ to the PR branch. Wait for its fixes (if any) to land before the gate reads stat
 ### 6. Gate (the non-rubber-stamp step)
 
 The gate also runs as an **Agent-spawned sub-agent, not a `context: fork`**
-(ticket 0216) — same rationale as phases 2–4. Spawn one **read-only** background
-Agent, **`model: sonnet`** (a reviewer, below the coder tier), cwd **pinned to**
+(ticket 0216) — same rationale as phases 2–4. Spawn one **read-only, foreground**
+Agent (`run_in_background: false`, so the fork blocks on the verdict),
+**`model: sonnet`** (a reviewer, below the coder tier), cwd **pinned to**
 `/tmp/review-<pr-number>` (the equivalent fork call is
 `/verify-gate <pr-number> worktree=/tmp/review-<pr-number>`); never
 `isolation: "worktree"`. Containment rails as above: no `cd` out of the pinned
@@ -216,7 +247,8 @@ round: 1 | 2
 - **REROLL, round 1** → spawn a fix subagent with `isolation: "worktree"`,
   `model: opus` (a mutator/coder — top available tier where it earns its keep, not the
   reviewer's sonnet; effort is not an Agent launch param, so it tracks the
-  session effort), feeding it the unresolved lists as input. Fix agent gets ≤10 min. On push, **re-enter phase 6 by
+  session effort), launched **foreground** (`run_in_background: false`, so the
+  fork blocks until it pushes — see **Fork execution contract**), feeding it the unresolved lists as input. Fix agent gets ≤10 min. On push, **re-enter phase 6 by
   re-spawning the read-only gate Agent** (pinned cwd `/tmp/review-<pr-number>`, as in
   phase 6) with `round=2` — not a fork invocation.
 - **REROLL, round 2** → upgrade to ESCALATE (no third round). Post a PR comment with the

--- a/tests/test_gaze_fork_blocking.py
+++ b/tests/test_gaze_fork_blocking.py
@@ -1,0 +1,99 @@
+"""The gaze fork must block on its reviewers, never orphan them (ticket 0250).
+
+The lesson 0250 paid for, twice: `/gaze` runs as a `context: fork`. A fork's
+turn ends the instant it stops calling tools. If it launches its reviewer
+battery as **background** agents (`run_in_background: true`) and then "waits
+for all to return", it does not wait — background completions re-invoke the
+MAIN loop, not the fork, so the fork ends immediately, returning a fan-out
+narration ("reviewers are running in parallel…") as its final message.
+Phases 5 (simplify) and 6 (gate) never run in the fork and no verdict is
+produced (aedist 0538 `/gaze 977`, aedist 0540 `/gaze 978` — twice).
+
+The fix (approach a in the ticket): the reviewer and gate fan-out launches
+must be **foreground / synchronous** so the fork blocks until they return.
+This test makes that enforceable instead of conventional:
+
+1. No launch in the gaze body describes its reviewer/gate agents as
+   "background" or uses `run_in_background: true` — a fork cannot wait on
+   those.
+2. The body states the fan-out is foreground / blocking / synchronous
+   (`run_in_background: false`).
+3. The failure mode and caller-side recovery are documented in the skill.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+GAZE = REPO / "skills" / "gaze" / "SKILL.md"
+
+
+def _body(md_text: str) -> str:
+    """Return the SKILL.md content after the YAML frontmatter block."""
+    parts = md_text.split("---", 2)
+    return parts[2] if len(parts) >= 3 else md_text
+
+
+# A background-launch signal: "background agent(s)" (any whitespace, incl. a
+# line wrap) or an explicit `run_in_background: true`. Naming the anti-pattern
+# to forbid it is fine; issuing it as a launch directive is the defect. We
+# separate the two by negation context, not by the token alone — the skill
+# documents the trap verbatim so future readers recognise it.
+BACKGROUND_SIGNAL = re.compile(
+    r"background\s+agents?\b|run_in_background\s*[:=]\s*true", re.IGNORECASE
+)
+
+# Words that turn a background mention into a prohibition or an explanation of
+# the failure, not a launch directive.
+NEGATION = re.compile(
+    r"\b(not|never|don't|do not|instead|rather than|orphan|trap|does not|"
+    r"fork cannot|cannot wait|re-invoke|would|if.*returns)\b",
+    re.IGNORECASE,
+)
+
+# Foreground/blocking phrasing that proves the fork waits synchronously.
+FOREGROUND = re.compile(
+    r"foreground|synchronous(?:ly)?|blocking\s+(?:launch|call|agent|on)"
+    r"|run_in_background\s*[:=]\s*false",
+    re.IGNORECASE,
+)
+
+
+def _sentences(text: str) -> list[str]:
+    # Coarse sentence split on ., ;, : and newlines — enough to scope a
+    # background mention to its clause for the negation check.
+    return re.split(r"(?<=[.;:])\s+|\n+", text)
+
+
+def test_no_affirmative_background_launch():
+    body = _body(GAZE.read_text())
+    offenders = [
+        s.strip()
+        for s in _sentences(body)
+        if BACKGROUND_SIGNAL.search(s) and not NEGATION.search(s)
+    ]
+    assert not offenders, (
+        "gaze SKILL.md issues a background launch directive for its "
+        "reviewer/gate fan-out — a fork cannot wait on background agents; it "
+        "returns at fan-out start and orphans them (ticket 0250). Offending "
+        f"clauses: {offenders}"
+    )
+
+
+def test_fanout_is_foreground_blocking():
+    body = _body(GAZE.read_text())
+    assert FOREGROUND.search(body), (
+        "gaze SKILL.md must state its reviewer/gate fan-out is "
+        "foreground/synchronous (run_in_background: false) so the fork blocks "
+        "until every agent returns (ticket 0250, approach a)."
+    )
+
+
+def test_failure_mode_documented():
+    body = _body(GAZE.read_text()).lower()
+    # The skill must carry the fork-orphan failure mode + caller recovery.
+    assert "fan-out" in body or "fanout" in body
+    assert "orphan" in body or "before a verdict" in body or "never delivers" in body, (
+        "gaze SKILL.md must document the fork-returns-at-fan-out failure mode "
+        "and the caller-side recovery (ticket 0250, exit criterion 3)."
+    )

--- a/tickets/0250-gaze-fork-returns-at-fanout-start-never.erg
+++ b/tickets/0250-gaze-fork-returns-at-fanout-start-never.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-06-11T21:01Z claude created
 
+2026-07-10T11:51Z note root cause: gaze runs as context:fork; SKILL.md launched reviewers as background agents then 'waited' — but a fork's turn ends when it stops calling tools, and background completions re-invoke the MAIN loop, not the fork, so it returned at fan-out start. Fix (approach a): foreground run_in_background:false launches for phases 2-4, gate, and fix agent, so the fork blocks. Added Fork execution contract section + caller recovery. Ratchet: tests/test_gaze_fork_blocking.py.
 --- body ---
 ## Context
 Twice-confirmed defect. When `/gaze <pr>` runs as a forked skill execution,

--- a/tickets/closed/0250-gaze-fork-returns-at-fanout-start-never.erg
+++ b/tickets/closed/0250-gaze-fork-returns-at-fanout-start-never.erg
@@ -2,11 +2,13 @@
 Title: gaze fork returns at fanout-start, never delivers the gate verdict
 Created: 2026-06-11
 Author: claude
+Closed: autoclosed — PR #457
 
 --- log ---
 2026-06-11T21:01Z claude created
 
 2026-07-10T11:51Z note root cause: gaze runs as context:fork; SKILL.md launched reviewers as background agents then 'waited' — but a fork's turn ends when it stops calling tools, and background completions re-invoke the MAIN loop, not the fork, so it returned at fan-out start. Fix (approach a): foreground run_in_background:false launches for phases 2-4, gate, and fix agent, so the fork blocks. Added Fork execution contract section + caller recovery. Ratchet: tests/test_gaze_fork_blocking.py.
+2026-07-10T15:27Z Minh Ha-Duong closed — autoclosed — PR #457
 --- body ---
 ## Context
 Twice-confirmed defect. When `/gaze <pr>` runs as a forked skill execution,


### PR DESCRIPTION
## Summary

`/gaze` runs as a `context: fork`. The skill launched its reviewer battery as
**background** agents and then "waited for all to return" — but a fork's turn
ends the moment it stops calling tools, and background completions re-invoke
the **MAIN loop**, not the fork. So the fork returned at fan-out start (a
"reviewers are running in parallel…" narration) as its final message, and
phases 5 (simplify) and 6 (gate) never ran: no verdict, orphaned reviewers.
Confirmed twice (aedist `/gaze 977`, `/gaze 978`, 2026-06-11).

## Fix (approach (a) from the ticket)

- Launch phases 2–4 reviewers, the phase-6 gate, and the REROLL fix agent as
  **foreground** (`run_in_background: false`) Agent calls, so the fork blocks
  on each result before proceeding.
- New **Fork execution contract** section states the invariant and the
  caller-side recovery: if a bare fan-out narration ever comes back, run
  `/verify-gate <pr>` directly rather than relaunching the reviewer battery.
- Reviewer model pinning (`sonnet`) and the single REROLL fix-agent
  `isolation: "worktree"` grant are unchanged (existing contract test still
  passes).

## Test

`tests/test_gaze_fork_blocking.py` — a negation-aware ratchet: the skill may
still name the anti-pattern verbatim (for documentation) while a launch
*directive* to background the fan-out fails the test. Proven RED on the
original phrasing, GREEN on the fix. `make check`: 642 passed.

Pre-PR `/verify-adherence`: PASS (no mechanical or semantic findings) — `/gaze`
may skip the mechanical phase.

**Ticket:** tickets/0250-gaze-fork-returns-at-fanout-start-never.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)