### PR TITLE
memory: rtk push-no-op variant + erg-pr-merge auto-readies drafts (#463)

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_draft_pr_blocks_merge.md
+++ b/projects/-home-haduong--claude/memory/feedback_draft_pr_blocks_merge.md
@@ -9,10 +9,17 @@ A GitHub PR left in **draft** state cannot be merged, and each merge path fails
 differently and unhelpfully:
 - `gh pr merge --auto` → `GraphQL: Pull request is a draft (enablePullRequestAutoMerge)`
 - `gh pr merge --merge` → `GraphQL: Pull Request is still a draft (mergePullRequest)`
-- `erg-pr-merge` runs its ticket close+archive+push **first**, then bounces on
-  the draft state — leaving the ticket closed and archived locally but the PR
-  unmerged. This is the non-idempotency trap: re-running fails `close: no ticket
-  found`, so finish with `gh pr merge --merge` directly after `gh pr ready`.
+- `erg-pr-merge` (installed copies **before PR #463**) runs its ticket
+  close+archive+push **first**, then bounces on the draft state — leaving the
+  ticket closed and archived locally but the PR unmerged. This is the
+  non-idempotency trap: re-running fails `close: no ticket found`, so finish
+  with `gh pr merge --merge` directly after `gh pr ready`.
+
+**Update (PR #463, 2026-07-10):** `erg-pr-merge` now auto-readies a draft
+(`gh pr ready`) *before* the close step, so the trap above no longer fires
+through that path — once the primary `~/.claude` checkout has pulled #463. The
+manual `gh pr ready` is still needed for a direct `gh pr merge`, and for any
+installed copy that predates #463.
 
 **Why:** other sessions open PRs as drafts; the state is invisible unless you
 query `isDraft`, and the merge error names GraphQL, not the draft, so it reads

--- a/projects/-home-haduong--claude/memory/feedback_rtk_rewrites_git_output.md
+++ b/projects/-home-haduong--claude/memory/feedback_rtk_rewrites_git_output.md
@@ -12,10 +12,19 @@ form. This silently corrupts any downstream parse: `comm` on two
 `git diff --name-only | sort` lists aborts with "l'entrée n'est pas dans l'ordre
 trié", and `--porcelain` greps miss the real field prefixes.
 
-**Why:** the rewrite is invisible until a parser chokes on the injected text —
-you lose time blaming the pipeline, not the wrapper.
+Worse than a parse glitch: a wrapped **mutation can silently no-op**. A
+`git push --force-with-lease` once printed a mangled line ending in `ok` yet
+did not push — local and `origin/<branch>` stayed diverged, and CI kept
+grading the old commit (2026-07-10). The "ok" is not proof the push happened.
 
-**How to apply:** when you need raw, machine-parseable git output, bypass the
-hook with `rtk proxy git <subcommand> ...`. Reserve plain `git` for output you
-read yourself. Bit repeatedly during the 2026-07-10 eight-PR merge session
-(file-overlap `comm`, porcelain worktree parse). Related: [[feedback_gh_pr_edit_broken_use_rest]].
+**Why:** the rewrite is invisible until a parser chokes on the injected text —
+you lose time blaming the pipeline, not the wrapper — and a garbled mutation
+looks like success.
+
+**How to apply:** when you need raw, machine-parseable git output OR a
+mutation whose success you must trust, bypass the hook with
+`rtk proxy git <subcommand> ...`. After any push, verify
+`git rev-parse HEAD` == `git rev-parse origin/<branch>` before trusting it.
+Reserve plain `git` for output you read yourself. Bit repeatedly during the
+2026-07-10 merge sessions (file-overlap `comm`, porcelain worktree parse,
+force-push no-op). Related: [[feedback_gh_pr_edit_broken_use_rest]].


### PR DESCRIPTION
## What

Two accuracy updates to harness memory from the 2026-07-10 merge sessions:

- **`feedback_rtk_rewrites_git_output`** — adds the dangerous variant: a wrapped `git push` can print `ok` yet not push (local stayed diverged from origin, CI graded the old commit). Verify `HEAD == origin/<branch>` after a push; use `rtk proxy` for trusted mutations.
- **`feedback_draft_pr_blocks_merge`** — notes that `erg-pr-merge` now auto-readies drafts as of PR #463, so the draft-bounce trap no longer fires through it once the primary checkout pulls #463; the manual `gh pr ready` is still needed for direct `gh pr merge` and pre-#463 copies.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)