### PR TITLE
gaze/review-pr: fork concurrency contract at every launch site (0263)

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -194,11 +194,8 @@ Post the single review on the PR and return the synthesized findings (blockers
 + tagged minors) as the structured block. This inner panel is itself a fan-out:
 Agent C must launch its perspective agents **foreground**
 (`run_in_background: false`), all in one message, and block until every one
-returns before it synthesizes — a nested fan-out is **not** exempt from the
-fork contract. If Agent C ends its turn with perspective agents in flight, its
-return is premature: gaze inherits the orphan failure one layer down (no
-synthesis, no posted review), exactly the defect the outer contract prevents
-(ticket 0263, `/gaze 479`, 2026-07-11).
+returns before it synthesizes — the fork contract applies recursively (see
+**Fork execution contract**; ticket 0263, `/gaze 479`, 2026-07-11).
 
 Wait for all spawned agents to complete. Collect their structured outputs.
 

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -52,6 +52,13 @@ phases 5–6 never run. This orphaned two real gate runs (aedist `/gaze 977`
 and `/gaze 978`, 2026-06-11), each forcing the caller to relaunch a duplicate
 reviewer battery.
 
+**The contract applies recursively.** Any nested fan-out performed on `/gaze`'s
+behalf — a reviewer Agent (e.g. Agent C) that itself spins a panel of
+perspective agents — inherits this same rule: the inner launch must be
+foreground too, or the orphan failure simply moves one layer down. A launch
+site is bound by the fork contract whether it is this skill's own or a
+sub-agent's.
+
 **Caller-side recovery.** If `/gaze <pr>` ever returns a bare fan-out
 narration with no `## /verify-gate verdict` block (APPROVED/REROLL/ESCALATE),
 treat it as a non-result: do **not** relaunch the reviewer battery. Wait for
@@ -184,7 +191,14 @@ prefix — `verifiable:` (a reproducible failing assertion is attached),
 hedged "might break X" phrasing is forbidden — produce the assertion or
 downgrade to `consider:`. Blockers (request-changes / major) are untagged.
 Post the single review on the PR and return the synthesized findings (blockers
-+ tagged minors) as the structured block.
++ tagged minors) as the structured block. This inner panel is itself a fan-out:
+Agent C must launch its perspective agents **foreground**
+(`run_in_background: false`), all in one message, and block until every one
+returns before it synthesizes — a nested fan-out is **not** exempt from the
+fork contract. If Agent C ends its turn with perspective agents in flight, its
+return is premature: gaze inherits the orphan failure one layer down (no
+synthesis, no posted review), exactly the defect the outer contract prevents
+(ticket 0263, `/gaze 479`, 2026-07-11).
 
 Wait for all spawned agents to complete. Collect their structured outputs.
 

--- a/skills/review-pr-prose/SKILL.md
+++ b/skills/review-pr-prose/SKILL.md
@@ -31,6 +31,15 @@ Spin disciplinary agents in parallel, each in a fresh context, each pinned to
 an unpinned Agent inherits the session model and silently runs the fan-out at
 top tier). Prose review reads **full text**, not just diff.
 
+**Concurrency contract (rules/workflow.md § "Concurrency discipline"):
+parallel-FOREGROUND.** This skill runs as a `context: fork` (see frontmatter),
+and a fork's turn ends the instant it stops calling tools. Launch the panel in
+**one message** as **foreground** Agent calls (`run_in_background: false`) so
+the fork blocks until every reviewer returns, then synthesizes. Never launch
+them in the background: a fork cannot wait on background agents — it ends its
+turn at the launch, the completions re-invoke the MAIN loop, and no synthesis
+runs and no review is ever posted.
+
 ## Setup
 
 1. Identify the text: which `.qmd`/`.md` files changed? What is the target venue?

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -32,12 +32,24 @@ below the coder tier (rules/workflow.md § "Sonnet reviews Opus's work"), and an
 unpinned Agent inherits the session model, so on a top-tier session this fan-out
 silently becomes a top-model wave.
 
+**Concurrency contract (rules/workflow.md § "Concurrency discipline"):
+parallel-FOREGROUND.** This skill runs as a `context: fork` (see frontmatter),
+and a fork's turn ends the instant it stops calling tools. Launch the panel in
+**one message** as **foreground** Agent calls (`run_in_background: false`) so
+the fork blocks until every reviewer returns, then synthesizes. Never launch
+them in the background: a fork cannot wait on background agents — it ends its
+turn at the launch, the completions re-invoke the MAIN loop, and no synthesis
+runs and no review is ever posted.
+
 ## Setup
 
 1. **Read the issue** linked to the PR. Note the exit criteria.
 2. **Read the diff** of the merge request.
 3. **Assess risk level** and determine proportional depth (see table below).
-4. **Launch review agents** in parallel:
+4. **Launch review agents** in parallel — **foreground**
+   (`run_in_background: false`), all in one message, per the concurrency
+   contract above; the fork must block on the panel, never end its turn with
+   reviewers in flight:
 
 | Agent | Focus | Key question |
 |---|---|---|

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -47,9 +47,7 @@ runs and no review is ever posted.
 2. **Read the diff** of the merge request.
 3. **Assess risk level** and determine proportional depth (see table below).
 4. **Launch review agents** in parallel — **foreground**
-   (`run_in_background: false`), all in one message, per the concurrency
-   contract above; the fork must block on the panel, never end its turn with
-   reviewers in flight:
+   (`run_in_background: false`), per the concurrency contract above:
 
 | Agent | Focus | Key question |
 |---|---|---|

--- a/tests/test_gaze_fork_blocking.py
+++ b/tests/test_gaze_fork_blocking.py
@@ -25,18 +25,18 @@ import re
 from pathlib import Path
 
 import pytest
+from test_verify_fork_contracts import fork_skill_files
 
 REPO = Path(__file__).resolve().parents[1]
 GAZE = REPO / "skills" / "gaze" / "SKILL.md"
 
-# The three skills that launch a parallel fan-out from inside a `context: fork`.
-# gaze delegates to the other two; all three must carry the foreground contract
-# *locally*, at the launch site, not merely somewhere in the file (ticket 0263).
-FORK_LAUNCH_SKILLS = {
-    "gaze": GAZE,
-    "review-pr": REPO / "skills" / "review-pr" / "SKILL.md",
-    "review-pr-prose": REPO / "skills" / "review-pr-prose" / "SKILL.md",
-}
+# Every `context: fork` skill must carry the foreground contract *locally*, at
+# each parallel-agent launch site, not merely somewhere in the file (ticket
+# 0263). Auto-discovered from frontmatter via fork_skill_files() so a new fork
+# skill is covered without editing a hand-maintained list — a blind all-skills
+# sweep would over-fire on raid/release, which legitimately launch background
+# agents because they are not forks and can wait on background completions.
+FORK_LAUNCH_SKILLS = {p.parent.name: p for p in fork_skill_files()}
 
 
 def _body(md_text: str) -> str:

--- a/tests/test_gaze_fork_blocking.py
+++ b/tests/test_gaze_fork_blocking.py
@@ -71,9 +71,14 @@ FOREGROUND = re.compile(
 
 
 def _sentences(text: str) -> list[str]:
-    # Coarse sentence split on ., ;, : and newlines — enough to scope a
-    # background mention to its clause for the negation check.
-    return re.split(r"(?<=[.;:])\s+|\n+", text)
+    # Coarse sentence split on ., ; and newlines — enough to scope a background
+    # mention to its clause for the negation check. Deliberately NOT on ":": the
+    # colon lives inside the very tokens we test (`run_in_background: true/false`),
+    # so splitting there would tear `run_in_background:` from its value and hide
+    # the directive from BACKGROUND_SIGNAL/FOREGROUND (ticket 0263 B2). Dropping
+    # ":" only merges adjacent clauses, which makes negation scoping strictly
+    # safer (a merged clause is more likely to carry a negation word, never less).
+    return re.split(r"(?<=[.;])\s+|\n+", text)
 
 
 def _paragraphs(text: str) -> list[str]:
@@ -83,14 +88,44 @@ def _paragraphs(text: str) -> list[str]:
 
 # A launch-indicator paragraph describes spinning up a battery of agents to run
 # in parallel. The three conjuncts together are what makes it a *launch site*
-# (as opposed to prose that merely mentions parallelism).
-IN_PARALLEL = re.compile(r"\bin parallel\b", re.IGNORECASE)
+# (as opposed to prose that merely mentions parallelism). The parallel signal is
+# the bare word "parallel", not only the "in parallel" bigram: gaze's primary
+# fan-out paragraph reads "as parallel foreground Agent calls" / "parallel Agent
+# calls", which the tighter bigram missed, letting the ratchet skip the very
+# launch site it exists to guard (ticket 0263 B1). The AGENTS + SPAWN_VERB
+# conjuncts keep bare parallelism prose (e.g. "builds compile in parallel") out.
+IN_PARALLEL = re.compile(r"\bparallel\b", re.IGNORECASE)
 AGENTS = re.compile(r"\bagents?\b", re.IGNORECASE)
 SPAWN_VERB = re.compile(r"\b(spin|spawn|launch|run)\b", re.IGNORECASE)
 
 
 def _is_launch_paragraph(p: str) -> bool:
     return bool(IN_PARALLEL.search(p) and AGENTS.search(p) and SPAWN_VERB.search(p))
+
+
+def _has_nonnegated(pattern: re.Pattern, window: str) -> bool:
+    """True if `pattern` matches in at least one clause of `window` that is not
+    in negation context — reuses the file-wide NEGATION/_sentences machinery so
+    a historical or forbidden mention does not count as a live directive."""
+    return any(
+        pattern.search(s) and not NEGATION.search(s) for s in _sentences(window)
+    )
+
+
+def _window_offends(window: str) -> bool:
+    """Whether a launch-paragraph window violates the local foreground contract.
+
+    Two ways to offend (ticket 0263 B2):
+    - a live (non-negated) background directive sits in the window — a fork
+      cannot wait on background agents, so this orphans the children regardless
+      of any foreground token elsewhere; and
+    - no *non-negated* foreground/blocking evidence is present — a historical or
+      forbidden "foreground" mention ("previously ran foreground", "does not run
+      foreground") does not prove the fork waits.
+    """
+    if _has_nonnegated(BACKGROUND_SIGNAL, window):
+        return True
+    return not _has_nonnegated(FOREGROUND, window)
 
 
 def test_no_affirmative_background_launch():
@@ -147,7 +182,7 @@ def test_launch_paragraph_carries_local_foreground_contract(name):
         if not _is_launch_paragraph(p):
             continue
         window = p + "\n" + (paras[i + 1] if i + 1 < len(paras) else "")
-        if not FOREGROUND.search(window):
+        if _window_offends(window):
             offenders.append(p.strip()[:220])
     assert not offenders, (
         f"{name} SKILL.md has a parallel-agent launch paragraph with no local "
@@ -156,3 +191,88 @@ def test_launch_paragraph_carries_local_foreground_contract(name):
         "fan-out in background orphans the children one layer down (ticket "
         f"0263, /gaze 479). Offending paragraph(s): {offenders}"
     )
+
+
+# --- B1: launch-site detection must catch the primary fan-out phrasing --------
+#
+# gaze's primary review fan-out paragraph reads "...as parallel foreground Agent
+# calls..." — it carries no literal "in parallel" bigram, so the old detector
+# never classified it as a launch site and the ratchet skipped it: stripping its
+# local foreground contract stayed green (/gaze 482 round-1 mutation). These
+# synthetic fixtures pin the broadened detection without depending on the exact
+# current SKILL.md prose.
+
+
+def test_is_launch_paragraph_detects_parallel_foreground_phrasing():
+    assert _is_launch_paragraph(
+        "Spawn the applicable agents as parallel foreground Agent calls."
+    )
+
+
+def test_is_launch_paragraph_detects_parallel_agent_calls():
+    assert _is_launch_paragraph(
+        "Launch the reviewers as parallel Agent calls in one message."
+    )
+
+
+def test_is_launch_paragraph_ignores_non_launch_parallel_prose():
+    # A bare mention of parallelism without an agent-spawn directive is not a
+    # launch site — the three conjuncts (parallel + agents + spawn verb) hold.
+    assert not _is_launch_paragraph("The two builds compile in parallel on CI.")
+
+
+def test_real_gaze_primary_launch_paragraph_in_scope():
+    paras = _paragraphs(_body(GAZE.read_text()))
+    launch = [p for p in paras if _is_launch_paragraph(p)]
+    assert any("parallel foreground" in p.lower() for p in launch), (
+        "gaze's primary review fan-out paragraph is not classified as a launch "
+        "site, so the locality ratchet never inspects it — stripping its local "
+        "foreground contract would go unnoticed (ticket 0263 B1)."
+    )
+    assert len(launch) >= 2
+
+
+# --- B2: foreground evidence must survive negation, background must not slip ---
+#
+# The window check had no negation awareness: a live `run_in_background: true`
+# directive, or a negated/historical "foreground" mention, still satisfied the
+# contract because FOREGROUND matched the token regardless of context.
+
+
+def test_window_offends_live_background_directive_despite_foreground_token():
+    window = (
+        "Spawn the panel as parallel Agent calls with "
+        "run_in_background: true and wait. They run foreground-ish."
+    )
+    assert _window_offends(window), (
+        "a live background launch directive must offend even with a stray "
+        "foreground token nearby (ticket 0263 B2a)"
+    )
+
+
+def test_window_offends_negated_historical_foreground():
+    window = (
+        "Launch the reviewers as parallel background agents "
+        "(run_in_background: true). This skill previously ran its panel "
+        "foreground before the 2026-05 redesign."
+    )
+    assert _window_offends(window), (
+        "a live background directive alongside a historical foreground mention "
+        "must offend (ticket 0263 B2b)"
+    )
+
+
+def test_window_offends_when_foreground_only_negated():
+    window = "Spawn parallel agents. This skill does not run foreground."
+    assert _window_offends(window), (
+        "foreground evidence in a negation clause does not prove the fork "
+        "waits (ticket 0263 B2b)"
+    )
+
+
+def test_window_accepts_local_foreground_contract():
+    window = (
+        "Spawn the agents as parallel foreground Agent calls "
+        "(run_in_background: false), blocking until every one returns."
+    )
+    assert not _window_offends(window)

--- a/tests/test_gaze_fork_blocking.py
+++ b/tests/test_gaze_fork_blocking.py
@@ -24,8 +24,19 @@ This test makes that enforceable instead of conventional:
 import re
 from pathlib import Path
 
+import pytest
+
 REPO = Path(__file__).resolve().parents[1]
 GAZE = REPO / "skills" / "gaze" / "SKILL.md"
+
+# The three skills that launch a parallel fan-out from inside a `context: fork`.
+# gaze delegates to the other two; all three must carry the foreground contract
+# *locally*, at the launch site, not merely somewhere in the file (ticket 0263).
+FORK_LAUNCH_SKILLS = {
+    "gaze": GAZE,
+    "review-pr": REPO / "skills" / "review-pr" / "SKILL.md",
+    "review-pr-prose": REPO / "skills" / "review-pr-prose" / "SKILL.md",
+}
 
 
 def _body(md_text: str) -> str:
@@ -65,6 +76,23 @@ def _sentences(text: str) -> list[str]:
     return re.split(r"(?<=[.;:])\s+|\n+", text)
 
 
+def _paragraphs(text: str) -> list[str]:
+    """Split a skill body into blank-line-separated paragraphs."""
+    return [p for p in re.split(r"\n[ \t]*\n", text) if p.strip()]
+
+
+# A launch-indicator paragraph describes spinning up a battery of agents to run
+# in parallel. The three conjuncts together are what makes it a *launch site*
+# (as opposed to prose that merely mentions parallelism).
+IN_PARALLEL = re.compile(r"\bin parallel\b", re.IGNORECASE)
+AGENTS = re.compile(r"\bagents?\b", re.IGNORECASE)
+SPAWN_VERB = re.compile(r"\b(spin|spawn|launch|run)\b", re.IGNORECASE)
+
+
+def _is_launch_paragraph(p: str) -> bool:
+    return bool(IN_PARALLEL.search(p) and AGENTS.search(p) and SPAWN_VERB.search(p))
+
+
 def test_no_affirmative_background_launch():
     body = _body(GAZE.read_text())
     offenders = [
@@ -96,4 +124,35 @@ def test_failure_mode_documented():
     assert "orphan" in body or "before a verdict" in body or "never delivers" in body, (
         "gaze SKILL.md must document the fork-returns-at-fan-out failure mode "
         "and the caller-side recovery (ticket 0250, exit criterion 3)."
+    )
+
+
+# --- Paragraph-scoped locality ratchet (ticket 0263) ------------------------
+#
+# The file-wide tests above passed while /gaze 479 (2026-07-11) still orphaned
+# its panel: gaze's Agent C paragraph told the inner fan-out to "run ... in
+# parallel" with no local concurrency directive, and the two sub-skills it
+# delegates to (review-pr, review-pr-prose — both `context: fork`) carried zero
+# foreground language anywhere. A single foreground mention elsewhere in the
+# file satisfied the outer ratchet; the launch site itself stayed silent. This
+# ratchet is *local*: every paragraph that is a parallel-agent launch site must
+# carry the foreground contract in that same paragraph (or the next one).
+
+
+@pytest.mark.parametrize("name", sorted(FORK_LAUNCH_SKILLS))
+def test_launch_paragraph_carries_local_foreground_contract(name):
+    paras = _paragraphs(_body(FORK_LAUNCH_SKILLS[name].read_text()))
+    offenders = []
+    for i, p in enumerate(paras):
+        if not _is_launch_paragraph(p):
+            continue
+        window = p + "\n" + (paras[i + 1] if i + 1 < len(paras) else "")
+        if not FOREGROUND.search(window):
+            offenders.append(p.strip()[:220])
+    assert not offenders, (
+        f"{name} SKILL.md has a parallel-agent launch paragraph with no local "
+        "foreground/blocking contract (run_in_background: false) in that same "
+        "paragraph or the next — a forked skill that ends its turn with its "
+        "fan-out in background orphans the children one layer down (ticket "
+        f"0263, /gaze 479). Offending paragraph(s): {offenders}"
     )

--- a/tickets/0263-gaze-forked-run-returns-before-its-backg.erg
+++ b/tickets/0263-gaze-forked-run-returns-before-its-backg.erg
@@ -8,6 +8,7 @@ Author: Minh Ha-Duong
 
 2026-07-11T13:05Z claude note raid plan — locality defect: fork contract absent at Agent C nested fan-out and in review-pr/review-pr-prose (both context:fork, zero concurrency text); paragraph-scoped ratchet replaces file-wide check; fresh evidence /gaze 479 2026-07-11
 2026-07-11T13:27Z bump verify-reroll — round 1: review-pr BLOCKERS B1/B2 both reproduced live on HEAD e191515 — B1: gaze/SKILL.md phases-2-4 primary launch paragraph ('Spawn the applicable agents ... as parallel foreground Agent calls') has no literal 'in parallel' bigram so _is_launch_paragraph() never scopes the locality ratchet to it; stripping its foreground language keeps all 8 tests green. B2: FOREGROUND regex has no negation filter — planting run_in_background: true beside a negated/historical 'foreground' mention in review-pr-prose's concurrency-contract paragraph keeps test_launch_paragraph_carries_local_foreground_contract[review-pr-prose] green.
+2026-07-11T13:35Z note live probe: /gaze 482 (2026-07-11) ran as a fork with all fan-outs foreground — reviewer panel, simplify agents, round-1 gate and fix agent each returned inline, no orphaned children; end-to-end posted verdict is this run's own PR-482 verdict comment
 --- body ---
 ## Context
 

--- a/tickets/0263-gaze-forked-run-returns-before-its-backg.erg
+++ b/tickets/0263-gaze-forked-run-returns-before-its-backg.erg
@@ -7,6 +7,7 @@ Author: Minh Ha-Duong
 2026-06-11T09:59Z Minh Ha-Duong created
 
 2026-07-11T13:05Z claude note raid plan — locality defect: fork contract absent at Agent C nested fan-out and in review-pr/review-pr-prose (both context:fork, zero concurrency text); paragraph-scoped ratchet replaces file-wide check; fresh evidence /gaze 479 2026-07-11
+2026-07-11T13:27Z bump verify-reroll — round 1: review-pr BLOCKERS B1/B2 both reproduced live on HEAD e191515 — B1: gaze/SKILL.md phases-2-4 primary launch paragraph ('Spawn the applicable agents ... as parallel foreground Agent calls') has no literal 'in parallel' bigram so _is_launch_paragraph() never scopes the locality ratchet to it; stripping its foreground language keeps all 8 tests green. B2: FOREGROUND regex has no negation filter — planting run_in_background: true beside a negated/historical 'foreground' mention in review-pr-prose's concurrency-contract paragraph keeps test_launch_paragraph_carries_local_foreground_contract[review-pr-prose] green.
 --- body ---
 ## Context
 

--- a/tickets/closed/0263-gaze-forked-run-returns-before-its-backg.erg
+++ b/tickets/closed/0263-gaze-forked-run-returns-before-its-backg.erg
@@ -2,6 +2,7 @@
 Title: gaze: forked run returns before its background reviewers finish (background sessions get no verdict)
 Created: 2026-06-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #482
 
 --- log ---
 2026-06-11T09:59Z Minh Ha-Duong created
@@ -9,6 +10,7 @@ Author: Minh Ha-Duong
 2026-07-11T13:05Z claude note raid plan — locality defect: fork contract absent at Agent C nested fan-out and in review-pr/review-pr-prose (both context:fork, zero concurrency text); paragraph-scoped ratchet replaces file-wide check; fresh evidence /gaze 479 2026-07-11
 2026-07-11T13:27Z bump verify-reroll — round 1: review-pr BLOCKERS B1/B2 both reproduced live on HEAD e191515 — B1: gaze/SKILL.md phases-2-4 primary launch paragraph ('Spawn the applicable agents ... as parallel foreground Agent calls') has no literal 'in parallel' bigram so _is_launch_paragraph() never scopes the locality ratchet to it; stripping its foreground language keeps all 8 tests green. B2: FOREGROUND regex has no negation filter — planting run_in_background: true beside a negated/historical 'foreground' mention in review-pr-prose's concurrency-contract paragraph keeps test_launch_paragraph_carries_local_foreground_contract[review-pr-prose] green.
 2026-07-11T13:35Z note live probe: /gaze 482 (2026-07-11) ran as a fork with all fan-outs foreground — reviewer panel, simplify agents, round-1 gate and fix agent each returned inline, no orphaned children; end-to-end posted verdict is this run's own PR-482 verdict comment
+2026-07-11T14:15Z Minh Ha-Duong closed — autoclosed — PR #482
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What / why

The file-wide ratchet in `test_gaze_fork_blocking.py` verified gaze's fork
concurrency contract with a single `re.search` for foreground language
*anywhere* in the file. It passed — while `/gaze 479` (2026-07-11, interactive
session) still orphaned its review panel. The defect is contract **locality**,
not absence:

- gaze's Agent C (the PR-review sub-agent) told its inner fan-out to "run the
  proportional perspective set in parallel" with **no local** concurrency
  directive; gaze's own foreground language (phases 2–4/6) satisfied the
  file-wide check, so the launch site's silence was invisible.
- The two sub-skills Agent C delegates to — `review-pr` and `review-pr-prose`,
  **both `context: fork`** — carried **zero** foreground/blocking/run_in_background
  language. A forked skill that ends its turn with its panel in background
  orphans the children: no synthesis, no posted review.

## New ratchet (paragraph-scoped, not file-wide)

`test_launch_paragraph_carries_local_foreground_contract` (parametrized over
gaze / review-pr / review-pr-prose): split each body into blank-line
paragraphs; every paragraph that is a parallel-agent **launch site** (matches
`in parallel` + `agents?` + a spawn verb `spin|spawn|launch|run`) must match
the FOREGROUND pattern (`run_in_background: false`, foreground, blocking) in
that same paragraph or the next. The three original file-wide tests stay — they
guard the outer layer.

Written against the pattern, not the sentences added. RED→GREEN evidence:

- **RED** (pre-fix): all three parametrized cases failed — gaze Agent C
  paragraph, review-pr's launch step (and its intro "Spin multiple agents"),
  review-pr-prose's panel step. The 3 file-wide tests passed throughout.
- **GREEN** (post-fix): `6 passed` (3 file-wide + 3 paragraph-scoped).

## Fixes (bodies only; skill descriptions unchanged)

- `skills/gaze/SKILL.md` — Agent C's embedded procedure now requires the inner
  panel to launch foreground (`run_in_background: false`, one message) and block
  before synthesizing; a nested fan-out is not exempt, or gaze inherits the
  orphan failure one layer down. Added a "contract applies recursively" note by
  `## Fork execution contract`.
- `skills/review-pr/SKILL.md` — declared parallel-FOREGROUND contract per
  rules/workflow.md § "Concurrency discipline", at both the intro and the
  "Launch review agents" step, with the failure mode stated (background launch →
  fork ends turn at launch → no synthesis, no posted review).
- `skills/review-pr-prose/SKILL.md` — same addition at the panel-launch step,
  wording kept consistent with review-pr.

## Gates

- `make check` — 651 passed.
- `make check-skills-drift` — in sync (descriptions unchanged, bodies only).
- `scripts/check-agnostic.sh skills tickets` — clean.

## Exit criteria

Criteria 1 and 2 (fork never ends its turn with reviewers in flight; launch
mode declared per the concurrency rule) are now enforced by the paragraph-scoped
ratchet across all three launch sites. Criterion 3 ("background-session run
produces a posted verdict end-to-end") is a runtime property no unit test can
prove; this raid's own Phase 6 per-ticket `/gaze` runs are the live probe, and
the ticket log will record the observation.

**Ticket:** tickets/0263-gaze-forked-run-returns-before-its-backg.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
