### PR TITLE
ticket(0273): agnostic-guard honors marker on multi-line command continuation

### DIFF
--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Detect consumer-project assumptions in harness skills and tickets.
 # Usage: check-agnostic.sh [dir ...]   (default: skills tickets)
-# Escape hatch: add  <!-- harness-extension-point -->  on the same or preceding line.
+# Escape hatch: add  <!-- harness-extension-point -->  on the same or preceding line,
+# or (for a `\`-continued multi-line command) on any of its continuation lines.
 # `closed/` subdirs are skipped — closed tickets are frozen archives, not amended.
 set -euo pipefail
 
@@ -46,6 +47,25 @@ check_pattern() {
         fi
         if echo "$line $prev" | grep -q 'harness-extension-point'; then
             continue
+        fi
+        # Multi-line command: if the flagged line ends in a `\` continuation,
+        # scan forward across the continued lines. A marker anywhere in the same
+        # logical command (its natural home is the closing continuation line)
+        # exempts the whole command.
+        if printf '%s' "$line" | grep -q '\\[[:space:]]*$'; then
+            scan=$lineno
+            marked=0
+            while :; do
+                scan=$((scan + 1))
+                cont=$(sed -n "${scan}p" "$file")
+                [ -z "$cont" ] && [ "$scan" -gt "$lineno" ] && break
+                if echo "$cont" | grep -q 'harness-extension-point'; then
+                    marked=1
+                    break
+                fi
+                printf '%s' "$cont" | grep -q '\\[[:space:]]*$' || break
+            done
+            [ "$marked" -eq 1 ] && continue
         fi
         echo "VIOLATION [$pattern]: $file:$lineno: $line"
         fail=1

--- a/tests/test_check_agnostic.py
+++ b/tests/test_check_agnostic.py
@@ -123,3 +123,44 @@ def test_catches_mixed_case_and_underscore_script_names(tmp_path):
     assert result.returncode != 0, result.stdout
     assert "VIOLATION" in result.stdout
     assert "scripts/Build_Step2.py" in result.stdout
+
+
+# --- Multi-line command continuation markers (ticket 0273) ---
+#
+# The marker's natural home on a multi-line command is the closing continuation
+# line, not the line carrying the flagged token. A marker anywhere in the same
+# logical command (across `\`-continued lines) must exempt the whole command.
+
+MARKED_MULTILINE = (
+    "# Example skill\n\n"
+    "```bash\n"
+    's=$(gh pr view "$PR" --json state \\\n'
+    "    --jq '.state' \\\n"
+    "    2>/dev/null) || return 1  # harness-extension-point\n"
+    "```\n"
+)
+UNMARKED_MULTILINE = (
+    "# Example skill\n\n"
+    "```bash\n"
+    's=$(gh pr view "$PR" --json state \\\n'
+    "    --jq '.state' \\\n"
+    "    2>/dev/null) || return 1\n"
+    "```\n"
+)
+
+
+def test_marker_on_continuation_line_exempts_command(tmp_path):
+    """A marker on the command's closing continuation line exempts the whole command."""
+    d = _skill_dir(tmp_path)
+    (d / "SKILL.md").write_text(MARKED_MULTILINE)
+    result = _run(d)
+    assert result.returncode == 0, result.stdout
+
+
+def test_unmarked_multiline_command_still_flagged(tmp_path):
+    """No marker anywhere in the command → still a violation (no over-exemption)."""
+    d = _skill_dir(tmp_path)
+    (d / "SKILL.md").write_text(UNMARKED_MULTILINE)
+    result = _run(d)
+    assert result.returncode != 0, result.stdout
+    assert "VIOLATION" in result.stdout

--- a/tickets/closed/0273-agnostic-guard-misses-harness-extension.erg
+++ b/tickets/closed/0273-agnostic-guard-misses-harness-extension.erg
@@ -2,10 +2,12 @@
 Title: agnostic-guard misses harness-extension-point marker on multi-line command continuation
 Created: 2026-07-10
 Author: minh
+Closed: fixed
 
 --- log ---
 2026-07-10T16:13Z minh created
 
+2026-07-10T16:24Z Minh Ha-Duong closed — fixed
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`scripts/check-agnostic.sh` exempted a flagged line only when the `harness-extension-point` marker sat on that line or its immediate predecessor. On a `\`-continued multi-line command the natural home for the marker is the closing continuation line, so the guard flagged the first line even though the command was clearly marked. It bounced CI twice in one session (PRs #463, #465 on `skills/merge/erg-pr-merge`).

Fix: when the flagged line ends in a `\` continuation, scan forward across the continued lines and exempt the whole command if any line carries the marker. The single-line same/preceding-line check is unchanged, so genuinely unmarked multi-line commands still fail (no over-exemption).

## Test

- `test_marker_on_continuation_line_exempts_command` — marker on the closing continuation line exempts the command (was RED).
- `test_unmarked_multiline_command_still_flagged` — no marker anywhere → still a violation.
- Existing single-line and script-path behavior unchanged.

## Verification

- [x] Marker on a continuation line exempts the whole command
- [x] Unmarked multi-line command still fails
- [x] `bash scripts/check-agnostic.sh` clean on the whole repo
- [x] `make check` green
- [x] `/verify-adherence` PASS (mechanical phase clean — /gaze may skip it)

**Ticket:** tickets/0273-agnostic-guard-misses-harness-extension.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)