### PR TITLE
rules(workflow): monster-ticket decompose reflex

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -144,6 +144,8 @@ When compacting, preserve the list of modified files, test commands, and current
 
 **Rename/refactor sweeps cover the full logical unit.** When fixing one stale instance of a renamed term, sweep the smallest containing logical unit (CI step, function, config block) for siblings, and check parallel units (e.g. step 1 vs step 2 in the same workflow). Fix all occurrences in one commit.
 
+**Monster ticket found → propose decompose, not hold or brute-fanout.** A ticket with a large blast radius (touches ~15+ files, or rewrites a symbol/directory that other open tickets or a large import fan-in depend on), a build-gated or real-data exit (`make all`, a DVC repro, a training run), more than one MOA sign-off unit bundled in, or a dependency chain hidden in its prose rather than declared as `Blocked-by` — is neither a scheduling problem to skip nor a parallel-agent problem to fan out; either way it collides with siblings or blows the execute-agent timeout. Draft a tracking/epic ticket naming the blast radius, the partition boundary, any up-front architectural decision, and the wave order — then child tickets each sized to one sign-off unit, each `Blocked-by` its real prerequisite and NEVER the tracker. Autonomous run: file the split directly (the partition is mechanical once the blast radius is known — same standing as "sweep results are decisions"). Interactive session: propose the split to the author first — the partition boundary can be an architectural call the MOA owns, not the MOE's.
+
 # Identity
 
 The Imperial Dragon is not a bird. No avian analogies, ever — in skills, explanations, or naming rationale. Scale, power, taxonomy.

--- a/skills/pick-ticket/SKILL.md
+++ b/skills/pick-ticket/SKILL.md
@@ -54,7 +54,12 @@ Select one ticket for the current sweep run.
      files, change docs/config/tests rather than core logic, are easily
      reversible, and have no external dependencies
 
-   Exclude tickets whose scope won't fit the beat window (~50 min):
+   Exclude tickets whose scope won't fit the beat window (~50 min).
+   Before writing a beat-skip, apply the monster-ticket checklist
+   (`rules/workflow.md` § Autonomous Action Rules): if it's a monster,
+   decompose it into a tracking + child tickets so the children re-enter
+   the ready pool, and reserve the beat-skip for a ticket that is
+   well-scoped but simply too big for this window:
    write a beat-skip entry `{ "id": "...", "until": "{now+24h}", "reason": "scope-too-large: ..." }`
 
    Exclude tickets whose body contains a `## Attempt log` section with a

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -77,6 +77,8 @@ Prioritize:
 
 Read each ticket + STATE.md. Group by milestone. Identify dependency order and wave structure.
 
+Apply the monster-ticket checklist (`rules/workflow.md` § Autonomous Action Rules) to each candidate before wave grouping; decompose monsters into tracking + child tickets rather than holding them or fanning them into a colliding wave.
+
 ## Phase 2: Imagine (parallel)
 
 For each ticket, launch an agent (background, no isolation needed — read-only;


### PR DESCRIPTION
## What

Adds a standing reflex to `rules/workflow.md` § Autonomous Action Rules: when the agent encounters a **monster ticket**, it proposes de-risking + decomposition (a tracked epic with child tickets) rather than beat-skipping/holding it or blindly fanning it into a parallel wave.

Generalizes the project memory `feedback_raid_scope_triage_before_fanout` (climate-finance-het) into a harness-wide rule, and routes two existing skill call-sites through the new checklist.

## Changes

- **`rules/workflow.md`** — one new bullet after "Rename/refactor sweeps cover the full logical unit", in the section's terse declarative voice. Defines the monster criteria (large blast radius / build-gated or real-data exit / >1 MOA sign-off unit / prose-hidden dependency chain) and the decompose response, split by mode: autonomous files the partition directly; interactive proposes it to the MOA first.
- **`skills/pick-ticket/SKILL.md`** — the step-3 `scope-too-large` beat-skip now applies the monster checklist first: decompose a monster so its children re-enter the ready pool; reserve the beat-skip for a well-scoped ticket that is merely too big for this window.
- **`skills/raid/SKILL.md`** — Phase 1 Select applies the checklist to each candidate before wave grouping.

## Guards

- Body edits only; no frontmatter `description:` touched.
- `make check-skills-drift` — green (catalog in sync, no regen needed).
- `make check-agnostic-skills` — green.
- `tests/test_skill_descriptions.py`, `tests/test_model_rightsizing.py` — 7 passed.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)