### PR TITLE
roar: union sweep in step-8 integration review (green tests don't build)

### DIFF
--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -67,7 +67,7 @@ branch — there are no remote branches nor merge requests to inspect.
 
 7. **Close** the ticket if still open.
 8. **Check for tracking ticket**: if the closed ticket has a parent, check whether all sibling sub-tickets are now closed.
-    - All closed → integration review: re-read all child diffs, run full test suite, verify exit criteria.
+    - All closed → integration review: re-read all child diffs, run full test suite, verify exit criteria, and run a **repo-wide union sweep for the change class** (stale refs, moved/renamed paths) — a green suite does not exercise the build graph, so a dangling build reference survives every per-PR check. It is caught only by grepping the whole tree for the class of change at integration, not per-PR. (2026-07-11, 0240 reorg: a merged `.mk` prerequisite kept a moved script's old flat path; per-move greps and green `make check-fast` all passed — only the integration union grep found it.)
     - Any open → do nothing, tracker stays open.
 9. **Exit worktree** (if in one):
     a. Preflight from inside the worktree:


### PR DESCRIPTION
## What

Adds a **repo-wide union sweep for the change class** to roar step 8's integration review (`skills/roar/SKILL.md`).

## Why

A green test suite does not exercise the build graph. A dangling build reference — a moved/renamed path in a `Makefile`/`.mk` prerequisite, a `dvc.yaml` dep, a doc-provenance line — survives every per-PR check and every green `make check-fast`.

Proven by the 0240 `scripts/`-by-phase reorg (climate-finance-het, 2026-07-11): a merged `.mk` prerequisite kept a moved script's old flat path. All four per-move zero-stale greps passed, the full fast suite was green — only a repo-wide union grep for the change class *at integration* found it. Per-PR verification is necessary but not sufficient; the whole-tree sweep is the safety net.

## Scope

One-line addition to step 8's `All closed → integration review` bullet. Body edit only — no frontmatter/description change; `make check-skills-drift` OK.

**Ticket:** none