### PR TITLE
memory(climate-finance-het): consolidate index + adopt 7 orphaned entries

### DIFF
--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
@@ -10,119 +10,47 @@
 ## ⚠️ Read first — project relocated/renamed 2026-06-19
 - [Reorg 0159 relocation](project_reorg_0159_relocation.md) — engine now `~/CNRS/projets/actifs/climate-finance-het/` (GitHub `climate-finance-het`); records in `papiers/<state>/<track>/`; older memories referencing the old path/name are stale. Follow-up: ticket 0160.
 
-## Corpus terminology
-- Full corpus: "scholarship around climate finance" (not "climate finance scholarship" — too narrow)
-- Core subset (cited_by_count >= 50): the influential works
+## Project facts
+- Corpus: full = "scholarship around climate finance" (not "climate finance scholarship" — too narrow); core subset = `cited_by_count >= 50` (influential works).
+- Three-act periodization (I 1990–2006 / II 2007–2014, breaks 2007+2013 / III 2015–2025, Paris marginal): history-first, corpus corroborates (detection blind to COP calendar). Full detail in `writing.md` rule; see [[feedback_oversell_breaks]].
+- Œconomia figure decisions: user rejected the z-score plot ("too technical for HPS"), a hand-curated Table 1 ("I want code. Clustering to DETECT."), and inset legend swatches ("failed idea").
+- Parked ideas (post-submission): `docs/braindump-2026-03-18.md`; [project_ollama_experiment.md](project_ollama_experiment.md).
 
-## Naming quirk
-- SciSpace scripts/files used "scispsace" (typo in CSV source column); fixed in #452 — catalog_merge now derives source name from filename
+## User & workflow
+- [user_cnrs_section41.md](user_cnrs_section41.md) — CNRS Section 41; peer-reviewed HPS/STS credibility over IF. [user_orcid.md](user_orcid.md) — ORCID 0000-0001-9988-2100 (never guess). [user_moa_moe_contract.md](user_moa_moe_contract.md) — user is MOA, Claude is MOE.
+- Preferences: autonomous for all search (don't stop to ask); worktrees for branches; a PR per ticket (reviews via GitHub); runs parallel sessions — don't assume files are stale.
+- [reference_agent_identity.md](reference_agent_identity.md) — HDMX-coding-agent is a git-author alias; GH actions appear as MinhHaDuong; use `--comment` not `--approve` for self-review.
 
-## Three-act periodization (history, corpus-corroborated)
-- I. Before climate finance (1990–2006)
-- II. Crystallization (2007–2014) — breaks at 2007 (cosine) and 2013 (JS)
-- III. Established field (2015–2025) — only a marginal JS rise at Paris 2015, no rupture
-- Framing: history-first, corpus *corroborates* (detection blind to COP calendar). Don't say "endogenous / not imposed from COP". See [[feedback_oversell_breaks]].
+## Machines, data & tools
+- **padme** (remote): repo `~/Climate_finance` (NOT under ~/CNRS/); `uv` at `~/.local/bin/uv` (absent from non-interactive PATH — prepend `PATH=$HOME/.local/bin`); GPUs A4000 16GB + RTX 3060 12GB; torch extras `--extra cpu` (doudou) / `--extra cu130` (padme); cache config in `/etc/environment` (non-interactive SSH skips `/etc/profile.d/`); Ollama often ~19GB RSS; `nohup` long tasks, logs in `/tmp/`.
+- **OpenRouter**: key in `~/.bashrc` (OPENROUTER_API_KEY); background bash doesn't inherit — export explicitly; request flat JSON keys (LLMs default to numbered).
+- **OpenAlex**: premium key ($2/day) in `.env`; S2 key in docs/ (1 req/s even with key); JETP query disabled (ambiguous acronym, physics-journal noise).
+- **Perf**: never `iterrows()` on 20K+ DataFrames — vectorize with pandas masks.
+- Toolchain/data ops: [project_uv_path_fix.md](project_uv_path_fix.md), [project_worktree_env_data.md](project_worktree_env_data.md), [project_doifetch_sync.md](project_doifetch_sync.md), [project_dvc_integration.md](project_dvc_integration.md).
 
-## Oeconomia figure design decisions
-- User rejected z-score plot as "too technical for HPS audience"
-- User rejected hand-curated Table 1: "I want code. Clustering to DETECT."
-- User rejected inset legend swatches as "failed idea"
+## Papers & submission
+- Œconomia R&R: [project_oeconomia_rr_pipeline.md](project_oeconomia_rr_pipeline.md) (version ladder), [project_rr_traceability_ledger.md](project_rr_traceability_ledger.md) (60-remark ledger + HITL sign-off), [project_0171_conclusion_rebuild.md](project_0171_conclusion_rebuild.md), [feedback_version_increment_planning.md](feedback_version_increment_planning.md).
+- Reports & build: [project_techrep_rewrite.md](project_techrep_rewrite.md), [project_techrep_split.md](project_techrep_split.md), [project_writing_build_phase_separation.md](project_writing_build_phase_separation.md), [project_frozen_manuscript_vs_live_companions.md](project_frozen_manuscript_vs_live_companions.md), [project_repo_layout_decision.md](project_repo_layout_decision.md).
+- Next papers: [project_paper_ceiling_growth_imaginary.md](project_paper_ceiling_growth_imaginary.md), [project_paper_instrument_circulation.md](project_paper_instrument_circulation.md).
+- Journals: [project_journal_strategy.md](project_journal_strategy.md), [reference_rdj4hss.md](reference_rdj4hss.md), [project_gide_conference.md](project_gide_conference.md).
+- Biblio & cited-works gate: [reference_bib_fulltext_index.md](reference_bib_fulltext_index.md), [reference_cited_works_local_docs_articles.md](reference_cited_works_local_docs_articles.md), [reference_paywalled_acquisition.md](reference_paywalled_acquisition.md), [reference_publist.md](reference_publist.md).
+- Tooling: OPIDoR DMP import — use RDA/maDMP JSON, select "RDA" in the format picker (UI switches to English after). [feedback_quarto_var_vs_meta.md](feedback_quarto_var_vs_meta.md), [reference_trackchange_review_workflow.md](reference_trackchange_review_workflow.md).
 
-## User context
-- [user_cnrs_section41.md](user_cnrs_section41.md) — CNRS Section 41 researcher; publications optimized for peer-reviewed credibility in HPS/STS, not prestige/IF
-- [user_orcid.md](user_orcid.md) — ORCID: 0000-0001-9988-2100 (never guess)
-
-## Workflow preferences
-- **Be autonomous for all search** — do not stop to ask, just proceed
-- **Use worktrees** for feature branches
-- **Create PRs** for each ticket — user wants to review via GitHub PRs
-- User runs parallel sessions — don't assume data files are stale
-
-## Agent identity
-- [reference_agent_identity.md](reference_agent_identity.md) — HDMX-coding-agent is a git-author alias only; all GH actions appear as MinhHaDuong; use `--comment` not `--approve` for self-review
-
-## Remote machine: padme
-- Repo at `~/Climate_finance` (NOT under ~/CNRS/)
-- Ollama often running (~19GB RSS) — budget memory accordingly
-- `uv` at `~/.local/bin/uv` (not in default PATH for non-interactive ssh)
-- Use `nohup` for long-running tasks; logs in `/tmp/`
-- GPUs: NVIDIA A4000 (16GB) + RTX 3060 (12GB)
-- torch via uv extras: `--extra cpu` (doudou) or `--extra cu130` (padme, CUDA 13.0)
-- Cache config in `/etc/environment` (UV_CACHE_DIR, RUFF, MYPY → `/data/cache/`); pytest in `/etc/profile.d/dev-cache.sh`
-- Non-interactive SSH doesn't source `/etc/profile.d/` — use `/etc/environment` for env vars that must always apply
-
-## DOIfetch sync procedure
-- See [project_doifetch_sync.md](project_doifetch_sync.md) for full details
-
-## DVC integration
-- See [project_dvc_integration.md](project_dvc_integration.md) for full details
-
-## OpenRouter / LLM
-- API key in `~/.bashrc` (OPENROUTER_API_KEY)
-- Background bash tasks don't inherit `~/.bashrc` — must export key explicitly
-- Prompt must request flat JSON keys (not numbered) — LLMs default to numbered
-
-## OpenAlex
-- Premium API key ($2/day) in `.env` (loaded via python-dotenv)
-- S2 API key available (in docs/), rate-limited to 1 req/s even with key
-- JETP query disabled (ambiguous acronym, 72K hits mostly physics journal noise)
-
-## Performance notes
-- Never use `iterrows()` on 20K+ DataFrames — vectorize with pandas masks
-
-## Toolchain
-- [project_uv_path_fix.md](project_uv_path_fix.md) — `$(UV_RUN)` + PATH export in Makefile (#719); follow-on 0088 for release templates
-- [project_worktree_env_data.md](project_worktree_env_data.md) — worktrees: shared uv env on /data (#797), data on-demand via `make data` (#801), absolute core.hooksPath gotcha; tickets 0145/0157
-
-## Technical report
-- [project_techrep_rewrite.md](project_techrep_rewrite.md) — structural rewrite plan: reproducibility note framing, two-part structure, variable geometry
-- [project_techrep_split.md](project_techrep_split.md) — split into corpus-report.qmd + analysis-only technical-report.qmd (2026-04-14)
-
-## Break detection
-- [feedback_oversell_breaks.md](feedback_oversell_breaks.md) — mid-2010s JS divergence is real; don't claim "Paris didn't matter"; computation corroborates history
-
-## Imperial Dragon harness
-- [project_imperial_dragon.md](project_imperial_dragon.md) — Dragon Dreaming → Imperial Dragon (5 claws); generic harness at ~/.claude/ backed by ImperialDragonHarness repo; PR #628
-
-## Telemetry & instrumentation
-- [reference_stats_cache.md](reference_stats_cache.md) — ~/.claude/stats-cache.json: free daily usage checkpoint for all surfaces
-- [reference_agentic_harness.md](reference_agentic_harness.md) — superseded by ImperialDragonHarness; old ~/.agent/ clone still has history
-
-## Oeconomia R&R
-- [project_oeconomia_rr_pipeline.md](project_oeconomia_rr_pipeline.md) — major R&R (2026-05-24); version ladder v2.0.1–v2.0.5 gated by tracker tickets; PR #800
-- [project_rr_traceability_ledger.md](project_rr_traceability_ledger.md) — 60-remark response ledger path + author rule: no non-actionable close, HITL sign-off per row
-- [feedback_version_increment_planning.md](feedback_version_increment_planning.md) — plan as version increments, ratchet-first, not waterfall; I draft decision options
-
-## Journal strategy
-- [project_journal_strategy.md](project_journal_strategy.md) — data paper → RDJ4HSS (diamond OA), methods paper deferred (QSS/Cultural Analytics/JEM shortlist)
-- [reference_rdj4hss.md](reference_rdj4hss.md) — RDJ4HSS format specs (2,500 words, sections, citation style) derived from published exemplar
-- [project_gide_conference.md](project_gide_conference.md) — Charles Gide conference (Vannes, 2026-07-02–07); RHPE call for papers (Classiques Garnier), ~7p HET paper
-
-## Parked ideas (post-submission)
-- `docs/braindump-2026-03-18.md` in repo — repro packages, Makefile modularization, skill-based agent coordination, local issue tracking, conversation replay
-- [project_ollama_experiment.md](project_ollama_experiment.md) — benchmarking local LLMs (Ollama on Padme) on the project harness overnight
-
-## OPIDoR
-- [reference_opidor.md](reference_opidor.md) — DMP import: use RDA/maDMP JSON format, select "RDA" in format picker; UI switches to English after import
-
-## Publications list
-- [reference_publist.md](reference_publist.md) — ~/CNRS/html/src/Ha-Duong.bib → make → index.html; @article only for accepted papers
-
-## Quarto
-- [feedback_quarto_var_vs_meta.md](feedback_quarto_var_vs_meta.md) — `{{< var >}}` only reads `_variables.yml`; use `{{< meta >}}` with `metadata-files:` instead
-- [reference_trackchange_review_workflow.md](reference_trackchange_review_workflow.md) — marked-PDF review loop: `\rradd` blue track-change macro + per-doc render; accept = strip to clean source
+## Harness & telemetry
+- [project_imperial_dragon.md](project_imperial_dragon.md), [reference_stats_cache.md](reference_stats_cache.md), [reference_agentic_harness.md](reference_agentic_harness.md), [reference_repo_no_ci.md](reference_repo_no_ci.md).
 
 ## Feedback
-- [feedback_erg_close_archive.md](feedback_erg_close_archive.md) — PROVISIONAL (pending erg close step-4 auto-archive): `erg close` and `erg archive` are separate; run both when closing pre-PR or /gaze flags the unarchived ticket (burned a round on 0149)
+- [feedback_erg_close_archive.md](feedback_erg_close_archive.md) — PROVISIONAL: `erg close` and `erg archive` are separate; run both when closing pre-PR or /gaze flags the unarchived ticket (burned a round on 0149)
+- [feedback_prclose_onbranch_ticket_none.md](feedback_prclose_onbranch_ticket_none.md) — ticket closed+archived on-branch → PR body needs `Ticket: none`, not `**Ticket:** tickets/closed/NNNN` (erg-pr-merge rejects the archived path; burned 2 retries on #1000)
 - [feedback_enterworktree_stuck_cwd.md](feedback_enterworktree_stuck_cwd.md) — EnterWorktree/cwd-skills target the wrong repo when session base cwd is parked off-project; fall back to manual `git worktree add` + `git -C`
-- [feedback_het_register.md](feedback_het_register.md) — manuscript prose = HET academic register, not American motivational/business-book cadence (no "cash out", "this is what X is", punchy beats)
+- [feedback_het_register.md](feedback_het_register.md) — manuscript prose = HET academic register, not American motivational/business-book cadence
 - [feedback_yaml_quoting.md](feedback_yaml_quoting.md) — use `'"phrase"'` not `"phrase"` in corpus_collect.yaml for phrase search queries
 - [feedback_no_long_running.md](feedback_no_long_running.md) — don't launch long-running tasks (make, rendering); let user run in their terminal
 - [feedback_phase_separation.md](feedback_phase_separation.md) — make manuscript must never trigger Phase 1 scripts or API calls
 - [feedback_data_direction.md](feedback_data_direction.md) — data flows padme→doudou only; never push data from doudou to padme
 - [feedback_no_heavy_deps.md](feedback_no_heavy_deps.md) — don't add heavy deps (jupyter) when a simple approach (YAML, hardcode) works
 - [feedback_review_agent_worktree.md](feedback_review_agent_worktree.md) — review agents must read from PR branch worktree, not main
-- [feedback_overnight_exploration.md](feedback_overnight_exploration.md) — overnight sessions must prioritize deliverables (next paper), not just code tooling; use runbooks/overnight-exploration.md
+- [feedback_overnight_exploration.md](feedback_overnight_exploration.md) — overnight sessions must prioritize deliverables (next paper), not just tooling; use runbooks/overnight-exploration.md
 - [feedback_no_apc.md](feedback_no_apc.md) — APCs are scams; choose diamond OA venues (integrity, excellence, care)
 - [feedback_parallel_work.md](feedback_parallel_work.md) — user works in VSCode terminal in parallel; check filesystem before asserting something hasn't been done
 - [feedback_no_amend_pr.md](feedback_no_amend_pr.md) — don't amend commits on open PRs; force push makes GitHub diffs confusing
@@ -132,10 +60,9 @@
 - [feedback_worktree_local_hook_commit.md](feedback_worktree_local_hook_commit.md) — commit a branch's own hook fix via `git -c core.hooksPath=<worktree>/hooks` when hooksPath is absolute
 - [feedback_branch_before_edit.md](feedback_branch_before_edit.md) — always checkout target branch before editing files; never edit on main then move
 - [feedback_onstart_trigger.md](feedback_onstart_trigger.md) — on-start runbook must execute automatically before first response, not wait to be asked
-- [feedback_harness_not_here.md](feedback_harness_not_here.md) — harness now at ~/.claude/ (Imperial Dragon); project .claude/ has project-specific residuals only
 - [feedback_make_corpus.md](feedback_make_corpus.md) — never suggest bare `dvc repro`; always use `make corpus` (padme) or `make corpus-sync` (doudou)
 - [feedback_no_rebase_dvc.md](feedback_no_rebase_dvc.md) — never rebase when DVC symlinks are dirty; use merge + stash/pop
-- [feedback_simplest_fix.md](feedback_simplest_fix.md) — don't add hooks/exceptions; restructure the operation to work within existing rules (e.g. ff merge vs --no-ff)
+- [feedback_simplest_fix.md](feedback_simplest_fix.md) — don't add hooks/exceptions; restructure the operation to work within existing rules (ff merge vs --no-ff)
 - [feedback_ssh_padme.md](feedback_ssh_padme.md) — can SSH from doudou to padme; don't say "I can't reach padme"
 - [feedback_ssh_padme_path.md](feedback_ssh_padme_path.md) — always prepend PATH=$HOME/.local/bin for padme SSH (uv not in non-interactive PATH)
 - [feedback_weekend_boundary.md](feedback_weekend_boundary.md) — no project work on weekends; mental health is non-negotiable
@@ -148,41 +75,36 @@
 - [feedback_verify_deferral_tracker.md](feedback_verify_deferral_tracker.md) — verify deferral tracker still open + in-scope before closing; rehome if orphaned
 - [feedback_no_tool_for_single_use.md](feedback_no_tool_for_single_use.md) — single-use op → run the command, don't build a tested reusable tool (scrapped #804)
 - [feedback_file_decisions_with_submission.md](feedback_file_decisions_with_submission.md) — file journal decisions/referee reports as tracked text beside their submission folder; verify extraction before deleting source
-- [feedback_manuscript_number_provenance.md](feedback_manuscript_number_provenance.md) — cite only pipeline numbers that trace to an archived output; v1-pinned manuscript can silently drift from live-pipeline stats (the 0.68 case)
-- [feedback_read_before_cite.md](feedback_read_before_cite.md) — a reference enters the manuscript only after it is read and its core-relevance argued; no referee-checkbox padding (Mitchell/Deaton/Escobar case)
-- [feedback_fetch_before_sibling_merge.md](feedback_fetch_before_sibling_merge.md) — multi-PR wave on one file: fetch before each sibling merge + grep-verify the union (stale origin/main silently drops siblings' additions)
-- [feedback_atomic_tickets_validation_units.md](feedback_atomic_tickets_validation_units.md) — Tickets must be atomic — one MOA validation unit per ticket/PR; any number in an instruction is contingent, the principle binds
-- [feedback_bytecheck_old_vs_new_not_golden.md](feedback_bytecheck_old_vs_new_not_golden.md) — Byte-check a behavior-preserving refactor by running old code vs new code on the SAME current data, never against a committed/main-checkout golden (which drifts with the corpus)
-- [feedback_caps_force_pruning_not_compression.md](feedback_caps_force_pruning_not_compression.md) — A line/size cap (e.g. STATE.md's 40-line limit) forces pruning stale content — never compression to game the number
-- [feedback_cite_at_existing_locus.md](feedback_cite_at_existing_locus.md) — Integrating a referee-requested citation — find the passage that already makes the point, and the non-redundant locus, before adding prose
-- [feedback_cross_repo_ticket_in_owning_repo.md](feedback_cross_repo_ticket_in_owning_repo.md) — File a follow-up ticket in the repo that OWNS the target file, not the consuming project that discovered the need
-- [feedback_decide_dont_micromanage.md](feedback_decide_dont_micromanage.md) — Make the coherent decision across the whole logical unit; don't hardcode, don't half-do, don't ask piecemeal
-- [feedback_followup_lets_parent_close.md](feedback_followup_lets_parent_close.md) — A follow-up ticket exists so the parent can CLOSE now; don't keep the parent open as a pseudo-tracker
-- [feedback_force_push_denied_rebuild_clean.md](feedback_force_push_denied_rebuild_clean.md) — When the session denies force-push, don't fight it — rebuild the stale branch cleanly on current main (new branch, copy deliverables, fresh commit, ff push)
-- [feedback_gate_after_full_review.md](feedback_gate_after_full_review.md) — Don't run verify-gate until the full review fan-out (esp. correctness/red-team) has returned — a premature APPROVED gets overturned
-- [feedback_hitl_decision_cite_evidence.md](feedback_hitl_decision_cite_evidence.md) — When recording an author's HITL decision in a commit/doc/ticket, cite the evidence so a diff-only reviewer can verify it
-- [feedback_isolated_venv_proves_installability.md](feedback_isolated_venv_proves_installability.md) — Green tests from an env that already has a dep don't prove a package installs; test in a fresh isolated venv
-- [feedback_no_shared_env_sync_during_sibling_agent.md](feedback_no_shared_env_sync_during_sibling_agent.md) — Never uv sync the shared /data env while a sibling background agent is mid-run — it thrashes their install fingerprint
-- [feedback_pilot_one_instance_critiques_the_ticket.md](feedback_pilot_one_instance_critiques_the_ticket.md) — Before building a compute_*.py analysis from a ticket spec, pilot one instance read-only — it can falsify the ticket's design, not just preview the data
-- [feedback_pin_test_mutation_teeth.md](feedback_pin_test_mutation_teeth.md) — A regression-pin test passes on current behavior; prove its teeth by mutating the guarded mechanism, and quantify a suspected inefficiency before refining it
-- [feedback_pr_creates_ticket_no_close.md](feedback_pr_creates_ticket_no_close.md) — A PR that FILES a new follow-up ticket must use Ticket-ref / Ticket none — never **Ticket:**, which closes it on merge
-- [feedback_propagate_notes_to_tickets.md](feedback_propagate_notes_to_tickets.md) — Session notes that assign inputs to tickets (\"alimente 0137\") must be written INTO those tickets at once; Execute agents start cold from the ticket file alone
-- [feedback_ratchet_stale_after_rebuild.md](feedback_ratchet_stale_after_rebuild.md) — A green prose-ratchet suite does not mean the ceilings match the current manuscript — a base rebuild leaves them stale.
-- [feedback_reorg_tracker_first_class_guard.md](feedback_reorg_tracker_first_class_guard.md) — Multi-ticket reorg needs a tracker filed BEFORE executing, and guards must be class-level (keyed on producer phase), not per-file whitelists
-- [feedback_rule9_detector_variable_path_blindspot.md](feedback_rule9_detector_variable_path_blindspot.md) — The arch-rule-9 test misses contract reads via a path variable — its detector matches read-call and contract-filename on the SAME line only
-- [feedback_settled_debates_to_brief.md](feedback_settled_debates_to_brief.md) — A settled debate must be written into the enforced register (editorial brief) at settlement time, or it gets re-litigated
-- [feedback_stale_worktree_make.md](feedback_stale_worktree_make.md) — After merging from a worktree, the session stays bound to it; builds run stale code — run make from the main checkout
-- [feedback_verify_active_before_defer_tag.md](feedback_verify_active_before_defer_tag.md) — Before a bulk defer-tag / triage pass, fetch origin/main and verify no ticket is being actively worked by a parallel session
-- [feedback_verify_datadep_worktree_symlink.md](feedback_verify_datadep_worktree_symlink.md) — Validate a data-dependent Makefile/Phase-2 change in a worktree by symlinking the primary checkout's contract files, then building the affected targets
-- [feedback_visual_verify_citations.md](feedback_visual_verify_citations.md) — Render the PDF and eyeball it — visual verification catches citation/bib errors that grep and CI cannot
-- [project_0171_conclusion_rebuild.md](project_0171_conclusion_rebuild.md) — Œconomia R&R ticket 0171 — conclusion rebuild status and the two manuscript-writing disciplines the author enforces (falsifier-ex-ante, conclusion-introduces-no-new-facts)
-- [project_frozen_manuscript_vs_live_companions.md](project_frozen_manuscript_vs_live_companions.md) — The manuscript is a frozen submission (git-tracked pinned deliverables); the 4 companion papers are live data-derived — they are NOT symmetric for clean-room builds.
-- [project_paper_ceiling_growth_imaginary.md](project_paper_ceiling_growth_imaginary.md) — Next-paper intention — an integrated-modeling paper building the joint-production (von Neumann–Sraffa) IAM whose absence the sent Matarasso–Ha-Duong paper historicizes; plus Edmond/MeSSH 2026 infrastructure scaffold
-- [project_paper_instrument_circulation.md](project_paper_instrument_circulation.md) — Next-paper seed — direction of circulation of climate-finance instrument concepts (grey/institutional-first vs theory), spun out of closed ticket 0166
-- [project_repo_layout_decision.md](project_repo_layout_decision.md) — Repo-layout adjudication (2026-07-10) — deliverables/ ratified, src/ declined, shared harvest/index → libs/ for AEDIST
-- [project_writing_build_phase_separation.md](project_writing_build_phase_separation.md) — Writing workpackages build clean-room from git-tracked handoff artifacts; manuscript.mk is the template (0131/0163)
-- [reference_bib_fulltext_index.md](reference_bib_fulltext_index.md) — How docs/articles fulltext links to main.bib via file= fields; OA-fetch and DOI-title audit method
-- [reference_cited_works_local_docs_articles.md](reference_cited_works_local_docs_articles.md) — Project rule — every cited work's PDF must be available locally in docs/articles/ (gitignored); moved to Zotero at publication
-- [reference_paywalled_acquisition.md](reference_paywalled_acquisition.md) — How to acquire paywalled fulltext for cited works — ISTEX, BibCNRS/EZproxy, Click&Read+Anna's Archive, DOIfetch; the cited-works gate
-- [reference_repo_no_ci.md](reference_repo_no_ci.md) — climate-finance-het has no GitHub CI — erg-pr-merge's \"checks never registered\" abort is a false blocker; merge directly after mergeStateStatus CLEAN
-- [user_moa_moe_contract.md](user_moa_moe_contract.md) — Working contract — user is MOA (owner, decides what/why), Claude is MOE (orchestrates agents of appropriate complexity/effort)
+- [feedback_manuscript_number_provenance.md](feedback_manuscript_number_provenance.md) — cite only pipeline numbers that trace to an archived output; v1-pinned manuscript can drift from live-pipeline stats (the 0.68 case)
+- [feedback_read_before_cite.md](feedback_read_before_cite.md) — a reference enters the manuscript only after it is read and its core-relevance argued; no referee-checkbox padding
+- [feedback_fetch_before_sibling_merge.md](feedback_fetch_before_sibling_merge.md) — multi-PR wave on one file: fetch before each sibling merge + grep-verify the union (also in git.md)
+- [feedback_no_rebase_when_force_push_denied.md](feedback_no_rebase_when_force_push_denied.md) — force-push denied → don't rebase a pushed PR branch before merge; it strands local ahead of remote and breaks erg-pr-merge's non-idempotent close+push
+- [feedback_atomic_tickets_validation_units.md](feedback_atomic_tickets_validation_units.md) — tickets must be atomic — one MOA validation unit per ticket/PR
+- [feedback_bytecheck_old_vs_new_not_golden.md](feedback_bytecheck_old_vs_new_not_golden.md) — byte-check a behaviour-preserving refactor by running old vs new code on the SAME current data, never against a committed golden
+- [feedback_caps_force_pruning_not_compression.md](feedback_caps_force_pruning_not_compression.md) — a line/size cap forces pruning stale content — never compression to game the number
+- [feedback_cite_at_existing_locus.md](feedback_cite_at_existing_locus.md) — integrating a referee-requested citation — find the passage that already makes the point, the non-redundant locus, before adding prose
+- [feedback_cross_repo_ticket_in_owning_repo.md](feedback_cross_repo_ticket_in_owning_repo.md) — file a follow-up ticket in the repo that OWNS the target file, not the consuming project that discovered the need
+- [feedback_decide_dont_micromanage.md](feedback_decide_dont_micromanage.md) — make the coherent decision across the whole logical unit; don't hardcode, don't half-do, don't ask piecemeal
+- [feedback_followup_lets_parent_close.md](feedback_followup_lets_parent_close.md) — a follow-up ticket exists so the parent can CLOSE now; don't keep the parent open as a pseudo-tracker
+- [feedback_force_push_denied_rebuild_clean.md](feedback_force_push_denied_rebuild_clean.md) — force-push denied → rebuild the stale branch cleanly on current main (new branch, copy deliverables, fresh commit, ff push)
+- [feedback_gate_after_full_review.md](feedback_gate_after_full_review.md) — don't run verify-gate until the full review fan-out (esp. correctness/red-team) has returned
+- [feedback_hitl_decision_cite_evidence.md](feedback_hitl_decision_cite_evidence.md) — when recording an author's HITL decision, cite the evidence so a diff-only reviewer can verify it
+- [feedback_isolated_venv_proves_installability.md](feedback_isolated_venv_proves_installability.md) — green tests from an env that already has a dep don't prove a package installs; test in a fresh isolated venv
+- [feedback_no_shared_env_sync_during_sibling_agent.md](feedback_no_shared_env_sync_during_sibling_agent.md) — never uv sync the shared /data env while a sibling background agent is mid-run
+- [feedback_pilot_one_instance_critiques_the_ticket.md](feedback_pilot_one_instance_critiques_the_ticket.md) — before building a compute_*.py analysis from a ticket spec, pilot one instance read-only — it can falsify the ticket's design
+- [feedback_pin_test_mutation_teeth.md](feedback_pin_test_mutation_teeth.md) — a regression-pin test passes on current behaviour; prove its teeth by mutating the guarded mechanism
+- [feedback_pr_creates_ticket_no_close.md](feedback_pr_creates_ticket_no_close.md) — a PR that FILES a new follow-up ticket must use Ticket-ref / Ticket none — never **Ticket:**
+- [feedback_propagate_notes_to_tickets.md](feedback_propagate_notes_to_tickets.md) — session notes that assign inputs to tickets must be written INTO those tickets at once; Execute agents start cold
+- [feedback_ratchet_stale_after_rebuild.md](feedback_ratchet_stale_after_rebuild.md) — a green prose-ratchet suite doesn't mean the ceilings match the current manuscript — a base rebuild leaves them stale
+- [feedback_reorg_tracker_first_class_guard.md](feedback_reorg_tracker_first_class_guard.md) — multi-ticket reorg needs a tracker filed BEFORE executing, and guards must be class-level, not per-file whitelists
+- [feedback_rule9_detector_variable_path_blindspot.md](feedback_rule9_detector_variable_path_blindspot.md) — the arch-rule-9 test misses contract reads via a path variable (matches read-call and filename on the SAME line only)
+- [feedback_settled_debates_to_brief.md](feedback_settled_debates_to_brief.md) — a settled debate must be written into the enforced register (editorial brief) at settlement time, or it gets re-litigated
+- [feedback_stale_worktree_make.md](feedback_stale_worktree_make.md) — after merging from a worktree, the session stays bound to it; run make from the main checkout
+- [feedback_verify_active_before_defer_tag.md](feedback_verify_active_before_defer_tag.md) — before a bulk defer-tag/triage pass, fetch origin/main and verify no ticket is being actively worked
+- [feedback_agent_prompt_worktree_rooted_paths.md](feedback_agent_prompt_worktree_rooted_paths.md) — a worktree-isolated Agent prompt must use repo-relative paths, never the primary-checkout absolute path
+- [feedback_gate_execute_on_all_scopers.md](feedback_gate_execute_on_all_scopers.md) — gate a raid's execute wave on ALL scopers returning, not a quorum; the late scoper often carries the scope-narrowing finding
+- [feedback_verify_datadep_worktree_symlink.md](feedback_verify_datadep_worktree_symlink.md) — validate a data-dependent Makefile/Phase-2 change in a worktree by symlinking the primary checkout's contract files
+- [feedback_verify_makefile_pathrefactor_with_make_n.md](feedback_verify_makefile_pathrefactor_with_make_n.md) — verify a Makefile path/variable refactor with `make -n` + one runtime spot-check + grep; a full downstream build is the wrong gate
+- [feedback_visual_verify_citations.md](feedback_visual_verify_citations.md) — render the PDF and eyeball it — visual verification catches citation/bib errors grep and CI cannot
+- [feedback_ruff_fix_breaks_reexport_facades.md](feedback_ruff_fix_breaks_reexport_facades.md) — ruff --fix silently guts re-export facades; probe reach-through imports after, and per-file-ignores go stale on rename (0232)
+- [feedback_evict_to_gitignored_dir_bootstrap.md](feedback_evict_to_gitignored_dir_bootstrap.md) — moving a pipeline output to a gitignored dir removes the free dir-bootstrap; validate_io producers must os.makedirs first

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_agent_prompt_worktree_rooted_paths.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_agent_prompt_worktree_rooted_paths.md
@@ -1,0 +1,27 @@
+---
+name: feedback_agent_prompt_worktree_rooted_paths
+description: "A worktree-isolated Agent prompt must use worktree-rooted/relative paths, never the primary-checkout absolute path — else the agent edits the shared main checkout."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 4ffdf7ae-8403-47bc-87ed-e116676de228
+---
+
+When launching an `Agent(isolation:"worktree")` coder, the prompt must NOT hardcode
+the **primary-checkout absolute path** (e.g. `/home/haduong/CNRS/projets/actifs/climate-finance-het/Makefile`).
+The agent takes those paths literally and edits the **shared main checkout on main**,
+not its own worktree — the isolation guard is path-based, so an absolute primary
+path sails straight through it ([[feedback_worktree_isolation_is_path_based]]).
+
+**Why:** raid 0218 (2026-07-10). My execute prompt quoted the scoper's absolute
+primary paths. The worktree-isolated agent edited the primary checkout's `Makefile`
++ `scripts/*.py`; its own worktree stayed clean (zero commits), and a parallel
+session's `git checkout`/`reset` then wiped the leaked edits. Net: the whole
+execute attempt landed nothing, and briefly dirtied a sibling session's checkout.
+
+**How to apply:** In every Agent-coder prompt, tell it to `cd` into its worktree
+first and reference files by **repo-relative path** (`Makefile`, `scripts/x.py`) or
+by `$(git rev-parse --show-toplevel)/…`. When a scoping agent hands back
+`file:line` refs rooted at the primary path, strip the prefix to relative before
+pasting into the executor prompt. Same trap on the Bash surface (`sed -i /abs/primary/...`).
+Related: [[feedback_enterworktree_stuck_cwd]], the harness "Worktree paths" rule.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_evict_to_gitignored_dir_bootstrap.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_evict_to_gitignored_dir_bootstrap.md
@@ -1,0 +1,33 @@
+---
+name: feedback_evict_to_gitignored_dir_bootstrap
+description: Evicting a pipeline output from a git-tracked dir to a gitignored one removes the free dir-bootstrap — producers using validate_io must os.makedirs first.
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 64204d5a-1630-4c3c-951c-028469088605
+---
+
+When moving a Phase-2 output from `content/tables/` (git-tracked, always present)
+to a gitignored/regenerable dir like `data/derived/tables/` (`$(DERIVED)`), the
+destination directory is NOT guaranteed to exist on a clean tree or under `make -j`.
+
+**Why:** producers that write via `script_io_args.validate_io()` only *check* the
+output dir exists (they `raise FileNotFoundError` if absent) — they do not create
+it. `content/tables/` existed for free (tracked with deliverables), so the check
+always passed. Pre-eviction, `analyze_bimodality` even *created* `data/derived/tables`
+as a side effect because its `validate_io` target was `content/tables` and it later
+`makedirs`'d `pole_dir=DERIVED`. Move the `validate_io` target itself to `$(DERIVED)`
+and that bootstrap vanishes → "Output directory does not exist" on isolated/`-j` builds.
+
+**How to apply:** every producer whose `--output` now lands in the gitignored dir must
+`os.makedirs(os.path.dirname(io_args.output) or ".", exist_ok=True)` *before* `validate_io`
+(don't change `validate_io` — its raise-on-missing-dir is pinned by
+`test_io_discipline`). Check `import os` is present. Also: regression/test harnesses
+with a tmp-isolation path whitelist (e.g. `compute_regression_hashes.py::_redirect_args`
+matched only `content/`, `tests/`) must add the new `data/derived/` prefix, or they
+write to the real tree and the existence check fails. Verify end-to-end: `rm -r
+data/derived && make data/derived/tables/<file>` on a clean tree must succeed.
+
+Ticket 0218 (eviction of 17 residual Phase-2 `tab_*` intermediates). Related:
+[[feedback_verify_datadep_worktree_symlink]] (symlink primary's contract files to
+build data-dependent targets in a worktree).

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_gate_execute_on_all_scopers.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_gate_execute_on_all_scopers.md
@@ -1,0 +1,26 @@
+---
+name: feedback_gate_execute_on_all_scopers
+description: "Gate a raid's execute-launch on ALL scoping agents returning, not a quorum — a late scoper can surface a scope-narrowing finding that rewrites the ticket."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 4ffdf7ae-8403-47bc-87ed-e116676de228
+---
+
+In a raid, do not launch the Execute wave until **every** Phase-2/3 scoping agent
+has returned. A slow scoper is often slow *because* the ticket is the hairy one —
+exactly the plan most likely to be wrong.
+
+**Why:** raid 2026-07-10. Three of four scopers returned; I said "all four scoped"
+and launched all four executors. The fourth (0218) was still running and came back
+with a **major** finding: the ticket undercounted its class 4-5x (sub-Makefile
+`*_TABLES` dir-vars route ~70 more targets), and the naive generalized guard would
+false-positive-storm. The 0218 executor ran without that correction and produced
+nothing usable.
+
+**How to apply:** Collect the full scoper set, read every drift/antipattern/scope
+finding, THEN compose executor prompts (folding in each scoper's corrections). If
+one scoper lags, wait for it or drop its ticket from the wave — never launch its
+executor off the un-scoped ticket. Pairs with
+[[feedback_agent_prompt_worktree_rooted_paths]] (the same 0218 run's second error).
+Related: [[feedback_pilot_one_instance_critiques_the_ticket]].

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_harness_not_here.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_harness_not_here.md
@@ -1,16 +1,5 @@
----
-name: Harness consolidation plan
-description: User-level harness moving to ~/.agent/ (from ~/CNRS/code/agentic-harness). Project-level agent config consolidates in <project>/.agent/. Progressively separate user vs project.
-type: project
----
-
-Harness architecture (as of 2026-03-25):
-- **User-level**: `~/.agent/` (moving from `~/CNRS/code/agentic-harness`)
-- **Project-level**: `<project>/.agent/` (consolidating from scattered AGENTS.md, runbooks/, docs/*-guidelines.md, hooks/)
-
-Plan: (1) move agentic-harness → ~/.agent/, (2) consolidate project agent infra into .agent/, (3) progressively separate user vs project content.
-
-Offline tickets (PR #385 / branch t237-local-ticket-system) is dogfooding on its own branch.
-
-**Why:** User wants clean separation between reusable agent framework and project-specific config.
-**How to apply:** Harness work now happens both here (project .agent/) and in ~/.agent/ (user-level). Don't mix project-specific content into user-level.
+# DELETED 2026-07-10: Harness consolidation plan (~/.agent/ migration)
+# Reason: superseded — the reusable harness is now ~/.claude/ (ImperialDragonHarness);
+#   the ~/.agent/ (from ~/CNRS/code/agentic-harness) migration described here never
+#   became canonical. Not referenced by the index.
+# Original content preserved in git history.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_no_rebase_when_force_push_denied.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_no_rebase_when_force_push_denied.md
@@ -1,0 +1,31 @@
+---
+name: feedback_no_rebase_when_force_push_denied
+description: "When the session denies force-push, do NOT rebase a pushed PR branch before merge — merge as-is; the rebase strands local ahead of remote and breaks erg-pr-merge's non-idempotent close+push"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 12e5b0a9-df08-49c1-a87a-fbee972ce165
+---
+
+git.md says "rebase at every gate," but that assumes force-push is available.
+When the session **denies `git push --force-with-lease`** (a common guard in
+this harness), do NOT rebase a branch whose PR is already pushed and mergeable.
+
+**Why:** rebasing rewrites the branch's commit SHAs, so local diverges from
+`origin/<branch>`. You then can't force-push the rewrite. Worse, `erg-pr-merge`
+next runs its non-idempotent step — `erg close` commits the ticket archive on
+top of your *local* (rewritten) branch and tries a plain `git push`, which is
+rejected non-fast-forward. Now the ticket is closed+archived locally but the
+close commit is not on the remote, and re-running `erg-pr-merge` fails
+("no ticket found"). Recovery: `git checkout <origin-branch-tip>` (detached),
+`git cherry-pick <close-commit>`, ff-push, then `gh pr merge --merge` directly
+(raid 234/235, 2026-07-10, PR #998).
+
+**How to apply:** the rebase's only benefit is currency, which verify-gate
+reports as a non-blocking *nit*. If `mergeStateStatus` is CLEAN and the base is
+conflict-free (parallel work landed in different files), skip the rebase and let
+`erg-pr-merge` / the GitHub API merge as-is with a merge commit. Only when the
+bases genuinely conflict do you need to integrate — and then `git merge
+origin/main` into the branch (not rebase), which keeps local == remote after a
+normal push. See [[feedback_force_push_denied_rebuild_clean]] and
+[[feedback_fetch_before_sibling_merge]].

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_prclose_onbranch_ticket_none.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_prclose_onbranch_ticket_none.md
@@ -1,0 +1,32 @@
+---
+name: feedback_prclose_onbranch_ticket_none
+description: "If you close+archive a ticket on-branch (hunt already-done path), the PR body must say `Ticket: none`, not `**Ticket:** tickets/closed/NNNN` — erg-pr-merge rejects the archived path and would double-close"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 3f035edb-1270-4e9c-b00d-7d4c1c76882f
+---
+
+When a ticket is closed AND archived on the branch *before* the PR merges (the
+hunt already-done flow, or any pre-merge close per [[feedback_erg_close_archive]]),
+the ticket file has already moved to `tickets/closed/NNNN-...`. Two things then
+break the normal `**Ticket:** tickets/NNNN` close-claim convention:
+
+1. **Regex mismatch.** `erg-pr-merge` parses close claims with
+   `^\*{0,2}ticket:?\*{0,2}:?\s*tickets/\K\d+` — it expects digits *immediately*
+   after `tickets/`. A `tickets/closed/0236-...` path does not match, so the
+   script reports "no close-claim in PR body" and aborts (`set -e`).
+2. **Double-close trap.** Even if the regex matched, `erg-pr-merge` would run
+   `erg close` again on an already-archived ticket → "no ticket found" (the
+   non-idempotent trap from `rules/git.md`).
+
+**How to apply:** if the branch already carries the close+archive commit, put
+`Ticket: none` in the PR body (with a prose note that ticket NNNN is closed
+in-branch, commit SHA). Do NOT use `**Ticket:** tickets/closed/...`. Cost of
+getting it wrong: burned two merge retries on PR #1000 (2026-07-10) — first the
+draft state, then this close-claim mismatch.
+
+**Alternative (cleaner for next time):** leave the ticket *open* on-branch and
+let `erg-pr-merge` close+archive it at merge via a normal `**Ticket:**
+tickets/NNNN` line — the tool is built to do exactly that. Pre-closing on-branch
+only makes sense for the hunt already-done path where no PR-side close is wanted.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ruff_fix_breaks_reexport_facades.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ruff_fix_breaks_reexport_facades.md
@@ -1,0 +1,42 @@
+---
+name: feedback_ruff_fix_breaks_reexport_facades
+description: "ruff --fix silently guts re-export facades; verify with a reach-through import probe, and per-file-ignores go stale on rename"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 09065d34-1e60-425f-ac1f-6118c4153d3e
+---
+
+A repo-wide `ruff check . --fix` (ticket 0232) silently removed F401 "unused"
+imports from **re-export facade** modules — modules whose imports exist only so
+tests/scripts can do `from <facade> import <symbol>` for a symbol defined
+elsewhere. `--fix` broke `catalog_openalex` (`fetch_query`, `build_filter`),
+`catalog_syllabi` (whole `syllabi_*` blocks), and `compute_clustering_comparison`
+(`build_tfidf_space`, `build_citation_space`). check-fast caught it as
+ImportError, but only because those tests happened to run.
+
+**Root cause of the silent breakage:** the project's `per-file-ignores` facade
+exemptions had gone **stale after two script renames** — `collect_syllabi.py` →
+`catalog_syllabi.py` and `compare_clustering.py` →
+`compute_clustering_comparison.py`. The ignore still named the pre-rename file,
+so the facade lost its F401 shield without anyone noticing until `--fix` ran.
+
+**Why:** F401 cannot tell "unused" from "re-exported public surface." The only
+signals are `__all__`, a `# noqa: F401`, or a `per-file-ignores` entry — and the
+last silently detaches when the file is renamed.
+
+**How to apply:**
+- After ANY repo-wide `ruff --fix`, run a reach-through probe before trusting it:
+  parse every `from <scripts_module> import X` in `tests/`, `importlib` the
+  module, assert `hasattr(mod, X)`. Catches facade breakage the fast tier misses
+  if the consuming test isn't run. (Probe script pattern worked in 0232.)
+- When renaming a script that appears in `[tool.ruff.lint.per-file-ignores]`
+  (or any config filename list), grep the config for the old basename in the
+  same commit — the ignore does not follow the rename.
+- Restore a broken facade by reverting the file to the pre-fix version and
+  fixing the `per-file-ignores` name, OR restore just the consumed symbols with
+  a per-line `# noqa: F401 -- re-exported`.
+
+Related: [[feedback_grep_before_commit]], [[project_repo_layout_decision]].
+The 0230 ruff adherence guard (still open, unblocked by 0232) will pin the
+clean state so this can't silently regress.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_verify_makefile_pathrefactor_with_make_n.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_verify_makefile_pathrefactor_with_make_n.md
@@ -1,0 +1,39 @@
+---
+name: feedback_verify_makefile_pathrefactor_with_make_n
+description: "Verify a data-dependent Makefile path/variable refactor with `make -n` + one runtime target spot-check + grep — never a full downstream build, which needs the corpus and can fail on unrelated phase entanglement."
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 4ffdf7ae-8403-47bc-87ed-e116676de228
+---
+
+For a Makefile refactor that only moves **where** outputs are written (a
+directory-variable flip like `DIV_TABLES := content/tables` → `$(DERIVED)`,
+ticket 0231), the correct verifier is:
+
+1. **`make -n <every affected target>`** — executes nothing, but performs Make's
+   real variable expansion, so it proves producer `--output` AND consumer
+   `--input` both resolve to the new location and that zero old-location paths
+   survive in any recipe. This is the load-bearing proof. Symlink the primary
+   checkout's contract files into the worktree first so `-n` gets past
+   prerequisite checks ([[feedback_verify_datadep_worktree_symlink]]).
+2. **One runtime spot-check** — build a single cheap target and confirm the file
+   lands at the new path (0231: `venue-concentration-table` wrote to
+   `data/derived/`). The other subsystems use the identical `--output $@`/`$(VAR)`
+   mechanism, so one is enough; skip the heavy compute.
+3. **grep** for hardcoded old-location paths in the scripts (the fallback defaults
+   `make -n` can't see because Make always passes explicit args).
+
+**Why:** 0231 session (2026-07-10). The ticket's stated gate was a full
+`make papers`. It was the WRONG gate: it needs the 322 MB corpus, is slow, and it
+died twice on things unrelated to the refactor (a missing Phase-1 `citations.csv`,
+then `import umap` in a Phase-2 clustering step) — a full writing/render build
+drags in the whole analysis, so its failures rarely implicate your path change.
+`make -n` + the venue spot-check + grep confirmed 0231 in seconds; the full build
+confirmed nothing about the flip before failing on an env gap.
+
+**How to apply:** don't accept "run `make <big-target>`" as the confirmation for a
+path/variable refactor. Prove the graph with `make -n`, spot-check one target at
+runtime, grep the scripts. Reserve the full build for changes that alter analysis
+*content*, not artifact *location*. (The phase-entanglement those build failures
+exposed — `make papers` is not Phase-3 — is ticket 0237.)

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_offpeak_promotion.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_offpeak_promotion.md
@@ -1,3 +1,0 @@
-# DELETED 2026-06-23: Claude off-peak usage promotion
-# Reason: time-bound to March 13–28 2026 (expired); keeping it implies an active promo.
-# Original content preserved in git history.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_repo_relocated_het.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_repo_relocated_het.md
@@ -1,5 +1,0 @@
-# DELETED 2026-06-23: Repo relocated to climate-finance-het
-# Reason: superseded by project_reorg_0159_relocation. This entry's "GitHub remote
-#   still Oeconomia-Climate-finance.git" is outdated — the repo is now
-#   MinhHaDuong/climate-finance-het (confirmed by 2026-06-23 PR URLs).
-# Original content preserved in git history.


### PR DESCRIPTION
## What

Lands a memory consolidation for the `climate-finance-het` project that was left uncommitted on the primary checkout (stranded WIP from an earlier session).

- **Index rewrite** — `MEMORY.md` regrouped from free-form sections into structured groups (project facts / user & workflow / machines, data & tools / papers & submission / harness & telemetry).
- **7 orphaned entries adopted** — new `feedback_*` files the index already linked but that were never git-tracked (the IDH gitignore-whitelist trap: files under `projects/` need `git add -f`). Committing without them would ship an index pointing at absent files.
- **1 stale entry tombstoned** — `feedback_harness_not_here` (a `~/.agent/` migration plan superseded by the current `~/.claude/` harness), tombstoned rather than hard-deleted.
- **2 spent tombstones removed** — `project_offpeak_promotion`, `project_repo_relocated_het` (already `# DELETED 2026-06-23`; originals in git history).

## Why

Uncommitted WIP on the primary `main` blocks that project's beat cycles (dirty-tree gate) and risks losing the 7 untracked entries if the tree is cleaned. Verified self-consistent: every index link resolves, no orphans, all 7 new entries have valid frontmatter.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)