### PR TITLE
memory: IDH CI lacks erg-github verify — leave tickets open in hunt

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_dont_pre_close_ticket_in_execution.md
+++ b/projects/-home-haduong--claude/memory/feedback_dont_pre_close_ticket_in_execution.md
@@ -23,4 +23,15 @@ the *work* only, leave the ticket file untouched in `tickets/`. Let the merge do
 the close. This is the preventive form of the git.md merge-bounce recovery note
 ("close: no ticket found on a retry" → finish with `gh pr merge --merge`) — same
 resolution, but don't create the condition in the first place. (Bit on IDH 0269,
-2026-07-10.) See [[feedback_erg_pr_merge_needs_close_claim]].
+2026-07-10; recurred same day on 0273 via the hunt flow.) See
+[[feedback_erg_pr_merge_needs_close_claim]].
+
+**The AGENTS.md trap:** `tickets/AGENTS.md` says "`tickets/erg-github` adds a
+verify check that fails a PR referencing a still-open ticket -- so close the
+ticket in the same PR (`erg close`)." That is what makes pre-closing feel
+mandatory. But **IDH's CI does not wire in `erg-github verify`** — `.github/
+workflows/CI.yml` runs only `erg check tickets/` (format validation, passes on
+an open ticket) and `check-agnostic.sh`. So the erg-github verify gate is absent
+here: an open ticket passes CI fine, and pre-closing only breaks `erg-pr-merge`.
+The "close in same PR" guidance applies to a repo that actually has that verify
+check active; IDH is not one. Leave the ticket open.


### PR DESCRIPTION
## Summary

While wrapping up ticket 0273 I repeated the pre-close mistake that memory `feedback_dont_pre_close_ticket_in_execution` (filed same day for 0269) already warns against: closing + archiving the ticket in the execution branch, which no-ops `erg-pr-merge`'s close step and forces a manual `gh pr merge`.

Root cause of the recurrence: `tickets/AGENTS.md` says to "close the ticket in the same PR (`erg close`)" because `tickets/erg-github` adds a verify check that fails a PR referencing an open ticket. But **IDH's CI does not wire in that check** — `.github/workflows/CI.yml` runs only `erg check tickets/` (format validation, which passes on an open ticket) and `check-agnostic.sh`. So pre-closing is never required here and only breaks the merge script.

This PR adds a clarifying paragraph to the memory so the next hunt leaves the ticket open.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)