### PR TITLE
reuse gate + intent-based supervisor reframing (0274)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/merge` | Atomically close the linked ticket(s) and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI). |
 | `/molt` | Repo housekeeping — git sync, healthcheck, eager fix-now repairs, and ticket creation for open-ticket findings. Safe to call interactively or from automated sweeps. |
 | `/nightbeat-report` | Review what the overnight autonomous pipeline (nightbeat) did each morning: parse logs, narrate work done, surface harness improvement opportunities. |
-| `/nightbeat-supervisor` | Supervise the overnight autonomous pipeline (nightbeat) continuously: watch each cycle outcome, merge ready PRs, diagnose and repair failures, escalate when stuck. |
+| `/nightbeat-supervisor` | Supervise an overnight autonomous work run: keep the authorized ticket queue moving, integrate verified work, diagnose and repair failures, and deliver a self-contained morning report. The nightbeat supervisor governs by intent — a goal and three hard invariants bind; every mechanism (frequency, wake-up, delegation, building blocks) is the executor's declared choice. |
 | `/perch` | Mid-session orientation — summarize what's done, surface unresolved points. Assesses clear-readiness and offers to do the work if conditions are right. |
 | `/pick-ticket` | Pick the lowest-risk available ticket for an autonomous run. |
 | `/raid` | Work through multiple tickets autonomously: pick targets, implement each in isolated worktree waves, verify, and merge APPROVED PRs after verify-gate clears. |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/merge` | Atomically close the linked ticket(s) and merge a PR. Must be run from the PR head branch. Works in git worktrees and on VMs. GitHub-only (requires the GitHub CLI). |
 | `/molt` | Repo housekeeping — git sync, healthcheck, eager fix-now repairs, and ticket creation for open-ticket findings. Safe to call interactively or from automated sweeps. |
 | `/nightbeat-report` | Review what the overnight autonomous pipeline (nightbeat) did each morning: parse logs, narrate work done, surface harness improvement opportunities. |
-| `/nightbeat-supervisor` | Supervise an overnight autonomous work run: keep the authorized ticket queue moving, integrate verified work, diagnose and repair failures, and deliver a self-contained morning report. The nightbeat supervisor governs by intent — a goal and three hard invariants bind; every mechanism (frequency, wake-up, delegation, building blocks) is the executor's declared choice. |
+| `/nightbeat-supervisor` | Supervise an overnight autonomous work run: keep the authorized ticket queue moving, integrate verified work, diagnose and repair failures, and deliver a self-contained morning report. |
 | `/perch` | Mid-session orientation — summarize what's done, surface unresolved points. Assesses clear-readiness and offers to do the work if conditions are right. |
 | `/pick-ticket` | Pick the lowest-risk available ticket for an autonomous run. |
 | `/raid` | Work through multiple tickets autonomously: pick targets, implement each in isolated worktree waves, verify, and merge APPROVED PRs after verify-gate clears. |

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -104,6 +104,18 @@ applied to build outputs.
 - **Max 8 concurrent agents** (authorized 2026-06-08). Beyond that, coordination overhead exceeds the gains. Keep watch: when 3+ agents touch the same file or registry, open a coordination PR first (see Phase 5.0 in raid skill).
 - **One well-prompted agent first.** Only add agents when a single agent clearly can't handle the task.
 
+# Reuse gate for autonomous orchestration
+
+Before designing any multi-cycle autonomous orchestration (scheduled loops,
+overnight supervisors, wave runners), inventory the existing skills and
+runbooks catalog and declare, as part of the run plan, either which existing
+piece is reused or why none fits. The declaration is the compliance artifact —
+it makes the reuse decision verifiable ex post, where a silent improvisation
+is not. (Cost of skipping this, 2026-07-10: an hourly autonomous loop was
+improvised from scratch while `nightbeat-supervisor` sat undiscovered in the
+catalog, and its static itinerary missed a mid-run child ticket a live queue
+would have picked up.)
+
 # Ticket discipline for multi-PR work
 
 **A PR closes every ticket named in its `**Ticket:**` lines.** `erg-pr-merge` closes ALL tickets listed in the PR body's `**Ticket:**` lines — unconditionally, regardless of whether all exit-criteria checkboxes are ticked. One ticket per PR remains the recommended review hygiene; list multiple only when they genuinely land together (e.g. raid-wave filings). The `**Ticket:**` (or bare `Ticket:`) line is the close claim. To cite a ticket without closing it, use `Ticket-ref: tickets/NNNN-...`; for a PR that closes nothing, `Ticket: none`. Title prefixes like `chore(0216):` are subject references, never close claims.

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -138,9 +138,7 @@ When compacting, preserve the list of modified files, test commands, and current
 
 # Writing Skills and Hooks
 
-**Forge-agnostic language**: Never hardcode `gh` commands or GitHub references in skills or rules. Use "merge request" not "PR", "ticket" not "issue", "forge" not "GitHub". Skills describe *what* to do, not *which tool* to use.
-
-**Tool-agnostic language (generalizes the above)**: Skills and rules name *capabilities*, not the current tool that provides them — "schedule a wake-up" not a specific timer-tool name, "delegate to a subagent" not a specific agent-tool name, "list ready tickets" not a specific picker-skill name. The harness is portable across tool generations; tool names rot, capabilities don't.
+**Tool-agnostic language**: Skills and rules name *capabilities*, not the current tool that provides them — "schedule a wake-up" not a specific timer-tool name, "delegate to a subagent" not a specific agent-tool name, "list ready tickets" not a specific picker-skill name. The forge case is the canonical instance: never hardcode `gh` commands or GitHub references — "merge request" not "PR", "ticket" not "issue", "forge" not "GitHub". The harness is portable across tool generations; tool names rot, capabilities don't.
 
 **Hook output framing**: Use declarative wording ("Worktree isolation is enabled…") not imperative commands ("INSTRUCTION: call EnterWorktree now"). The model classifies imperative hook instructions as prompt injection and ignores them.
 

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -140,6 +140,8 @@ When compacting, preserve the list of modified files, test commands, and current
 
 **Forge-agnostic language**: Never hardcode `gh` commands or GitHub references in skills or rules. Use "merge request" not "PR", "ticket" not "issue", "forge" not "GitHub". Skills describe *what* to do, not *which tool* to use.
 
+**Tool-agnostic language (generalizes the above)**: Skills and rules name *capabilities*, not the current tool that provides them — "schedule a wake-up" not a specific timer-tool name, "delegate to a subagent" not a specific agent-tool name, "list ready tickets" not a specific picker-skill name. The harness is portable across tool generations; tool names rot, capabilities don't.
+
 **Hook output framing**: Use declarative wording ("Worktree isolation is enabled…") not imperative commands ("INSTRUCTION: call EnterWorktree now"). The model classifies imperative hook instructions as prompt injection and ignores them.
 
 **Concurrency discipline**: Every multi-item skill step declares whether items run parallel-background or sequential-blocking, and states why. Model defaults differ across versions; the skill text is the contract.

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -47,6 +47,9 @@ auditable choice, not a silence.
    re-ticketed, never swallowed.
 3. The bounds set at launch (perimeter, cycle/budget ceiling, prohibitions)
    are hard.
+4. The run never modifies its own governing definitions: skill definition
+   files are read-only mid-run, and the components that drive the run
+   (scheduler, cycle-runner) are quiesced before any edit to them.
 
 ## Executor's latitude
 
@@ -81,7 +84,8 @@ next one lands on). Independent failure diagnoses may be delegated to
   than fixing an itinerary at launch — a child of an authorized parent filed
   mid-run is in scope on the next cycle.
 - Stop the run's scheduler before editing the cycle-runner code, restart it
-  after; never edit skill definition files mid-run.
+  after; never edit skill definition files mid-run (this instantiates
+  invariant 4).
 - **Commit tracked writes immediately.** Every write to a tracked file in
   `$HARNESS_DIR` (`settings.json`, `scripts/beat.py`, `tickets/*.erg`) must be <!-- harness-extension-point -->
   followed by `git add <file> && git commit -m 'chore(supervisor): <description>'`

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -1,39 +1,86 @@
 ---
 name: nightbeat-supervisor
-description: Supervise the overnight autonomous pipeline (nightbeat) continuously: watch each cycle outcome, merge ready PRs, diagnose and repair failures, escalate when stuck.
+description: Supervise an overnight autonomous work run: keep the authorized ticket queue moving, integrate verified work, diagnose and repair failures, and deliver a self-contained morning report. The nightbeat supervisor governs by intent — a goal and three hard invariants bind; every mechanism (frequency, wake-up, delegation, building blocks) is the executor's declared choice.
 user-invocable: true
 argument-hint: "[--since ISO-TS]"
 ---
 
 # Nightbeat Supervisor
 
-Survey beat outcomes each cycle and close the loop: merge ready PRs, chase
-failures to their root cause, repair within authority, escalate when stuck.
+This skill is an intent-based contract (mission command): the **Goal** and
+**Invariants** below bind the run; everything else is the **executor's
+latitude**, exercised and declared at run start. The mechanisms named later in
+this file are illustrative defaults, not the contract.
 
-**Non-negotiables**: never merge without `verdict: APPROVED`; stop the main
-timer before editing `beat.py`, restart after; never edit skill SKILL.md files.
+## Goal
 
-**Commit tracked writes immediately.** Every write to a tracked file in
-`$HARNESS_DIR` (`settings.json`, `scripts/beat.py`, `tickets/*.erg`) must be <!-- harness-extension-point -->
-followed by `git add <file> && git commit -m 'chore(supervisor): <description>'`
-before proceeding to the next action. Uncommitted tracked files cause the next
-beat cycle's dirty-tree pre-flight to abort.
+Advance, overnight, the ticket perimeter the author authorized, without
+crossing any human-in-the-loop boundary, and deliver a self-contained morning
+report.
 
-**Commit on a branch, not main.** Every `chore(supervisor): …` commit below
-lands a tracked write in `$HARNESS_DIR`. If `$HARNESS_DIR` is the **primary**
-checkout, its pre-commit hook refuses commits on `main` (everything lands via
-branch + PR). Before the first such commit in a cycle, ensure you are on a
-supervisor branch — `git -C $HARNESS_DIR rev-parse --abbrev-ref HEAD` must not
-be `main`; if it is, `git -C $HARNESS_DIR switch -c supervisor-$(date +%F)` —
-and open a PR for the accumulated chore commits rather than pushing to main.
-(Commits made from a raid/agent worktree are unaffected; the guard only fires in
-the primary checkout.)
+## Invariants (the only prescriptions)
+
+1. The queue is *live*: a ticket filed during the run enters the perimeter if
+   its lineage traces to an authorized parent; tickets labeled needs-human or
+   deferred are always excluded.
+2. Nothing integrates without verification; a failure is diagnosed then
+   retried or re-ticketed, never swallowed.
+3. The bounds set at launch (perimeter, cycle/budget ceiling, prohibitions)
+   are hard.
+
+## Executor's latitude
+
+Frequency, wake-up mechanism, work decomposition, delegation, and choice of
+building blocks — whatever their current names — are the executor's decisions,
+declared at run start. Per the reuse gate in `rules/workflow.md`, that
+declaration states which existing skills or runbooks are reused, or why none
+fits. Capabilities the executor typically composes: schedule a wake-up, list
+ready tickets, delegate work to a subagent, run the verification gate,
+integrate a merge request, append to a journal.
+
+---
+
+# Illustrative defaults
+
+Everything below is **one possible organization** — the arrangement proven in
+production so far — offered as a starting point under the executor's latitude.
+An executor may replace any of it, provided the invariants hold.
+
+**Default cycle shape**: survey → integrate ready work → diagnose and repair →
+escalate → journal. The steps run **sequentially within a cycle** — each
+consumes the previous step's output. Merge candidates within the integrate
+step are also **sequential-blocking** (each integration moves the base the
+next one lands on). Independent failure diagnoses may be delegated to
+**parallel** subagents, within the concurrency cap in `rules/workflow.md`.
+
+**Default working discipline**:
+
+- Never integrate without an APPROVED verdict from the verification gate
+  (this instantiates invariant 2).
+- Instantiate invariant 1 by re-listing ready tickets at every wake-up rather
+  than fixing an itinerary at launch — a child of an authorized parent filed
+  mid-run is in scope on the next cycle.
+- Stop the run's scheduler before editing the cycle-runner code, restart it
+  after; never edit skill definition files mid-run.
+- **Commit tracked writes immediately.** Every write to a tracked file in
+  `$HARNESS_DIR` (`settings.json`, `scripts/beat.py`, `tickets/*.erg`) must be <!-- harness-extension-point -->
+  followed by `git add <file> && git commit -m 'chore(supervisor): <description>'`
+  before proceeding to the next action. Uncommitted tracked files cause the
+  next cycle's dirty-tree pre-flight to abort.
+- **Commit on a branch, not main.** If `$HARNESS_DIR` is the **primary**
+  checkout, its pre-commit hook refuses commits on `main` (everything lands
+  via branch + merge request). Before the first supervisor commit in a cycle,
+  ensure `git -C $HARNESS_DIR rev-parse --abbrev-ref HEAD` is not `main`; if
+  it is, `git -C $HARNESS_DIR switch -c supervisor-$(date +%F)` — and open a
+  merge request for the accumulated chore commits rather than pushing to main.
+  (Commits made from an isolated worktree are unaffected; the guard only fires
+  in the primary checkout.)
 
 ## 1. Survey
 
-Pre-flight: probe the primary checkout (ticket 0247). A dream or beat run that
-died mid-flight can strand the harness checkout off main with a dirty tree,
-silently blocking the daily-pull timer and every later beat's dirty-tree
+Pre-flight: probe the primary checkout (ticket 0247). A run that died
+mid-flight can strand the harness checkout off main with a dirty tree,
+silently blocking the daily-pull schedule and every later cycle's dirty-tree
 pre-flight:
 
 ```bash
@@ -43,54 +90,59 @@ $HARNESS_DIR/scripts/check-primary-checkout.sh "$HARNESS_DIR"
 Non-zero means stranded (off main, or dirty beyond settings.json). The
 consolidation commit is safe on its branch, so `git -C "$HARNESS_DIR" switch
 main` restores the position; if the tree is dirty for another reason, diagnose
-or escalate rather than proceeding — beats keep failing until it is clean.
+or escalate rather than proceeding — cycles keep failing until it is clean.
 
-Pre-flight: verify no dual-journal state exists (`canonical` vs `logs/` path). If both
-`<project>/nightbeat-supervisor-journal.jsonl` and `<project>/logs/nightbeat-supervisor-journal.jsonl`
-exist as independent files (not a symlink), stop and open a ticket before proceeding.
-The survey script enforces this automatically and exits non-zero if the condition is detected.
+Pre-flight: verify no dual-journal state exists (`canonical` vs `logs/` path).
+If both `<project>/nightbeat-supervisor-journal.jsonl` and
+`<project>/logs/nightbeat-supervisor-journal.jsonl` exist as independent files
+(not a symlink), stop and open a ticket before proceeding. The survey helper
+enforces this automatically and exits non-zero if the condition is detected.
 
 ```bash
 python3 $HARNESS_DIR/scripts/nightbeat-supervisor-survey.py [--since ISO-TS]
 ```
 
-If `--since` is absent from `$ARGUMENTS`, the script derives the watermark from
-the latest `ts` in `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl` (defaults
-to 24h ago if no journal exists). Reads `$HARNESS_DIR/logs/beat-outcomes.jsonl`
-and finds open PRs for raid-success tickets via remote branch lookup and forge API.
-Outputs `{prs_to_merge, failures, watermark_ts, journal_context}`.
+If `--since` is absent from `$ARGUMENTS`, the helper derives the watermark
+from the latest `ts` in `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl`
+(defaults to 24h ago if no journal exists). It reads
+`$HARNESS_DIR/logs/beat-outcomes.jsonl` and finds open merge requests for
+succeeded tickets via remote branch lookup and the forge API. Outputs
+`{prs_to_merge, failures, watermark_ts, journal_context}`.
 If both lists are empty, write a journal `action=idle` entry and stop.
 
-## 2. Merge ready PRs
+## 2. Integrate ready work
 
-For each entry in `prs_to_merge` (which includes `pr_number`, `github_repo`,
-and `project_path` derived by the survey script from the project's git remote):
+For each entry in `prs_to_merge` (which includes the merge-request number,
+the forge repo identifier, and `project_path` derived by the survey helper
+from the project's git remote), sequentially:
 
-1. `bash $HARNESS_DIR/skills/nightbeat-supervisor/check-pr-diff <pr_number> <github_repo>` — non-zero exit is a HOLD; add to failures with the script's reason.
-2. Switch to the target project and check out the PR branch:
-   ```bash
-   cd <project_path>
-   git fetch origin
-   gh pr checkout <pr_number> --repo <github_repo>   # harness-extension-point
-   ```
-   Then: `/verify-gate <pr_number>` — APPROVED → `/merge <pr_number>`. REROLL → append the failing criteria as a note on the linked ticket (create the ticket if none is referenced in the PR body), then commit the ticket file:
+1. `bash $HARNESS_DIR/skills/nightbeat-supervisor/check-pr-diff <pr_number> <github_repo>`
+   — non-zero exit is a HOLD; add to failures with the helper's reason.
+2. In the target project (`cd <project_path>`), fetch and check out the
+   merge-request branch with the forge tooling of the day. <!-- harness-extension-point -->
+   Then run the verification gate on the merge request:
+   APPROVED → integrate it with the merge capability.
+   REROLL → append the failing criteria as a note on the linked ticket
+   (create the ticket if none
+   is referenced in the merge-request body), then commit the ticket file:
    ```bash
    cd $HARNESS_DIR
    git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): append REROLL note to <ticket>'
    ```
    and move on. ESCALATE → go to step 4.
-   After verify-gate and merge complete, `cd $HARNESS_DIR` to return to the harness directory for the next PR.
+   After the gate and integration complete, return to `$HARNESS_DIR` for the
+   next candidate.
 
 ## 3. Diagnose and repair
 
-For each failure, read the nightbeat log and ask **why** until you reach an
+For each failure, read the cycle log and ask **why** until you reach an
 actionable root cause:
 
 > Why did it fail? → Why did that happen? → Why was that condition present?
 
 When you reach a root cause, repair if within authority:
 
-- **Missing permission** → add to `settings.json` allowlist, then
+- **Missing permission** → add to the `settings.json` allowlist, then
   `git add settings.json && git commit -m 'chore(supervisor): add <permission> to allowlist'`.
 - **Budget too small for the actual scope of work** → before raising, apply
   the convergence guard:
@@ -104,26 +156,27 @@ When you reach a root cause, repair if within authority:
      hard ceiling remains 2× the module-level constant — the 1.5× threshold
      is a warning only, not a new cap).
   If neither guard triggers: raise the per-project `ProjectConfig` field in
-  `beat.py` by 20%, capped at 2× the module-level constant; never touch the
-  module-level constant. Then
+  the cycle-runner (`beat.py`) by 20%, capped at 2× the module-level
+  constant; never touch the module-level constant. Then
   `git add scripts/beat.py && git commit -m 'chore(supervisor): raise <field> budget for <project>'`. <!-- harness-extension-point -->
-- **Raid timeout during verify/review** (`outcome=timeout` AND why-chain
+- **Timeout during verify/review** (`outcome=timeout` AND why-chain
   shows verify/review slowness, not implementation slowness) → raise
   `raid_timeout_s` in the per-project config by 20%, capped at
   2× `RAID_TIMEOUT_S` (3600 s). Then
   `git add scripts/beat.py && git commit -m 'chore(supervisor): raise raid_timeout_s for <project>'`. <!-- harness-extension-point -->
   Implementation slowness is a "ticket too
   large" signal — do not raise the timeout for that.
-- **Ticket too large to finish in one beat** → split into one ticket per
+- **Ticket too large to finish in one cycle** → split into one ticket per
   independent unit of work; leave the parent open as an umbrella. Each child
-  ticket must carry `Blocked-by: <umbrella-id>` so pick-ticket can auto-close
-  the umbrella when all children are done (it uses inverse lookup, not a
-  `Blocks:` header — that header is not valid in %erg v1). Commit the new
-  ticket files by naming each child (`git add tickets/<child-id>-*.erg`, one per
-  child), then `git commit -m 'chore(supervisor): split <ticket> into children'`
+  ticket must carry `Blocked-by: <umbrella-id>` so the ticket picker can
+  auto-close the umbrella when all children are done (it uses inverse lookup,
+  not a `Blocks:` header — that header is not valid in %erg v1). Commit the
+  new ticket files by naming each child (`git add tickets/<child-id>-*.erg`,
+  one per child), then
+  `git commit -m 'chore(supervisor): split <ticket> into children'`
   — never `git add` over the whole `tickets/` glob, which also sweeps a stray
   `.erg` left by another agent in the shared checkout.
-- **Dead timer** → restart it.
+- **Dead wake-up scheduler** → restart it.
 - **Dirty working tree** (`outcome=aborted-dirty-tree`) → if the dirty files
   are machine-local state (beat-outcomes.jsonl, STATE.md, build artifacts),
   commit or stash them; otherwise open a ticket naming the dirty files and
@@ -137,11 +190,11 @@ auto-repair. Then `git add tickets/<ticket>.erg && git commit -m 'chore(supervis
 
 ## 4. Escalate
 
-Triggers: ESCALATE from verify-gate, why-chain without a repairable finding,
-or the same root cause recurring ≥ 3 consecutive runs for a project.
+Triggers: ESCALATE from the verification gate, why-chain without a repairable
+finding, or the same root cause recurring ≥ 3 consecutive runs for a project.
 
-Call `advisor` if available. Otherwise `Agent(model="opus")` with the log
-context (no extended thinking in Agent mode — honest degradation). Create a
+Call an advisor capability if available; otherwise delegate to a
+strong-reasoning subagent with the log context. Create a
 ticket with the verdict if the fix is outside authority. Commit the ticket:
 `git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): escalation ticket for <project>'`.
 
@@ -163,7 +216,7 @@ fi
 ```
 This is a safety net — every write should already be committed by the steps
 above. If the guard fires, it means a write point was missed; log the warning
-so the next nightbeat-report flags it for a skill fix.
+so the next morning report flags it for a skill fix.
 
 End with:
 

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nightbeat-supervisor
-description: Supervise an overnight autonomous work run: keep the authorized ticket queue moving, integrate verified work, diagnose and repair failures, and deliver a self-contained morning report. The nightbeat supervisor governs by intent — a goal and three hard invariants bind; every mechanism (frequency, wake-up, delegation, building blocks) is the executor's declared choice.
+description: Supervise an overnight autonomous work run: keep the authorized ticket queue moving, integrate verified work, diagnose and repair failures, and deliver a self-contained morning report.
 user-invocable: true
 argument-hint: "[--since ISO-TS]"
 ---
@@ -60,7 +60,7 @@ integrate a merge request, append to a journal.
 
 ---
 
-# Illustrative defaults
+## Illustrative defaults
 
 Everything below is **one possible organization** — the arrangement proven in
 production so far — offered as a starting point under the executor's latitude.
@@ -96,7 +96,7 @@ next one lands on). Independent failure diagnoses may be delegated to
   (Commits made from an isolated worktree are unaffected; the guard only fires
   in the primary checkout.)
 
-## 1. Survey
+### 1. Survey
 
 Pre-flight: probe the primary checkout (ticket 0247). A run that died
 mid-flight can strand the harness checkout off main with a dirty tree,
@@ -130,7 +130,7 @@ succeeded tickets via remote branch lookup and the forge API. Outputs
 `{prs_to_merge, failures, watermark_ts, journal_context}`.
 If both lists are empty, write a journal `action=idle` entry and stop.
 
-## 2. Integrate ready work
+### 2. Integrate ready work
 
 For each entry in `prs_to_merge` (which includes the merge-request number,
 the forge repo identifier, and `project_path` derived by the survey helper
@@ -143,8 +143,8 @@ from the project's git remote), sequentially:
    Then run the verification gate on the merge request:
    APPROVED → integrate it with the merge capability.
    REROLL → append the failing criteria as a note on the linked ticket
-   (create the ticket if none
-   is referenced in the merge-request body), then commit the ticket file:
+   (create one if the merge-request body references none), then commit the
+   ticket file:
    ```bash
    cd $HARNESS_DIR
    git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): append REROLL note to <ticket>'
@@ -153,7 +153,7 @@ from the project's git remote), sequentially:
    After the gate and integration complete, return to `$HARNESS_DIR` for the
    next candidate.
 
-## 3. Diagnose and repair
+### 3. Diagnose and repair
 
 For each failure, read the cycle log and ask **why** until you reach an
 actionable root cause:
@@ -208,7 +208,7 @@ If the why-chain bottoms out without reaching anything repairable: escalate
 **Anything else**: open a ticket stating the root cause chain; do not
 auto-repair. Then `git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): ticket for <root-cause>'`.
 
-## 4. Escalate
+### 4. Escalate
 
 Triggers: ESCALATE from the verification gate, why-chain without a repairable
 finding, or the same root cause recurring ≥ 3 consecutive runs for a project.
@@ -218,7 +218,7 @@ strong-reasoning subagent with the log context. Create a
 ticket with the verdict if the fix is outside authority. Commit the ticket:
 `git add tickets/<ticket>.erg && git commit -m 'chore(supervisor): escalation ticket for <project>'`.
 
-## 5. Done
+### 5. Done
 
 Append one journal entry per action taken this cycle to
 `$HARNESS_DIR/nightbeat-supervisor-journal.jsonl`. If no actions were taken,

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -14,6 +14,17 @@ this file are illustrative defaults, not the contract.
 
 ## Goal
 
+**Doctrine — autonomous mode trades supervision for time.** The run loses the
+human eye but is freed from the interactivity constraint: nobody is waiting on
+the next reply. The executor therefore shifts its operational cursor toward
+spending that freed time on verification — more independent verification
+passes than an interactive session would afford (independent means a different
+lens or a different agent, never the producer re-reading itself) — and, when
+confidence is low or a judgment call exceeds its depth, escalates, including
+consulting a more capable agent for advice, instead of guessing.
+Cheap-but-plausible loses to slow-but-verified; the deadline is dawn, not the
+next message. The invariants below follow from this premise.
+
 Advance, overnight, the ticket perimeter the author authorized, without
 crossing any human-in-the-loop boundary, and deliver a self-contained morning
 report.
@@ -23,8 +34,10 @@ report.
 1. The queue is *live*: a ticket filed during the run enters the perimeter if
    its lineage traces to an authorized parent; tickets labeled needs-human or
    deferred are always excluded.
-2. Nothing integrates without verification; a failure is diagnosed then
-   retried or re-ticketed, never swallowed.
+2. Nothing integrates without verification, and verification depth scales
+   with the time available — overnight, that means multiple independent
+   passes, not a single self-check; a failure is diagnosed then retried or
+   re-ticketed, never swallowed.
 3. The bounds set at launch (perimeter, cycle/budget ceiling, prohibitions)
    are hard.
 

--- a/skills/nightbeat-supervisor/SKILL.md
+++ b/skills/nightbeat-supervisor/SKILL.md
@@ -29,6 +29,13 @@ Advance, overnight, the ticket perimeter the author authorized, without
 crossing any human-in-the-loop boundary, and deliver a self-contained morning
 report.
 
+The morning report carries an audit trace: for each unit of work integrated
+during the run, it states which independent verification passes ran and which
+escalation (e.g. consulting a more capable agent) was used — or why none was
+needed. As with the reuse gate, the declaration is the compliance artifact:
+not escalating stays within the executor's latitude, but as a declared,
+auditable choice, not a silence.
+
 ## Invariants (the only prescriptions)
 
 1. The queue is *live*: a ticket filed during the run enters the perimeter if
@@ -235,4 +242,8 @@ End with:
 
 ```
 supervisor: <ts> — merged: N, repaired: N, tickets: N, escalated: N
+  <integrated unit>: passes=<independent verification passes run>; escalation=<which, or none: reason>
 ```
+
+One `<integrated unit>` line per unit of work integrated this run — this is
+the audit trace the Goal block requires.

--- a/tests/test_nightbeat_supervisor_skill.py
+++ b/tests/test_nightbeat_supervisor_skill.py
@@ -43,3 +43,21 @@ def test_tracked_write_points_have_commit():
 def test_commit_principle_declared():
     text = _read_skill()
     assert "Commit tracked writes immediately" in text
+
+
+def test_self_modification_guard_is_an_invariant():
+    """The read-only-own-definitions guard must be binding, not advisory.
+
+    It belongs inside the Invariants section, so an executor cannot edit skill
+    definition files mid-run while remaining formally compliant.
+    """
+    text = _read_skill()
+    start = text.find("## Invariants (the only prescriptions)")
+    assert start != -1, "Invariants section header missing"
+    end = text.find("## Executor's latitude", start)
+    assert end != -1, "Executor's latitude section missing"
+    invariants = " ".join(text[start:end].split())
+    assert "skill definition files" in invariants, (
+        "self-modification guard not inside the Invariants section"
+    )
+    assert "read-only" in invariants

--- a/tickets/0274-reuse-gate-intent-based-supervisor-refra.erg
+++ b/tickets/0274-reuse-gate-intent-based-supervisor-refra.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-11T06:16Z claude created
 
+2026-07-11T06:56Z bump verify-reroll — round 1: self-modification guard (never edit skill definition files mid-run) demoted from binding rule to a replaceable Illustrative default; unresolved as of 09fca09
 --- body ---
 ## Context
 

--- a/tickets/0274-reuse-gate-intent-based-supervisor-refra.erg
+++ b/tickets/0274-reuse-gate-intent-based-supervisor-refra.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: reuse gate + intent-based supervisor reframing
+Created: 2026-07-11
+Author: claude
+
+--- log ---
+2026-07-11T06:16Z claude created
+
+--- body ---
+## Context
+
+A Five-Whys run tonight in the climate-finance-het project surfaced two
+harness-level root causes behind one failure pair:
+
+(a) An hourly autonomous orchestration was improvised via a scheduled-wakeup
+loop without ever consulting the skills catalog, so the existing
+`nightbeat-supervisor` skill went undiscovered.
+
+(b) The improvised run used a static ticket itinerary, so a follow-up ticket
+filed mid-run (that project's 0249, child of an authorized parent) was never
+picked up.
+
+Root causes: no reuse gate exists before improvising orchestration, and the
+supervisor skill prescribes mechanisms (specific scripts, timers, commands)
+instead of intent, which makes it look inapplicable whenever the mechanism
+at hand differs.
+
+## Actions
+
+1. `rules/workflow.md` — add a reuse-gate paragraph near the subagent /
+   orchestration material: before designing any multi-cycle autonomous
+   orchestration, inventory the skills and runbooks catalog and declare in
+   the run plan which existing piece is reused or why none fits.
+2. `rules/workflow.md` § Writing Skills and Hooks — generalize the
+   forge-agnostic bullet to tool-agnostic: skills and rules name
+   capabilities, not the current tool that provides them.
+3. `skills/nightbeat-supervisor/SKILL.md` — reframe by intent (mission
+   command): Goal / Invariants (live queue, verify-before-integrate, hard
+   bounds) / Executor's latitude, with the current operational guidance
+   recast as illustrative defaults. Capability language throughout.
+
+## Verification
+
+- [ ] Reuse-gate paragraph present in `rules/workflow.md`, declarative tone
+- [ ] Tool-agnostic extension present in § Writing Skills and Hooks
+- [ ] SKILL.md restructured Goal / Invariants / Executor's latitude;
+      description first sentence plain and searchable
+- [ ] `make skills-catalog` regenerated README.md; `make check-skills-drift` passes
+- [ ] `make check-fast` passes
+
+## Exit criteria
+
+- [ ] All three edits merged in one PR closing this ticket
+- [ ] A future orchestration plan can be audited ex post for the reuse
+      declaration (the paragraph makes the declaration mandatory)
+- [ ] The supervisor skill contract is the three invariants, not any
+      specific script or timer name

--- a/tickets/closed/0274-reuse-gate-intent-based-supervisor-refra.erg
+++ b/tickets/closed/0274-reuse-gate-intent-based-supervisor-refra.erg
@@ -2,11 +2,13 @@
 Title: reuse gate + intent-based supervisor reframing
 Created: 2026-07-11
 Author: claude
+Closed: autoclosed — PR #472
 
 --- log ---
 2026-07-11T06:16Z claude created
 
 2026-07-11T06:56Z bump verify-reroll — round 1: self-modification guard (never edit skill definition files mid-run) demoted from binding rule to a replaceable Illustrative default; unresolved as of 09fca09
+2026-07-11T07:04Z Minh Ha-Duong closed — autoclosed — PR #472
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

One validation unit, three coordinated edits, from a Five-Whys run tonight in the climate-finance-het project: (a) an hourly autonomous orchestration was improvised via a scheduled-wakeup loop without consulting the skills catalog, so `nightbeat-supervisor` went undiscovered; (b) the improvised run used a static ticket itinerary, so a follow-up ticket filed mid-run (that project's 0249, child of an authorized parent) was never picked up.

1. **`rules/workflow.md` — reuse gate** (new section after Subagents): before designing any multi-cycle autonomous orchestration, inventory the skills/runbooks catalog and declare in the run plan which existing piece is reused or why none fits. The declaration makes compliance verifiable ex post.
2. **`rules/workflow.md` § Writing Skills and Hooks — tool-agnostic language**: generalizes the forge-agnostic bullet — skills and rules name capabilities, not the current tool that provides them; tool names rot, capabilities don't.
3. **`skills/nightbeat-supervisor/SKILL.md` — intent-based reframe** (mission command), opening on the author's doctrine: **autonomous mode trades supervision for time** — the run loses the human eye but nobody waits on the next reply, so the freed time goes to verification (independent passes: different lens or different agent, never producer self-reread) and to escalation, including consulting a more capable agent, when confidence is low. The contract is Goal + three invariants (live queue via lineage to an authorized parent; verify-before-integrate with depth scaling to the time available — overnight, multiple independent passes, not a single self-check; hard launch bounds); frequency, wake-up mechanism, decomposition, delegation, and building blocks are the executor's declared latitude. The **morning report carries an audit trace** (author's call — report, not invariant 2): per integrated unit, which independent verification passes ran and which escalation was used, or why none was needed — not escalating stays within latitude but becomes a declared, auditable choice, not a silence; the illustrative end-of-run template gains a matching per-unit line. The former mechanism-first steps survive as illustrative defaults, explicitly marked one possible organization. Concurrency declared per step (sequential cycle, sequential merge sweep, parallel-capable diagnoses).

## Why one PR

The rule creates the gate; the skill becomes the reusable piece the gate points to. Landing them separately leaves either a gate pointing at a mechanism-first skill or a reframed skill with no discovery gate.

## Verification

- [x] `make skills-catalog` regenerated README.md (description changed); `make check-skills-drift` OK (re-run after doctrine and audit-trace commits)
- [x] `scripts/check-agnostic.sh skills tickets` clean (re-run after doctrine and audit-trace commits)
- [x] `make check-fast` exit 0 (re-run after audit-trace commit; no failures)
- [x] `test_nightbeat_supervisor_skill.py` + `test_skill_descriptions.py` — 5 passed (commit-discipline markers preserved in the defaults section)
- [x] `erg check tickets/` PASS

**Ticket:** tickets/0274-reuse-gate-intent-based-supervisor-refra.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)