### PR TITLE
ticket(0271): erg-pr-merge auto-readies a draft PR before merging

### DIFF
--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -33,4 +33,4 @@ The script reads close intent from the PR **body** only — never the title:
 
 Report stdout/stderr verbatim. If the script exits non-zero, stop and show the error.
 
-Merge is queued via auto-merge; it lands when required checks pass (falls back to watch-then-merge where auto-merge is disabled).
+Merge is queued via auto-merge; it lands when required checks pass (falls back to watch-then-merge where auto-merge is disabled). A **draft** PR (roar/raid sweeps file bootstrap PRs as draft) is marked ready automatically before merging — invoking `/merge` is explicit intent to merge.

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -73,7 +73,7 @@ fi
 IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
 if [[ "$IS_DRAFT" == "true" ]]; then
     echo "PR #${PR} is a draft — marking ready for review before merge..."
-    gh pr ready "$PR" || die "could not mark PR #${PR} ready — run 'gh pr ready ${PR}' and retry"
+    gh pr ready "$PR" || die "could not mark PR #${PR} ready — run 'gh pr ready ${PR}' and retry"  # harness-extension-point
 fi
 
 # ── Step 1: find ticket ID ────────────────────────────────────────────────────

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -38,7 +38,7 @@ fi
 
 echo "PR #$PR"
 
-PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body) # harness-extension-point
+PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body,isDraft) # harness-extension-point
 PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
 BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.baseRefName')
 CURRENT_BRANCH=$(git branch --show-current)
@@ -64,6 +64,16 @@ PENDING=$(echo "$PR_JSON" | jq -r '
     | length')
 if [[ "$PENDING" -gt 0 ]]; then
     die "CI has ${PENDING} check(s) still running — wait for completion"
+fi
+
+# A draft PR is rejected by both auto-merge ("Pull Request is still a draft")
+# and the watch-then-merge fallback. Roar/raid sweeps file bootstrap PRs as
+# draft deliberately; invoking this script is explicit intent to merge, so mark
+# the PR ready rather than aborting at the merge step. (harness-extension-point)
+IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
+if [[ "$IS_DRAFT" == "true" ]]; then
+    echo "PR #${PR} is a draft — marking ready for review before merge..."
+    gh pr ready "$PR" || die "could not mark PR #${PR} ready — run 'gh pr ready ${PR}' and retry"
 fi
 
 # ── Step 1: find ticket ID ────────────────────────────────────────────────────

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -56,9 +56,12 @@ case "$1 $2" in
     # the big composite query
     jq -n \
       --arg n "$STUB_PR" --arg h "$STUB_BRANCH" --arg b "$STUB_BASE" \
-      --arg body "$STUB_BODY" \
-      '{number:($n|tonumber),headRefName:$h,baseRefName:$b,mergeable:"MERGEABLE",statusCheckRollup:[],body:$body}'
+      --arg body "$STUB_BODY" --arg draft "${STUB_IS_DRAFT:-false}" \
+      '{number:($n|tonumber),headRefName:$h,baseRefName:$b,mergeable:"MERGEABLE",statusCheckRollup:[],body:$body,isDraft:($draft=="true")}'
     exit 0 ;;
+  "pr ready")
+    echo "$*" >> "${STUB_READY_LOG:-/dev/null}"
+    echo "stub: marked ready"; exit 0 ;;
   "pr merge")
     echo "$*" >> "${STUB_MERGE_LOG:-/dev/null}"
     if [[ "$*" == *"--auto"* ]]; then
@@ -161,6 +164,8 @@ run_merge() {  # $1 body, $2 title  — runs the script with cwd in the repo
       STUB_AUTO_NOTMERGEABLE_ONCE="${STUB_AUTO_NOTMERGEABLE_ONCE:-}" \
       STUB_MERGEABLE_UNKNOWN_ONCE="${STUB_MERGEABLE_UNKNOWN_ONCE:-}" \
       STUB_CHECKS_NOCHECKS_ONCE="${STUB_CHECKS_NOCHECKS_ONCE:-}" \
+      STUB_IS_DRAFT="${STUB_IS_DRAFT:-false}" \
+      STUB_READY_LOG="${STUB_READY_LOG:-/dev/null}" \
       ERG_PR_MERGE_POLL_INTERVAL=0 \
       bash "$SCRIPT" 42 )
 }
@@ -463,5 +468,39 @@ else
     echo "FAIL: erg-pr-merge exited non-zero on no-checks registration race"; fail=1
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# Case 15: draft PR (ticket 0271). Roar/raid sweeps file bootstrap PRs as draft;
+# both auto-merge and the watch-then-merge fallback reject a draft. Invoking the
+# script is explicit intent to merge, so it must `gh pr ready` the PR first,
+# then merge and close the ticket. Anti-regression: a non-draft PR (every other
+# case) must NOT call `gh pr ready`.
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo draftcase 0271
+RLOG="$WORK/ready15.log"; : > "$RLOG"
+BODY15=$'Summary.\n\n**Ticket:** tickets/0271-fixture.erg\n'
+if STUB_IS_DRAFT=true STUB_READY_LOG="$RLOG" \
+   run_merge "$BODY15" "ticket(0271): draft" >/dev/null 2>&1; then
+    d_miss=0
+    closed_has 0271 || { echo "  not closed: 0271"; d_miss=1; }
+    grep -q -- 'pr ready' "$RLOG" || { echo "  draft PR was not marked ready"; d_miss=1; }
+    if (( d_miss )); then echo "FAIL: draft PR not readied before merge"; fail=1
+    else echo "PASS: draft PR marked ready, then closed and merged"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on draft PR"; fail=1
+fi
+
+# Case 15b: a non-draft PR must NOT invoke `gh pr ready` (no over-firing).
+seed_repo nondraftcase 0272
+RLOG2="$WORK/ready15b.log"; : > "$RLOG2"
+BODY15b=$'Summary.\n\n**Ticket:** tickets/0272-fixture.erg\n'
+if STUB_IS_DRAFT=false STUB_READY_LOG="$RLOG2" \
+   run_merge "$BODY15b" "ticket(0272): nondraft" >/dev/null 2>&1; then
+    if grep -q -- 'pr ready' "$RLOG2"; then
+        echo "FAIL: non-draft PR wrongly marked ready"; fail=1
+    else echo "PASS: non-draft PR does not call gh pr ready (no over-firing)"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on non-draft PR"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled"
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied"

--- a/tickets/0271-erg-pr-merge-auto-ready-a-draft-pr-befor.erg
+++ b/tickets/0271-erg-pr-merge-auto-ready-a-draft-pr-befor.erg
@@ -1,0 +1,31 @@
+%erg 0.1
+Title: erg-pr-merge: auto-ready a draft PR before merging
+Created: 2026-07-10
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-10T15:43Z HDMX-coding-agent created
+
+--- body ---
+## Context
+`erg-pr-merge` aborts on a draft PR. Roar/raid sweeps file bootstrap tickets as
+*draft* PRs deliberately (they stay a to-do). When the work is later implemented
+and `/merge` is invoked, auto-merge rejects it ("Pull Request is still a draft")
+and the watch-then-merge fallback also stalls. Observed 2026-07-10 merging
+climate-finance PR #992: the script closed+archived the ticket, then aborted at
+the merge step; the human had to `gh pr ready` by hand and re-merge.
+
+## Change
+Query `isDraft` in the PR JSON; if true, `gh pr ready "$PR"` before the merge
+step. Invoking the script is explicit intent to merge, so readying is correct
+(not a silent policy change). Abort with a clear message if `gh pr ready` fails.
+
+## Test
+tests/test_erg_pr_merge.sh Case 15: a draft PR (STUB_IS_DRAFT=true) must call
+`gh pr ready` (asserted via a ready-log) then close+merge; Case 15b: a non-draft
+PR must NOT call `gh pr ready`. Mutation-verified: neutralizing the ready call
+turns Case 15 RED.
+
+## Exit criteria
+- [x] Draft PR is readied before merge; non-draft PR is not.
+- [x] `bash tests/test_erg_pr_merge.sh` green (16 cases).

--- a/tickets/closed/0271-erg-pr-merge-auto-ready-a-draft-pr-befor.erg
+++ b/tickets/closed/0271-erg-pr-merge-auto-ready-a-draft-pr-befor.erg
@@ -2,10 +2,12 @@
 Title: erg-pr-merge: auto-ready a draft PR before merging
 Created: 2026-07-10
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #463
 
 --- log ---
 2026-07-10T15:43Z HDMX-coding-agent created
 
+2026-07-10T16:00Z Minh Ha-Duong closed — autoclosed — PR #463
 --- body ---
 ## Context
 `erg-pr-merge` aborts on a draft PR. Roar/raid sweeps file bootstrap tickets as


### PR DESCRIPTION
`erg-pr-merge` aborted on a **draft** PR: auto-merge rejects it ("Pull Request is still a draft") and the watch-then-merge fallback stalls. Roar/raid sweeps file bootstrap PRs as draft deliberately, so when the work lands and `/merge` runs, the script closed+archived the ticket then stranded at the merge step — needing a manual `gh pr ready` (observed merging climate-finance PR #992, 2026-07-10).

## Change
- Query `isDraft` in the PR JSON; if true, `gh pr ready "$PR"` before the merge step. Invoking the script is explicit intent to merge, so readying is correct — not a silent policy change. Abort with a clear message if `gh pr ready` fails.
- SKILL.md notes the draft auto-ready behaviour.

## Test
- `tests/test_erg_pr_merge.sh` Case 15 (draft → readied, closed, merged) + Case 15b (non-draft → NOT readied, no over-firing). 16 cases green.
- Mutation-verified: neutralizing the ready call turns Case 15 RED, 15b unaffected.

**Ticket:** tickets/0271-erg-pr-merge-auto-ready-a-draft-pr-befor.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)