### PR TITLE
dream: consolidate climate-finance-het memory (72→74)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -1753,6 +1753,846 @@
       "first_seen": "2026-07-07T15:06:50Z",
       "last_confirmed": "2026-07-07T15:06:50Z",
       "promoted": false
+    },
+    "feedback_a4_paper": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:24Z",
+      "last_confirmed": "2026-07-10T21:05:24Z",
+      "promoted": false
+    },
+    "feedback_agent_prompt_worktree_rooted_paths": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:24Z",
+      "last_confirmed": "2026-07-10T21:05:24Z",
+      "promoted": false
+    },
+    "feedback_atomic_tickets_validation_units": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:24Z",
+      "last_confirmed": "2026-07-10T21:05:24Z",
+      "promoted": false
+    },
+    "feedback_branch_before_edit": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:24Z",
+      "last_confirmed": "2026-07-10T21:05:24Z",
+      "promoted": false
+    },
+    "feedback_bytecheck_old_vs_new_not_golden": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:24Z",
+      "last_confirmed": "2026-07-10T21:05:24Z",
+      "promoted": false
+    },
+    "feedback_caps_force_pruning_not_compression": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:24Z",
+      "last_confirmed": "2026-07-10T21:05:24Z",
+      "promoted": false
+    },
+    "feedback_cite_at_existing_locus": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_cross_repo_ticket_in_owning_repo": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_data_direction": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_decide_dont_micromanage": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_dropna_before_merge": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_enterworktree_stuck_cwd": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_erg_close_archive": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_evict_to_gitignored_dir_bootstrap": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_fetch_before_sibling_merge": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_file_decisions_with_submission": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_followup_lets_parent_close": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_force_push_denied_rebuild_clean": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_gate_after_full_review": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_gate_execute_on_all_scopers": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:25Z",
+      "last_confirmed": "2026-07-10T21:05:25Z",
+      "promoted": false
+    },
+    "feedback_grep_before_commit": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_het_register": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_hitl_decision_cite_evidence": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_inspect_ref_readonly": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_isolated_venv_proves_installability": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_letter_voice_flags": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_make_corpus": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_manuscript_number_provenance": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_no_amend_pr": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_no_apc": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_no_heavy_deps": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_no_long_running": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_no_md_in_md": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:26Z",
+      "last_confirmed": "2026-07-10T21:05:26Z",
+      "promoted": false
+    },
+    "feedback_no_noverify": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_no_rebase_dvc": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_no_rebase_when_force_push_denied": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_no_shared_env_sync_during_sibling_agent": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_no_tool_for_single_use": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_overnight_exploration": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_oversell_breaks": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_parallel_work": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_phase_separation": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_pilot_one_instance_critiques_the_ticket": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_pin_test_mutation_teeth": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_prclose_onbranch_ticket_none": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_pr_creates_ticket_no_close": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_propagate_notes_to_tickets": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:27Z",
+      "last_confirmed": "2026-07-10T21:05:27Z",
+      "promoted": false
+    },
+    "feedback_quarto_var_vs_meta": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_ratchet_stale_after_rebuild": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_read_before_cite": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_render_bitcompare_is_the_gate": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_reorg_tracker_first_class_guard": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_review_agent_worktree": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_ruff_fix_breaks_reexport_facades": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_rule9_detector_variable_path_blindspot": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_settled_debates_to_brief": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_simplest_fix": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_ssh_padme": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_stale_worktree_make": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_tectonic_next": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:28Z",
+      "last_confirmed": "2026-07-10T21:05:28Z",
+      "promoted": false
+    },
+    "feedback_verify_active_before_defer_tag": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_verify_ai_generated_includes": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_verify_before_advising": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_verify_datadep_worktree_symlink": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_verify_deferral_tracker": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_verify_makefile_pathrefactor_with_make_n": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_version_increment_planning": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_visual_verify_citations": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_weekend_boundary": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_worktree_local_hook_commit": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_worktree_search": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "feedback_yaml_quoting": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "project_0171_conclusion_rebuild": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "project_deliverables_render_next_to_source": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:29Z",
+      "last_confirmed": "2026-07-10T21:05:29Z",
+      "promoted": false
+    },
+    "project_doifetch_sync": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_dvc_integration": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_frozen_manuscript_vs_live_companions": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_gide_conference": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_imperial_dragon": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_journal_strategy": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_oeconomia_rr_pipeline": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_ollama_experiment": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_paper_ceiling_growth_imaginary": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_paper_instrument_circulation": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_reorg_0159_relocation": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_repo_layout_decision": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_rr_traceability_ledger": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_techrep_rewrite": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:30Z",
+      "last_confirmed": "2026-07-10T21:05:30Z",
+      "promoted": false
+    },
+    "project_techrep_split": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "project_uv_path_fix": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "project_worktree_env_data": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "project_writing_build_phase_separation": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_agentic_harness": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_agent_identity": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_bib_fulltext_index": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_cited_works_local_docs_articles": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_paywalled_acquisition": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_publist": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_rdj4hss": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_repo_no_ci": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_stats_cache": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:31Z",
+      "last_confirmed": "2026-07-10T21:05:31Z",
+      "promoted": false
+    },
+    "reference_trackchange_review_workflow": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:32Z",
+      "last_confirmed": "2026-07-10T21:05:32Z",
+      "promoted": false
+    },
+    "user_cnrs_section41": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:32Z",
+      "last_confirmed": "2026-07-10T21:05:32Z",
+      "promoted": false
+    },
+    "user_moa_moe_contract": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:32Z",
+      "last_confirmed": "2026-07-10T21:05:32Z",
+      "promoted": false
+    },
+    "user_orcid": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-10T21:05:32Z",
+      "last_confirmed": "2026-07-10T21:05:32Z",
+      "promoted": false
     }
   }
 }

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
@@ -30,7 +30,7 @@
 
 ## Papers & submission
 - Œconomia R&R: [project_oeconomia_rr_pipeline.md](project_oeconomia_rr_pipeline.md) (version ladder), [project_rr_traceability_ledger.md](project_rr_traceability_ledger.md) (60-remark ledger + HITL sign-off), [project_0171_conclusion_rebuild.md](project_0171_conclusion_rebuild.md), [feedback_version_increment_planning.md](feedback_version_increment_planning.md).
-- Reports & build: [project_techrep_rewrite.md](project_techrep_rewrite.md), [project_techrep_split.md](project_techrep_split.md), [project_writing_build_phase_separation.md](project_writing_build_phase_separation.md), [project_frozen_manuscript_vs_live_companions.md](project_frozen_manuscript_vs_live_companions.md), [project_repo_layout_decision.md](project_repo_layout_decision.md).
+- Reports & build: [project_techrep_rewrite.md](project_techrep_rewrite.md), [project_techrep_split.md](project_techrep_split.md), [project_writing_build_phase_separation.md](project_writing_build_phase_separation.md), [project_frozen_manuscript_vs_live_companions.md](project_frozen_manuscript_vs_live_companions.md), [project_repo_layout_decision.md](project_repo_layout_decision.md), [project_deliverables_render_next_to_source.md](project_deliverables_render_next_to_source.md) (raid 237 — deliverables/ landed, output/ retired).
 - Next papers: [project_paper_ceiling_growth_imaginary.md](project_paper_ceiling_growth_imaginary.md), [project_paper_instrument_circulation.md](project_paper_instrument_circulation.md).
 - Journals: [project_journal_strategy.md](project_journal_strategy.md), [reference_rdj4hss.md](reference_rdj4hss.md), [project_gide_conference.md](project_gide_conference.md).
 - Biblio & cited-works gate: [reference_bib_fulltext_index.md](reference_bib_fulltext_index.md), [reference_cited_works_local_docs_articles.md](reference_cited_works_local_docs_articles.md), [reference_paywalled_acquisition.md](reference_paywalled_acquisition.md), [reference_publist.md](reference_publist.md).
@@ -46,6 +46,7 @@
 - [feedback_het_register.md](feedback_het_register.md) — manuscript prose = HET academic register, not American motivational/business-book cadence
 - [feedback_yaml_quoting.md](feedback_yaml_quoting.md) — use `'"phrase"'` not `"phrase"` in corpus_collect.yaml for phrase search queries
 - [feedback_no_long_running.md](feedback_no_long_running.md) — don't launch long-running tasks (make, rendering); let user run in their terminal
+- [feedback_render_bitcompare_is_the_gate.md](feedback_render_bitcompare_is_the_gate.md) — for a pure build/layout refactor, render old-vs-new + byte-compare content is THE validation gate (clean-room manuscript is ~12s, SOURCE_DATE_EPOCH=0); don't over-apply no-long-running to skip it
 - [feedback_phase_separation.md](feedback_phase_separation.md) — make manuscript must never trigger Phase 1 scripts or API calls
 - [feedback_data_direction.md](feedback_data_direction.md) — data flows padme→doudou only; never push data from doudou to padme
 - [feedback_no_heavy_deps.md](feedback_no_heavy_deps.md) — don't add heavy deps (jupyter) when a simple approach (YAML, hardcode) works
@@ -54,17 +55,18 @@
 - [feedback_no_apc.md](feedback_no_apc.md) — APCs are scams; choose diamond OA venues (integrity, excellence, care)
 - [feedback_parallel_work.md](feedback_parallel_work.md) — user works in VSCode terminal in parallel; check filesystem before asserting something hasn't been done
 - [feedback_no_amend_pr.md](feedback_no_amend_pr.md) — don't amend commits on open PRs; force push makes GitHub diffs confusing
+- [feedback_verify_ai_generated_includes.md](feedback_verify_ai_generated_includes.md) — never cite from an AI-generated-not-human-reviewed include without verifying (phantom ref caught in §11)
+- [feedback_letter_voice_flags.md](feedback_letter_voice_flags.md) — align prose on style-anchor-v205 BEFORE showing it (A-not-B cadence, -ly stacks, jargon); letters in 1st person singular
+- [feedback_a4_paper.md](feedback_a4_paper.md) — always A4 paper format for generated PDFs, never US letter
 - [feedback_no_md_in_md.md](feedback_no_md_in_md.md) — never put markdown (## headings) inside fenced blocks; extract to a real file
 - [feedback_worktree_search.md](feedback_worktree_search.md) — scan parent dirs and /tmp for stale worktree directories, not just `git worktree list`
 - [feedback_no_noverify.md](feedback_no_noverify.md) — never bypass pre-commit hooks with --no-verify; always branch first
 - [feedback_worktree_local_hook_commit.md](feedback_worktree_local_hook_commit.md) — commit a branch's own hook fix via `git -c core.hooksPath=<worktree>/hooks` when hooksPath is absolute
 - [feedback_branch_before_edit.md](feedback_branch_before_edit.md) — always checkout target branch before editing files; never edit on main then move
-- [feedback_onstart_trigger.md](feedback_onstart_trigger.md) — on-start runbook must execute automatically before first response, not wait to be asked
 - [feedback_make_corpus.md](feedback_make_corpus.md) — never suggest bare `dvc repro`; always use `make corpus` (padme) or `make corpus-sync` (doudou)
 - [feedback_no_rebase_dvc.md](feedback_no_rebase_dvc.md) — never rebase when DVC symlinks are dirty; use merge + stash/pop
 - [feedback_simplest_fix.md](feedback_simplest_fix.md) — don't add hooks/exceptions; restructure the operation to work within existing rules (ff merge vs --no-ff)
-- [feedback_ssh_padme.md](feedback_ssh_padme.md) — can SSH from doudou to padme; don't say "I can't reach padme"
-- [feedback_ssh_padme_path.md](feedback_ssh_padme_path.md) — always prepend PATH=$HOME/.local/bin for padme SSH (uv not in non-interactive PATH)
+- [feedback_ssh_padme.md](feedback_ssh_padme.md) — can SSH doudou→padme; always prepend PATH=$HOME/.local/bin (uv not in non-interactive PATH)
 - [feedback_weekend_boundary.md](feedback_weekend_boundary.md) — no project work on weekends; mental health is non-negotiable
 - [feedback_verify_before_advising.md](feedback_verify_before_advising.md) — always WebFetch conference/journal URLs before offering strategic advice
 - [feedback_dropna_before_merge.md](feedback_dropna_before_merge.md) — always dropna before merge/set_index on DOI; pandas NaN==NaN causes cartesian explosion

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_a4_paper.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_a4_paper.md
@@ -1,0 +1,20 @@
+---
+name: feedback-a4-paper
+description: "Always generate PDFs in A4 paper format, never US letter"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 8a3dc47b-4c38-4220-b393-129612e7453c
+---
+
+Always use A4 paper format for every PDF generated for the author (pandoc,
+LaTeX, reports, letters).
+
+**Why:** Author directive 2026-07-10 ("Always use A4 paper format"), after a
+pandoc-generated response letter came out in US letter. European academic
+context; Œconomia and all French institutions use A4.
+
+**How to apply:** pandoc → `-V papersize=a4`; raw LaTeX → `a4paper` class
+option or `geometry`. Quarto project deliverables already configure their own
+geometry — this applies to ad-hoc documents I generate (letters, notes,
+reports).

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_letter_voice_flags.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_letter_voice_flags.md
@@ -1,0 +1,24 @@
+---
+name: feedback-letter-voice-flags
+description: "Author's recurring prose flags (A-not-B cadence, -ly stacks, engineering jargon) — align on style-anchor-v205 BEFORE showing prose; letters in first person singular"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 8a3dc47b-4c38-4220-b393-129612e7453c
+---
+
+When drafting prose the author will read (letters, manuscript passages), align
+on his voice BEFORE showing it, not after he flags it.
+
+**Why:** the 0152 letter session (2026-07-10) cost several correction rounds
+for defects the style anchor already predicts: the A-not-B antithesis cadence
+("rewritten rather than patched") even when each instance seems substantive
+(keep at most ~3 that carry real argument); stacked -ly adverbs in one
+sentence; engineering metaphors ("load-bearing" — now in ai-tells.yml);
+"cashes out" philosophy idiom.
+
+**How to apply:** anchor on `docs/style-anchor-v205.md` (short declaratives,
+willing first person, one measured hedge at a time, concrete analogies,
+closings that land a point). Response letters: FIRST PERSON SINGULAR — sole
+author. All generated PDFs: A4 ([[feedback-a4-paper]]). Manuscript-wide
+alignment is ticket 0243 (Fable-led, few-shot on the anchor samples).

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_onstart_trigger.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_onstart_trigger.md
@@ -1,11 +1,3 @@
----
-name: on-start trigger must run automatically
-description: The on-start runbook must execute before the first response, without being asked — it's a trigger, not a request
-type: feedback
----
-
-Run `runbooks/on-start.md` fully before the first reply in every conversation. Do not wait for the user to mention it.
-
-**Why:** The user had to ask twice — first pointing to the runbook, then calling out that it still wasn't followed. The gate (step 3: branch before proceeding) was announced but not executed.
-
-**How to apply:** At conversation start, read and execute all on-start steps (setup, orient, branch+announce) before responding to the user's message. The branch creation is a hard gate — don't announce a phase without having the branch checked out.
+# DELETED 2026-07-10T21:20Z: on-start runbook must execute automatically
+# Reason: superseded by the SessionStart hook mechanism (rules/workflow.md).
+# Original content preserved in git history.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_render_bitcompare_is_the_gate.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_render_bitcompare_is_the_gate.md
@@ -1,0 +1,46 @@
+---
+name: feedback_render_bitcompare_is_the_gate
+description: "For a pure build/layout refactor, render old-vs-new and byte-compare content — don't defer validation to the author citing \"no long renders\""
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 2317022c-d609-4ac0-b6fa-8e23969f5f97
+---
+
+For a **pure refactor** of the build/render layout (e.g. the deliverables/ reorg,
+ticket 0226), the correct validation gate is **render old vs new on the SAME
+inputs and byte-compare the content**, and I should run it myself — not punt it
+to the author as "requires author render-validation."
+
+**Why:** I initially claimed I "can't render-validate" and left it to the author.
+The author pushed back ("Why can't you render and bit-compare?"). It was over-
+application of [[feedback_no_long_running]] — a *preference* about slow builds,
+not a technical impossibility. The manuscript renders **clean-room in ~12s** via
+the standalone `make -f deliverables/manuscript/manuscript.mk` path, and the repo
+already exports `SOURCE_DATE_EPOCH := 0` (Makefile + manuscript.mk) so PDFs are
+byte-reproducible. This is the [[feedback_bytecheck_old_vs_new_not_golden]]
+discipline applied to renders.
+
+**How to apply:**
+- Baseline: render OLD (origin/main) → `PDF_old`; render NEW (branch) → `PDF_new`,
+  both with `SOURCE_DATE_EPOCH=0`.
+- Equivalence proof = `pdftotext` content sha equality (byte-`cmp` as strict
+  check; a residual byte diff is usually only the embedded source-path metadata —
+  confirm, don't wave away). Byte-identical text sha ⇒ the refactor preserved the
+  document.
+- `feedback_no_long_running` still holds for *heavy* builds (`make analysis`,
+  full corpus, `make papers` while Phase-2-entangled). Clean-room manuscript
+  render is not that — it's seconds. Companion papers need Phase-2 artifacts on
+  disk (symlink them, per [[feedback_verify_datadep_worktree_symlink]]); the clean
+  point to byte-validate them is after 0237 makes `make papers` artifact-driven.
+
+**Two defects this gate caught that green `make check-fast` (931 tests) did NOT:**
+1. **Quarto single-file `quarto render <file>.qmd` ignores the project
+   `output-dir`** — it writes the PDF *next to the source*, so the per-folder
+   `_quarto.yml: output-dir: ../../output/content` was dead config. Fix adopted
+   (author decision): render **next to source** in `deliverables/<x>/`, drop the
+   top-level `output/` dir. See [[project_deliverables_render_next_to_source]].
+2. **`make` returns 0 on a render whose recipe writes to the wrong path** — exit
+   code checks the recipe, not target-file existence. A target that equals where
+   quarto actually writes makes `make` verify it. Makefile-text tests
+   (`test_makefile_contract`) can't see this — only a real render does.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ssh_padme.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ssh_padme.md
@@ -1,11 +1,16 @@
 ---
-name: SSH to padme is available
-description: Can SSH from doudou to padme to check progress, run commands, monitor pipeline
-type: feedback
+name: feedback-ssh-padme
+description: Can SSH from doudou to padme; always prepend PATH=$HOME/.local/bin (uv absent from non-interactive PATH)
+metadata:
+  type: feedback
 ---
 
-SSH to padme works from doudou: `ssh padme '...'`. Use it to check pipeline progress, tail logs, inspect processes.
+I can SSH from doudou to padme — never claim "I can't reach padme".
 
-**Why:** User pointed out that bash + ssh means we can monitor padme directly — don't say "I can't reach padme."
+**Why:** both machines are the author's; padme hosts the data/GPU side.
+Non-interactive SSH skips the login profile, so `uv` (at `~/.local/bin/uv`)
+is not on PATH.
 
-**How to apply:** When the user asks to check padme status, use `ssh padme` directly. Remember `uv` is at `~/.local/bin/uv` (not in PATH for non-interactive SSH). Repo is at `~/Oeconomia-Climate-finance`.
+**How to apply:** `ssh padme 'PATH=$HOME/.local/bin:$PATH <command>'` — prepend
+the PATH on every non-interactive invocation. (Merged from
+feedback_ssh_padme_path, dream consolidation 2026-07-10.)

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ssh_padme_path.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ssh_padme_path.md
@@ -1,13 +1,3 @@
----
-name: Always prepend PATH for padme SSH commands
-description: Non-interactive SSH to padme doesn't source .bashrc — uv, make targets using uv all fail without explicit PATH
-type: feedback
-originSessionId: 5171a15b-fd7c-4404-981c-490a8509eab5
----
-Always prepend `export PATH=$HOME/.local/bin:$PATH` when running commands on padme via SSH.
-`uv` is at `~/.local/bin/uv` which is not in the default PATH for non-interactive sessions.
-This affects `make` targets that call `uv run`, not just direct `uv` invocations.
-
-**Why:** Repeated failures — `uv: command not found` — when running `make manuscript`, `make divergence-tables`, etc. via `ssh padme "cd ~/Climate_finance && make ..."`.
-
-**How to apply:** Every `ssh padme` command that might invoke `uv` (directly or via Make) must include the PATH export. Use: `ssh padme "export PATH=\$HOME/.local/bin:\$PATH && cd ~/Climate_finance && make ..."`.
+# DELETED 2026-07-10T21:20Z: padme SSH PATH prefix
+# Reason: merged into feedback_ssh_padme.md (same subject, one entry).
+# Original content preserved in git history.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_verify_ai_generated_includes.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_verify_ai_generated_includes.md
@@ -1,0 +1,24 @@
+---
+name: feedback-verify-ai-generated-includes
+description: "Never cite or reuse content from an \"AI-generated, not human-reviewed\" include without verifying its attributions — one contained a phantom reference"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 8a3dc47b-4c38-4220-b393-129612e7453c
+---
+
+Never cite, quote, or build an argument on content from a techrep include
+marked "AI-generated, not human-reviewed" without first verifying its
+attributions and numbers against resolvable metadata.
+
+**Why:** 2026-07-10 (ticket 0152): `bibliometric-context.md` (§11) contained a
+PHANTOM reference ("Baran et al. 2024" — no such paper; the real study is
+Rusydiana 2023), a wrong corpus size (657 vs 2,311), and a false claim ("none
+report validity metrics" — the CiteSpace studies do). Web-verifying all four
+named studies took one agent run; the errors would otherwise have reached a
+response-to-reviewers letter.
+
+**How to apply:** before using such an include, resolve every author-year
+attribution via CrossRef/DOI (agent run), trace pipeline numbers to archived
+outputs, and correct in place with a dated provenance comment. Ticket 0244
+tracks the four remaining unverified includes. Related: [[feedback-read-before-cite]].

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_deliverables_render_next_to_source.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_deliverables_render_next_to_source.md
@@ -1,0 +1,60 @@
+---
+name: project_deliverables_render_next_to_source
+description: The deliverables/ reorg — each paper/deck is a self-contained deliverables/<x>/ Quarto project; PDFs render next-to-source; top-level output/ is gone
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 2317022c-d609-4ac0-b6fa-8e23969f5f97
+---
+
+**Landed 2026-07-10, raid 237, PRs #1002 (ticket 0226) + #1003 (ticket 0237).**
+The build+prose children of tracker 0223 (which is the code+prose axis of the
+0221 repo-layout reorg). Tracker 0223 stays OPEN — the code workstream 0225 is
+still open.
+
+## New layout
+- Each deliverable is its own Quarto project under `deliverables/<x>/` with its
+  own `_quarto.yml` (no more `content/` mega-project + `_quarto-manuscript*.yml`
+  exclusion masks — those are deleted). 11 docs across 9 folders: `manuscript/`
+  (manuscript.qmd + manuscript-Gide.qmd + manuscript.mk), `data-paper/`,
+  `corpus-report/`, `technical-report/`, `multilayer/` (multilayer-detection +
+  -techrep), `agentic/`, `zoo/`, `slides-gide/`, `slides-eshet/`.
+- Shared assets in `deliverables/_shared/` (`bibliography/`, `_includes/`,
+  generated `figures/` + `tables/`, `technical-report-vars.yml`); referenced by
+  `../_shared/...`. Includes resolve relative to the TOP rendering doc, and every
+  folder sits one level under `deliverables/`, so the prefix is uniform.
+
+## Render lands next-to-source; output/ is retired
+- **Quarto single-file `quarto render <file>.qmd` ignores the project
+  `output-dir`** — it writes the PDF/DOCX beside the source. So each render target
+  is `deliverables/<x>/<doc>.<pdf|docx>` (gitignored), the Make target EQUALS the
+  actual output (Make now verifies it — the old `output/content/*.pdf` targets and
+  the whole top-level `output/` dir are gone). Release is out-of-project (copies
+  into `papiers/<state>/<track>/` / archive tarballs), so it doesn't need `output/`.
+  See [[feedback_render_bitcompare_is_the_gate]] for the two defects this caught.
+
+## Build split by phase (0237)
+- Each deliverable owns a Phase-3 render `.mk` (render-only). Concern `.mk`
+  (`divergence.mk`, `zoo.mk`, `multilayer-detection.mk`, `venues.mk`,
+  `separation.mk`) are pure Phase-2 — 0 render rules. `paths.mk` is the shared
+  var interface `-include`d by both sides.
+- `make papers`/`manuscript` are **phony recursive `$(MAKE) -f deliverables/<x>/<x>.mk`**
+  recipes, NOT `-include` — a plain include would let the root Makefile's
+  `$(REFINED)`-dependent inline figure recipes trigger Phase-2. `make papers` is
+  now corpus-free (no `check-corpus`, no `uv run`); the contract is "run
+  `make analysis`, then render." Guard: `test_build_phase_separation.py`'s
+  `test_no_mk_file_mixes_render_and_compute` (adherence, classifies by recipe).
+- `multilayer-detection.mk`'s Phase-2 remainder stays at root (feeds two
+  deliverables → analysis concern, not deliverable-scoped); rename to
+  `scripts/analysis/` deferred to 0225.
+
+## Consequences to remember
+- **A future cherry-pick onto `submission/oeconomia-varia`** (frozen at old
+  `content/` paths) needs path remapping — main and the submission branch diverge
+  on file location from #1002 forward. See [[project_frozen_manuscript_vs_live_companions]].
+- Companions `technical-report`, `multilayer*`, `zoo` need `make analysis`
+  (zoo/companion figures: `schematic_*.png`, `fig_zoo_*.png`, `fig_companion_*.png`)
+  before they render — those figures are NOT git-tracked and were absent in the
+  checkout, so they could not be byte-validated during the raid (manuscript,
+  corpus-report, data-paper WERE, all byte-identical old-vs-new).
+- `architecture.md` § Project structure + § Artifact homes were updated to match.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_doifetch_sync.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_doifetch_sync.md
@@ -30,4 +30,4 @@ The DOIfetch tool lives **outside the repo** at `/home/haduong/CNRS/code/DOIfetc
    cp docs/missing_references.txt /home/haduong/CNRS/code/DOIfetch/references/missing_references.txt
    ```
 
-**Why:** DOIfetch is an external tool (out of repo) that fetches PDFs by DOI/ISBN/URL. It reads `references/missing_references.txt` as its input queue and writes fetched PDFs to `papers/`. The project's `gen_missing_references.py` script generates that input from `content/bibliography/main.bib` vs `docs/articles/`.
+**Why:** DOIfetch is an external tool (out of repo) that fetches PDFs by DOI/ISBN/URL. It reads `references/missing_references.txt` as its input queue and writes fetched PDFs to `papers/`. The project's `qa_missing_references.py` script generates that input from `content/bibliography/main.bib` vs `docs/articles/`.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_doifetch_sync.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_doifetch_sync.md
@@ -19,7 +19,9 @@ The DOIfetch tool lives **outside the repo** at `/home/haduong/CNRS/code/DOIfetc
 
 2. **Regenerate missing references list:**
    ```bash
-   uv run python scripts/gen_missing_references.py
+   uv run python scripts/qa_missing_references.py --output docs/missing_references.txt
+   # (renamed from gen_missing_references.py in the prefix sweep #547;
+   #  needs bibtexparser -- run from the main checkout, worktree venvs may lack it)
    # Writes docs/missing_references.txt
    ```
 


### PR DESCRIPTION
Nightly-style consolidation run from /lair. NOOP 68 · UPDATE 2 (ssh_padme absorbs ssh_padme_path; doifetch_sync tracks the qa_missing_references.py rename) · DELETE 2 (onstart_trigger superseded by the SessionStart hook; ssh_padme_path merged into ssh_padme) · ADD 5 (a4_paper, letter_voice_flags, verify_ai_generated_includes, render_bitcompare_is_the_gate, project_deliverables_render_next_to_source). Index count 72→74: four of the five adds are standalone index lines while project_deliverables folds into the Reports & build category line. 105 survivor slugs recorded in provenance; no promotion candidates; no decay flags.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)