### PR TITLE
tickets: file 0275 — dream mechanical count derivation

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Sync main: check the primary checkout's branch first](feedback_sync_main_check_primary_branch_first.md) — the primary checkout may sit on a feature branch; ff-merging origin/main there advances THAT branch. Update by ref (`fetch origin main:main`); preserve dirty overlapping files by backup + re-apply, never discard or bare-stash (2026-07-11)
 - [R&R intake is laborious](feedback_rr_intake_is_laborious.md) — Ingesting an editor decision + reviewer comments has no skill; done by hand it burns turns (Gmail re-search, comment recount, coverage verified 2-3×). Check `release/` not Gmail, archive to a known path, verify coverage once. Fix ticketed IDH 0265 (2026-06-18)
 - [No ruff ping-pong](feedback_no_ruff_ping_pong.md) — PostToolUse ruff hook fires after EVERY Edit; batch related edits so no intermediate state has unused imports; write new files complete in one Write
 - [Skill-lifecycle edits need whole-run reasoning](feedback_skill_lifecycle_edit_whole_run.md) — Adding an exit/cleanup step to a multi-step skill: place it at the true run-end and trace every commit/side-effect between, not at the step where the symptom appears; run /gaze on skill-control-flow changes (IDH 0247)

--- a/projects/-home-haduong--claude/memory/feedback_sync_main_check_primary_branch_first.md
+++ b/projects/-home-haduong--claude/memory/feedback_sync_main_check_primary_branch_first.md
@@ -1,0 +1,28 @@
+---
+name: sync-main-check-primary-branch-first
+description: Primary checkout may sit on a feature branch — "sync local main" via merge --ff-only advances THAT branch; update main by ref (fetch origin main:main) and preserve dirty overlapping files across the sync
+metadata:
+  type: feedback
+---
+
+"Sync local main" on the primary checkout (`git -C ~/.claude merge --ff-only
+origin/main`) silently fast-forwards **whatever branch is checked out there** —
+on 2026-07-11 that was another session's `monster-ticket-reflex`, not main
+(harmless only because its PR #473 had already merged). Two companion traps in
+the same operation: (a) the checkout can carry another session's uncommitted
+memory write (index lines + `!!`-ignored entry files, see
+[[idh-gitignore-whitelist-add-f]]) that collides with an incoming merge touching
+the same file; (b) plain `git branch -f main origin/main` is unsafe if main is
+checked out elsewhere.
+
+**Why:** the primary checkout is shared state across sessions; assuming it is
+on main turns a routine sync into a mutation of someone else's branch or a
+clobber of their in-flight write.
+
+**How to apply:** before any primary-checkout sync: `git -C ~/.claude branch
+--show-current` and `git -C ~/.claude status --short`. Update main without
+touching the checkout via `git -C ~/.claude fetch origin main:main` (ff-only by
+default). If the working tree must move to the new main and a dirty file
+overlaps the incoming diff: back the file up, `git checkout -- <file>`,
+ff-merge, then re-apply only the dirty lines on top — never discard, never bare
+stash (stash stack is shared, see rules/git.md).

--- a/tickets/0275-dream-derive-consolidation-counts-mechan.erg
+++ b/tickets/0275-dream-derive-consolidation-counts-mechan.erg
@@ -1,0 +1,57 @@
+%erg 0.1
+Title: dream: derive consolidation counts mechanically, not by prose recall
+Created: 2026-07-11
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-11T07:32Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+PR #471 (dream consolidation of climate-finance-het memory) shipped with a
+title claiming "76→74" when the real index count was 72→74, a NOOP count
+exceeding the base, and an ADD list naming 3 of 5 new files. /gaze round 1
+rerolled on it; an opus fix agent had to recompute the arithmetic by hand.
+Root cause: `skills/dream/SKILL.md` (report section, "Counts: N entries
+before → M after") asks for counts but never says how to obtain them, so the
+executor recalls them from prose instead of measuring.
+
+## Relevant files
+
+- `skills/dream/SKILL.md` — report/PR-body instructions to amend
+- `tests/test_dream*.py` — where a ratchet test would live
+
+## Actions
+
+1. Amend the dream report instructions: before/after entry counts come from
+   counting index lines in MEMORY.md at base vs head (e.g. `git show
+   <base>:<path> | grep -c '^- \['` vs the working copy), never from memory
+   of the run.
+2. Require the ADD/UPDATE/DELETE/NOOP breakdown to reconcile: NOOP + UPDATE +
+   DELETE = before; NOOP + UPDATE + ADD = after. State the identity in the
+   skill so the executor self-checks before opening the PR.
+3. Require the ADD list to be the exact set of created files from
+   `git diff --name-only --diff-filter=A`, not a narrative sample.
+
+## Test
+
+- Ratchet on the skill text: assert the count-derivation and reconciliation
+  instructions are present (RED on current SKILL.md, GREEN after).
+
+## Verification
+
+- [ ] SKILL.md names a mechanical source for every number in the report
+- [ ] Reconciliation identity stated
+- [ ] Ratchet test RED-before/GREEN-after demonstrated
+
+## Invariants
+
+- Existing dream behavior (consolidation logic, tombstones, provenance)
+  unchanged; this touches only the reporting contract.
+- `make check-fast` and skill-lint stay green.
+
+## Exit criteria
+
+- [ ] A future dream PR body's arithmetic is reproducible from the diff alone
+- [ ] Ratchet test merged


### PR DESCRIPTION
## What

Roar wrap-up filings after merging #472 and #471:

1. Ticket 0275: the dream skill must derive its consolidation report numbers (before/after index counts, ADD/UPDATE/DELETE/NOOP breakdown, ADD file list) mechanically from the diff, with a stated reconciliation identity — not recall them from prose.
2. One memory entry: syncing local main must check which branch the primary checkout is on first (this session ff-merged another session's branch; harmless by luck), with the safe by-ref idiom.

## Why

Step-3 sweep: #471's title said 76→74 when the index went 72→74, NOOP exceeded the base, and the ADD list named 3 of 5 files — a full /gaze reroll spent on reporting arithmetic. `skills/dream/SKILL.md` asks for counts but names no source; the ticket is the class-shaped regression guard (its exit criteria include a ratchet test).

Ticket-ref: tickets/0275-dream-derive-consolidation-counts-mechan.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)