### PR TITLE
eager sync follow-ups: mechanical post-merge wiring, dedup, report surfacing (0277)

### DIFF
--- a/scripts/beat.py
+++ b/scripts/beat.py
@@ -761,70 +761,30 @@ def _sync_origin_main(project: Path) -> None:
     Called before housekeeping so that both housekeeping_needed() and
     pick-ticket see current ticket state from merged PRs.  All failures
     are non-fatal — the beat continues regardless.
+
+    Delegates to scripts/sync-local-main.sh — the one sync implementation
+    shared with the session-start hook and the merge skill (ticket 0277).
+    Unlike the former Python reimplementation, the script also handles the
+    default branch being checked out in a linked worktree.
     """
-    default_branch = _default_branch(project)
-
-    # Fetch only the default branch; skip on network or auth failure.
-    fetch = subprocess.run(  # noqa: S603
-        ["git", "fetch", "origin", default_branch],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=project,
-    )
-    if fetch.returncode != 0:
-        _log(
-            f"=== sync: git fetch failed — "
-            f"{(fetch.stderr.strip().splitlines() or ['network error'])[-1][:80]} ==="
+    script = Path(__file__).resolve().parent / "sync-local-main.sh"
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["bash", str(script), str(project)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
         )
+    except subprocess.TimeoutExpired:
+        _log(f"=== sync: timed out after 120s {_now_iso()} ===")
         return
-
-    # Advance local default branch.
-    branch = subprocess.run(  # noqa: S603
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=project,
-    ).stdout.strip()
-
-    if branch == default_branch:
-        # Checked out: ff-merge to advance HEAD.
-        merge = subprocess.run(  # noqa: S603
-            ["git", "merge", "--ff-only", f"origin/{default_branch}"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=project,
-        )
-        summary = (merge.stdout.strip().splitlines() or ["already up to date"])[0]
-        if merge.returncode == 0:
-            _log(f"=== sync: {default_branch}: {summary} {_now_iso()} ===")
-        else:
-            _log(
-                f"=== sync: ff-merge skipped — "
-                f"{(merge.stderr.strip().splitlines() or ['local commits ahead'])[-1][:80]} ==="
-            )
-    elif branch != "HEAD":
-        # Not checked out: update local ref without touching HEAD.
-        update = subprocess.run(  # noqa: S603
-            ["git", "fetch", "origin", f"{default_branch}:{default_branch}"],
-            capture_output=True,
-            text=True,
-            check=False,
-            cwd=project,
-        )
-        if update.returncode == 0:
-            _log(
-                f"=== sync: {default_branch} updated from origin (HEAD on {branch}) {_now_iso()} ==="
-            )
-        else:
-            _log(
-                f"=== sync: {default_branch} update skipped — "
-                f"{(update.stderr.strip().splitlines() or ['non-fast-forward'])[-1][:80]} ==="
-            )
-    else:
-        _log(f"=== sync: skipped — detached HEAD {_now_iso()} ===")
+    report = result.stdout.strip() or "already in sync"
+    if result.returncode != 0:
+        # The script's contract is exit 0; a non-zero exit means it is
+        # missing or broken, not that the repo is stale.
+        report = (result.stderr.strip().splitlines() or ["sync script failed"])[-1][:120]
+    _log(f"=== sync: {report} {_now_iso()} ===")
 
 
 # ── Main ───────────────────────────────────────────────────────────────────────

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -37,14 +37,14 @@ cat "$_script_dir/../rules/README.md" 2>/dev/null || true
 cat "$_script_dir/../memory/MEMORY.md" 2>/dev/null || true
 
 # Surface the previous session start's local-main sync report when it needed
-# attention (dirty overlap, divergence, refusal). A clean fast-forward stays
-# silent — only the outcomes that need a human decision reach the
-# conversation. (ticket 0277)
+# attention (dirty overlap, divergence, refusal). A clean fast-forward — and a
+# routine offline "fetch failed — skipped" — stays silent: only the outcomes
+# that need a human decision reach the conversation. (ticket 0277)
 if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
     _gcd=$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || _gcd=""
     _sync_report="${_gcd:+$_gcd/sync-local-main.last}"
     if [ -n "$_sync_report" ] && [ -f "$_sync_report" ] \
-       && grep -qE 'untouched|diverged|refused|failed' "$_sync_report" 2>/dev/null; then
+       && grep -qE 'untouched|diverged|refused' "$_sync_report" 2>/dev/null; then
         echo "Local-main sync (previous session start): $(cat "$_sync_report")"
     fi
 fi
@@ -66,8 +66,12 @@ fi
 # session's first git commands is safe. The report lands in
 # <git-common-dir>/sync-local-main.last (we are past the stdout cutoff);
 # the next session start surfaces it above the cutoff if it needs attention.
+# Write via tmp + mv: concurrent session starts share the common dir, and an
+# atomic rename keeps the report whole (last-writer-wins, never interleaved).
 _gcd=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || _gcd=""
 if [ -n "$_gcd" ]; then
-    ( timeout 60 "$_script_dir/sync-local-main.sh" "$CLAUDE_PROJECT_DIR" \
-        > "$_gcd/sync-local-main.last" 2>&1 & )
+    ( { timeout 60 "$_script_dir/sync-local-main.sh" "$CLAUDE_PROJECT_DIR" \
+          > "$_gcd/sync-local-main.last.$$" 2>&1 \
+        && mv -f "$_gcd/sync-local-main.last.$$" "$_gcd/sync-local-main.last" \
+        || rm -f "$_gcd/sync-local-main.last.$$"; } & )
 fi

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -36,6 +36,19 @@ cat "$_script_dir/../rules/README.md" 2>/dev/null || true
 # Kept tight — decay pass removes stale entries so injection cost stays bounded.
 cat "$_script_dir/../memory/MEMORY.md" 2>/dev/null || true
 
+# Surface the previous session start's local-main sync report when it needed
+# attention (dirty overlap, divergence, refusal). A clean fast-forward stays
+# silent — only the outcomes that need a human decision reach the
+# conversation. (ticket 0277)
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+    _gcd=$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || _gcd=""
+    _sync_report="${_gcd:+$_gcd/sync-local-main.last}"
+    if [ -n "$_sync_report" ] && [ -f "$_sync_report" ] \
+       && grep -qE 'untouched|diverged|refused|failed' "$_sync_report" 2>/dev/null; then
+        echo "Local-main sync (previous session start): $(cat "$_sync_report")"
+    fi
+fi
+
 # --- Nothing below this line may produce stdout (hook output = conversation context) ---
 exec >/dev/null 2>&1
 
@@ -50,5 +63,11 @@ fi
 # Eager local-main sync (rules/git.md § Local main syncs eagerly).
 # Backgrounded so an offline fetch can never stall session start; the script
 # is ff-only and never touches dirty or diverged state, so racing the
-# session's first git commands is safe.
-( timeout 60 "$_script_dir/sync-local-main.sh" "$CLAUDE_PROJECT_DIR" & )
+# session's first git commands is safe. The report lands in
+# <git-common-dir>/sync-local-main.last (we are past the stdout cutoff);
+# the next session start surfaces it above the cutoff if it needs attention.
+_gcd=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || _gcd=""
+if [ -n "$_gcd" ]; then
+    ( timeout 60 "$_script_dir/sync-local-main.sh" "$CLAUDE_PROJECT_DIR" \
+        > "$_gcd/sync-local-main.last" 2>&1 & )
+fi

--- a/scripts/sync-local-main.sh
+++ b/scripts/sync-local-main.sh
@@ -2,8 +2,13 @@
 # Sync the local default branch (main/master) to origin, safely, from any
 # checkout or linked worktree of the repo.
 #
+# Usage: sync-local-main.sh [checkout-dir] [branch]
+#   checkout-dir  any checkout/worktree of the repo (default: .)
+#   branch        branch to sync (default: detected default branch) — for
+#                 repos whose integration branch is not main/master (0277)
+#
 # Guarantees (see rules/git.md § Local main syncs eagerly):
-# - only the default branch moves — never whatever branch happens to be
+# - only the named/default branch moves — never whatever branch happens to be
 #   checked out where the script runs;
 # - fast-forward only: a diverged local default branch is reported, not moved;
 # - no working tree is discarded or stashed: when the default branch is
@@ -19,8 +24,12 @@ cd "${1:-.}" 2>/dev/null || { echo "sync-local-main: no such directory '${1:-.}'
 git rev-parse --git-common-dir >/dev/null 2>&1 || { echo "sync-local-main: not a git repo — skipped"; exit 0; }
 git remote get-url origin >/dev/null 2>&1 || { echo "sync-local-main: no origin remote — nothing to sync"; exit 0; }
 
-# Default branch from origin/HEAD; fall back to main, then master.
-default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||') || true
+# Branch to sync: explicit second argument, else the default branch from
+# origin/HEAD, falling back to main, then master.
+default="${2:-}"
+if [ -z "$default" ]; then
+    default=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||') || true
+fi
 if [ -z "${default:-}" ]; then
     if git show-ref --verify --quiet refs/heads/main; then default=main
     elif git show-ref --verify --quiet refs/heads/master; then default=master

--- a/scripts/sync-local-main.sh
+++ b/scripts/sync-local-main.sh
@@ -5,7 +5,7 @@
 # Usage: sync-local-main.sh [checkout-dir] [branch]
 #   checkout-dir  any checkout/worktree of the repo (default: .)
 #   branch        branch to sync (default: detected default branch) — for
-#                 repos whose integration branch is not main/master (0277)
+#                 repos whose integration branch is not main/master (ticket 0277)
 #
 # Guarantees (see rules/git.md § Local main syncs eagerly):
 # - only the named/default branch moves — never whatever branch happens to be

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -37,15 +37,15 @@ Merge is queued via auto-merge; it lands when required checks pass (falls back t
 
 ## After the merge lands
 
-Once the merge is confirmed (PR state MERGED — poll if it was queued), sync
-the local default branch:
+The script itself polls for the merge to land and then runs
+`~/.claude/scripts/sync-local-main.sh` on the base branch (rules/git.md
+§ Local main syncs eagerly) — no manual sync step. Two outputs still need
+action:
 
-```bash
-~/.claude/scripts/sync-local-main.sh
-```
+- "Merge queued but not yet landed" — the bounded poll ran out (slow CI).
+  Confirm the PR reaches MERGED, then run `~/.claude/scripts/sync-local-main.sh`.
+- "left untouched" in the sync report — dirty overlap or divergence where the
+  base branch is checked out; report it to the caller rather than forcing.
 
-This is the eager-sync gate of rules/git.md § Local main syncs eagerly: it
-fast-forwards main by ref (or in whichever worktree has it checked out) and
-never touches dirty or diverged state — report its output if it says
-"left untouched". Do not substitute a hand-rolled `merge --ff-only` on the
-primary checkout: that advances whatever branch is checked out there.
+Do not substitute a hand-rolled `merge --ff-only` on the primary checkout:
+that advances whatever branch is checked out there.

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -282,7 +282,7 @@ if try_auto_merge; then
         sync_local_base
     else
         MERGE_LANDED=0
-        echo "Merge not confirmed landed — check 'gh pr view ${PR}', then sync local ${BASE_BRANCH} after it lands (sync-local-main.sh)."
+        echo "Merge not confirmed landed — check PR #${PR}'s state, then sync local ${BASE_BRANCH} after it lands (sync-local-main.sh)."
     fi
 else
     # Genuine auto-merge-unavailable: repo has auto-merge disabled. Legacy

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -154,7 +154,7 @@ fi
 POLL_INTERVAL="${ERG_PR_MERGE_POLL_INTERVAL:-10}"   # seconds between polls
 MERGE_POLL_TRIES="${ERG_PR_MERGE_POLL_TRIES:-5}"    # mergeability settle polls
 WATCH_RACE_TRIES="${ERG_PR_MERGE_WATCH_TRIES:-3}"   # checks-watch race retries
-MERGED_POLL_TRIES="${ERG_PR_MERGE_MERGED_TRIES:-12}" # merged-state polls (0277)
+MERGED_POLL_TRIES="${ERG_PR_MERGE_MERGED_POLL_TRIES:-12}" # merged-state polls (ticket 0277)
 
 # Eager local-main sync once the merge lands (ticket 0277; rules/git.md
 # § Local main syncs eagerly). Overridable so the test suite injects a stub.
@@ -256,7 +256,7 @@ sync_local_base() {
     if [[ -x "$SYNC_LOCAL_MAIN" ]]; then
         "$SYNC_LOCAL_MAIN" . "$BASE_BRANCH" || true
     else
-        echo "sync-local-main.sh not found — sync local ${BASE_BRANCH} manually"
+        echo "sync-local-main.sh not found or not executable — sync local ${BASE_BRANCH} manually"
     fi
     return 0
 }

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -154,6 +154,11 @@ fi
 POLL_INTERVAL="${ERG_PR_MERGE_POLL_INTERVAL:-10}"   # seconds between polls
 MERGE_POLL_TRIES="${ERG_PR_MERGE_POLL_TRIES:-5}"    # mergeability settle polls
 WATCH_RACE_TRIES="${ERG_PR_MERGE_WATCH_TRIES:-3}"   # checks-watch race retries
+MERGED_POLL_TRIES="${ERG_PR_MERGE_MERGED_TRIES:-12}" # merged-state polls (0277)
+
+# Eager local-main sync once the merge lands (ticket 0277; rules/git.md
+# § Local main syncs eagerly). Overridable so the test suite injects a stub.
+SYNC_LOCAL_MAIN="${ERG_PR_MERGE_SYNC:-$(cd "$(dirname "$0")" && pwd)/../../scripts/sync-local-main.sh}"
 
 # Poll until GitHub finishes recomputing mergeability. The Step-2 close-commit
 # push flips `mergeable` to UNKNOWN transiently; bounded so a genuinely-stuck
@@ -231,6 +236,31 @@ watch_checks_or_die() {
     die "CI checks never registered after ${WATCH_RACE_TRIES} attempts (no checks reported) — aborting merge"
 }
 
+# Poll until the PR reports MERGED — bounded, for the auto-queued path where
+# the merge lands only after required checks pass. (ticket 0277)
+wait_for_merged() {
+    local i state
+    for (( i=0; i<MERGED_POLL_TRIES; i++ )); do
+        state=$(gh pr view "$PR" --json state --jq '.state' 2>/dev/null || echo UNKNOWN)  # harness-extension-point
+        [[ "$state" == "MERGED" ]] && return 0
+        sleep "$POLL_INTERVAL"
+    done
+    return 1
+}
+
+# Sync the local base branch once the merge has landed. Never fatal: the sync
+# outcome must not change this script's merge/close semantics or exit code.
+# A missing script (e.g. erg-pr-merge copied out of the harness tree) degrades
+# to the manual reminder. (ticket 0277)
+sync_local_base() {
+    if [[ -x "$SYNC_LOCAL_MAIN" ]]; then
+        "$SYNC_LOCAL_MAIN" . "$BASE_BRANCH" || true
+    else
+        echo "sync-local-main.sh not found — sync local ${BASE_BRANCH} manually"
+    fi
+    return 0
+}
+
 echo "Queueing merge for PR #${PR}..."
 if in_worktree; then
     MERGE_FLAGS=(--merge --auto)
@@ -241,6 +271,14 @@ fi
 if try_auto_merge; then
     echo "Merge queued; lands when required checks pass."
     AUTO_QUEUED=1
+    if wait_for_merged; then
+        echo "PR #${PR} merged."
+        MERGE_LANDED=1
+        sync_local_base
+    else
+        MERGE_LANDED=0
+        echo "Merge queued but not yet landed — sync local ${BASE_BRANCH} after it lands (sync-local-main.sh)."
+    fi
 else
     # Genuine auto-merge-unavailable: repo has auto-merge disabled. Legacy
     # watch-then-merge path so the script stays usable without
@@ -255,6 +293,8 @@ else
             || die "merge failed and PR is not merged — check 'gh pr view $PR'"  # harness-extension-point
     fi
     AUTO_QUEUED=0
+    MERGE_LANDED=1
+    sync_local_base
 fi
 
 # ── Step 4: return to base branch (skipped inside a worktree) ────────────────
@@ -262,7 +302,11 @@ fi
 if in_worktree; then
     echo "In git worktree — exit the worktree when done."
 elif [[ "${AUTO_QUEUED:-0}" -eq 1 ]]; then
-    echo "Auto-merge queued — leaving local ${BASE_BRANCH} untouched; sync after the PR lands."
+    if [[ "${MERGE_LANDED:-0}" -eq 1 ]]; then
+        echo "Local ${BASE_BRANCH} synced (see sync-local-main report above, if any)."
+    else
+        echo "Auto-merge queued — leaving local ${BASE_BRANCH} untouched; sync after the PR lands."
+    fi
 else
     git checkout "$BASE_BRANCH"
     # Safe fast-forward: skip when local branch has unpushed commits

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -243,7 +243,12 @@ wait_for_merged() {
     for (( i=0; i<MERGED_POLL_TRIES; i++ )); do
         state=$(gh pr view "$PR" --json state --jq '.state' 2>/dev/null || echo UNKNOWN)  # harness-extension-point
         [[ "$state" == "MERGED" ]] && return 0
-        sleep "$POLL_INTERVAL"
+        # Closed without merging: this merge will never land — stop polling.
+        [[ "$state" == "CLOSED" ]] && return 1
+        # No sleep after the final poll — the timeout path returns immediately.
+        if (( i + 1 < MERGED_POLL_TRIES )); then
+            sleep "$POLL_INTERVAL"
+        fi
     done
     return 1
 }
@@ -277,7 +282,7 @@ if try_auto_merge; then
         sync_local_base
     else
         MERGE_LANDED=0
-        echo "Merge queued but not yet landed — sync local ${BASE_BRANCH} after it lands (sync-local-main.sh)."
+        echo "Merge not confirmed landed — check 'gh pr view ${PR}', then sync local ${BASE_BRANCH} after it lands (sync-local-main.sh)."
     fi
 else
     # Genuine auto-merge-unavailable: repo has auto-merge disabled. Legacy

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -2408,3 +2408,68 @@ class TestFallbackRotation:
             beat.main()
 
         assert raid_calls == [tmp_project]
+
+
+# ── _sync_origin_main — shared sync script behavior (ticket 0277) ─────────────
+
+
+def _run_git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+
+
+@pytest.mark.integration
+class TestSyncOriginMainSharedScript:
+    """_sync_origin_main delegates to scripts/sync-local-main.sh (ticket 0277).
+
+    The linked-worktree case is the discriminating one: the old Python
+    reimplementation looked only at the project checkout's own branch, so with
+    main checked out in a linked worktree it tried `fetch main:main`, was
+    refused, and silently left main stale. The shared script ff-merges in
+    whichever worktree holds main.
+    """
+
+    def _seed(self, tmp_path: Path) -> tuple[Path, str]:
+        origin = tmp_path / "origin.git"
+        seed = tmp_path / "seed"
+        clone = tmp_path / "clone"
+        _run_git("init", "--quiet", "--bare", "--initial-branch=main", str(origin), cwd=tmp_path)
+        _run_git("init", "--quiet", "--initial-branch=main", str(seed), cwd=tmp_path)
+        (seed / "f.txt").write_text("one\n")
+        _run_git("add", "f.txt", cwd=seed)
+        _run_git(
+            "-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false",
+            "commit", "--quiet", "-m", "c1", cwd=seed,
+        )
+        _run_git("remote", "add", "origin", str(origin), cwd=seed)
+        _run_git("push", "--quiet", "origin", "main", cwd=seed)
+        _run_git("clone", "--quiet", str(origin), str(clone), cwd=tmp_path)
+        (seed / "f.txt").write_text("two\n")
+        _run_git(
+            "-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false",
+            "commit", "--quiet", "-am", "c2", cwd=seed,
+        )
+        _run_git("push", "--quiet", "origin", "main", cwd=seed)
+        new_sha = _run_git("rev-parse", "main", cwd=seed).stdout.strip()
+        return clone, new_sha
+
+    def test_advances_main_checked_out_in_linked_worktree(self, tmp_path):
+        clone, new_sha = self._seed(tmp_path)
+        _run_git("switch", "--quiet", "-c", "feature", cwd=clone)
+        _run_git(
+            "worktree", "add", "--quiet", str(tmp_path / "wt-main"), "main", cwd=clone
+        )
+
+        beat._sync_origin_main(clone)
+
+        got = _run_git("rev-parse", "refs/heads/main", cwd=clone).stdout.strip()
+        assert got == new_sha, "main left stale while checked out in a linked worktree"
+
+    def test_plain_clone_fast_forwards_main(self, tmp_path):
+        clone, new_sha = self._seed(tmp_path)
+
+        beat._sync_origin_main(clone)
+
+        got = _run_git("rev-parse", "refs/heads/main", cwd=clone).stdout.strip()
+        assert got == new_sha

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -186,7 +186,7 @@ run_merge() {  # $1 body, $2 title  — runs the script with cwd in the repo
       STUB_STATE="${STUB_STATE:-MERGED}" \
       STUB_SYNC_LOG="${STUB_SYNC_LOG:-/dev/null}" \
       ERG_PR_MERGE_SYNC="${ERG_PR_MERGE_SYNC:-}" \
-      ERG_PR_MERGE_MERGED_TRIES="${ERG_PR_MERGE_MERGED_TRIES:-2}" \
+      ERG_PR_MERGE_MERGED_POLL_TRIES="${ERG_PR_MERGE_MERGED_POLL_TRIES:-2}" \
       ERG_PR_MERGE_POLL_INTERVAL=0 \
       bash "$SCRIPT" 42 )
 }

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -54,6 +54,10 @@ case "$1 $2" in
       if [[ "$args" == *"autoMergeRequest"* ]]; then
         echo "${STUB_MERGE_EFFECT:-no}"; exit 0
       fi
+      # wait_for_merged probe: --json state --jq '.state' (ticket 0277)
+      if [[ "$args" == *"state"* ]]; then
+        echo "${STUB_STATE:-MERGED}"; exit 0
+      fi
     fi
     if [[ "$args" == *"title"* ]]; then
       jq -n --arg t "$STUB_TITLE" '{title:$t}'; exit 0
@@ -179,6 +183,10 @@ run_merge() {  # $1 body, $2 title  — runs the script with cwd in the repo
       STUB_READY_LOG="${STUB_READY_LOG:-/dev/null}" \
       STUB_MERGE_COSMETIC_FAIL="${STUB_MERGE_COSMETIC_FAIL:-0}" \
       STUB_MERGE_EFFECT="${STUB_MERGE_EFFECT:-no}" \
+      STUB_STATE="${STUB_STATE:-MERGED}" \
+      STUB_SYNC_LOG="${STUB_SYNC_LOG:-/dev/null}" \
+      ERG_PR_MERGE_SYNC="${ERG_PR_MERGE_SYNC:-}" \
+      ERG_PR_MERGE_MERGED_TRIES="${ERG_PR_MERGE_MERGED_TRIES:-2}" \
       ERG_PR_MERGE_POLL_INTERVAL=0 \
       bash "$SCRIPT" 42 )
 }
@@ -543,5 +551,77 @@ else
     echo "PASS: genuine merge failure still aborts (merge_took_effect=no)"
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# Case 17: eager local-main sync (ticket 0277). Once the queued merge lands
+# (state MERGED), the script must invoke sync-local-main exactly once, passing
+# the base branch. ERG_PR_MERGE_SYNC points at a logging stub so the assertion
+# is on invocations, not on git effects.
+# ════════════════════════════════════════════════════════════════════════════
+SYNC_STUB_DIR="$WORK/sync-stub"
+mkdir -p "$SYNC_STUB_DIR"
+cat > "$SYNC_STUB_DIR/sync-ok" <<'SYNCSTUB'
+#!/usr/bin/env bash
+echo "$@" >> "$STUB_SYNC_LOG"
+echo "sync-stub: synced"
+SYNCSTUB
+cat > "$SYNC_STUB_DIR/sync-fail" <<'SYNCSTUB'
+#!/usr/bin/env bash
+echo "$@" >> "$STUB_SYNC_LOG"
+echo "sync-stub: failing deliberately" >&2
+exit 1
+SYNCSTUB
+chmod +x "$SYNC_STUB_DIR/sync-ok" "$SYNC_STUB_DIR/sync-fail"
+
+seed_repo synccase 0277
+SLOG17="$WORK/sync17.log"; : > "$SLOG17"
+BODY17=$'Summary.\n\n**Ticket:** tickets/0277-fixture.erg\n'
+if STUB_STATE=MERGED ERG_PR_MERGE_SYNC="$SYNC_STUB_DIR/sync-ok" \
+   STUB_SYNC_LOG="$SLOG17" \
+   run_merge "$BODY17" "ticket(0277): sync" >/dev/null 2>&1; then
+    s_miss=0
+    calls=$(wc -l < "$SLOG17")
+    [[ "$calls" -eq 1 ]] || { echo "  expected exactly 1 sync call, got $calls"; s_miss=1; }
+    grep -q -- "$BASE" "$SLOG17" || { echo "  sync not passed the base branch '$BASE'"; s_miss=1; }
+    if (( s_miss )); then echo "FAIL: merged PR did not trigger exactly one base-branch sync"; fail=1
+    else echo "PASS: merge landed -> sync-local-main invoked once with the base branch"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on the sync happy path"; fail=1
+fi
+
+# Case 17b: sync failure is non-fatal — merge/close semantics and exit code
+# unchanged (ticket 0277 invariant).
+seed_repo syncfail 0278
+SLOG17b="$WORK/sync17b.log"; : > "$SLOG17b"
+BODY17b=$'Summary.\n\n**Ticket:** tickets/0278-fixture.erg\n'
+if STUB_STATE=MERGED ERG_PR_MERGE_SYNC="$SYNC_STUB_DIR/sync-fail" \
+   STUB_SYNC_LOG="$SLOG17b" \
+   run_merge "$BODY17b" "ticket(0278): syncfail" >/dev/null 2>&1; then
+    if closed_has 0278 && [[ "$(wc -l < "$SLOG17b")" -eq 1 ]]; then
+        echo "PASS: sync failure tolerated — script still exits 0, ticket closed"
+    else
+        echo "FAIL: sync-failure case lost the close or the sync call"; fail=1
+    fi
+else
+    echo "FAIL: a failing sync changed erg-pr-merge's exit code"; fail=1
+fi
+
+# Case 17c: merge queued but not yet landed (state stays OPEN past the bounded
+# poll) — NO sync call, still exit 0, and the output tells the caller to sync
+# after it lands.
+seed_repo syncqueued 0279
+SLOG17c="$WORK/sync17c.log"; : > "$SLOG17c"
+BODY17c=$'Summary.\n\n**Ticket:** tickets/0279-fixture.erg\n'
+if out=$(STUB_STATE=OPEN ERG_PR_MERGE_SYNC="$SYNC_STUB_DIR/sync-ok" \
+   STUB_SYNC_LOG="$SLOG17c" \
+   run_merge "$BODY17c" "ticket(0279): queued" 2>&1); then
+    q_miss=0
+    [[ "$(wc -l < "$SLOG17c")" -eq 0 ]] || { echo "  sync called before the merge landed"; q_miss=1; }
+    echo "$out" | grep -qi "after it lands" || { echo "  no sync-later reminder in output"; q_miss=1; }
+    if (( q_miss )); then echo "FAIL: queued-not-landed path mishandled"; fail=1
+    else echo "PASS: queued-not-landed -> no premature sync, reminder printed, exit 0"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero when the queued merge had not landed"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated"
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands"

--- a/tests/test_sync_local_main.sh
+++ b/tests/test_sync_local_main.sh
@@ -132,6 +132,26 @@ else
     _fail "nonexistent path must skip cleanly (got: $out, exit $?)"
 fi
 
+# --- case 10: explicit branch argument → the NAMED branch syncs, the default
+# branch is left where it was (ticket 0277) -----------------------------------
+_setup brancharg
+seed="$SANDBOX/brancharg-seed"
+( cd "$seed" && git switch --quiet -c dev &&
+  echo d1 > d.txt && git add d.txt && git commit --quiet -m d1 &&
+  git push --quiet origin dev &&
+  echo d2 > d.txt && git commit --quiet -am d2 && git push --quiet origin dev )
+dev_new=$(git -C "$seed" rev-parse dev)
+git -C "$CLONE" fetch --quiet origin dev
+git -C "$CLONE" branch --quiet dev "$(git -C "$CLONE" rev-parse origin/dev^)"
+main_before=$(_main_sha "$CLONE")
+if bash "$SYNC" "$CLONE" dev >/dev/null \
+   && [ "$(git -C "$CLONE" rev-parse refs/heads/dev)" = "$dev_new" ] \
+   && [ "$(_main_sha "$CLONE")" = "$main_before" ]; then
+    _pass "branch argument syncs the named branch and leaves the default branch alone"
+else
+    _fail "branch argument should sync only the named branch (dev)"
+fi
+
 if (( fail )); then
     exit 1
 fi

--- a/tickets/closed/0277-sync-local-main-follow-ups-mechanical-po.erg
+++ b/tickets/closed/0277-sync-local-main-follow-ups-mechanical-po.erg
@@ -2,10 +2,12 @@
 Title: sync-local-main follow-ups: mechanical post-merge wiring, dedup, report surfacing
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #479
 
 --- log ---
 2026-07-11T10:41Z Minh Ha-Duong created
 
+2026-07-11T11:29Z Minh Ha-Duong closed — autoclosed — PR #479
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

Closes the four follow-ups from PR #475's gaze verdict — no call site relies on the model remembering to sync anymore:

1. **`skills/merge/erg-pr-merge`** — after queueing auto-merge, polls (bounded, `ERG_PR_MERGE_MERGED_POLL_TRIES`, default 12×10s) for the PR to reach MERGED, then runs `sync-local-main.sh` on the base branch; the watch-then-merge fallback syncs right after its merge. Sync outcome never changes exit code or close semantics; `ERG_PR_MERGE_SYNC` injects a stub for tests. SKILL.md drops the manual step.
2. **`scripts/beat.py`** — `_sync_origin_main` delegates to the shared script. This also fixes a real gap: with main checked out in a linked worktree, the old Python path's `fetch main:main` was refused and main stayed silently stale.
3. **`scripts/on-start.sh`** — the backgrounded sync's report persists atomically (tmp+mv) to `<git-common-dir>/sync-local-main.last`; the next session start surfaces it above the stdout cutoff only when it matches an attention pattern (untouched/diverged/refused).
4. **`scripts/sync-local-main.sh`** — optional second argument naming the branch to sync (erg-pr-merge passes the PR's actual base branch).

## Verification

- [x] TDD: all new tests confirmed RED before implementation — shell cases 10 (branch arg), 17/17b/17c (sync-on-merge, failure-tolerated, queued-not-landed) and pytest `TestSyncOriginMainSharedScript` (linked-worktree case reproduces the old code's refusal verbatim)
- [x] `make check` — 648 pytest tests + all shell/drift/agnostic gates, exit 0 (re-run after review fixes)
- [x] `/verify-adherence t277-sync-followups` — **PASS**, 0 mechanical failures, 0 semantic findings (gaze may skip the mechanical phase)
- [x] Five-perspective review panel ran; all findings fixed or rationale recorded (see review-synthesis comment)

**Ticket:** tickets/0277-sync-local-main-follow-ups-mechanical-po.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)