### PR TITLE
gitignore: track per-project agent memory (projects/*/memory/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,17 @@
 !memory/
 !memory/**
 memory/.provenance.lock
+
+# Per-project agent memory (projects/<hash>/memory/): track note bodies + index.
+# The top-level `*` + git's parent-exclusion rule silently ignored these — only
+# force-added ones survived. Re-include the path chain down to memory/ (not the
+# bulky transcripts/session files under projects/), and keep ignoring the
+# transient provenance lock (mirrors the top-level memory/ rules above).
+!projects/
+!projects/*/
+!projects/*/memory/
+!projects/*/memory/**
+projects/*/memory/.provenance.lock
 !tickets/
 !tickets/**
 tickets/tools/go/*.test

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_moving_files_narrows_guard_globs.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_moving_files_narrows_guard_globs.md
@@ -1,0 +1,34 @@
+---
+name: feedback_moving_files_narrows_guard_globs
+description: Relocating files silently narrows fixed-directory guard globs; a green suite hides the lost coverage
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d329f489-e346-4cba-8c47-36d92cd64019
+---
+
+Relocating files that a test guard enumerates by globbing a **fixed directory**
+(e.g. `glob("<root>/*.mk")`) silently drops the moved files out of that guard's
+coverage. The test keeps **passing** — not because the contract still holds, but
+because it now parametrizes over fewer files. A green suite actively hides the
+regression.
+
+**Why:** these guards are class-ratchets (scan every producer/fragment for an
+anti-pattern). Their teeth come from *coverage*, so narrowing coverage is a
+silent defeat, invisible to a diff review and to `make lint`.
+
+**How to apply:** when a reorg/rename moves files, `grep` the whole test tree for
+every enumeration of that file type (`glob(...*.EXT)`, `listdir ... endswith`),
+not just the sites that break the build. Extend each to the new location. Better:
+route all of them through ONE shared discovery helper so a future move updates one
+place, and add a meta-guard that fails on any hand-rolled glob outside the helper.
+Concretely on climate-finance-het (0239 relocating 5 `.mk` → `scripts/analysis/`):
+5 sites hand-rolled `.mk` enumeration; only 2 broke the build, 1 more was caught
+by `/gaze`, and 2 (`test_makefile_contract`, `test_deliverables_layout`) had a
+*latent* gap — passing but no longer covering the moved files. Filed as 0248.
+
+This is the enumeration-glob cousin of [[feedback_reorg_tracker_first_class_guard]]
+(guards must be class-level, not per-file whitelists) and the same "green tests
+hide a misplaced/uncovered output" family as [[feedback_bytecheck_old_vs_new_not_golden]].
+Verify a pure move with the artifact/graph itself (`make -n` recipe-identity +
+one runtime build), never a green suite alone.

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_raid_scope_triage_before_fanout.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_raid_scope_triage_before_fanout.md
@@ -1,0 +1,40 @@
+---
+name: feedback_raid_scope_triage_before_fanout
+description: "A /raid over N tickets is not automatically an N-wide fan-out; triage for chains, shared-subtree conflict, and data-heavy gates first"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d329f489-e346-4cba-8c47-36d92cd64019
+---
+
+A `/raid A B C D` invocation names the *candidate* set, not the concurrency. Before
+launching execute agents, triage the set and degrade the wave to the
+autonomously-safe subset:
+
+1. **Dependency edges** — a `Blocked-by` between two named tickets makes them a
+   chain, not a parallel wave. The blocked child cannot start this session.
+2. **Shared-subtree conflict** — if several tickets rewrite the same tree, parallel
+   worktree agents collide catastrophically. A 173-file move that repoints imports
+   across the repo (`utils` imported 169×) conflicts with every sibling that touches
+   `scripts/`; running them together loses work at merge.
+3. **Data-heavy / long-running exit gate** — a ticket whose gate is `make clean &&
+   make all` (full data build) or a 173-file move exceeds the 10-min execute-agent
+   timeout AND violates the no-long-running-build preference
+   ([[feedback_no_long_running]]). Hold it for a supervised run; don't feed it to a
+   background agent.
+
+**Why:** fanning out the literal N would have launched four conflicting agents on
+one subtree with a doomed 173-file/make-all agent among them — a costly failure the
+invocation's surface (four ticket IDs) hides.
+
+**How to apply:** verify the tree cheaply (file count, import fan-in, whether the
+target script even has a Make target), state the wave restructure, and ask the author
+only the one call that's genuinely theirs (run the heavy ticket now vs hold). Then run
+the safe subset. Concretely (raid 240/241/242/248, 2026-07-11): held 0240 (173-file
+move + make all) and 0241 (blocked-by 0240); ran only 0248 (tests-only) + 0242
+(one-file sever) as two parallel agents on disjoint files — both merged clean.
+
+Pairs with [[feedback_pilot_one_instance_critiques_the_ticket]] (the same pass that
+sizes the raid also falsifies a ticket's guessed approach — 0242's "extract a label
+helper" was wrong; the real coupling was two live plotter calls) and
+[[feedback_gate_execute_on_all_scopers]].

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_file_relocation_move_surface.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_file_relocation_move_surface.md
@@ -1,0 +1,48 @@
+---
+name: project_file_relocation_move_surface
+description: "Relocating a script/entry-point in climate-finance-het touches 8 surfaces, not just git mv — the full repoint checklist"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: d329f489-e346-4cba-8c47-36d92cd64019
+---
+
+Moving a `scripts/*.py` entry point to a subdir (or renaming it) in
+climate-finance-het is **never** just `git mv`. The 0240 reorg (132 files across
+qa→harvest→analysis→figures) discovered the surface incrementally — each move
+found one more the prior missed. The complete repoint checklist:
+
+1. **Build refs** — `Makefile` + `scripts/analysis/*.mk` + `deliverables/*/*.mk`
+   (rule prerequisites AND recipe paths). A rule line often mixes a mover with
+   stay-flat libs (`plot_style.py`, `utils.py`) — repoint only the mover.
+2. **`dvc.yaml`** — Phase-1 `catalog_/enrich_/corpus_/qa_` scripts are dvc
+   stages; repoint `cmd:` and `deps:`. A stale dvc dep is a silent dangling dep
+   (no guard catches it). (`dvc.lock` self-heals on next `dvc repro` — don't
+   hand-edit it.)
+3. **Test refs, 3 kinds** — bare-name `from X import` (subdirs aren't source
+   roots), `spec_from_file_location("scripts/X.py")`, source-inspection
+   `open("scripts/X.py").read()`.
+4. **Doc provenance** — `deliverables/_shared/_includes/*.md`, `docs/*.md`
+   (incl. `editorial-brief.md`), `.agent/guidelines/*.md`, the moved file's own
+   docstring. Path lines only, no prose change.
+5. **`pyproject.toml` per-file-ignores** — a `[tool.ruff.lint.per-file-ignores]`
+   keyed on `"scripts/X.py"` narrows on the move and resurfaces intentional
+   F401s as errors ([[feedback_ruff_fix_breaks_reexport_facades]]).
+6. **Subprocess-from-foreign-cwd** — a test that subprocess-runs a moved script
+   from a tmp dir needs `tests/_source_roots.py::source_root_env()` (its own dir
+   is no longer the flat root).
+7. **Guard predicates** — scans gated on `name.startswith(PREFIX)` must use
+   `os.path.basename(name).startswith(...)`, or every subdir'd file drops out
+   silently ([[feedback_moving_files_narrows_guard_globs]]).
+8. **Archive cp-loops** — `build/build_*_archive.sh` must `cp --parents` the real
+   path, not a flat `cp "scripts/$s"` (ticket 0261).
+
+**Verify a move** by recipe-identity (`make -n <target>` differs only by the
+path segment — the [[feedback_bytecheck_old_vs_new_not_golden]] discipline for
+build graphs) + a **repo-wide union grep** at integration time, NOT per-PR greps
+alone: the 0240 integration sweep caught a dangling `venues.mk` ref that all
+per-move greps + green `make check-fast` missed (green tests never build).
+Imports resolve because the repo puts source roots (`scripts` +
+`libs/openalex-corpus/src`) on the path in every execution context — see
+architecture.md § Shared conventions (ticket 0253); a move needs no `import`
+edit inside the moved file.

--- a/tickets/0278-track-the-untracked-per-project-memory-b.erg
+++ b/tickets/0278-track-the-untracked-per-project-memory-b.erg
@@ -1,0 +1,52 @@
+%erg 0.1
+Title: Track the untracked per-project memory backlog across all projects
+Created: 2026-07-11
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-11T11:08Z Minh Ha-Duong created
+
+--- body ---
+## Context
+The `.gitignore` top-level `*` catch-all + git's parent-exclusion rule silently
+ignored per-project memory under `projects/<hash>/memory/` — the `!memory/**`
+negation only re-includes the *top-level* `memory/`, and `projects/` was never
+re-included. Historically ~441 note bodies across 9 projects got force-added and
+stay tracked, but new memory bodies fall through: ~522 note bodies were untracked
+and unbacked (a machine loss drops them).
+
+The fixing PR (branch `track-project-memory-gitignore`) adds the `.gitignore`
+re-inclusion for `projects/*/memory/**` and commits the **climate-finance-het**
+project's 3 orphans as the reviewed exemplar. This ticket covers the remaining
+backlog in the OTHER projects — deliberately deferred so ~500 files don't land
+unreviewed in one commit.
+
+## Actions
+1. After the fixing PR merges, for EACH other `projects/<hash>/` dir: list its
+   untracked memory bodies (`git status --porcelain projects/<hash>/memory/`).
+2. Eyeball each project's set before adding — memory bodies may name paths but
+   never credentials (global rule); flag anything machine-specific or stale that
+   should NOT be committed and leave it, noting why.
+3. `git add projects/<hash>/memory/` (explicit path — never `git add -A`, which
+   would also surface transcripts) and commit per project (or a few at a time),
+   so the review stays tractable.
+4. Confirm each project's `MEMORY.md` index is tracked too (some may not be).
+
+## Test / verify
+- After: `git status` shows no untracked `projects/*/memory/*.md`.
+- `comm` the on-disk `find projects/*/memory -name '*.md'` set against
+  `git ls-files 'projects/*/memory/*.md'` — the only diff should be explicitly
+  excluded files (with a recorded reason).
+- The transient `projects/*/memory/.provenance.lock` stays ignored (the fix
+  re-ignores it, mirroring the top-level rule).
+
+## Invariants
+- Never `git add -A` under `projects/` — it un-ignores memory only; transcripts
+  and session files must stay ignored.
+- No credentials in any committed note (global rule; verify on eyeball).
+
+## Exit criteria
+- Every project's memory bodies + `MEMORY.md` are tracked, or explicitly left
+  out with a one-line reason.
+- `git status` clean of untracked `projects/*/memory/*.md` across all projects.
+


### PR DESCRIPTION
## Problem

Per-project memory under `projects/<hash>/memory/` was silently untracked: the `.gitignore` top-level `*` + git's parent-exclusion rule defeats the `!memory/**` negation (which only re-includes the *top-level* `memory/`), and `projects/` was never re-included. ~441 note bodies got force-added historically and stay tracked, but **new memory bodies fall through — ~522 untracked and unbacked** (a machine loss drops them). Not a design choice; a bug.

## Fix (scoped to this project)

- `.gitignore`: re-include the path chain to `projects/*/memory/**` (not transcripts/session files), keep ignoring the transient `.provenance.lock`. Verified: my 3 notes become trackable, transcripts stay ignored.
- Commit **climate-finance-het**'s 3 orphaned notes (this session's) as the reviewed exemplar.

## Backlog → ticket 0278

The other ~8 projects' backlog (~500 files) is filed as **0278**, deferred so it doesn't land unreviewed in one commit. Each project gets an eyeballed `git add projects/<hash>/memory/` (never `-A`).

Body/gitignore change only; `erg check` PASS.

**Ticket:** none