### PR TITLE
rules(python): ruff adherence test via shutil.which + pinned dev dep

### DIFF
--- a/rules/coding-python.md
+++ b/rules/coding-python.md
@@ -29,12 +29,14 @@ Dependencies: **always `uv sync`** (never pip). `uv run python scripts/...` to e
 - `make lint`: adherence tier only (`-m adherence`) — ruff / mypy / hygiene / contracts.
 - `make check`: everything — run before opening a PR. No coverage is lost by tiering a test slower; `make check` still runs it.
 
-Every Python project must have a ruff adherence test so lint failures are caught locally before CI:
+Every Python project must have a ruff adherence test so lint failures are caught locally before CI. Declare `ruff` as a **pinned dev dependency** (e.g. `ruff>=0.11,<0.12`) and `uv lock` it — an adherence guard's verdict must be machine-independent, and an ambient/system ruff drifts between machines and silently changes rules on upgrade. Resolve the binary with `shutil.which`, not a nested `uv run ruff`: pytest already runs inside the project venv under `make lint`, so the pinned ruff is on PATH; a nested `uv run` re-enters uv from inside uv, spawns a subprocess per call, and breaks under `UV_NO_SYNC` in a clean CI/cloud container.
 
 ```python
 @pytest.mark.adherence
 def test_ruff():
-    result = subprocess.run(["uv", "run", "ruff", "check", "."], capture_output=True)
+    ruff = shutil.which("ruff")
+    assert ruff is not None, "ruff not found — declare it as a pinned dev dependency"
+    result = subprocess.run([ruff, "check", "."], capture_output=True)
     assert result.returncode == 0, result.stdout.decode()
 ```
 


### PR DESCRIPTION
## What

Updates the canonical ruff-adherence-test snippet in `rules/coding-python.md`:
- resolve ruff with `shutil.which` (asserted non-None), not a nested `uv run ruff`;
- require ruff to be a **pinned dev dependency** (`uv lock`), with the rationale.

## Why

Validated in `climate-finance-het` ticket 0230 (guard) and reinforced by its roar sweep (ticket 0236, where the same repo's `test_script_hygiene` had the nested-`uv run` form twice):

- **Nested `uv run` is container-fragile.** pytest already runs inside the project venv under `make lint`, so a nested `uv run ruff` re-enters uv from inside uv, spawns a subprocess per call, and behaves differently under `UV_NO_SYNC` in a clean CI/cloud container. `shutil.which` resolves the venv-local binary directly.
- **Ambient ruff makes the verdict machine-dependent.** A system ruff drifts between machines (doudou 0.11.12 vs whatever padme has) and silently changes rules on a global upgrade. A pinned dev dep + `uv.lock` is the only version normaliser — decisive when the repo has no CI.

No skill added/renamed, so no catalog regen needed.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)