### PR TITLE
rules: refactor validation gate + Make target-equals-output

### DIFF
--- a/rules/coding-python.md
+++ b/rules/coding-python.md
@@ -74,6 +74,7 @@ Two patterns keep the fast tier honest — generalizable, adopt per project (ref
 ## Build (Make)
 
 - **One output per rule.** Each target should produce a known file so timestamps work.
+- **The target must be the exact path the recipe writes.** `make` checks the recipe's *exit code*, not whether the file appeared — so a tool that writes elsewhere leaves the rule "succeeding" (exit 0) with `$@` absent, silently breaking every downstream consumer and forcing an eternal rebuild. The trap bites when a tool ignores the output path you configured: Quarto's single-file `quarto render <f>.qmd` ignores the project `output-dir` and writes *next to the source*. Name the target where the tool actually writes, or `mv … $@` in the recipe (climate-finance-het deliverables/ reorg, 2026-07-10 — a Makefile-text test can't catch this; only a real build does).
 - **Sentinel stamps for dynamic outputs.** Use a stamp file when a script produces data-dependent filenames.
 - **No `.PHONY` for real work.** Use `.PHONY` only for aliases.
 - **No hand-curated data in the pipeline.** Every CSV/tex file referenced by slides or report must have a Makefile target that generates it from `measurements.jsonl` or another tracked source.

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -68,6 +68,29 @@ for input Z; cause not yet established," not a verdict dressed as a finding.
 feature — intact binary, deterministic, reproduced by the stdlib — was
 misdiagnosed as a "broken toolchain" and nearly got a spurious reinstall ticket.)
 
+# Refactor validation — byte-compare the artifact, not just green tests
+
+A **pure refactor** — a build/layout/rename change that must not alter output
+(moving files, re-cutting a Makefile, renaming a symbol) — is validated by
+producing the artifact **before and after on the same inputs and byte-comparing
+the content**, not by a green test suite. Tests pass on a refactor that silently
+changed or *misplaced* the output; a byte-identical old-vs-new render is the
+proof they can't give. This is the [git.md](./git.md) byte-check discipline (old
+code vs new code on the *same current data*, never against a committed golden)
+applied to build outputs.
+
+- Determinism first: set `SOURCE_DATE_EPOCH` (most toolchains honour it) so a
+  timestamp doesn't masquerade as a content diff. If the format still embeds a
+  path or build dir, compare *content* (`pdftotext`/`pdfimages` hash, extracted
+  text) with a raw byte `cmp` as the strict check — and explain any residual diff
+  (metadata-only vs content) rather than waving it away.
+- Don't over-apply "let the user run the long build" (a *preference*) into "I
+  can't validate this." A clean-room render is often seconds, and the byte-compare
+  is exactly what catches the defect a green suite misses (climate-finance-het
+  deliverables/ reorg, 2026-07-10: 932 tests green, yet the render wrote to the
+  wrong path and a Quarto `output-dir` was dead config — both invisible until the
+  old-vs-new render).
+
 # When to Ask the Author
 
 - You're stuck after three different approaches (including expert fan-out).


### PR DESCRIPTION
Two rule additions distilled from the climate-finance-het deliverables/ reorg (raid 237, 2026-07-10), where **932 green tests missed two build defects** that an old-vs-new byte-compare caught.

**`workflow.md` § Refactor validation** (new section, always-scope): a pure build/layout/rename refactor is validated by rendering the artifact old-vs-new on the same inputs and **byte-comparing content**, not by a green suite. Determinism via `SOURCE_DATE_EPOCH`; content-hash (`pdftotext`) when metadata embeds paths. Explicitly corrects over-applying the "let the user run long builds" preference into "I can't validate."

**`coding-python.md` § Build (Make)** (new bullet): a rule's target must equal the exact path its recipe writes — `make` checks the recipe's exit code, not file existence, so a tool that writes elsewhere (Quarto single-file render ignoring the project `output-dir`) "succeeds" with `$@` absent. Name the target where the tool writes, or `mv … $@`.

Both cite the 2026-07-10 case as dated evidence, per the rules' house style. Draft for your review.

Ticket: none