### PR TITLE
memory: track the per-project backlog — 103 notes across 27 projects (0278)

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_autonomous_merge.md
+++ b/projects/-home-haduong--claude/memory/feedback_autonomous_merge.md
@@ -1,0 +1,11 @@
+---
+name: Autonomous merge for trivial ticket housework
+description: Trivial ticket housework PRs (renames, decollisions, log fixes) may be merged without asking the user first
+type: feedback
+originSessionId: 6443cf93-df9d-409c-bc74-bce8772c384b
+---
+Trivial ticket housework is allowed autonomous merge — no need to ask the user for confirmation.
+
+**Why:** These changes (ticket renames, ID decollisions, log section fixes) carry no risk and asking adds friction.
+
+**How to apply:** PRs whose entire diff is ticket file renaming or metadata corrections (no code, no skill logic, no beat.py) can be merged immediately after opening, without prompting the user.

--- a/projects/-home-haduong--claude/memory/feedback_cli_verb_in_subcommand.md
+++ b/projects/-home-haduong--claude/memory/feedback_cli_verb_in_subcommand.md
@@ -1,0 +1,14 @@
+---
+name: feedback-cli-verb-in-subcommand
+description: "For CLI scripts, the script name is the noun (what it manages); verbs live in sub-commands. Avoid `install-deps.sh uninstall` and other Démarrer-pour-Arrêter absurdities."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e29953e5-db9e-48c8-9b55-60f58cd5901a
+---
+
+When designing a CLI script with sub-commands, the script name should be a **noun** describing what it manages; the **verb** belongs to the sub-command. `idh-deps.sh install|update|remove|status` reads naturally; `install-deps.sh uninstall` is the Windows "click Start to Shut down" absurdity.
+
+**Why:** User flagged `install-deps.sh uninstall` mid-ticket with the Windows analogy. The verb in the filename pre-commits the script to one action and makes any opposite sub-command paradoxical. Naming hygiene matters for the dev-Monday-before-coffee persona.
+
+**How to apply:** Before naming a multi-action script, list its sub-commands and check that every sub-command reads coherently after the script name. If `<script> <verb>` produces an oxymoron for any verb, rename the script to a noun. Related: [[feedback-rename-sweep-full-unit]] — when fixing the script name, sweep all references in the ticket/spec/docs in the same edit.

--- a/projects/-home-haduong--claude/memory/feedback_layer_correctness.md
+++ b/projects/-home-haduong--claude/memory/feedback_layer_correctness.md
@@ -1,0 +1,23 @@
+---
+name: layer correctness — harness vs consumer project
+description: When designing IDH skills/tickets, keep harness generic; project-specific pain (pytest commands, PR numbers, body conventions) belongs in the consumer repo.
+type: feedback
+originSessionId: de328483-9e54-44dc-a2ec-5bb34ca10ef1
+---
+IDH skills and tickets must stay project-agnostic. Consumer-project
+reflection memos (e.g. from Climate_finance PR 691/692) often drive
+IDH ticket creation, but the fix should expose an extension point in
+the harness — never bake consumer assumptions (`uv run pytest`,
+PR-body patterns, hard-coded paths) into `skills/*/SKILL.md` or IDH
+ticket bodies.
+
+**Why:** user pushed back firmly on two instances in one session.
+Tickets 0001, 0002, 0003, 0006 were all carved out of IDH after
+leaking project pain upstream. User's phrasing: *"What's that doing
+in IDH repo?"*
+
+**How to apply:** when drafting an IDH ticket, ask "is every line
+here true for any project using this harness?" If not, split: keep
+the generic piece in IDH (extension point, hook, interface), file the
+specific piece in the consumer repo. See IDH ticket 0016 for the
+standing guard work filed as the class-level regression test.

--- a/projects/-home-haduong--claude/memory/feedback_raid_worktree_rebase.md
+++ b/projects/-home-haduong--claude/memory/feedback_raid_worktree_rebase.md
@@ -1,0 +1,14 @@
+---
+name: feedback-raid-worktree-rebase
+description: Raid execute agents run in isolated worktrees and miss same-session main commits — always rebase PR branch onto main before merging
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: b5a6ca12-1650-436c-ad0a-e0d4f7ab8da1
+---
+
+Rebase the PR branch onto current `main` before merging when a raid execute agent built the branch in an isolated worktree. The worktree forks from a snapshot of main at creation time, so any commits made to main during the same session (ticket closures, migrations, etc.) will be absent from the PR branch — causing CI failures on validate-tickets or similar checks.
+
+**Why:** Raid worktree isolation is correct for execution, but the merge step runs after the session has accumulated further main commits that CI expects to see.
+
+**How to apply:** In Phase 7 (Merge), run `git fetch origin main && git rebase origin/main` on the PR branch before calling `erg-pr-merge`. Also watch for `erg migrate` side-effects: the `init` subcommand refreshes AGENTS.md/integration.md/spec from the binary's embedded templates, which may re-introduce legacy verbs that the status-verb-guard will catch.

--- a/projects/-home-haduong--claude/memory/feedback_validator_strengthen_order.md
+++ b/projects/-home-haduong--claude/memory/feedback_validator_strengthen_order.md
@@ -1,0 +1,11 @@
+---
+name: Repair before strengthening a validator
+description: When adding a stricter rule after fixing the bug that violated it, sequence the repair commits BEFORE the rule commit so the validator does not block its own repair work
+type: feedback
+originSessionId: 90d5a236-5de6-4511-a1e4-6dd20af8996d
+---
+When strengthening a validator (or pre-commit hook, or schema check) after fixing the bug that produced violations: order the commits as (1) fix the producer, (2) repair existing violations, (3) add the rule. Reversing 2 and 3 makes the rule reject every commit that touches a still-violating ticket — including the repair commits themselves.
+
+**Why:** advisor surfaced this exact pitfall on ticket 0060. I was about to commit the validator extension and the repairs together; the validator would have rejected the repair commit because the still-corrupt sibling tickets in the working tree fail the new rule the moment it's compiled into the binary used by any pre-commit hook. Splitting into three commits (fix → repair → rule) keeps each step independently bisectable and avoids self-blocking.
+
+**How to apply:** any time you propose to add a "must not contain X" rule and there are existing instances of X in the codebase, plan three commits in that order. Same shape applies to lint rules, type-check escalations, schema constraints, and pre-commit grep ratchets — anywhere the rule itself is enforced against the same tree it's added to.

--- a/projects/-home-haduong--claude/memory/project_paper_harnesses_psychology.md
+++ b/projects/-home-haduong--claude/memory/project_paper_harnesses_psychology.md
@@ -1,0 +1,20 @@
+---
+name: Paper idea — Harnesses vs. human psychology
+description: Research paper concept: AI coding harnesses evaluated against what psychology says about how humans actually work
+type: project
+originSessionId: 4083a1a2-83d2-4d64-9a33-49b531751e54
+---
+Paper idea: **Harnesses vs. What Human Psychology Tells Us About How People Work**
+
+Framing: AI coding harnesses (IDH, GSD, etc.) impose structure on collaborative AI–human work sessions. Do they align with or fight against what cognitive psychology knows about how humans actually work?
+
+Candidate tensions to examine:
+- Flow state preservation vs. harness checkpoints (interruptions, phase announcements)
+- GTD / chunking vs. Five-Claws ceremony
+- Attention residue (task-switching cost) vs. worktree isolation
+- Human interruption recovery time vs. `/perch` re-orientation
+- Autonomy / trust calibration vs. permission prompts
+
+**Why:** Arose during a session comparing GSD and IDH harness capabilities (2026-04-29). Not yet assigned to any project or collaborator.
+
+**How to apply:** When the user next thinks about research directions or has a writing slot open, surface this. Could be a systems/HCI paper or a short essay.

--- a/projects/-home-haduong--claude/memory/user_language.md
+++ b/projects/-home-haduong--claude/memory/user_language.md
@@ -1,0 +1,11 @@
+---
+name: User language convention
+description: User addresses Claude in French (often formal); work artifacts stay in English
+type: user
+originSessionId: 95af4412-2e3f-4bfc-9fb4-dacb33cc91ed
+---
+The user opens conversations in French — often quite formal ("auriez-vous l'amabilité de…", "Veuillez…"). Match their register: respond in French when they speak French.
+
+**But work artifacts stay in English**: commit messages, PR titles/bodies, ticket bodies, code comments, file content. They didn't object to English work artifacts even while we conversed in French — and the existing repo is English throughout.
+
+**How to apply:** chat in French when addressed in French; write code/commits/PRs in English regardless. If unsure, mirror what's already in the file.

--- a/projects/-home-haduong-CNRS-code-DOIfetch/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-code-DOIfetch/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# DOIfetch — memory index
+
+- [Remote topology](remote-topology.md) — origin is READ-only upstream; push to the `fork` remote (MinhHaDuong/DOIfetch), the real trunk.

--- a/projects/-home-haduong-CNRS-code-DOIfetch/memory/remote-topology.md
+++ b/projects/-home-haduong-CNRS-code-DOIfetch/memory/remote-topology.md
@@ -1,0 +1,21 @@
+---
+name: remote-topology
+description: DOIfetch git remotes — origin is READ-only upstream; the real trunk is the MinhHaDuong fork
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 20e2bac5-d52d-434d-9e46-7d8a3fce29ba
+---
+
+DOIfetch's `origin` is `hanhan6688/DoiHarvest` — READ-only (viewerPermission
+READ); pushing there fails with 403. The maintained trunk is the fork
+`MinhHaDuong/DOIfetch` (renamed 2026-07-08 from the auto-created `DoiHarvest`),
+wired as the `fork` remote. Upstream is abandoned (last commit 2025-08-07) and
+~50 commits behind; the fork carries the full modern history.
+
+Merge flow: land feature branches locally onto `main` (fast-forward where the
+branch descends from `main`; rebase `--onto main` when it diverged), then
+`git push fork main`. Do NOT try to push to `origin`.
+
+The fork still shows GitHub's "forked from" banner (isFork true); detaching it
+needs a GitHub Support request — cosmetic, deferred.

--- a/projects/-home-haduong-CNRS-code-activity-report-writer/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-code-activity-report-writer/memory/MEMORY.md
@@ -1,0 +1,28 @@
+# Activity Report Writer - Memory
+
+## Project status
+
+- **Rapport à vague CID 52**: 22 pages, 131 KB. All 9 sections drafted.
+- **Avis différé** from CID 52 (July 2025). Complément addresses: production scientifique, encadrement, responsabilités collectives, mise en oeuvre AEDIST.
+- **Build**: `cd rapport-vague-cid52 && make all` → PDF at `output/rapport-vague-cid52.pdf`
+
+## File organization
+
+- `CLAUDE.md` → contains only `@AGENTS.md`
+- `AGENTS.md` → general writing/formatting rules (reader-targeted writing, SF-DORA, enumerated lists, unnumbered subsections, realized-before-planned)
+- `rapport-vague-cid52/AGENTS.md` → project-specific rules (CNRS formatting, CID 52 criteria, multi-agent review procedure, publication counts, HAL notes, sensitive topics)
+
+## User preferences
+
+- CLAUDE.md should only contain `@AGENTS.md` — all instructions go in AGENTS.md
+- Prefers parallel agent orchestration for large tasks
+- Writes in French for the rapport, instructions may be in French or English
+- Values scientific substance over administrative detail
+- SF-DORA strict: no h-index, no IF, no citation counts anywhere
+
+## Key directories for fact-checking
+
+- BibTeX: `~/CNRS/html/files/Ha-Duong.bib`
+- RIBACs: `~/CNRS/secretariat/rapports-d-activite/RIBAC/`
+- Avancement DR1: `~/CNRS/secretariat/rapports-d-activite/avancement/2025/`
+- Projects: `~/CNRS/projets/actifs/`, `~/CNRS/projets/sent/`, `~/CNRS/projets/placard/`

--- a/projects/-home-haduong-CNRS-code-git-erg/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-code-git-erg/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Project memory index — git-erg
+
+- [Asset-edit CI gates](asset-edit-ci-gates.md) — ASCII-only embedded assets + archive-before-push; `make regen-assets` doesn't gate, run `make test`.

--- a/projects/-home-haduong-CNRS-code-git-erg/memory/asset-edit-ci-gates.md
+++ b/projects/-home-haduong-CNRS-code-git-erg/memory/asset-edit-ci-gates.md
@@ -1,0 +1,19 @@
+---
+name: asset-edit-ci-gates
+description: Two CI traps when editing git-erg embedded assets or closing tickets — ASCII-only assets and archive-before-push; both now caught by `make test`.
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 340eae9b-77b2-475c-8803-c27a4823fe21
+---
+
+Editing `src/go/assets/*` (AGENTS.md, .ergrc) or closing a ticket has two gates that `make regen-assets` does NOT enforce (it only copies files). Both are now caught by `make test` locally — run it before pushing:
+
+1. **Embedded assets must be pure ASCII.** `tests/test_init.sh` rejects any non-ASCII/non-printable byte in the init-unpacked assets. Since ticket 0245 (merged 2026-06-18, PR #308) the guard loops over every asset in `initAssetPaths` (`.ergrc` AND `AGENTS.md`), not just AGENTS.md. LLM edits routinely slip in a Unicode em-dash `—` or curly quotes; use the house ` -- ` instead.
+2. **A closed ticket must be archived into `tickets/closed/` before push.** Adding a `Closed:` header but leaving the file in `tickets/` makes `erg check` fail with "closed ticket not in closed/ directory". Run `erg archive <id>` (or `git mv` it) in the same commit.
+
+**`make test` now runs a store-shape gate.** Ticket 0246 (merged 2026-06-18, PR #309) added a `check-store` Makefile target (`erg check tickets/`) folded into `make test`'s prerequisites. So `make test` does THREE things now: Go unit tests, shell suites, AND `erg check tickets/` — an unarchived closed ticket / duplicate ID fails locally, not only in CI's `test-check`. (This is also why CONTRIBUTING.md drifted — ticket 0247.)
+
+**Why:** PR #305 (ticket 0244) hit both gate-1 and gate-2 at once — an em-dash in the asset and an unarchived closed ticket — and `bash -e` masked the second behind the first, so each surfaced only after fixing the prior. Tickets 0245/0246 closed both gaps.
+
+**How to apply:** after any asset edit or ticket close, run `make test` locally before pushing — it now catches both classes. `make regen-assets` alone still runs no check.

--- a/projects/-home-haduong-CNRS-code-maiba/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-code-maiba/memory/MEMORY.md
@@ -1,0 +1,5 @@
+- [Use rispy for RIS parsing](feedback_use_rispy.md) — Don't write custom RIS parser; use rispy library (YAGNI)
+- [Orchestrator: serialize tickets](feedback_orchestrator_sequential.md) — User lands tickets one at a time through their own review; don't parallelize sibling tickets
+- [Persistent-state writes are opt-in](feedback_state_opt_in.md) — Caches, logs, journals default off; users opt in explicitly (per §2.3 zero-state default)
+- [Spike unverified library APIs](feedback_spike_before_implement.md) — Verify external-library symbols exist in the installed version before drafting the TDD red test
+- [Bundle imports with usage in one Edit](feedback_formatter_strips_imports.md) — PostToolUse ruff --fix strips imports between Edits; add import + first usage atomically

--- a/projects/-home-haduong-CNRS-code-maiba/memory/feedback_formatter_strips_imports.md
+++ b/projects/-home-haduong-CNRS-code-maiba/memory/feedback_formatter_strips_imports.md
@@ -1,0 +1,27 @@
+---
+name: Bundle imports with usage in a single Edit
+description: The PostToolUse formatter (ruff --fix) strips imports it judges unused between Edit calls; a multi-step "add import → then add usage" sequence loses the import.
+type: feedback
+originSessionId: 6c9f06c6-a3f7-479b-b581-076baff198c3
+---
+When the project's PostToolUse hook runs `ruff check --fix` after every
+Edit, any import without a usage in the file at that moment gets stripped
+before the next Edit fires. This bit me repeatedly in sessions on this
+repo — most painfully when the first ticket-0012 executor agent stalled
+in a "formatter loop" that I had to take over manually.
+
+**Why:** when the user gives instructions like "I'll fix the bug in this PR", you should make it work in one Edit, atomic.
+**How to apply:** when adding a new import to an existing file, include
+its first usage in the same Edit call. Patterns that work:
+
+- One Edit that replaces a region spanning imports AND the first
+  call site (acceptable for small files; large old_strings).
+- For larger refactors, use Write to replace the whole file at once.
+- If split is unavoidable, anchor the import with `_ = imported_name`
+  on a single line right after the import block, in the same Edit.
+  Remove the anchor in a later Edit once a real usage exists.
+
+Patterns that DON'T work:
+- Edit 1 adds import → Edit 2 adds usage. Import is gone by Edit 2.
+- Edit that adds import alongside a *commented-out* usage. Comments
+  don't count.

--- a/projects/-home-haduong-CNRS-code-maiba/memory/feedback_orchestrator_sequential.md
+++ b/projects/-home-haduong-CNRS-code-maiba/memory/feedback_orchestrator_sequential.md
@@ -1,0 +1,14 @@
+---
+name: Orchestrator: serialize tickets, don't fan out
+description: User runs MAIBA tickets one at a time, not in parallel — even when /orchestrator could wave them
+type: feedback
+originSessionId: 7b2e23f2-cad6-4682-b6d7-24bd090e73b4
+---
+When invoked with `/orchestrator <id>` for a single ticket, treat it as a serial step in a queue the user is driving by hand. Do not pre-empt or parallelize tickets that are also open.
+
+**Why:** User explicitly redirected when I started executing a ticket while a sibling was still open: "I will do 10 after 9 not in parallel." They want to land each ticket cleanly through their own review before the next begins, not stack two unmerged PRs that touch overlapping surface.
+
+**How to apply:**
+- Before launching any execute agent for a ticket, check whether any sibling ticket touching the same surface is still `open` or `doing`. If so, stop and ask the user whether to proceed.
+- The orchestrator skill's wave-management is fine for batches the user explicitly hands you ("/orchestrator all open" or a comma-list); it is NOT fine for "/orchestrator NNNN" where other tickets are mid-flight.
+- Don't relitigate this — the user's queueing is intentional.

--- a/projects/-home-haduong-CNRS-code-maiba/memory/feedback_spike_before_implement.md
+++ b/projects/-home-haduong-CNRS-code-maiba/memory/feedback_spike_before_implement.md
@@ -1,0 +1,11 @@
+---
+name: Spike unverified library APIs before drafting tests
+description: When a ticket prescribes specific imports/functions from an external library, run a 10-line spike to verify the API exists in the installed version before writing the TDD red test.
+type: feedback
+originSessionId: bedc8f6c-19b5-4a8f-8ef3-63817b717c63
+---
+When a ticket names specific library APIs (`hishel.CacheClient`, `hishel.FileStorage`, etc.) — verify the API exists in the version you'll install before writing the TDD red test or the implementation.
+
+**Why:** Ticket 0009 prescribed `hishel.CacheClient` + `FileStorage`, but hishel 1.2 had renamed these to `hishel.httpx.SyncCacheClient` + `hishel.SyncSqliteStorage`. The drafted test would have failed for the wrong reason (ImportError, not assertion failure), wasting a TDD red-loop iteration. A 10-line spike before the red test confirmed the real API and the respx ↔ hishel transport interaction.
+
+**How to apply:** If the ticket prescribes external-library symbols you haven't used recently, before writing the failing test or the implementation, run `uv run python -c "import X; print(dir(X))"` or write a 10-line spike that exercises the integration point. Update the ticket body with the corrected API reference and commit before launching the execute agent. Spike outcomes belong in the ticket, not in commit messages — future re-readers should see them as part of the ticket's context.

--- a/projects/-home-haduong-CNRS-code-maiba/memory/feedback_state_opt_in.md
+++ b/projects/-home-haduong-CNRS-code-maiba/memory/feedback_state_opt_in.md
@@ -1,0 +1,11 @@
+---
+name: Persistent-state writes are opt-in
+description: Cache, log, and journal writes default to off; user opts in explicitly. ARCHITECTURE.md §2.3 defaults to zero state.
+type: feedback
+originSessionId: bedc8f6c-19b5-4a8f-8ef3-63817b717c63
+---
+When MAIBA writes anything to disk that isn't the explicitly requested output RIS — caches, logs, run journals, sidecar files — the default must be off. Users opt in with a flag (`--cache`, `--log`, etc.).
+
+**Why:** ARCHITECTURE.md §2.3 commits to "zero state by default — RIS in / RIS out, no DB, no cache." On-by-default writes quietly relax that contract for one-shot users who didn't ask for it. Author called this out on PR #21 (HTTP cache initially shipped on-by-default; flipped to opt-in via `--cache` before merge).
+
+**How to apply:** When designing any feature that touches the filesystem outside the user-named output path, default the flag to `False`. Document the opt-in in `--help`. The dev-loop ergonomics argument (fast re-runs) is a one-character flag away; the principle of "don't write state without asking" is stronger than convenience.

--- a/projects/-home-haduong-CNRS-code-maiba/memory/feedback_use_rispy.md
+++ b/projects/-home-haduong-CNRS-code-maiba/memory/feedback_use_rispy.md
@@ -1,0 +1,11 @@
+---
+name: Use rispy for RIS parsing
+description: User explicitly requires using the rispy library instead of writing a custom RIS parser — YAGNI principle
+type: feedback
+originSessionId: 6c9f06c6-a3f7-479b-b581-076baff198c3
+---
+Use the `rispy` library for RIS parsing instead of writing a custom parser.
+
+**Why:** Writing a custom RIS parser is a textbook YAGNI violation when a maintained library (`rispy`) exists. The user called this out explicitly.
+
+**How to apply:** In ticket 0001 and any RIS-related code, depend on `rispy` for reading/writing RIS files. The `maiba.ris` module should be a thin wrapper over rispy, adapting its output to the `Item` pydantic model. Don't reimplement what rispy already does.

--- a/projects/-home-haduong-CNRS-html-src/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-html-src/memory/MEMORY.md
@@ -1,0 +1,6 @@
+# Project memory index
+
+- [hal-anubis-bypass](hal-anubis-bypass.md) — fetch HAL deposits via api.archives-ouvertes.fr + file subdomains when hal.science is Anubis-walled
+- [show-rendered-page-for-visuals](show-rendered-page-for-visuals.md) — render and open the page before asking the user's opinion on a visual change
+
+> Project-fundamental facts (no-remote/master workflow, worktree untracked-assets gotcha) live in the committed `AGENTS.md`, not here.

--- a/projects/-home-haduong-CNRS-html-src/memory/hal-anubis-bypass.md
+++ b/projects/-home-haduong-CNRS-html-src/memory/hal-anubis-bypass.md
@@ -1,0 +1,24 @@
+---
+name: hal-anubis-bypass
+description: How to fetch HAL deposits when the hal.science web frontend is Anubis-walled
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: c2eb4049-9136-4d7d-994f-33814cd6ac75
+---
+
+When the `hal.science` web frontend is behind the Anubis anti-bot wall (WebFetch
+returns "Access Denied"), two HAL endpoints bypass it:
+
+- **Structured search**: `https://api.archives-ouvertes.fr/search/?q=...&wt=csv`
+  — full Solr query API. Useful fields: `halId_s, title_s, language_s, docType_s,
+  files_s, fileMain_s, producedDate_s`. `files_s` lists *every* file in a deposit
+  (a bilingual VIETSE report often bundles EN + VN PDFs under one halId with a
+  bilingual `title_s`). Filter by author: `authFullName_t:"Minh Ha-Duong"`.
+- **File download**: the per-deposit subdomain endpoint
+  (`enpc.hal.science/<halId>/file/<name>.pdf`, `shs.hal.science/...`) serves the
+  raw PDF with plain `curl` — not Anubis-walled.
+
+Used in ticket 0016 to recover the Vietnamese biomass policy note bundled inside
+hal-03059625. The author's local `~/CNRS/papiers/published/` tree is the other
+recovery channel for dead-site (vietse.vn) VN PDFs.

--- a/projects/-home-haduong-CNRS-html-src/memory/show-rendered-page-for-visuals.md
+++ b/projects/-home-haduong-CNRS-html-src/memory/show-rendered-page-for-visuals.md
@@ -1,0 +1,30 @@
+---
+name: show-rendered-page-for-visuals
+description: "Before asking the user's opinion on a visual/CSS change, render and open the page — don't just describe the diff"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: b21a547b-b2f9-43c0-affd-80e10ab82651
+---
+
+When a change affects visuals (CSS, layout, typography, colors), build/render the
+page and open it in the browser before asking the user what they think. Don't
+settle for describing the diff in prose.
+
+**Why:** The user judges visuals by looking, not by reading CSS. A described
+change ("dashed, 40%-alpha underline") can't be evaluated without seeing it on
+the actual busy layout it has to coexist with.
+
+**How to apply:** After a visual edit, run the project build (see `Makefile` /
+`index.py`) to produce the rendered HTML, then open it (e.g. `xdg-open` the
+output file, or a screenshot) and point the user at it — *then* ask for the call
+on alpha/style/dial.
+
+**Build it faithfully or you will misread the page.** In a worktree, `../files`
+and `../images` are absent, so `bib2htm` silently downgrades every PDF-backed
+title from `<a class="title">` to a plain `<span>` — the page renders *without
+its title links*, which once led me to wrongly tell the user "titles aren't
+links." Symlink the assets before building (`ln -sfn
+/home/haduong/CNRS/html/files /home/haduong/CNRS/html/src/.claude/worktrees/files`).
+See `html/src/AGENTS.md` § "Worktrees: untracked assets live above the repo
+root" — read it before any preview build.

--- a/projects/-home-haduong-CNRS-html/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-html/memory/MEMORY.md
@@ -1,0 +1,7 @@
+# Memory index — CNRS/html homepage
+
+One line per memory. Content lives in the linked files, not here.
+
+- [Homepage backup push](homepage-backup-push.md) — at end of a committing session, propose `git push padme master` (off-machine backup).
+- [Deploy-root content retirement](deploy-root-content-retirement.md) — keep-vs-retire served-but-unreferenced dirs: citation + source-backup checks before deleting.
+- [Publication embargo stance](publication-embargo-stance.md) — open access is the default; publisher/HAL embargoes are a courtesy, not binding on self-archiving.

--- a/projects/-home-haduong-CNRS-html/memory/deploy-root-content-retirement.md
+++ b/projects/-home-haduong-CNRS-html/memory/deploy-root-content-retirement.md
@@ -1,0 +1,29 @@
+---
+name: deploy-root-content-retirement
+description: How to decide keep-vs-retire for served-but-unreferenced deploy-root content on the homepage.
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 0cda7768-577a-43b3-8a82-679d31d99a91
+---
+
+The homepage deploy root (`~/CNRS/html`, mirrored to `/httpdocs/` by `make
+sync`) accumulates legacy dirs that are served live but referenced by nothing the
+generator emits. Before retiring any such dir, run two checks — "0 in-tree
+references" is NOT sufficient grounds to delete:
+
+1. **External-citation check.** Is the URL cited outside the tree? `Lacq_CCS_Pilot/`
+   is KEPT because the published 2013 report cites its URLs, despite 0 in-tree refs.
+2. **Source-backup check.** Is the content a derivative whose source is filed
+   elsewhere? `page/recap_2020/` was retired (commit 5e960fc) because it was a 2020
+   "Voeux" greeting whose source lives in `~/Media/Pictures/2020/` — personal
+   content that belonged in `Media/`, not under CNRS, and deliberately not in Google.
+
+Retirement procedure (both sides): delete server-side over FTP
+(`lftp -e 'rm -r /httpdocs/<dir>; ...'`), confirm the URL 404s and the homepage
+still 200s, remove the local copy, drop the dir's line from `.gitignore` (these
+dirs are gitignored, so only that line is a tracked change), commit, push padme.
+
+Open candidate: `CleanED-blog-archive/` (ticket 0025) — same shape, not yet
+assessed. The recurring drift is tracked by [[homepage-backup-push]] sessions; a
+standing drift-detector test is ticket 0026.

--- a/projects/-home-haduong-CNRS-html/memory/homepage-backup-push.md
+++ b/projects/-home-haduong-CNRS-html/memory/homepage-backup-push.md
@@ -1,0 +1,25 @@
+---
+name: homepage-backup-push
+description: "At the end of a homepage-repo session with commits, propose pushing the off-machine backup to padme."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 0cda7768-577a-43b3-8a82-679d31d99a91
+---
+
+The `~/CNRS/html` homepage repo is local, direct-to-master, with **no forge
+remote** — the only off-machine copy is a bare git backup on host `padme`:
+
+```
+git push padme master      # run from ~/CNRS/html (upstream tracking is set, so plain `git push` works too)
+```
+
+Remote `padme` → `padme:projets/homepage` (bare repo, created 2026-06-16, ticket 0021).
+
+**Why:** commits live only on doudou plus this backup; they are not safe
+off-machine until pushed. The user asked (2026-06-16) to be reminded each session.
+
+**How to apply:** when wrapping up a session that committed to this repo (during
+`/lair`, `/roar`, or any natural end-of-session), propose running the backup
+push. The ~1.5 GB of assets (`files/`, legacy dirs) are gitignored and are **not**
+in this backup — they keep syncing by FTP (`make sync`), a separate concern.

--- a/projects/-home-haduong-CNRS-html/memory/publication-embargo-stance.md
+++ b/projects/-home-haduong-CNRS-html/memory/publication-embargo-stance.md
@@ -1,0 +1,24 @@
+---
+name: publication-embargo-stance
+description: "Minh's stance on publisher/HAL embargoes — open access is the default; embargo is a courtesy, not an obligation."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 9b753682-df07-4f51-bdf7-4d68ea815510
+---
+
+For his own publications, Minh treats a publisher/HAL embargo as a courtesy to
+the editor, not a moral obligation: the research is publicly funded and the
+publisher pays him nothing, so in his view it is "paid for by the public" and
+belongs in open access. On 2026-06-23 he chose to serve the *Regards croisés sur
+l'économie* interview postprint on his homepage immediately, overriding the
+2027-03-01 HAL embargo he had granted.
+
+**Why:** his default leans open; he does not regard an unpaid courtesy embargo as
+binding on his own self-archiving.
+
+**How to apply:** when he asks to serve/post a postprint, do it even if a nominal
+embargo is in effect. Flag the conflict once (he values knowing), but expect him
+to choose open — don't keep re-blocking. When stamping such a postprint, mark it
+as an author version and cite the final published reference (see how the homepage
+serves it via [[deploy-root-content-retirement]] conventions).

--- a/projects/-home-haduong-CNRS-missions-actif-2026-07-02-Vannes-Colloque-Charles-Gides/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-07-02-Vannes-Colloque-Charles-Gides/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory index
+
+- [cfhet-handoff-figures](cfhet-handoff-figures.md) — figures versionnées (fig_bars_v1/fig_breaks/fig_composition) vs sorties brutes gitignorées dans climate-finance-het.
+- [gide-slides](gide-slides.md) — deck colloque Gide : emplacement (content/slides-gide.qmd), build, assets, état relecture.

--- a/projects/-home-haduong-CNRS-missions-actif-2026-07-02-Vannes-Colloque-Charles-Gides/memory/cfhet-handoff-figures.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-07-02-Vannes-Colloque-Charles-Gides/memory/cfhet-handoff-figures.md
@@ -1,0 +1,27 @@
+---
+name: cfhet-handoff-figures
+description: climate-finance-het — which figure files the writing phase consumes vs gitignored pipeline outputs
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 3a2802ee-f462-4671-a81e-3f0791af6741
+---
+
+Dans `climate-finance-het`, `.gitignore` exclut `content/figures/*`, mais trois
+figures sont force-versionnées car consommées par la phase rédaction
+(`manuscript-Gide.qmd`, slides) :
+
+- **`fig_bars_v1.png`** — Figure 1 (croissance de la littérature)
+- **`fig_breaks.png`** — Figure 2 (vitesse de renouvellement / ruptures)
+- **`fig_composition.png`** — Figure 3 (recomposition thématique)
+
+Les variantes **non suffixées** `fig_bars.png` et `fig_breakpoints.png` sont des
+sorties brutes du pipeline calcul, **gitignorées** → absentes d'un worktree frais.
+Pour tout livrable rédaction (slides, manuscrit), référencer les fichiers versionnés
+ci-dessus, jamais les variantes brutes.
+
+Conséquence build : un worktree frais ne peut pas faire `quarto render` du projet
+entier (des includes de tables gitignorées, p.ex. `tables/tab_corpus_sources.md`,
+manquent). Rendre les slides en isolation (copie autonome du `.qmd` + les 3 figures
+versionnées + `slides-assets/`, sans `_quarto.yml`), ou builder depuis le checkout
+principal où tout est généré. Slides Gide : `content/slides-gide.qmd`.

--- a/projects/-home-haduong-CNRS-missions-actif-2026-07-02-Vannes-Colloque-Charles-Gides/memory/gide-slides.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-07-02-Vannes-Colloque-Charles-Gides/memory/gide-slides.md
@@ -1,0 +1,24 @@
+---
+name: gide-slides
+description: "Deck de présentation pour le colloque Charles Gide (Vannes, juillet 2026) — emplacement, build, état"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 3a2802ee-f462-4671-a81e-3f0791af6741
+---
+
+Présentation pour le 21e colloque Charles Gide, Vannes, 2–4 juillet 2026
+(« Économistes sous contrainte », d'après `manuscript-Gide.qmd`).
+
+- Source : `climate-finance-het/content/slides-gide.qmd` (Beamer/metropolis, fr, ~31 pages dont overlays).
+- Build : `quarto render content/slides-gide.qmd --to beamer` **depuis le checkout principal**
+  (un worktree frais échoue au scan projet : tables gitignorées absentes). PDF copié dans
+  le dossier mission Vannes : `slides-Gide.pdf`.
+- Assets : `content/slides-assets/` — 2 photos CC versionnées (COP29, ligne 380 kV) + logo CIRED +
+  bandeau tutelles ; portrait Corfee-Morlot + couvertures OCDE/Oxfam **gitignorés** (©, à recopier
+  depuis le checkout principal pour builder dans un worktree). `CREDITS.md` documente tout.
+- Figures : voir [[cfhet-handoff-figures]]. La figure thèmes a une variante `fig_composition_wide.png`
+  (option `--wide` de `plot_fig2_composition.py` : 2×3 paysage, titres coupés au « & », sans sous-titres).
+- État : relu par panel de 4 reviewers (PR #848–857 mergées). Restent volontairement non traités :
+  hedge constructiviste slide 5 (assumé en Q&A), « économie des conventions » comme tradition (=
+  révision papier, pas faite). Le talk ne doit pas devancer le papier.

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu-Payment/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu-Payment/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index
+
+- [Dossier vacations Jussieu](dossier-vacations-jussieu.md) — formulaire rempli 2026-06-04 ; en attente : réponse Chevalier (48 h vs 32 h) + autorisation cumul DRH CNRS

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu-Payment/memory/dossier-vacations-jussieu.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu-Payment/memory/dossier-vacations-jussieu.md
@@ -1,0 +1,22 @@
+---
+name: dossier-vacations-jussieu
+description: "État du dossier de recrutement vacataire Sorbonne (cours IEE 2025-26) — rempli le 2026-06-04, deux points en attente"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 8866a629-6115-446d-999e-dd0c57db788a
+---
+
+Dossier de paiement des vacations « Introduction aux Enjeux Environnementaux » (Sorbonne Université, FSI, Cycle d'intégration), demandé par Robin Chevalier (robin.chevalier@sorbonne-universite.fr) le 2026-05-27.
+
+**Fait (2026-06-04)** : formulaire rempli + signé (signature bleue) → `Formulaire_Agent public_25_HA-DUONG.docx/.pdf` ; 7 pièces PDF dans `pièces/`. Scripts régénérables : `/tmp/formulaire/fill.py` (chirurgie XML) + `finish.py` (python-docx) — pipeline : fill → finish → soffice convert.
+
+Services déclarés : 2 groupes TD × 8 séances × 2 h = 32 h TD, du 22/01 au 07/05/2026, + correction de 45 copies d'examen mutualisé.
+
+**Cumul** : la loi a changé — le CNRS ne délivre plus d'autorisation de cumul pour l'enseignement (art. L. 411-3-1 code de la recherche) : simple déclaration. Déclaration #588579 déposée sur la plateforme CNRS le 2026-06-04 (48 HeTD × 43,49 € = 2 087,52 € brut, du 22/01 au 07/05/2026). Capture en ruban : `pièces/8 - Déclaration de cumul CNRS.pdf`. L'Annexe 1 papier est probablement caduque.
+
+**Finalisation (2026-06-04 soir)** : Annexe 1 alignée à 48 h TD ; note « Services assurés » (2×16 h TD + 45 copies) en petit italique ; le PDF du formulaire ne contient que les 2 premières pages (le docx garde tout). Lettre explicative du régime déclaratif (`Lettre régime déclaratif cumul.pdf/.docx`) signée, renvoyant à la pièce 8.
+
+**En attente** : réponse de R. Chevalier (volume 48 h et acceptation du régime déclaratif) ; envoi du dossier complet.
+
+Sources des données : bulletin de paie 2025-12 (`~/perso/comptes/Retraite/Bulletins_de_paye_CNRS/`), CNI et carte vitale (`~/perso/facsimili/État civil Goloa/`), signature `~/perso/facsimili/Signature bleue.jpg`.

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/MEMORY.md
@@ -1,0 +1,4 @@
+- [Use full hierarchical group codes for Jussieu cohort](feedback_group_codes.md) — label SVCST groups with full code, never bare A/B
+- [Machine roles in IDH setup](project_machine_roles.md) — padme is server (nightbeat), doudou is laptop (no nightbeat)
+- [Barème fiche acteur IEE](project_bareme_fiches_acteur.md) — grille /20 + règles strictes Expression, colonnes IA hors-barème, cumul fiches multiples
+- [Moodle grade CSV format](feedback_moodle_grade_csv_format.md) — fill existing "(Brut)" column in place, never add columns; FR comma decimals

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/feedback_group_codes.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/feedback_group_codes.md
@@ -1,0 +1,11 @@
+---
+name: Use full hierarchical group codes for Jussieu cohort
+description: When labelling SVCST student groups, always use the full code (SVCST1-2A etc.), never bare A/B
+type: feedback
+originSessionId: 07f858c6-cb8e-4b42-8ea0-40987d104a0d
+---
+When working with the Jussieu 2026 student groups, label them with their full hierarchical Moodle code: `SVCST1-2A`, `SVCST1-2B`, `SVCST3-1A`, `SVCST3-1B`. Never use bare `A` / `B`.
+
+**Why:** The hierarchy is `SVCST{year}-{semester}{section}`. The `A`/`B` letter is a section within one parcours/semestre — it's only meaningful inside its parent. `SVCST1-2A` and `SVCST3-1A` are unrelated groups; pooling them is meaningless. Bare `A`/`B` invites that pooling once rows are filtered, sorted, or merged across sheets.
+
+**How to apply:** Any roster, score grid, attendance file, or report that names these groups should carry the full code in every row, even when a single sheet is dedicated to one parcours. Same rule for any future SVCST-style identifier the user shows me — preserve the full hierarchy, don't shorten the leaf.

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/feedback_moodle_grade_csv_format.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/feedback_moodle_grade_csv_format.md
@@ -1,0 +1,14 @@
+---
+name: feedback_moodle_grade_csv_format
+description: "Filling Jussieu Moodle grade-export CSVs — fill the existing \"(Brut)\" column in place, never add columns"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ffe4d1da-eb53-4984-8f30-892108c93d2e
+---
+
+When injecting exam totals into a Moodle grade-export CSV (e.g. `UL1SXIEE - S2-25 Notes-HADUONG.csv`), fill the **existing** grade column `Epreuve de cohorte (Brut)` (currently `-`) in place. Do NOT add new columns (P1..P5, Total) — that altered the format and was rejected.
+
+**Why:** the file is re-imported into Moodle; it must keep its exact shape (7 `;`-separated columns, header unchanged, FR decimal with comma like `18,5`, ungraded students keep `-`).
+
+**How to apply:** replace field index 5 only; verify with a line diff that *only* that column changed. Recover correct student numbers/spellings by matching handwritten names against the full roster CSV, not by reading handwritten IDs. See `Examen sur table/inject_grades.py`. Related: [[feedback_group_codes]].

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/project_bareme_fiches_acteur.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/project_bareme_fiches_acteur.md
@@ -1,0 +1,18 @@
+---
+name: project_bareme_fiches_acteur
+description: "Grading rubric and house rules for the IEE \"fiche acteur\" assignment (Jussieu cohort)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: f77cf02a-4622-426d-977c-7beec792cfe6
+---
+
+Barème de la **fiche acteur** (UE Introduction aux enjeux environnementaux, Sorbonne/Jussieu), controverse « éoliennes en mer ». Note chiffrée **/20** = somme de 7 critères : Expression (0–2), Description de l'acteur (0–3), Arguments mobilisés (0–3), Positionnement (0–3), Pouvoir d'agir (0–3), Liens avec les autres acteurs (0–3), Bibliographie (0–3).
+
+**Règles maison (overrides) explicitées par l'enseignant, à appliquer strictement :**
+- **Expression = 0** s'il manque, *sur le document lui-même*, le titre OU le nom de l'auteur OU la date de rédaction. L'identité connue via Moodle/le nom de fichier ne compte pas. Une date de *consultation* de source ou un label « année scolaire » ne compte pas comme date.
+- **Expression ≤ 1** s'il manque les numéros de page OU si le format n'est pas un PDF (.docx/.odt plafonnés à 1). Vérifier la pagination **visuellement** (rendu image), pas via pdftotext qui rate les pieds de page.
+- **Note réflexive sur l'usage de l'IA** : obligatoire (répété par l'enseignant) mais **hors-barème** → 2 colonnes séparées : `IA présence` (Oui/Non) + `IA clarté` (0–3 : 0 absente, 1 vague, 2 claire = outils nommés+comment+vérification, 3 exemplaire = prompts/comparaison/vérif sources). Un refus argumenté d'utiliser l'IA = présence Oui, clarté 1.
+- **Fiches multiples** (étudiant ayant rendu plusieurs acteurs) : additionner les points **par critère**, plafonné au max du critère.
+
+Livrable type : un CSV (séparateur `;`, UTF-8 BOM) avec Groupe, Nom, Prénom, N° étudiant, les 7 notes + motif Expression, Total /20 (hors IA), colonnes IA, Remarques. Voir aussi [[feedback_group_codes]] (codes groupes complets SVCST). Corpus 2026 : `~/CNRS/missions/actif/2026 cours Jussieu/Fiches acteur/notes_fiches_acteur.csv`.

--- a/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/project_machine_roles.md
+++ b/projects/-home-haduong-CNRS-missions-actif-2026-cours-Jussieu/memory/project_machine_roles.md
@@ -1,0 +1,19 @@
+---
+name: Machine roles in user's IDH setup
+description: Which hosts in the user's fleet run autonomous services (nightbeat, etc.) and which do not — laptop vs server distinction
+type: project
+originSessionId: 6bc66762-4ea9-46c7-9686-607d1938d97c
+---
+`padme` is the server: nightbeat (`claude-nightbeat.timer`) runs there overnight,
+30-min cadence weeknights 22:00–06:00 + all day weekends.
+
+`doudou` is a laptop. **No nightbeat there.** Only `claude-refresh.timer` (daily IDH pull)
+and `claude-telemetry-prune.timer` are appropriate user-systemd units for laptops.
+
+**Why:** Autonomous overnight services need uptime — laptops sleep, lids close, batteries die.
+The user explicitly does not want nightbeat on doudou.
+
+**How to apply:** When auditing "doudou setup" or any laptop host against upstream STATE.md's
+`doudou setup` checklist, treat the `install nightbeat systemd units` item as **not applicable**
+and flag only `~/.bashrc` source line + `erg` binary (PATH-level and per-project) as actionable.
+For any new host, ask whether it's a laptop or a server before suggesting autonomous timers.

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/MEMORY.md
@@ -1,0 +1,6 @@
+- [Managed-agent mobile dominance](feedback_ccr_mobile_dominance.md) — 86% sessions / 89% events Android-originated; frame as phone-first supervision; "CCR" removed from paper, use "managed-agent"
+- [gh pr merge worktree workaround](reference_gh_pr_merge_worktree.md) — when `gh pr merge` fails on worktree conflict, use `gh api -X PUT .../pulls/N/merge`
+- [Rebase after worktree deletion](feedback_rebase_deleted_worktree.md) — if worktree deleted mid-rebase, cherry-pick commits onto fresh branch from main
+- [last-prompt JSONL record](project_last_prompt_record.md) — slash invocations live in type:last-prompt records (no timestamp), not user message content; ClaudeLocalSource skips them intentionally
+- [slash data undercount](project_slash_data_sparse.md) — 28 rows is a known undercount (ticket 0026); §4.5 + Fig 6 disabled; do not use 28 as a reliable figure
+- [Machine-specific env in .env not settings.json](feedback_env_settings_json.md) — committed settings.json env overrides cause silent failures on other machines; use gitignored .env + Makefile --env-file

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/feedback_ccr_mobile_dominance.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/feedback_ccr_mobile_dominance.md
@@ -1,0 +1,15 @@
+---
+name: Managed-agent surface is mobile-dominant
+description: 86% of the user's managed-agent sessions are Android-originated; mobile supervision is the dominant pattern, not CLI. The paper now uses "managed-agent" not "CCR".
+type: feedback
+originSessionId: 35c8b6cf-a45d-4464-98ce-71e58d3245e1
+---
+When framing anything about the user's Claude Code workflow — in paper prose, in memos, in discussion — do not default to desktop/CLI as the primary mental model.
+
+**Empirical basis (captured 2026-04-22):** 105 managed-agent sessions, 90 (86%) originated from `origin: android`, 15 (14%) from `origin: web_claude_ai`. Median wall-clock duration 77 min, p95 26 h, max 91 h. Measured at the **event** level (what the paper cites), Android's share is **89%** (20,089 of 22,543 assistant events) because Android sessions carry more events per session. Cite the correct denominator for the claim: sessions → 86%, events → 89%.
+
+**Terminology (2026-04-23):** "CCR" (Claude Code Remote) has been removed from the paper and replaced throughout with "managed-agent". Do not reintroduce the CCR acronym in paper prose.
+
+**Why:** The paper's framing treats laptop + workstation CLI as the primary surface. This is measurable under-specification: the user does most supervision from their phone, dispatching long-running managed agents. Any prose implying "user at keyboard all day" mis-describes what they do.
+
+**How to apply:** When writing or reviewing paper prose about the user's workflow, when interpreting fan-out / M(N) / regime distributions, or when suggesting analysis directions — start from "phone-first supervision of managed agents" as the default model, and name CLI as one surface among three. If a draft implicitly assumes "user at keyboard all day", flag it as a framing bug.

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/feedback_env_settings_json.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/feedback_env_settings_json.md
@@ -1,0 +1,11 @@
+---
+name: Machine-specific env vars belong in .env, not settings.json
+description: .claude/settings.json env overrides are committed and machine-specific values cause silent failures on other machines
+type: feedback
+originSessionId: ed60f2cf-e8df-4506-b5b1-c1750f1fd999
+---
+Never put machine-specific env vars (paths, credentials) in `.claude/settings.json` — it's committed to git and silently overrides `.bashrc` on every machine. Use a gitignored `.env` file instead, loaded via `uv run --env-file .env` in the Makefile.
+
+**Why:** `CADENS_RAW_DIR=/data/projets/cadens/raw` (padme's path) was committed in `settings.json`, causing `load_raw_df()` to silently return an empty DataFrame on doudou. Cost a full debugging round-trip.
+
+**How to apply:** When an env var is machine-specific, put it in `.env` (gitignored), add `.env.example` with a placeholder, and wire `Makefile` targets with `$(if $(wildcard .env),--env-file .env,)`.

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/feedback_rebase_deleted_worktree.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/feedback_rebase_deleted_worktree.md
@@ -1,0 +1,17 @@
+---
+name: Rebase after worktree deletion
+description: How to recover a rebase when the worktree has been cleaned up mid-rebase
+type: feedback
+originSessionId: 551816f0-27aa-4176-b984-5bc0b6672a18
+---
+When a worktree is deleted mid-rebase (e.g., by session restart), the local branch may also be gone. But the commits are still in the git object store via the remote tracking ref (`origin/<branch>`). Recovery:
+
+1. `git log --oneline origin/<branch>` — confirm commits are accessible
+2. `git worktree add /tmp/<name> -b <new-branch> origin/main` — fresh worktree from current main
+3. `git cherry-pick <commit1> <commit2> <commit3>` — replay commits in order onto new branch
+4. Resolve conflicts (same pattern as a rebase), `git cherry-pick --continue --no-edit`
+5. Push new branch, create new PR
+
+**Why:** `gh pr merge` returning 405 "not mergeable" means dirty (conflicts), not a worktree issue. The worktree conflict error from `gh pr merge` is different — that one is fixed by `gh api -X PUT .../pulls/N/merge`.
+
+**How to apply:** Whenever a rebase is interrupted by session end, check if the worktree still exists before trying to resume. If gone, use the cherry-pick recovery flow above.

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/project_last_prompt_record.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/project_last_prompt_record.md
@@ -1,0 +1,18 @@
+---
+name: last-prompt JSONL record type
+description: Claude Code JSONL files contain type:last-prompt records that store raw slash invocations — not documented in harvester code
+type: project
+originSessionId: caf5fc44-2576-40d1-ae30-62303fa6a0b3
+---
+The local JSONL corpus (`~/.claude/projects/**/*.jsonl`) contains `type: last-prompt` records with structure:
+```json
+{"type": "last-prompt", "lastPrompt": "/skill-name args...", "sessionId": "..."}
+```
+
+These records capture slash invocations intercepted client-side before they reach the user message. They have **no timestamp** — use the last-seen timestamp from the same session as proxy.
+
+The `ClaudeLocalSource` harvester skips these records intentionally (it only needs turn-level metrics). The `slash_extract.py` module reads them directly from JSONL files.
+
+**Why:** Discovered during ticket 0022 implementation. Slash invocations in `type: user` message content yield zero hits on the live corpus.
+
+**How to apply:** Any future analysis of prompt text, command usage, or session intent should walk `last-prompt` records, not user message content.

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/project_slash_data_sparse.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/project_slash_data_sparse.md
@@ -1,0 +1,13 @@
+---
+name: slash invocation data undercount
+description: Slash invocation corpus reports only 28 rows but is a known undercount — user made substantially more. §4.5 and Fig 6 are disabled pending ticket 0026 fix.
+type: project
+originSessionId: caf5fc44-2576-40d1-ae30-62303fa6a0b3
+---
+`data/metrics/slash_invocations.csv` (as of 2026-04-23 window): 28 invocations, 4 distinct names (orchestrator, celebrate, review-pr, review-pr-prose), all `user-skill` category, all in April 2026. Zero built-in commands detected.
+
+**Known bug (2026-04-23):** The user confirmed they made substantially more than 28 slash invocations. The harvester or classifier is undercounting. Ticket 0026 is open to find and fix the source. §4.5 (Tool mastery) and Fig 6 are commented out in `paper/main.tex` until fixed.
+
+**Why:** Data is from `last-prompt` JSONL records. The undercount is likely due to missing log sources, surface coverage gaps, or classifier errors.
+
+**How to apply:** Do not use the 28-invocation count as a reliable figure in any prose or analysis. When §4.5 is re-enabled (post ticket-0026), verify all Slash* macros reflect corrected data before committing.

--- a/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/reference_gh_pr_merge_worktree.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Cadens/memory/reference_gh_pr_merge_worktree.md
@@ -1,0 +1,22 @@
+---
+name: gh pr merge worktree conflict workaround
+description: When gh pr merge fails with "'main' is already used by worktree", use the REST API directly (gh api -X PUT) instead
+type: reference
+originSessionId: 35c8b6cf-a45d-4464-98ce-71e58d3245e1
+---
+`gh pr merge <N>` tries to update the local main branch as a side effect. In an Imperial Dragon worktree setup this fails because `main` is checked out in the primary worktree:
+
+    fatal: 'main' is already used by worktree at '/home/haduong/CNRS/papiers/actif/<project>'
+
+Server-side merge without touching local state:
+
+    gh api -X PUT repos/MinhHaDuong/<repo>/pulls/<N>/merge \
+      -f merge_method=merge \
+      -f commit_title="Merge pull request #<N> from MinhHaDuong/<branch>" \
+      -f commit_message="<description>"
+
+Then delete the remote branch:
+
+    gh api -X DELETE repos/MinhHaDuong/<repo>/git/refs/heads/<branch>
+
+Use `merge_method=squash` or `merge_method=rebase` if the repo prefers those. This project (cadens) uses `merge` commits — visible in `git log --oneline` as "Merge pull request #N from …".

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/MEMORY.md
@@ -1,0 +1,9 @@
+- [User — CNRS researcher](user_cnrs.md) — author works at CNRS; Couperin transformative agreements cover most major APCs
+- [Project — fuzzy corpus paper target journal](project_target_journal.md) — submission strategy agreed 2026-04-20
+- [Project — formal model (progressive graph section)](project_formal_model_general.md) — fetched/discovered distinction, authority vs focus solutions, lemma/theorem structure
+- [Reference — Couperin agreements](reference_couperin.md) — check couperin.org for current OA/APC coverage before submission
+- [Project — merge policy](project_merge_policy.md) — direct push to main is blocked; route all merges through GitHub PR
+- [Feedback — worktree preflight](feedback_worktree_preflight.md) — check `git status` on main before editing in a worktree; parallel authors may have WIP on target files
+- [Feedback — lemma dependency check](feedback_lemma_dependency_check.md) — trace proof dependencies line by line before claiming a lemma is oversized
+- [Project — two-workpackage layout](project_workpackage_layout.md) — paper sources in paper/, analysis at root; handoffs are figures/ and output/tables/; build with make -f paper.mk
+- [Compute on padme, not doudou](feedback_compute_on_padme.md) — ML inference and heavy scripts go on padme, not local doudou

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/feedback_compute_on_padme.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/feedback_compute_on_padme.md
@@ -1,0 +1,11 @@
+---
+name: Compute on padme, not doudou
+description: Heavy compute (ML inference, embedding generation) must run on padme via SSH, not locally on doudou
+type: feedback
+originSessionId: 791ae788-5308-4716-b2da-e0639978e7a9
+---
+Run ML-heavy tasks (sentence-transformers encoding, large data processing) on padme via SSH, not on the local machine (doudou).
+
+**Why:** Local machine is too slow for batch encoding (5k works takes 2.75 min; 43k works ~23 min). Padme has better compute resources.
+
+**How to apply:** When a script involves ML inference or large-scale data processing, SSH to padme and run there instead of running locally. Check padme status first with `ssh padme "hostname && nvidia-smi"` or similar.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/feedback_lemma_dependency_check.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/feedback_lemma_dependency_check.md
@@ -1,0 +1,11 @@
+---
+name: Feedback — verify proof dependencies before claiming a lemma is oversized
+description: When asked whether a lemma is the minimum needed, read the proof of the theorem that uses it before answering
+type: feedback
+---
+
+Before claiming that a supporting lemma "proves more than needed", re-read the theorem's proof line by line and identify exactly what is invoked.
+
+**Why:** In this project said the fixed-graph convergence lemma proved "more than needed" for the inter-stage convergence theorem — suggesting Tarski sufficed. This was wrong. The theorem's proof for $\mu_*^{(s)} \leq \mu_*^{(s+1)}$ iterates $H^{(s+1)}$ from a sub-fixed-point and appeals to convergence, which is exactly the lemma's mechanism, not just existence.
+
+**How to apply:** When asked "is this lemma the minimum needed?", trace each line of the downstream proof to its dependencies before answering. Tarski gives existence; constructive convergence proofs give more and are often genuinely used.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/feedback_worktree_preflight.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/feedback_worktree_preflight.md
@@ -1,0 +1,23 @@
+---
+name: Check main for uncommitted edits before worktree work
+description: Inspect main's working tree before creating a worktree — if files I will modify have unstaged edits, surface this before proceeding
+type: feedback
+originSessionId: 1fc9c85f-fca5-498b-afdc-e23121463aec
+---
+Before entering a worktree for a task that will touch known files
+(e.g., `sections/*.tex`), run `git -C <main-repo-root> status` and check
+whether any of the files I intend to modify are already modified on main.
+
+**Why:** In the 2026-04-20 session, I created a worktree from HEAD without
+checking main's working tree. Main had unstaged edits to the same
+`formal_model_*.tex` files, made by a parallel author or bot. At merge time
+this caused avoidable conflicts and required a mid-session rebase plus
+force-push-permission-prompt cycle.
+
+**How to apply:** At the start of a revision task, after reading the target
+file but before committing changes in the worktree, run `git status` on the
+main repo. If the target files show `M` (modified), either:
+  1. Surface the uncommitted state to the user and ask whether those edits
+     should be committed/stashed first, or
+  2. Coordinate: the user may be running a parallel agent — confirm scope
+     before editing.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_formal_model_general.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_formal_model_general.md
@@ -1,0 +1,24 @@
+---
+name: Project — formal model (progressive graph section) structure
+description: Key design decisions established in section 5 (progressive graph discovery)
+type: project
+---
+
+Two normalization problems, two different solutions:
+- **Incoming (prestige/authority)**: normalized score can decrease as new citers are discovered → replaced by absolute thresholded score (S, T parameters)
+- **Outgoing (focus)**: reference list is finite and complete once fetched → restrict focus computation to *fetched* works; zero-denominator case handles the rest automatically
+
+**Fetched vs discovered** (not "known" — too ambiguous):
+- $\mathcal{F}^{(s)}$ = fetched: reference list retrieved, outgoing row complete
+- $\mathcal{W}^{(s)} \setminus \mathcal{F}^{(s)}$ = discovered: appeared as a reference, outgoing row zero
+- A discovered work can receive authority (if citers are known) but propagates nothing until fetched
+
+**Theorem structure**:
+- *Lemma*: convergence on a fixed observed graph (supporting result)
+- *Theorem*: convergence under progressive discovery (the result we want)
+- *Proposition*: outgoing-complete fetching policy instantiates the theorem's hypothesis
+
+The lemma is fully needed by the theorem: proving $\mu_*^{(s)} \leq \mu_*^{(s+1)}$ requires iterating $H^{(s+1)}$ from $\mu_*^{(s)}$, which invokes the lemma's convergence argument.
+
+**Why:** Established through a multi-session editorial pass (PRs #19, #20).
+**How to apply:** When editing or extending the progressive graph section, respect these distinctions. Don't add vocabulary like "observed work" without specifying fetched or discovered.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_merge_policy.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_merge_policy.md
@@ -1,0 +1,24 @@
+---
+name: Fuzzy-corpus repo enforces PR-based merges
+description: Direct push to main is blocked; also force-push to feature branches requires explicit user approval
+type: project
+originSessionId: 1fc9c85f-fca5-498b-afdc-e23121463aec
+---
+The fuzzy-corpus repository (on the author's GitHub) has a harness rule that
+blocks direct `git push origin main`. The user routes all merges through
+GitHub PR flow (observed 2026-04-20 when I offered "push main directly" vs
+"open a PR", and the user chose PR).
+
+Force-pushes to feature branches are also gated and require explicit user
+approval — even when the force-push is for a clean linear rebase of a
+single-author worktree branch.
+
+**Why:** PR flow preserves review trail and avoids history rewrites visible
+to the remote. The user values the GitHub merge commit as the canonical
+integration record.
+
+**How to apply:** For any change in this repo, default to: commit → push
+branch (regular push, no force) → `gh pr create` → user merges on GitHub.
+If a rebase creates divergence between local and remote branch, prefer
+pushing under a new branch name over force-pushing the existing one, unless
+explicitly authorized.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_target_journal.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_target_journal.md
@@ -1,0 +1,15 @@
+---
+name: Project — fuzzy-corpus paper submission strategy
+description: Target journal shortlist agreed 2026-04-20 for *Fuzzy Citation Snowballing for Corpus Discovery*
+type: project
+originSessionId: 7ea7aa00-d1f7-4880-ad37-80ce99975a73
+---
+The current manuscript *Fuzzy Citation Snowballing for Corpus Discovery* has an agreed submission strategy (2026-04-20):
+
+1. **Primary:** *Scientometrics* (Springer Nature, Couperin-covered, WOS+Scopus, IF 3.5). Chosen for highest citation ceiling in the scientometrics community.
+2. **Fall-back:** *Quantitative Science Studies* (MIT Press/ISSI, WOS+Scopus+DOAJ, IF 4.1). Use if Couperin Springer quota is exhausted or DOAJ badge becomes decisive.
+3. **Last resort:** *Journal of Informetrics* (Elsevier). Avoid as entry point due to post-2019 ISSI schism.
+
+**Why:** The citation-maximizing audience is the scientometrics/informetrics community — readers who build corpora and cite methods papers. Systematic-review venues (RSM) and fuzzy-math venues (FSS) would under-cite despite scope fit.
+
+**How to apply:** If the user discusses "submitting the paper", "the journal", or venue formatting, reach for these three in order. Shortlist and rationale live at [docs/journal-shortlist.md](docs/journal-shortlist.md) on main (merged via PR #2).

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_workpackage_layout.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/project_workpackage_layout.md
@@ -1,0 +1,17 @@
+---
+name: Project — two-workpackage layout (paper + analysis)
+description: Paper sources are in paper/, analysis pipeline at repo root; handoffs are figures/ and output/tables/
+type: project
+originSessionId: 791ae788-5308-4716-b2da-e0639978e7a9
+---
+After ticket 0040 (PR #40, merged 2026-04-23), the repo has a two-workpackage layout:
+
+- **Writing WP:** `paper/main.tex`, `paper/refs.bib`, `paper/sections/*.tex` — built by `paper.mk` using `tectonic -Z search-path=. paper/main.tex` from repo root. Needs only TeX Live; no Python.
+- **Analysis WP:** `scripts/`, `src/fuzzy_corpus/`, `Makefile` — produces handoff artifacts.
+- **Handoffs (committed):** `figures/*.pdf` and `output/tables/*.tex` — written by analysis, consumed by paper via tectonic's cross-directory search.
+
+**Why:** `tectonic -Z search-path=.` (run from repo root) covers `\input`, `\includegraphics`, and `\addbibresource` lookups across the `paper/` boundary without editing tex sources. Verified against tectonic PR #814 and issue #933.
+
+**All 9 sections** are wired into `paper/main.tex` (PR #41, #44). Anchored kernel tables 1–3 and Figure 1 are stubs pending sample-tier script runs on padme. Run scripts with `--data-dir "/home/haduong/CNRS/papiers/actif/Oeconomia - Climate finance/data"` — Climate Finance data is available locally at that path.
+
+**How to apply:** When editing or referencing paper sources, look in `paper/` not at repo root. When building, use `make -f paper.mk` or just `make`.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/reference_couperin.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/reference_couperin.md
@@ -1,0 +1,13 @@
+---
+name: Reference — Couperin transformative agreements
+description: Where to verify OA/APC coverage for CNRS corresponding authors before submission
+type: reference
+originSessionId: 7ea7aa00-d1f7-4880-ad37-80ce99975a73
+---
+Couperin (French consortium) negotiates transformative agreements that cover APCs for CNRS-affiliated corresponding authors. When discussing journal submission or OA strategy, check:
+
+- **Springer Nature:** https://www.couperin.org/negociations/accords-specifiques-so/springer-nature/ — 2024–2026 R&P agreement, quota-based (471 articles/year in 2026 + 100 reserve). Covers 1 975 hybrid + 30 full-OA journals.
+- **Couperin home (all agreements):** https://www.couperin.org/negociations/ — Elsevier, Wiley, CUP, and others listed by publisher.
+- **APC price lists (per publisher, updated annually):** linked from each agreement page as PDF.
+
+Before recommending a venue, verify the current year's quota status and whether the specific journal is in the eligible list.

--- a/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/user_cnrs.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Fuzzy-Corpus/memory/user_cnrs.md
@@ -1,0 +1,12 @@
+---
+name: User — CNRS researcher
+description: The user is a CNRS-affiliated academic publishing peer-reviewed papers; OA decisions depend on Couperin transformative agreements
+type: user
+originSessionId: 7ea7aa00-d1f7-4880-ad37-80ce99975a73
+---
+Minh Ha-Duong is a CNRS researcher (CIRED lab, environmental economics / energy-policy background) drafting peer-reviewed academic papers in this repository. Papers are published in English for international venues.
+
+Practical consequences for collaboration:
+- APC decisions should always be checked against Couperin transformative agreements (Elsevier, Wiley, Springer Nature, CUP). These usually cover free gold OA in hybrid journals without institutional cost.
+- WOS + Scopus indexing matters for research-evaluation visibility. HCERES lists are not the primary gating constraint but worth noting for long-term career use.
+- The user writes in academic-prose register; methodology papers are his comfort zone. Expect high mathematical rigor alongside empirical applications.

--- a/projects/-home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--discussion-HDM-PM/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--discussion-HDM-PM/memory/MEMORY.md
@@ -1,0 +1,16 @@
+# Projet Oeconomia - Joint production (discussion HDM-PM)
+
+## Contexte
+- Article en préparation pour Oeconomica, co-écrit par Minh Ha Duong (HDM) et Pierre Matarasso (PM)
+- Sujet : Von Neumann, Sraffa, Georgescu-Roegen, production jointe, modélisation de la Transition
+
+## Conversions docx/odt → md effectuées
+- Convention : auteur **Pierre Matarasso**, date = date du fichier source
+- `as received/*.docx` → `*.md` (4 fichiers : Von-Neumann-Sraffa12, 13, Von-Neumann_Wittgenstein-2, dantzig-at-iiasa)
+- `2025-12-05 Texte-CIRED.odt` → `2025-12-05 Texte-CIRED.md` (5 décembre 2025)
+- `Lettre-Minh.odt` → `Lettre-Minh.md` (18 décembre 2025) — longue lettre-essai de PM à HDM
+
+## Fichiers laissés tels quels
+- `discussion 2025-12-15.txt` — fil d'emails bruts HDM/PM, gardé en .txt (pas de reformatage md)
+- `doc-MATA/` — PDFs (Courrège 1985, Courrège.ea 1999, Matarasso.ea 2020) + dossier OCR
+- `.~lock.2025-12-05 Texte-CIRED.odt#` — lock LibreOffice, peut être supprimé

--- a/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity-conception/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity-conception/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index
+
+- [Repo scaffold surprise](project_git_erg_scaffold.md) — P1 repo root renamed/relocated to polycentric_activity/ (2026-07-03), local git+erg, no remote; env banner can be stale mid-session.

--- a/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity-conception/memory/project_git_erg_scaffold.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity-conception/memory/project_git_erg_scaffold.md
@@ -1,0 +1,45 @@
+---
+name: project-git-erg-scaffold
+description: "P1 project repo root is polycentric_activity/ (renamed from 'Polycentric activity/' 2026-07-03), with conception/ and docs/ as gitignored scratch subdirs"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: c78fd596-fa14-41fe-9ec6-22cd1f4fd694
+---
+
+As of 2026-07-03, the P1 project (*Local-to-Global No-Arbitrage on Production
+Networks*) lives at `/home/haduong/CNRS/papiers/actif/polycentric_activity/`
+— a real local git repository with a `tickets/` erg store (`tickets/erg`
+binary, `.ergrc`, `AGENTS.md`) and a LaTeX paper-writing chain (`main.tex`,
+`refs.bib`, `Makefile`, tectonic build). No remote is configured —
+everything is local-only, so merges land on `main` directly with no PR step
+possible.
+
+History, for context: the repo was first bootstrapped with `.git` accidentally
+nested one level down at `conception/` (root should have been the parent).
+Ticket 0003 flagged the resulting dead `.gitignore` patterns (`docs/`,
+`conception/` — meaningful only if the parent were root); it was resolved and
+closed same-day by relocating `.git` up to the parent, which was then renamed
+from `Polycentric activity/` (space, mixed case) to `polycentric_activity/`.
+`docs/` (PDF reference library) and `conception/` (exploratory notes,
+`note-idee-prix-polycentriques-*.md`, `p1-brique-*.tex`) are now correctly
+gitignored scratch subdirectories at the true root; `main.tex` does not
+`\input`/`\include` anything from `conception/`, so nothing in the tracked
+build depends on ignored content.
+
+**Surprising**: the session-start environment banner can report "Is a git
+repository: false" — true only at the start of a scaffolding effort, stale
+the moment a concurrent session initializes or relocates the repo mid-job.
+Don't trust that banner at face value mid-session; re-check with `git
+rev-parse --show-toplevel`.
+
+**How to apply**: this project's directory name changed (2026-07-03) from
+`Polycentric activity/conception` to `polycentric_activity` at repo root —
+a session whose project-memory folder is keyed to the old path slug won't
+automatically see these notes from a session rooted at the new path; treat
+this file as historical if a future session can't find it. Multiple
+concurrent sessions/worktrees are common in this project (seen 2026-07-03: a
+bib-warning fix, a librarian bibliography pass, and the repo relocation
+itself all landed on `main` mid-session from other work) — sync with `git
+log` before assuming `main` is where you last left it, per
+[[workflow-sync-before-work]].

--- a/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity/memory/MEMORY.md
@@ -1,0 +1,1 @@
+- [Récolte bibliographique horde + bibCNRS](bibcnrs-harvest-workflow.md) — hordes pour l'OA, page HTML de DOI + inotify sur ~/Downloads pour le paywalled

--- a/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity/memory/bibcnrs-harvest-workflow.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-Polycentric-activity/memory/bibcnrs-harvest-workflow.md
@@ -1,0 +1,20 @@
+---
+name: bibcnrs-harvest-workflow
+description: "Working pattern for building a full-text bibliography — agent horde for OA, then bibCNRS manual harvest watched via inotify on ~/Downloads"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: c33ff214-23dc-4f45-835b-03e43303a547
+---
+
+Pattern validated 2026-07-03 for the P1 bibliography (96 entries, 100% full-text coverage in one day).
+
+**Why:** Agents can only fetch legal open-access copies (arXiv, HAL, author pages, Cowles/NBER/RAND, public-domain scans); paywalled items need the user's bibCNRS access (Click & Read browser plugin) or personal copies, which no agent can drive.
+
+**How to apply:**
+1. Horde pass: one fetch agent per reference; instruct to grep the source notes first to disambiguate vague citations ("KRS 2002"), never Sci-Hub/LibGen, verify PDF magic bytes + first-page content, return a ready biblatex entry.
+2. Second wp-hunt pass with specific leads pays off: Rockafellar's UW page hosts his out-of-print books; INRIA RRs are on HAL; Cowles reprints its old papers; RAND classics are free; check copyright expiry for pre-1953 authors.
+3. For the remainder: serve the user a local HTML page of clickable https://doi.org/ links (Click & Read reroutes via bibCNRS), then arm `inotifywait -m -e close_write -e moved_to` on ~/Downloads filtered to .pdf; identify each arrival by `pdftotext -l 1`, rename to `<BibKey>-<Author><Year>.pdf`, move to docs/.
+4. Verify everything: file fields ↔ docs/ bijection (no missing, no orphans), magic bytes, title-words-in-first-3-pages match with visual check (pdftoppm + Read) for scans without text layer; `biber --tool` for syntax. The verification catches real errors — it found a wrong title (Afriat) and a wrong volume (Heckscher 1916 is Årg. 18 not 17, per the JSTOR cover page).
+
+Gotchas: Firefox downloads arrive as temp names then rename (watch moved_to); ISTEX serves ark__* filenames; user-supplied files may be 0-byte failed downloads — always check size; qpdf (snap) cannot read ~/.claude paths, use gs; project docs/ may be gitignored deliberately (copyrighted PDFs) — commit only refs.bib.

--- a/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Mémoire — livre « 100 milliards »
+
+- [Vérifier dans le vrai lieu](verifier-dans-le-vrai-lieu.md) — ne pas annoncer « propre/vérifié » depuis un contrôle qui n'a pas tourné ni depuis une sandbox ; travailler direct sur main.
+- [Workflow EDM](edm-workflow.md) — Zotero = système de référence ; `docs/` et `.bib` sont du staging (git-ignorés), synchronisés vers Zotero puis purgés à l'archivage après publication.
+- [git commit -- pathspec contourne l'index](git-commit-pathspec-bypasses-index.md) — un commit par pathspec lit l'arbre de travail, donc ignore silencieusement un `git rm --cached` stagé ; commiter l'index (plain `git commit`).

--- a/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/edm-workflow.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/edm-workflow.md
@@ -1,0 +1,32 @@
+---
+name: edm-workflow
+description: "User's EDM workflow (cross-project) — docs/ and .bib are staging; Zotero is the system of record; docs/ synced to Zotero and purged on archival after publication."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e7796be7-c37c-43f6-8702-99dbdd355e78
+---
+
+The user's electronic document management (EDM) discipline, applicable across
+writing/research projects (harness-level, not specific to one book):
+
+- **Zotero is the system of record** for source documents and bibliography.
+- **`docs/` is staging, not a home.** Source documents *and the author's own
+  research notes* (`docs/*.md`) are *staged* in project-local `docs/`, then
+  *stored in Zotero* (with correct item type + scraped metadata + attachment).
+  `docs/` is git-ignored in full (`*.pdf` / `*.html` / `*.md`) — never tracked
+  (neither binaries nor notes belong in the repo; Zotero holds them).
+- **Periodic sync + purge.** `docs/` is periodically checked/synced to Zotero,
+  and **purged on archival after publication** — Zotero retains the documents.
+- **Project `.bib` files are also staging**, to be synced to Zotero. The `.bib`
+  is provenance scaffolding, not the source of truth.
+
+**Why:** keeps git repos lean (no binary bloat, no 13 MB report PDFs in history),
+and centralizes durable provenance in Zotero where it persists and syncs. Staging
+areas are transient by design.
+
+**How to apply:** when indexing a source — fetch → stage the document in `docs/`
+→ archive in Zotero (RIS + `L1` attachment, correct type, real author/date/
+pagination) → record the citation. Gitignore `docs/*.pdf` / `docs/*.html`. Treat
+`docs/` and `.bib` as ephemeral; reconcile to Zotero. On publication, purge
+`docs/`. Reports carry a page count in metadata. See [[verifier-dans-le-vrai-lieu]].

--- a/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/git-commit-pathspec-bypasses-index.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/git-commit-pathspec-bypasses-index.md
@@ -1,0 +1,26 @@
+---
+name: git-commit-pathspec-bypasses-index
+description: "git gotcha — `git commit -- <pathspec>` commits the working tree of those paths, silently dropping staged `git rm --cached` deletions."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e7796be7-c37c-43f6-8702-99dbdd355e78
+---
+
+`git commit -- <pathspec>` does a *partial commit* that reads the **working
+tree** for the named paths, **bypassing the index**. So a staged
+`git rm --cached <file>` (deletion in the index, file still present on disk) is
+**silently ignored** — the file stays tracked, no error.
+
+Seen 2026-06-17: untracking `docs/*` for the EDM workflow. `git rm --cached docs/*`
+then `git commit -- docs/` produced a commit with **no deletions** (working tree
+still had the files), leaving them tracked. Caught only by a post-commit
+`git ls-files docs/`.
+
+**Why:** pathspec-limited commit = working-tree snapshot of those paths, not the
+staged index state. Untracking-while-keeping-on-disk lives only in the index.
+
+**How to apply:** to commit an untracking, stage the removals and run a **plain
+`git commit`** (no pathspec) — guard scope by ensuring nothing else is staged
+first. Never trust a pathspec commit to carry `rm --cached`. Always verify with
+`git ls-files <dir>` after. See [[edm-workflow]], [[verifier-dans-le-vrai-lieu]].

--- a/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/verifier-dans-le-vrai-lieu.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-livre-milliards-climat/memory/verifier-dans-le-vrai-lieu.md
@@ -1,0 +1,35 @@
+---
+name: verifier-dans-le-vrai-lieu
+description: "Ne jamais annoncer « vérifié / propre » depuis un contrôle qui n'a pas réellement tourné, ni depuis une copie isolée — vérifier dans le checkout réel et la sortie réelle."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d4e038ad-fda0-44ef-b26c-40436685369b
+---
+
+Sur ce projet livre, trois fois dans une même session j'ai présenté comme acquis
+ce qui ne l'était pas, et l'auteur l'a relevé sèchement (« tu m'enfumes ») :
+1. « notes purgées du PDF (0 occurrence) » alors que `pdftotext` était **absent** :
+   le `grep` tournait sur une entrée vide et renvoyait 0 — un faux négatif pris
+   pour une preuve.
+2. « build sans warning » en ne scannant que stderr, alors que les *Overfull
+   hbox* et le warning de glyphe vivaient ailleurs (le `.log` LaTeX, capturé par
+   tectonic).
+3. Tout le travail fait dans un **worktree isolé** pendant que le fichier que
+   l'auteur ouvre sur le disque (`dossier-proposition.md`) restait celui de la
+   veille — « régénéré » et « vérifié » dans une sandbox déconnectée.
+
+**Why:** un contrôle qui n'a pas vraiment tourné (outil absent, mauvais flux,
+mauvais répertoire) renvoie souvent un « 0 » ou un succès vide indiscernable d'un
+vrai pass. L'affirmer érode la confiance plus vite que n'importe quel bug.
+
+**How to apply:**
+- Avant de dire « 0 / propre / vérifié », confirmer que la commande a *fait* le
+  travail : outil présent (`command -v`), bon flux (les warnings LaTeX sont dans
+  le `.log`, pas sur stderr — compiler et grep le log), sortie réelle inspectée
+  (extraire le texte du PDF/docx, pas le markdown intermédiaire).
+- Vérifier et régénérer dans le **checkout réel de l'auteur**, pas dans une copie.
+  Ce projet travaille **direct sur `main`, sans worktree** (cf. [[CONVENTIONS]] /
+  AGENTS.md) : la sandbox cachait le travail au lieu de le livrer.
+- Dire honnêtement ce qui n'a pas pu être vérifié (ex. liens 403 anti-robot :
+  « non confirmé depuis ici, à voir au navigateur ») plutôt que d'affirmer.

--- a/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/feedback_sequential_instructions_order_matters.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/feedback_sequential_instructions_order_matters.md
@@ -1,0 +1,14 @@
+---
+name: feedback-sequential-instructions-order-matters
+description: Apply multi-part instructions in the given order — a later part (e.g. a tool switch) can redefine the design space of an earlier part.
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 00f42d32-9617-4639-b3b5-e14ec6e85a97
+---
+
+2026-07-08: User asked (1) teach clean/cleaner recipes to sub-Makefiles, then (2) switch builds to tectonic. I designed clean/cleaner against pdflatex leftovers, then bolted tectonic on — leaving a `clean` that swept aux files tectonic never writes while the PDF (the build's only product) survived. User: "Tu as inversé l'ordre de mes consignes du coup c'est pas clean."
+
+**Why:** Instruction order carries design intent. A later instruction that changes the toolchain/environment invalidates assumptions baked into the earlier one; designing them out of order produces recipes that reference a world that no longer exists.
+
+**How to apply:** When a request has sequenced parts, execute in the stated order, and after any part that changes the environment (build tool, framework, data source), re-derive the earlier parts' design from the new world before committing. Check each recipe/config against what the *current* toolchain actually produces.

--- a/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/reference_openalex_pre1970_citations.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/reference_openalex_pre1970_citations.md
@@ -1,0 +1,20 @@
+---
+name: reference-openalex-pre1970-citations
+description: "OpenAlex can't do reference-based (outgoing) citation analysis for pre-1970 works; incoming citations are reliable, outgoing/2-hop is a structural null."
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 3d931939-f824-43ba-bbb6-6993ee0dedae
+---
+
+2026-07-08, established by a 90k-token agent run for the HET Figure 1 (`conception/het-indirect-citations.md`, PR #23):
+
+**OpenAlex does not index the outgoing reference lists of pre-1970 works.** A direct-citation crawl among the 15 HET primaries (1916–1984) recovered only 1 of 5 known edges; the 2-hop indirect analysis `A ∩ cited-by(cited-by(A))` was a **structural null** — not evidence of no connection, just missing data. Two reasons: (a) old works have no indexed `referenced_works`; (b) many resolve only to modern reprints (de Finetti 1937 → a 1992 Springer record), so a year-bounded query excludes them.
+
+**What works vs not, for old works:**
+- **Incoming** citations (`filter=cites:ID`, who-cites-X) ARE reliable — modern citers are indexed. Any analysis must be built from incoming queries only.
+- **Outgoing** references / bibliographic coupling / anything needing the old work's own reference list — infeasible.
+- Some pre-1960 works don't resolve at all (Heckscher 1916 Swedish; Samuelson 1952 AER absent / title-search false positives).
+- Free tier now caps at **1000 requests/day** (`retry-after` ≈ 11h).
+
+**How to apply:** for any citation-structure figure/analysis over mid-century sources, don't promise a reference-overlap or indirect-bridge result from OpenAlex — it can't. The trustworthy route is hand-transcribing the bibliographies (as the HET direct citations were, into `tab:citations` / `citations_verified.csv`). State shared-reference claims qualitatively from the hand-audit, not from a database crawl. Related: [[feedback-verify-uncommitted-files-before-acting]].

--- a/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/user_musical_terms_precision.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/user_musical_terms_precision.md
@@ -1,0 +1,14 @@
+---
+name: user-musical-terms-precision
+description: "The author is a trumpeter — musical structure terms (coda, etc.) must be used with their exact musical meaning or not at all."
+metadata: 
+  node_type: memory
+  type: user
+  originSessionId: 00f42d32-9617-4639-b3b5-e14ec6e85a97
+---
+
+2026-07-08: rejected "Coda" as the title of a mid-paper section in the HET manuscript: "en tant que trompettiste, la coda c'est 'le signe renvoie au signe pour TERMINER au mot fin'" — a coda ends the piece; calling section 4 of 7 a coda is wrong. Also flagged it as an LLMy convenience word.
+
+**Why:** loose structural metaphors read as machine-written to this author, and wrong ones grate doubly when they touch music.
+
+**How to apply:** in this author's manuscripts, name sections by their function (boundary, dictionary, junctions), not by musical or literary structure words — unless the term is exact (a true final coda could be one). Same family as [[feedback-sequential-instructions-order-matters]]'s lesson on taking the author's framing literally; see also the sartorial-metaphor purge (PR #10).

--- a/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/user_no_irony.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/user_no_irony.md
@@ -1,0 +1,14 @@
+---
+name: user-no-irony
+description: "The author firmly proscribes irony in his communication — reflexive facts are stated flat, never savored."
+metadata: 
+  node_type: memory
+  type: user
+  originSessionId: 00f42d32-9617-4639-b3b5-e14ec6e85a97
+---
+
+2026-07-08: "je proscris fermement cette pratique dans ma communication." Triggered the de-winking pass on the HET manuscript (PR #13) and the global prose guard (harness PR #442: no authorial winks).
+
+**Why:** irony makes the narrator visible and complicit; this author wants findings stated flat, with the reader left to feel any reflexivity unaided.
+
+**How to apply:** in his manuscripts and in my own summaries to him, never frame a fact as an irony, a wink, or a litotes ("fittingly", "ironically", "should not surprise"). Reflexive facts (a law applying to itself, a name misattributed) are results — state them declaratively. Related: [[user-musical-terms-precision]].

--- a/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/user_single_bib_database_preference.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-polycentric-activity/memory/user_single_bib_database_preference.md
@@ -1,0 +1,14 @@
+---
+name: user-single-bib-database-preference
+description: "Author wants one shared refs.bib per project — no per-manuscript bib files, no filecontents-embedded bibliographies."
+metadata: 
+  node_type: memory
+  type: user
+  originSessionId: 00f42d32-9617-4639-b3b5-e14ec6e85a97
+---
+
+2026-07-08: offered the choice, the author rejected the split het-refs.bib design outright ("Splitter la base de données du projet et intégrer un fichier dans un fichier ne m'enchantent pas du tout"). Unified into refs.bib (PR #9).
+
+**Why:** one database is easier to maintain and audit; a filecontents* block hides entries inside a .tex file where bib tooling cannot see them.
+
+**How to apply:** new manuscripts cite `../refs.bib` directly. Manuscript-specific entries go in a banner-marked section of refs.bib. When the same work needs two bibliographic identities (original vs reprint, working paper vs journal), keep two distinct keys side by side with cross-referencing notes and a warning not to cite both in one manuscript — see the "HET companion" banner in refs.bib. Related: [[feedback-sequential-instructions-order-matters]].

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Memory index — cired.digital
+
+- [Merge method & tracker](cired-digital-merge-and-tracker.md) — rebase-only merges (squash+merge-commit both blocked as of 2026-07-09), GitHub Issues not erg
+- [MeSSH26 slides](cired-digital-messh26-slides.md) — Cirdi RAG talk deck: slides/slides-messh.qmd, `make slides`, accepted-abstract positioning
+- [Dependabot uv.lock drift](cired-digital-dependabot-uvlock-drift.md) — floor bumps don't update uv.lock; CI never runs --locked; check before merging

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/cired-digital-dependabot-uvlock-drift.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/cired-digital-dependabot-uvlock-drift.md
@@ -1,0 +1,16 @@
+---
+name: cired-digital-dependabot-uvlock-drift
+description: cired.digital Dependabot floor bumps drift uv.lock — check locked-vs-floor before merging
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 5d9e36fb-8b06-47db-869d-f03d3d5477f5
+---
+
+In `CIRED/cired.digital`, Dependabot PRs bump only `pyproject.toml` lower bounds and never touch `uv.lock`. CI (`.github/workflows/CI.yml`) installs with plain `uv sync --group dev` — no `--locked` — so a floor raised ABOVE the locked version still passes green while leaving `uv.lock` inconsistent on `main`.
+
+**Why:** plain `uv sync` re-resolves in the runner; the committed lockfile is never validated. Green CI does not mean the lockfile is consistent.
+
+**How to apply:** Before merging a Dependabot floor bump, compare the new floor against the locked version (`grep -A1 'name = "<pkg>"' uv.lock`). If the floor exceeds the lock, regenerate: consolidate the bumps on one branch, run `uv lock`, verify `uv lock --locked` exits 0, then merge. On 2026-06-23 PRs #261/#263/#264 (plotly, ibis-framework, pyarrow) all had floor > lock; consolidated into #271 with a synced lockfile, closed the originals as superseded.
+
+Standing fix not yet applied: add `uv lock --locked` to CI and/or configure Dependabot to manage `uv.lock`. Related: [[cired-digital-merge-and-tracker]]

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/cired-digital-merge-and-tracker.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/cired-digital-merge-and-tracker.md
@@ -1,0 +1,17 @@
+---
+name: cired-digital-merge-and-tracker
+description: cired.digital uses GitHub rebase-merge (squash now disabled) and GitHub Issues — not the global erg/merge-commit conventions
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 5d9e36fb-8b06-47db-869d-f03d3d5477f5
+---
+
+The `CIRED/cired.digital` repo does NOT follow several global harness conventions:
+
+- **Merge method is REBASE** (`gh pr merge --rebase`), as of 2026-07-09 (PR #274). The allowed-methods config CHANGED: `gh api repos/CIRED/cired.digital` now reports `allow_squash_merge: false`, `allow_merge_commit: true`, `allow_rebase_merge: true`. Yet **both squash and merge-commit fail**: `--squash` → "Squash merges are not allowed", `--merge` → "Merge commits are not allowed" (branch protection overrides the `allow_merge_commit: true` flag, as before). Only `--rebase` works. Prior to 2026-07-09 this repo was squash-only; do not trust either the old squash note or the global `rules/git.md` merge-commit note. Always probe the three methods if rebase ever bounces. CI checks (CodeQL Analyze ×3 + lint) must be green; they pass in ~1 min for docs/slides-only changes, so `--rebase --auto` merges promptly.
+- **No local ticket system**: no `tickets/` dir, no `erg` binary, no `STATE.md`. Work is tracked via **GitHub Issues** (`gh issue list`), contrary to the global "GitHub Issues are for cross-repo coordination only" rule.
+- **`delete_branch_on_merge` is FALSE** on this repo (true on the harness repo). The merged remote branch is NOT auto-deleted, so the global `rules/git.md` claim "All repos use deleteBranchOnMerge: true" is wrong here. After merging, delete the remote branch manually: `git push origin --delete <branch>`.
+- After `gh pr merge --squash --delete-branch` from inside a worktree, gh prints `fatal: 'main' is already used by worktree …` — this is harmless (the PR merges; the error is just gh failing to check out main locally). Verify with `gh pr view <N> --json state`. Note `--delete-branch` does not delete the remote branch here (see above) — do it manually.
+
+Related: [[cired-digital-dependabot-uvlock-drift]]

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/cired-digital-messh26-slides.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital-cired-digital/memory/cired-digital-messh26-slides.md
@@ -1,0 +1,19 @@
+---
+name: cired-digital-messh26-slides
+description: "MeSSH26 talk slides for Cirdi — location, build, and accepted-abstract positioning"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 3d4e980c-b6ec-47d6-ad5d-05af856ce8bf
+---
+
+Talk deck for **MeSSH26** (Méthodes pour les SHS, Aubervilliers, 9–10 July 2026),
+panel **"Fouille de texte"** (Thu 17h15–18h45, discussant Katja Ploog). 20 min + live demo.
+
+- **Accepted abstract / title**: *« De la recherche par mots-clés à la synthèse sémantique — retour d'expérience sur un dispositif RAG en SHS »* (in `~/CNRS/missions/actif/2026-07-09 MeSSH Campus Condorcet/program_messh_long.pdf`).
+- **Take-home** (deliberately nuanced, not imperative): HAL gives *lexical* access; *« Et si HAL offrait aussi l'accès sémantique ? »* — with governance/liability/scale named as open obstacles.
+- **Location**: `cired.digital` repo → `slides/slides-messh.qmd` (+ `slides/slides-assets/`), tracked. Rendered PDF + keep-tex are gitignored (`slides/.gitignore`).
+- **Build**: `make slides` → `quarto render slides-messh.qmd --to beamer` (metropolis, xelatex). Writing-side clean-room: consumes committed figures only, no data/uv. `--to beamer` is required (`--to pdf` renders a plain article, not beamer).
+- **Toolchain choice**: Quarto→Beamer mirrors the GIDE deck in `climate-finance-het` and the Quarto report `reports/rapport_usages_quarto_python.qmd`; figures cropped/downscaled from `~/CNRS/papiers/sent/CIRED.digital final report/fig/` for slide legibility (500 KB pre-commit large-file limit applies).
+- **Technical facts stated** (verified against code): engine = **R2R** (`r2r-api.cired.digital`), chunking by length, retrieval hybrid (`use_hybrid_search: true` = dense + BM25). ~1199 publications indexed. Costs measured: 1.71 M Mistral tokens = €0.32 (prod), ~25 M OpenAI tokens (dev).
+- Shipped over PRs #274 (v1+v2) and #275 (v3, post 4-reviewer panel). See [[cired-digital-merge-and-tracker]] for the rebase-only merge flow.

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/MEMORY.md
@@ -1,0 +1,8 @@
+# Project memory index
+
+One line per memory. Content lives in the linked file, never here.
+
+- [R2R upstream dormant](r2r-upstream-dormant.md) — Cirdi's RAG engine is abandonware since ~Nov 2025; SciPhi pivoted to Event Horizon Labs; pin v3.6.6, sustainability risk
+- [R2R embeddings on OpenAI](r2r-embeddings-openai-billing.md) — OpenAI key is the app's single billing dependency; quota-exhaustion 500s every query even though generation is Mistral
+- [Outer repo local-only, secrets gitignored](outer-repo-local-only-secrets.md) — CIRED.digital outer repo has no remote; secrets/ purged from history + gitignored, managed via push_secrets; cired.digital is a bare gitlink not a submodule
+- [Verify via real code path, not cache](feedback-verify-real-codepath.md) — confirm fixes with input that forces the real path; a cached/repeated query gave a false "fixed" after a key rotation

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/feedback-verify-real-codepath.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/feedback-verify-real-codepath.md
@@ -1,0 +1,14 @@
+---
+name: feedback-verify-real-codepath
+description: Verify a fix by forcing the real code path — not an input that can be served from cache
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 0b9e6aa0-015a-4ef1-af1c-fd89de5e1b2b
+---
+
+When confirming a fix, exercise it with input that forces the actual failing code path. Inputs that can be served from a cache (or any memoized/short-circuit layer) can return success while the underlying defect is still live.
+
+**Why:** On 2026-06-23, after rotating Cirdi's OpenAI key, a *repeated* RAG query returned HTTP 200 and looked fixed — but R2R caches query embeddings, so it never called OpenAI. A *novel* query (fresh embedding) revealed the key was actually rejected (401). The cache produced a false-positive "fixed." Same trap applies to CDNs, HTTP caches, build caches, browser caches, DNS, and memoization.
+
+**How to apply:** For any fix verified by observing behavior, vary the input enough to defeat caching (a unique/random query, a cache-busting param, a cold start, or clear the cache first). State which layer you bypassed. Pairs with the diagnosis discipline in `rules/workflow.md`: report the observation, and make sure the observation came from the real path. Related ops case: [[r2r-embeddings-openai-billing]].

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/outer-repo-local-only-secrets.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/outer-repo-local-only-secrets.md
@@ -1,0 +1,18 @@
+---
+name: outer-repo-local-only-secrets
+description: "Outer CIRED.digital repo is local-only (no git remote); secrets/ is gitignored, managed via push_secrets not git"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: d85d05f6-f79f-4dc3-923c-6868021a8cf6
+---
+
+The outer repo at `/home/haduong/CNRS/projets/actifs/CIRED.digital` (branch `master`) has **no git remote** — it is a local-only working repo. The inner app repo `cired.digital/` is the one with a forge (`git@github.com:CIRED/cired.digital.git`, branch `main`).
+
+Consequences:
+- The outer repo's branch-and-PR gate does **not** apply (nowhere to open a PR). Commits there land directly on `master`. The usual "master is read-only, everything via PR" rule presupposes a forge this repo lacks.
+- `cired.digital/` is tracked in the outer repo as a **bare gitlink** (mode 160000), not a registered submodule — there is no `.gitmodules`, so `git submodule` commands fail. The recorded gitlink SHA drifts from the inner repo's `main` and has no external consumer, so bumping it is low-stakes local bookkeeping — fold it into a normal commit rather than ceremonialising it.
+
+**Why:** On 2026-06-23 the outer repo was found tracking `secrets/env/*.env` and `secrets/hosting/*` (live API keys + DB passwords) with no `.gitignore` rule. Purged from all history with git-filter-repo and `secrets/` added to `.gitignore`. Exposure had been local-disk only (no remote ever).
+
+**How to apply:** `secrets/` lives on disk and on the VPS, synced via `cired.digital/deploy/ops/push_secrets.sh` (rsync) — never via git. Never re-track it. Edit secret files in `CIRED.digital/secrets/env/` then `push_secrets.sh`; a key swap also needs the r2r container **recreated**, not restarted — see [[r2r-embeddings-openai-billing]].

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/r2r-embeddings-openai-billing.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/r2r-embeddings-openai-billing.md
@@ -1,0 +1,20 @@
+---
+name: r2r-embeddings-openai-billing
+description: "Cirdi's R2R uses OpenAI for embeddings, so the OpenAI key is the whole app's single billing dependency"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: d85d05f6-f79f-4dc3-923c-6868021a8cf6
+---
+
+Cirdi's R2R is configured with `openai/text-embedding-3-small` for embeddings (`[embedding]` in the R2R config). Every user query is embedded *first* (the retrieval step), so if the OpenAI account is out of quota the whole RAG request returns HTTP 500 — even though generation runs on Mistral (`mistral/mistral-small-latest` in prod, per `src/frontend/settings.js`).
+
+On 2026-06-22 the app was down with exactly this: OpenAI 429 `insufficient_quota`. A top-up of the *same* key needs nothing. A key *swap* needs the new key in `secrets/env/r2r-full.env`, pushed via `deploy/ops/push_secrets.sh`, then the r2r container **recreated** — `cd ~/cired.digital/deploy && docker compose up -d --no-deps --force-recreate r2r` (or `deploy/ops/up.sh --remote`).
+
+**Gotcha that cost an hour:** `docker restart cidir2r-r2r-1` does NOT re-read `env_file` — it bounces the process with the env baked in at container *creation*. A swapped key only loads on `docker compose up` (recreate), never on `restart`. During the 2026-06-22 rotation, repeated `docker restart` kept serving the old key; it only *appeared* fixed because the old key had been topped up. After the old key was revoked it 401'd, and only `--force-recreate` loaded the new key. Verify a swap with a **novel** query (forces a fresh embedding) — a repeated query can return 200 from a cached embedding and mask a broken key. Confirm the loaded key by `docker exec cidir2r-r2r-1 sh -c 'printf %s "$OPENAI_API_KEY" | tail -c 4'` (last 4 chars only).
+
+Second gotcha: in `r2r-full.env` the key must be a real assignment `OPENAI_API_KEY=sk-proj-...`. A hand-edit once left the new key as a bare value (no `OPENAI_API_KEY=` prefix) → variable undefined.
+
+**Why:** "App broken" looked like a Mistral/Claude problem at first, but the failing dependency was OpenAI embeddings. Anthropic offers no embeddings API, so Claude console funds cannot cover this step.
+
+**How to apply:** When Cirdi queries 500 but health is "ok", check the OpenAI account quota first. Set a budget alert on the OpenAI project. Switching embedding providers is NOT a hotfix — the 1199 stored vectors are tied to `text-embedding-3-small` and would need full re-embedding. Related upstream risk: [[r2r-upstream-dormant]].

--- a/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/r2r-upstream-dormant.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-CIRED-digital/memory/r2r-upstream-dormant.md
@@ -1,0 +1,19 @@
+---
+name: r2r-upstream-dormant
+description: R2R (the RAG engine Cirdi self-hosts) is abandonware since ~Nov 2025; upstream team pivoted away
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: d85d05f6-f79f-4dc3-923c-6868021a8cf6
+---
+
+Cirdi self-hosts R2R by SciPhi. As of 2026-06, the open-source R2R project is effectively dormant:
+
+- Last shipped artifact: **v3.6.6** (PyPI + Docker `latest`, 2025-08-17; added GPT-5 support). No GitHub Release was cut for it — the Releases page is frozen at v3.6.5 (2025-06-06), which makes it *look* more dead than it is.
+- Last commit to `main`: **2025-11-07** (13 commits past v3.6.5 sit unreleased). Nothing since.
+- Cause: the team (YC W2024, formerly SciPhi) rebranded to **Event Horizon Labs**, now "AI research lab automating all of investing" — a hard pivot off RAG.
+- sciphi.ai marketing still claims "actively maintained"; the git/Docker/YC artifacts contradict it. Trust the artifacts.
+
+**Why:** Cirdi's retrieval engine has no upstream fixes or security patches coming. This is a sustainability risk that belongs in the report's costs-and-sustainability chapter, not just an ops footnote.
+
+**How to apply:** Newest pullable image is v3.6.6 (Aug 2025); production runs v3.6.3 — pin to `sciphiai/r2r:v3.6.6` rather than drifting on `:latest`. Treat v3.6.6 as the permanent ceiling. If Cirdi must outlive this, plan a migration to an alternative RAG stack. The embedding dependency on OpenAI is the separate single-point billing risk — see [[r2r-embeddings-openai-billing]].

--- a/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/MEMORY.md
@@ -1,0 +1,6 @@
+# MEMORY — Tracing Kieu
+
+- [Décisions créatives](project_kieu_decisions.md) — titre "Chemin de voix", 13 générées/9 finales, nouvelles figures, master HTML, méthode IA
+- [Pipeline IA — règles](feedback_pipeline_ia.md) — aucun data leak v0, voix-auteur dans le sweep, commencer par voix-auteur
+- [Style des voix](feedback_style_voix.md) — voix-tnh.md = patron de structure/longueur seulement, pas de moule stylistique
+- [Style coda et intro](feedback_coda_intro_style.md) — transition douce, pas le fragment pur des entrées ; voix de l'auteur

--- a/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/feedback_coda_intro_style.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/feedback_coda_intro_style.md
@@ -1,0 +1,11 @@
+---
+name: Style coda et intro
+description: La coda et l'introduction ne reprennent pas le ton fragmenté des entrées — transition douce, voix de l'auteur
+type: feedback
+originSessionId: 447a5b81-9dc7-4f91-b07a-d23f2ab3fde6
+---
+Ne pas calquer le style fragmenté des entrées (voix des figures) pour la coda et l'intro.
+
+**Why:** La coda et l'intro parlent depuis l'extérieur des neuf voix — c'est l'auteur qui cadre, pas une figure. Répliquer le style fragment pur effacerait cette distinction.
+
+**How to apply:** "Transition douce" — phrases courtes à moyennes, quelques blancs, mais phrases complètes et connectées. Pas de fragments secs, pas de longues périodes. Le style des entrées décélère vers la voix de l'auteur.

--- a/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/feedback_pipeline_ia.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/feedback_pipeline_ia.md
@@ -1,0 +1,29 @@
+---
+name: Pipeline IA — règles de méthode
+description: Règles absolues et contraintes de la méthode IA de génération des voix
+type: feedback
+originSessionId: 36d1acf3-4f7c-4c25-9343-05779577ace1
+---
+Règles à respecter impérativement dans le pipeline IA de génération des voix.
+
+**Règle 1 — Aucun data leak.** Les brouillons actuels (voix-*.md) ne peuvent pas servir de référence de style, de données d'entraînement, ni de baseline comparative. Isolement total entre v0 et le pipeline IA.
+
+**Why:** L'objectif est des voix authentiquement générées depuis les écrits originaux des figures, pas influencées par une v0 écrite par Claude.
+
+**How to apply:** Ne jamais proposer d'utiliser voix-*.md, intro.md, ou coda.md dans le contexte du fine-tuning ou de l'évaluation. Ces fichiers sont archivés en v0 et ne participent pas au pipeline.
+
+---
+
+**Règle 2 — Voix-auteur dans le sweep, pas en post-traitement.** La combinaison voix-héros/voix-auteur est une dimension du sweep de génération (aux côtés de la température), pas une étape après la sélection.
+
+**Why:** Pour que le best-of-N compare des candidats à différents niveaux de mélange — pas pour polir un texte déjà choisi.
+
+**How to apply:** Implémenter le poids voix-auteur comme hyperparamètre du sweep. Contrainte technique à vérifier : combinaison LoRA linéaire ou ratio dataset.
+
+---
+
+**Règle 3 — Commencer par voix-auteur.** Premier prototype = corpus voix-auteur (banhhanoi.art + papiers curatés), avant les 13 voix héros.
+
+**Why:** Utile quelle que soit la réponse éditoriale finale du projet. Valide aussi le pipeline sur PADME.
+
+**How to apply:** Ticket 0014 (corpus) → ticket 0015 (prototype voix-auteur) avant ticket 0016 (sweep × 13).

--- a/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/feedback_style_voix.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/feedback_style_voix.md
@@ -1,0 +1,13 @@
+---
+name: Style des voix — patron de structure seulement
+description: Ne pas calibrer le style sur voix-tnh.md — chaque voix a le sien propre
+type: feedback
+originSessionId: 1fa8eb07-7dcd-49d9-80d1-047f02af5a1b
+---
+Ne pas demander aux agents d'écriture de "calibrer le style" sur l'entrée Thích Nhất Hạnh existante.
+
+`voix-tnh.md` sert de patron de **structure** (Le passage + La voix, longueur ~150-200 mots par section) et de **sujet** (comment l'entrée fonctionne), mais **pas de moule stylistique**.
+
+**Why:** Le brief l'énonce clairement : "Ce brouillon sert de patron de structure, mais non de moule stylistique : chaque voix doit garder son rythme propre." L'utilisateur l'a rappelé explicitement quand j'ai proposé de calibrer le style.
+
+**How to apply:** Quand on lance des agents d'écriture pour les entrées du Kiều, leur dire de lire voix-tnh.md pour comprendre le format et la longueur — pas pour imiter le style. Chaque figure a sa propre prose, son propre rythme.

--- a/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/project_kieu_decisions.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-Tracing-Kieu/memory/project_kieu_decisions.md
@@ -1,0 +1,48 @@
+---
+name: Décisions créatives Chemin de voix
+description: Choix structurels et éditoriaux fixés pour la contribution — replanifiés 2026-04-27
+type: project
+originSessionId: 36d1acf3-4f7c-4c25-9343-05779577ace1
+---
+Contribution au Tracing Kieu : titre de la contribution = "Chemin de voix, traversée du Kiều". "Tracing Kieu" = titre de la publication externe, immutable. Échéance juin 2026.
+
+**Why:** Replanification complète 2026-04-27 — nouveau titre, nouvelles figures, méthode IA.
+
+**How to apply:** Ne pas rouvrir les décisions structurelles sauf si Minh le demande. Vérifier les tickets pour l'état courant.
+
+## Texte final = 9 voix (sur 13 générées)
+
+13 voix générées par pipeline IA (12 héros au mur + Héloïse). Les 9 voix finales sont choisies en phase d'assemblage.
+
+## Figures et passages
+
+| # | Voix | Vers | Statut |
+|---|------|------|--------|
+| - | Ada Lovelace | 1–8 | v0 brouillon (remplacé par IA) |
+| - | Thích Nhất Hạnh | 80–105 | v0 brouillon (remplacé par IA) |
+| - | Héloïse d'Argenteuil | 350–380 | v0 brouillon (remplacé par IA) |
+| - | Richard Feynman | 460–490 | v0 brouillon (remplacé par IA) |
+| - | Hồ Chí Minh | TBD (ticket 0003) | passage à rechoisir — cadre intellectuel |
+| - | Marie Curie | 1400–1450 | v0 brouillon (remplacé par IA) |
+| - | Aliénor d'Aquitaine | 2355–2380 | v0 brouillon (remplacé par IA) |
+| - | Zheng He | 2455–2500 | v0 brouillon (remplacé par IA) |
+| - | Alan Manne | 3095–3150 | v0 brouillon (remplacé par IA) |
+| - | Rahan | TBD (ticket 0009) | nouveau — BD Lécureux/Chéret |
+| - | Adrian Carton de Wiart | TBD (ticket 0009) | nouveau — *Happy Odyssey* |
+| - | Indiana Jones | TBD (ticket 0009) | nouveau — scripts films |
+| - | 12e héros | TBD | voir Heroes/ |
+
+## Décisions spécifiques
+
+- **Ada** : traduit Nguyễn Du (v.1–8), pas Kiều — seule entrée méta.
+- **HCM reframé** : intellectuel prolifique à impact social (journaliste, poète, *Carnets de prison*) — pas homme d'État. Passage à rechoisir centré sur écriture/transmission.
+- **Fictifs (Rahan, Indy) traités identiquement aux réels** — pas de distinction éditoriale.
+- **Brouillons v0** : archivés, aucun data leak vers le pipeline IA.
+
+## Master document
+
+HTML comme document de travail maître. Les voix-*.md + intro.md + coda.md sont archivés comme v0.
+
+## Méthode
+
+Voix générées par LoRA fine-tuning sur écrits originaux de chaque figure + voix-auteur (banhhanoi.art + papiers curatés). Sweep température × poids-auteur. Best-of-N : présélection 3 LLM → HITL Emma + auteur.

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/MEMORY.md
@@ -1,0 +1,9 @@
+# Memory index — chemin-de-voix
+
+- [Project data path](project_data_path.md) — data lives at ~/data/projets/chemin-de-voix, not ~/data/chemin-de-voix
+- [Python tooling: uv](feedback_uv_not_pip.md) — use uv + pyproject.toml, never pip install
+- [Infra PADME](infra_padme.md) — hostname=padme, repo=~/chemin-de-voix, corpus=/data/projets/…
+- [Format preference](feedback_format_preference.md) — demander le format avant d'implémenter, ne pas sur-ingénier
+- [Corpus exclusions](feedback_corpus_exclusions.md) — third-party dirs excluded via scripts/exclude-paths.conf, watch case-sensitivity
+- [Real billing for cost analysis](feedback_real_billing_not_estimates.md) — use OR dashboard/activity, never `$/Mtok × tokens` estimates
+- [OpenRouter billing sources](reference_openrouter_billing.md) — dashboard vs activity log vs `/api/v1/credits/activity`

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_corpus_exclusions.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_corpus_exclusions.md
@@ -1,0 +1,11 @@
+---
+name: Corpus exclusions — third-party content principle
+description: docs/ contrib/ and similar dirs hold third-party content; exclusions live in scripts/exclude-paths.conf
+type: feedback
+originSessionId: f58b9bc8-e325-49d0-8494-e53e72422e60
+---
+Add path fragments to `scripts/exclude-paths.conf` (one per line, comments with #).
+
+**Why:** Directories like `/docs/`, `/contrib/`, `/Documentation/`, `/coursebooks/` etc. typically contain third-party content (conference programmes, course readings, external references) — not the author's own prose. Pattern matching is case-sensitive substring on the full source path; iterative 50-file sampling validates each new pattern is AUTEUR-safe.
+
+**How to apply:** Edit `scripts/exclude-paths.conf`, then `uv run python scripts/decontaminate_corpus.py --execute` to remove the corresponding corpus files. The walk cache auto-invalidates via _CONFIG_FP. Watch for case-sensitivity gotchas (e.g. `/attic/` vs `/Attic/`, `.pdf` vs `.PDF` — both forms must be added if both occur).

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_format_preference.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_format_preference.md
@@ -1,0 +1,17 @@
+---
+name: Format preference — demander avant d'optimiser
+description: Ne pas sur-ingénier le format des données sans demander la préférence utilisateur
+type: feedback
+originSessionId: 06412290-2998-434a-8efa-7054c7857af7
+---
+Demander la préférence de format avant de proposer une "optimisation".
+
+Dans cette session : corpus harvest proposé en JSONL (une ligne par doc, HF-ready),
+puis revertí en txt individuels ("un texte par fichier") sur demande utilisateur.
+Deux commits inutiles.
+
+**Why:** L'utilisateur a une intuition claire sur la structure des données — un fichier par texte
+est plus lisible, browsable, et tout aussi HF-compatible avec Dataset.from_list().
+
+**How to apply:** Pour toute question de format de sortie (JSONL vs txt, un fichier vs plusieurs,
+structure de répertoire), poser la question d'abord plutôt que de choisir et d'implémenter.

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_real_billing_not_estimates.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_real_billing_not_estimates.md
@@ -1,0 +1,20 @@
+---
+name: feedback-real-billing-not-estimates
+description: "For cost analysis, use real OpenRouter billing (dashboard or activity log), not estimates from $/Mtok × token counts."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: de6d8e24-6965-414a-a4b6-ec52fd3b55dc
+---
+
+For LLM-cost analysis in this project, **use OpenRouter's real billing data**, never compute cost from `$/Mtok` rates × stored `prompt_tokens`/`completion_tokens`.
+
+**Why:** when offered an agent-scraped per-token price table during the medal-tally cost work (2026-05-19), user replied "En fait il faut mieux la facture réélles de OR, tient compte des tok vrais" and pasted the OR dashboard / activity log directly. The hallucination risk from web-scraping pricing pages is real (an Anthropic-cutoff agent will guess at modern model slugs and prices) and the real invoice is already authoritative — provider-side reasoning tokens, cache discounts, route-level pricing variations are all baked in.
+
+**How to apply:** the durable source-of-truth file is `config/openrouter_spend.yaml` (per-model `spend_usd`). To refresh it:
+
+- Dashboard view groups models on their own line when spend is non-trivial; smaller spend goes into `Others` and aggregated slugs like `DeepSeek V3.2` may bundle multiple actual models.
+- For models bundled in `Others`: filter by model in the OR **activity log** (`https://openrouter.ai/activity`) and sum per-call costs. NB: the activity view may paginate — flag as "lower bound" if visible count < bench-manifest count.
+- Don't trust LLM agent output that claims to have fetched current OR prices without a verifiable WebFetch trace.
+
+See [[reference-openrouter-billing]] for the data-source map.

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_uv_not_pip.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/feedback_uv_not_pip.md
@@ -1,0 +1,11 @@
+---
+name: Python tooling: uv not pip
+description: Always use uv + pyproject.toml for Python dependencies, never pip install
+type: feedback
+originSessionId: 06412290-2998-434a-8efa-7054c7857af7
+---
+Use `uv` and `pyproject.toml` for all Python dependency management in this project. Never use `pip install`.
+
+**Why:** User explicitly corrected during 0014 execute phase (2026-04-27): "Use uv and pyproject.toml pas pip install".
+
+**How to apply:** When an agent or script needs Python packages, use `uv add <package>` to add to pyproject.toml, or `uv run python script.py` to run in the uv environment. Check if pyproject.toml exists at repo root first; create it if absent.

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/infra_padme.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/infra_padme.md
@@ -1,0 +1,14 @@
+---
+name: Infra PADME
+description: Chemins et accès SSH de la machine GPU PADME
+type: reference
+originSessionId: 06412290-2998-434a-8efa-7054c7857af7
+---
+- **Hostname** : `padme` (NetBird VPN — doit être actif)
+- **Repo git** : `~/chemin-de-voix/` (cloné depuis GitHub MinhHaDuong/Tracing-Kieu)
+- **Corpus/données** : `/data/projets/chemin-de-voix/corpus/` (partition /data séparée, volumineuse)
+- **GPU** : A4000 16GB → QLoRA NF4 4-bit, bf16 LoRA préféré sur Qwen3.x
+- **Accès** : `ssh padme <commande>` depuis doudou quand VPN up
+
+Distinction importante : `/data/` = données volumineuses, `~/` = projets/code.
+Ne jamais cloner un repo dans `/data/`.

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/project_data_path.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/project_data_path.md
@@ -1,0 +1,19 @@
+---
+name: project-data-path
+description: "Training data lives at ~/data/projets/chemin-de-voix on doudou and /data/projets/chemin-de-voix on padme (mounted disk, from machine root)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: cc12a91e-6e67-476e-9156-1dfd3a6d4939
+---
+
+Data root differs per host:
+
+- **doudou** (workstation): `~/data/projets/chemin-de-voix/`
+- **padme** (GPU host): `/data/projets/chemin-de-voix/` (mounted disk, from machine root — NOT under `$HOME`)
+
+The repo already mixes both forms: `scripts/train_lora.py` hardcodes the padme absolute path, while `scripts/train_queue_gpu*.sh` and `train_auteur_followup.sh` use `$HOME/data/projets/chemin-de-voix/corpus` (doudou-compatible). This is intentional — the scripts run on the host whose path form they use.
+
+**Why:** Confirmed 2026-05-19. The original memory only knew about doudou; user clarified that ssh'ing to padme exposes `/data/projets/chemin-de-voix/` from machine root. README.md line 52 was both stale (`~/data/chemin-de-voix/` — wrong subpath) and pointed at a missing `setup-data.sh`. Fixed in worktree-t0242.
+
+**How to apply:** Any path reference in tickets, scripts, or agent prompts must distinguish doudou vs padme. Don't `~`-expand padme paths and don't assume the doudou path works under ssh. Subpaths inside the root: `corpus/raw/`, `corpus/clean/`, `models/`, `generations/`. See also [[infra_padme]].

--- a/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/reference_openrouter_billing.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-chemin-de-voix/memory/reference_openrouter_billing.md
@@ -1,0 +1,17 @@
+---
+name: reference-openrouter-billing
+description: Where OpenRouter billing data lives and how to retrieve it for the chemin-de-voix bench cost analysis.
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: de6d8e24-6965-414a-a4b6-ec52fd3b55dc
+---
+
+OpenRouter billing for this project has two surfaces:
+
+- **Dashboard** (`https://openrouter.ai/activity`): aggregate per-model spend table with Min/Max/Avg/Sum columns. Two time windows offered: "week" and "all". Models with low spend bundle into `Others`. Some labels are catch-all slugs (e.g. `DeepSeek V3.2` may cover multiple deepseek variants) — verify before attributing.
+- **Activity log** (same URL, scroll table): per-call rows with model, provider, app name, input/output tokens, exact cost USD. The app name "chemin-de-voix judge" appears on all calls regardless of whether the call is a judge or a generator — it's the OR app label, not the role. Filterable by model.
+
+**API** alternative — `GET /api/v1/credits/activity` (needs the user's OR key) returns the activity log programmatically. Not yet automated in this repo; a future script `scripts/fetch_or_spend.py` would regenerate `config/openrouter_spend.yaml` from it.
+
+The current `config/openrouter_spend.yaml` was hand-assembled from dashboard reads + per-call sums for the bench-only models that landed bundled in `Others`. See [[feedback-real-billing-not-estimates]] for the rationale (don't compute from `$/Mtok` × tokens).

--- a/projects/-home-haduong-CNRS-projets-actifs-padme/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-padme/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# PADME Project Memory
+
+## Commit practices
+- Always commit policy docs (main-logbook.md) together with their implementing scripts — they are a unit.
+- Never say "prêt à commit" without actually committing. Either commit directly or ask if the user wants to commit.

--- a/projects/-home-haduong-CNRS-projets-replicator/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-replicator/memory/MEMORY.md
@@ -1,0 +1,70 @@
+# Replicator Project Memory
+
+## Objectif
+Agent IA qui replique des papiers en economie pour les Replication Games (I4R).
+
+## Plans
+4 fichiers dans `plans/` :
+- `overview.plan` — decisions arretees, abstractions, tech choices, risques, milestones
+- `phase-a.plan` — Part A dataset assembly (**implemente**, 156 tests)
+- `phase-b.plan` — Part B agent replicateur (pas commence)
+- `phase-c.plan` — Part C boucle d'evaluation (pas commence)
+
+## Code implemente (Part A)
+156 tests passent. Package installable via `uv sync --extra dev`.
+- `cli.py` — `replicator dataset {fetch,ingest,link,stats,extract,repair,rebuild}`
+- `blobs.py` — blob store SHA-256, atomique, URL→hash cache (load_manifest_index)
+- `schema.py` — Paper (avec link_confidence, original_reference), paper_families (paper_pairs supprime)
+- `db.py` — CRUD, FTS, WAL, family ops (create_family, find_family_original, find_family_members)
+- `extract.py` — 3 niveaux (text/structure/markdown), idempotent, ecritures atomiques
+- `download.py` — async httpx + curl fallback (NBER/SSRN), retry, rate-limit, validate_pdf
+- `sources/` — 6 decouverte (i4r, ideas, econstor, osf, github, rr) + 3 resolution (crossref, unpaywall, scihub)
+- `build_dataset.py` — fetch, ingest, link_originals (LLM-first), rebuild, repair
+
+## Modele Familles (remplace Paires)
+- paper_families = 1 conversation : original + N replications + N responses + N commentaries
+- paper_type enrichi : original | replication_report | discussion_paper | response | commentary
+- Classification heuristique (regex) + LLM (paper_role) a l'etape de linking
+- paper_pairs deprecated (DDL conserve, code supprime)
+
+## Link originals pipeline (LLM-first)
+1. Classifier le type (reanalysis/response/commentary) — skip linking si response/commentary
+2. LLM extrait metadonnees original (titre, auteurs, DOI, reference verbatim, paper_role)
+3. Snippet : premiers 2000 + derniers 2000 chars ; retry 8000 si need_bibliography
+4. Resolution DOI : LLM DOI direct → Crossref title search → DOI extraction texte (fallback)
+5. Anti-meta filter (_is_comment_or_replication) + author matching
+6. Download : Unpaywall → NBER → SSRN → Publisher (skip paywall) → Sci-Hub → HITL
+7. Creation famille + original Paper + family_id sur les deux
+
+## Architecture future (noter, pas implemente)
+Pipeline async avec queues fichier/repertoires :
+- Ingestion note les metadonnees du papier source
+- Linker parcourt la DB, sort liste de references a telecharger
+- Service download trouve les papiers (ou non)
+- Service ingestion decouvre les PDFs, OCR, extraction, versement en famille
+- Possibilite de queues en fichier texte + repertoires watched
+
+## Prochaine etape
+- Valider le switch familles : re-link en cours, verifier avec audit
+- Verifier type reanalysis a l'ingestion (pas au linking)
+- Part B : agent replicateur (voir phase-b.plan)
+
+## Notes techniques
+- marker-pdf en extra optionnel (`pip install replicator[marker]`) — pin anthropic<0.47
+- Extraction fallback pymupdf4llm fonctionne bien
+- Pas de licence Stata — MVP sur R/Python/Julia
+- I4R AJAX: `page` et `per_page` (pas `paged`) — 412 entries
+- Sci-Hub bloque depuis la France (403), fonctionne avec VPN
+- curl necessaire pour NBER/SSRN (TLS fingerprinting bloque httpx)
+
+## Protocole I4R (6 etapes)
+1. Reproduction computationnelle  2. Inspection du code  3. Scoping
+4. Robustesse (multiverse)  5. Pre-analysis plan  6. Validite externe
+
+## Workflow git
+- Ne JAMAIS travailler sur `main` — toujours creer une branche
+- Branches courtes (feature branches)
+- Avant commit : tests, ruff check, ruff format, sync docs
+
+## Langue
+L'utilisateur communique en francais.

--- a/projects/-home-haduong-CNRS-secretariat/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-secretariat/memory/MEMORY.md
@@ -1,0 +1,38 @@
+# Secretariat - Memory
+
+## Structure
+
+~/CNRS/secretariat/ est organisé en 10 dossiers thématiques (voir README.md).
+Convention de nommage : minuscules, tirets, français.
+
+## Réorganisation effectuée (mars 2026)
+
+- Ancien `Rapport/` avec 30+ sous-dossiers `sent-*` classés en 5 types dans `rapports-d-activite/`
+- CRAC (2003-2010) convertis en PDF et fusionnés dans `RIBAC/` (série complète 2003-2025)
+- `PublicationAnalysis` frozen supprimé (94MB), code vit dans `~/CNRS/code/activity_report_writer/PublicationAnalysis/` (tag git `v2024-09-frozen`)
+- `contrib/` + `procedures/` scindés en 3 : `logos/`, `references/`, `procedures/`
+- `courrier/` déplacé vers `~/CNRS/gens/archive/courrier`
+- Nommage harmonisé : navigo->transport, positions->carriere, tickets-restau->restauration
+
+## Nettoyage effectué
+
+- Doublons identiques (MD5) supprimés
+- Fichiers éditables >5 ans supprimés quand PDF existe
+- 12 fichiers obsolètes supprimés de references/ (AERES, conventions expirées, etc.)
+- 4 fichiers obsolètes supprimés de procedures/ (CIRAD, véhicule 2009, SMASH FAQ 2006)
+- Instructions évaluation vague déplacées de vague/2025/contrib/ vers references/evaluation-vague/
+
+## Code associé
+
+~/CNRS/code/activity_report_writer/ contient 3 sous-projets :
+- PublicationAnalysis/ (git, tag v2024-09-frozen)
+- ribac-check/ (git, pyproject.toml + uv)
+- activity-analysis/ (git initialisé cette session)
+
+## Préférences utilisateur
+
+- Langue de travail : français
+- Décisions rapides, peu de discussion préalable
+- Préfère supprimer plutôt qu'archiver
+- Conserve les documents CIRED et les RIB même anciens
+- Section CNRS : 40 (anciennement 37 avant 2024)

--- a/projects/-home-haduong-perso-vacances-2025-09-28-Club-Med-Djerba/memory/MEMORY.md
+++ b/projects/-home-haduong-perso-vacances-2025-09-28-Club-Med-Djerba/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Club Med Djerba — Vol annulé TO8602
+
+Le contexte du dossier est dans AGENTS.md à la racine du répertoire de travail.
+CLAUDE.md y fait référence, donc il sera chargé automatiquement à chaque session.

--- a/projects/-home-haduong/memory/MEMORY.md
+++ b/projects/-home-haduong/memory/MEMORY.md
@@ -1,0 +1,6 @@
+- [Bibliography toolchain](user_bibliography_toolchain.md) — biblatex+biber, Zotero canonical, local .bib is staging, import at submission
+- [Trust the LLM](feedback_trust_the_llm.md) — skills contain only non-obvious constraints; don't re-teach domain knowledge or invent fake thresholds
+- [Skill topic boundaries](feedback_skill_topic_boundaries.md) — split rules across git/coding/state/workflow by root cause, not by consequence; one short bullet per file
+- [Avoid costume metaphor (HET)](feedback_avoid_costume_metaphor_het.md) — don't repeat/explain the "costume" framing on the HET paper; reads as LLM padding
+- [HET submission branches protected](project_het_submission_branches_protected.md) — climate-finance-het rejects deletion of submission/* branches (server-side rule)
+- [Check sibling tickets before reorg](feedback_check_sibling_tickets_before_reorg.md) — before a cross-repo move, check the other repo's tickets for a prior decision on the same question

--- a/projects/-home-haduong/memory/feedback_avoid_costume_metaphor_het.md
+++ b/projects/-home-haduong/memory/feedback_avoid_costume_metaphor_het.md
@@ -1,0 +1,27 @@
+---
+name: feedback-avoid-costume-metaphor-het
+description: "Don't lean on the \"costume\" metaphor when narrating the HET (Un theoreme, sept costumes) figure/paper work — reads as LLM padding"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 0c9f7969-3911-4abd-ad4a-764b38e32f51
+---
+
+Don't repeatedly invoke or explain the "costume" metaphor ("seven costumes",
+"costume branch", "the costume metaphor") when describing work on the HET
+paper (polycentric_activity, tracker tickets/0011, "Un theoreme, sept
+costumes" / "One Theorem, Seven Guises"). Use the actual branch names
+(spatial, de Finetti, Kantorovich, Koopmans, Gallai, Rockafellar, Afriat) or
+plain "branch"/"lineage" instead.
+
+**Why:** User feedback 2026-07-07: "Cease and desist with the costume
+metaphor. That's LLMy." The word itself is legitimate — it's the paper's own
+internal working title (ticket 0011 says it's the deliberate name of the
+deliverable) — but restating and re-explaining the metaphor in every message
+reads as a repetitive LLM tic, not as adding information.
+
+**How to apply:** Fine to reference the paper's actual title verbatim once
+(e.g. when first identifying the project). Don't reuse "costume" as a
+recurring descriptive device in prose. Also applies to generated artifacts
+for this project: plot titles/legend headers should say "branch" not
+"costume branch".

--- a/projects/-home-haduong/memory/feedback_check_sibling_tickets_before_reorg.md
+++ b/projects/-home-haduong/memory/feedback_check_sibling_tickets_before_reorg.md
@@ -1,0 +1,32 @@
+---
+name: feedback_check_sibling_tickets_before_reorg
+description: "before executing a cross-repo file move/reorg the user just approved via a quick choice, check sibling-project tickets for a prior documented decision on the same question"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: c40a15a0-a05a-4167-aa8f-6b7351eb49a6
+---
+
+When a user flags something as looking misplaced ("seems unrelated!") and,
+offered a quick multiple-choice on what to do, picks the more drastic option
+(e.g. "move it to the other repo") — pause and check whether a prior,
+independent decision on that exact question already exists before executing.
+
+**Why:** 2026-07-07, `climate-finance-het`: the user questioned why a
+citation-figure pipeline for a *different* paper lived in this repo. Asked
+"leave / move / leave-as-is", they picked "move it to polycentric_activity".
+Before starting the move, a check of that sibling repo's own tickets found
+one (`polycentric_activity` ticket 0027) — authored by the same user, same
+day — that already recorded the opposite as a deliberate call: keep the
+machinery here specifically to avoid duplicating it there. Surfacing that
+before touching any files let the user reconcile in one round-trip instead
+of after a real cross-repo migration was underway.
+
+**How to apply:** Before executing a reorg/move that spans repos or
+undoes something another artifact (ticket, PR, architecture note) already
+addressed, spend one search pass on the *other* side of the boundary —
+sibling repo's tickets, the original PR body, related architecture docs —
+for an existing decision. If found, present the conflict and let the user
+reconcile before acting, rather than either silently overriding it or
+silently deferring to the multiple-choice answer alone. This is cheap
+(one grep/read) relative to the cost of a wrong structural change.

--- a/projects/-home-haduong/memory/feedback_skill_topic_boundaries.md
+++ b/projects/-home-haduong/memory/feedback_skill_topic_boundaries.md
@@ -1,0 +1,11 @@
+---
+name: Skill files are topic-bounded; split mixed rules
+description: When drafting harness rules, keep each skill file (git/coding/state/workflow) to its own topic and split rules that span two topics across files
+type: feedback
+originSessionId: f363f3c5-63e5-4b4d-a38c-cc6f2533aed7
+---
+Harness skill files ([git.md](.claude/skills/harness-rules/git.md), [coding.md](.claude/skills/harness-rules/coding.md), [state.md](.claude/skills/harness-rules/state.md), [workflow.md](.claude/skills/harness-rules/workflow.md)) are organized by topic, not by chronology or use case. When a rule has consequences in more than one area, split the rule across files at the topic boundary instead of putting the whole thing in one file with a cross-reference in the body.
+
+**Why:** user corrected me after I put a rule about the analysis/writing build split into git.md because its *consequence* was about commit-vs-gitignore. The root cause was build structure (coding.md) and the git behaviour was downstream. The user wanted two short bullets, one per file.
+
+**How to apply:** before writing a bullet, ask "what topic is this rule's root cause?" and place it there. If the rule also has a consequence in another topic, write a second, shorter bullet in that file — don't bundle. Cross-link with a relative path so readers can navigate.

--- a/projects/-home-haduong/memory/feedback_trust_the_llm.md
+++ b/projects/-home-haduong/memory/feedback_trust_the_llm.md
@@ -1,0 +1,13 @@
+---
+name: Trust the LLM — skill authoring principle
+description: Skills should only contain non-obvious constraints. Do not re-teach domain knowledge, specify step-by-step procedures the LLM can infer, or invent fake-precision thresholds.
+type: feedback
+---
+
+Skills should only contain constraints the LLM cannot infer from the task description alone: policy decisions, output formats, safety invariants, organizational conventions, and things it would get wrong by default.
+
+**Why:** Over-specified skills re-teach domain knowledge (how to parse biblatex, how to do research, what git commands to use), which risks contradicting or confusing the LLM. Arbitrary thresholds without measurement backing (e.g., "50% token overlap", "≤3 years old") are make-believe rules. Silence is better than contradicting or confusing instructions.
+
+**How to apply:** When writing or reviewing a skill, ask: "Would the LLM get this wrong by default?" If no, delete the line. Keep: append-only invariants, output formats for tooling, escalation policy, organizational conventions (Zotero is canonical, biblatex not BibTeX). Cut: research methodology, git command flags, biblatex parsing instructions, academic writing style guidance.
+
+Validated 2026-04-17: slimmed 5 skills from 916 to 325 lines (-65%) with user approval.

--- a/projects/-home-haduong/memory/project_het_submission_branches_protected.md
+++ b/projects/-home-haduong/memory/project_het_submission_branches_protected.md
@@ -1,0 +1,28 @@
+---
+name: project_het_submission_branches_protected
+description: "climate-finance-het repo blocks deletion of submission/* branches via a server-side push rule — they are permanent records, not stale branches"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: c40a15a0-a05a-4167-aa8f-6b7351eb49a6
+---
+
+The `climate-finance-het` repo (`MinhHaDuong/climate-finance-het`) rejects
+`git push origin --delete submission/*` with "Cannot delete submission
+branches" — a server-side rule, not just convention. Confirmed 2026-07-07
+when the generic merged-branch cleanup loop from `[[git]]` tried to remove
+`submission/rdj-data-paper` (merged into main since March 2026) and was
+bounced.
+
+**Why:** Submission branches (`submission/oeconomia-varia`,
+`submission/rdj-data-paper`, etc.) are permanent historical records of what
+was actually sent to a journal/reviewer, mirroring the `papiers/<state>/<track>/`
+convention for non-code submission artifacts (architecture.md, ticket 0159).
+They are deliberately exempt from the merged-branch GC even after their
+content lands on main.
+
+**How to apply:** Skip `submission/*` when running the merge-base-ancestor
+branch-cleanup loop on this repo — don't bother attempting the delete, it
+will fail (harmlessly) and waste a round-trip. If you need to actually
+retire one, that requires an explicit repo-admin action (ruleset edit), not
+a routine hygiene pass.

--- a/projects/-home-haduong/memory/user_bibliography_toolchain.md
+++ b/projects/-home-haduong/memory/user_bibliography_toolchain.md
@@ -1,0 +1,18 @@
+---
+name: Bibliography toolchain
+description: User uses biblatex+biber (not BibTeX), Zotero as canonical library, local .bib files are staging
+type: user
+---
+
+Uses **biblatex** compiled with **biber**, not classic BibTeX.
+
+Canonical reference library is **Zotero** (v9+ as of April 2026, fast release cycle).
+Local `.bib` files in repos are staging areas — not the source of truth.
+
+Workflow: at manuscript submission, import approved `.bib` entries into Zotero
+(File → Import) with fulltext PDFs. Not before (citations churn during drafting),
+not after publication (you've moved on).
+
+Reference `.bib` for formatting conventions: `~/CNRS/html/src/Ha-Duong.bib`.
+Key style: `Author-NameYEAR:slug`. Biblatex fields: `date`, `journaltitle`,
+`eprint` + `eprinttype` for HAL/arXiv.

--- a/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/MEMORY.md
+++ b/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Memory index
+
+- [Discussion Dosquet conf Gide](project_gide_dosquet_discussion.md) — rapport de relecture du chap. 7 de Dosquet, Vannes 2026-07-02 ; emplacement dans missions/done + thèses clés
+- [Prose vs code workflow](feedback_prose_vs_code_workflow.md) — code en worktree+PR, prose éditée en place dans le checkout de l'auteur
+- [Plain directory names](feedback_plain_directory_names.md) — répertoires de workpackages nommés en clair, jamais p1/p3/het

--- a/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/feedback_plain_directory_names.md
+++ b/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/feedback_plain_directory_names.md
@@ -1,0 +1,21 @@
+---
+name: plain-directory-names
+description: "Nommer les répertoires de workpackages en clair, jamais par codes opaques (p1/p3/het)"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 1848c079-892d-4cc3-aff1-bf176e1c7e39
+---
+
+Les répertoires de workpackages dans les programmes de papiers se nomment en
+clair, par leur contenu (ex. `marches-carbone/`, `arbitrage-onchain/`,
+`sept-costumes/`), jamais par les codes du programme (`p1/`, `p3/`, `het/`).
+
+**Why:** Demandé explicitement par Minh (2026-07-06, organisation de
+polycentric_activity) : les codes P1/P3/P5/HET sont des identifiants de
+programme — ils vivent dans les notes de conception et les titres de tickets,
+pas dans l'arborescence.
+
+**How to apply:** À la création de la structure multi-papiers d'un dépôt,
+proposer des noms descriptifs et garder les codes uniquement comme références
+croisées dans les tickets/notes. Voir [[prose-vs-code-workflow]].

--- a/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/feedback_prose_vs_code_workflow.md
+++ b/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/feedback_prose_vs_code_workflow.md
@@ -1,0 +1,31 @@
+---
+name: prose-vs-code-workflow
+description: "Discipline différenciée par workpackage — code en worktree+PR, prose éditée en place dans le checkout de l'auteur"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 1848c079-892d-4cc3-aff1-bf176e1c7e39
+---
+
+Dans les dépôts de papiers multi-manuscrits (ex. polycentric_activity), Minh
+veut une discipline différenciée : code/données = machinerie complète
+(worktree, branche, PR, /gaze) ; prose de manuscrit = édition en place dans
+son checkout, commits au fil de l'eau sur main ou branche de papier, relecture
+par PDF recompilé et latexdiff entre tags — jamais de worktree jetable pour la
+prose interactive.
+
+**Why:** L'isolation worktree le coupe du texte : un manuscrit se co-édite en
+allers-retours courts (précédent : le workflow ODT annoté avec Pierre
+Matarasso sur le papier Œconomia). Le diff de PR n'est pas son interface de
+relecture pour la prose.
+
+**How to apply:** En session interactive sur de la prose, ne pas isoler —
+éditer dans le checkout. Les passes autonomes sur la prose produisent des
+rapports (panels de référés, registres de sources → conception/), jamais
+d'édits directs du manuscrit ; ce qui modifie le manuscrit passe soit par la
+session interactive, soit par branche+PR que l'auteur arbitre — jamais les
+deux modes en même temps sur le même fichier. Protection anti-collision par
+séparation des lanes (tickets autonomes → analysis/, conception/, refs.bib),
+pas par isolation git. Règle codifiée dans le harnais IDH : rules/git.md
+§ Prose vs code workpackages (PR de 2026-07-06). Voir aussi
+[[plain-directory-names]].

--- a/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/project_gide_dosquet_discussion.md
+++ b/projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/project_gide_dosquet_discussion.md
@@ -1,0 +1,46 @@
+---
+name: project-gide-dosquet-discussion
+description: "Rapport de relecture de Minh sur le chap. 7 de Dosquet (Monnaie et raison d'État, t. II), discuté au colloque Charles Gide de Vannes le 2 juillet 2026 — emplacement et thèses clés"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 29c381b0-e413-4048-9a60-db4dfcce7085
+---
+
+Minh a été discutant (session A.03) du 21e colloque de l'Association Charles
+Gide (Vannes, 2 juillet 2026) pour la communication de Yaël Dosquet, adossée au
+chap. 7 « Disciplines du travail et jeux de représentations du monde » de
+*Monnaie et raison d'État*, tome II *Le Moyen Âge* (L'Harmattan, 2025,
+p. 151–257).
+
+Son commentaire écrit, « Travail, monnaie, État : au-delà du travail
+discipliné » (1er juillet 2026), vit dans :
+`/home/haduong/CNRS/missions/done/Conférences/2026-07-02 Vannes Colloque Charles Gides/discussion de Dosquet chap 7 de Monnaie et raison d'État/`
+(`note_lecture_dosquet_chap7.odt`/`.pdf`, avec `DOSQUET2026_chap_7.pdf` et
+`talking_points_dosquet_A03.pdf`).
+
+Thèses du rapport : (1) le chapitre prend le travail *contraint* pour le
+travail en général — pessimisme tautologique par cadrage ; (2) épreuve
+historique par le recensement de 1926 (salariat privé ~43 % du travail effectif,
+prolétariat d'usine ~un quart) ; (3) grille 2×2 rémunéré×subordonné qui montre
+le triptyque esclavage/travail forcé/travail payé mal taillé ; (4) il souscrit à
+la thèse de souveraineté monétaire mais rejette la thèse de discipline
+capitaliste (solde, traitement, indépendants) ; (5) coda écologie : rendre à
+l'État son épaisseur régulatrice rend l'action écologique politique au lieu
+d'une défection individuelle.
+
+Contexte projet voisin : le papier propre de Minh à cette conf est
+`manuscript-Gide.qmd` (projet `climate-finance-het`), présenté à Vannes les
+2–4 juillet 2026.
+
+Suite épistolaire : le 6 juillet 2026 Dosquet a répondu par une longue lettre
+blessée mais amicale (reproche central : « mépris », chapitre jugé sans lire
+les chap. 1 et 3 ; seule vraie précision de fond : salariat issu du mercenariat
+antique, discipline d'usine issue de la plantation — deux filiations
+distinctes). Minh a répondu le 7 juillet par un mot bref et fraternel :
+confession du temps limité, livres « cartes de visite » à égalité, crédit de la
+distinction généalogique, réception du témoignage sur la précarité, désaccord
+de fond (définition du travail, rôle de l'État) reporté à une conversation en
+personne. Fautes d'orthographe laissées volontairement « pour signer humain ».
+La relation est préservée ; le désaccord intellectuel reste ouvert. Chapitres
+du livre en accès libre : www.monnaieetraisondetat.fr.

--- a/tickets/0279-re-home-memory-keyed-to-throwaway-scratc.erg
+++ b/tickets/0279-re-home-memory-keyed-to-throwaway-scratc.erg
@@ -1,0 +1,43 @@
+%erg 0.1
+Title: Re-home memory keyed to throwaway scratchpad project paths
+Created: 2026-07-11
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-11T13:08Z Minh Ha-Duong created
+
+--- body ---
+## Context
+Ticket 0278 tracked the per-project memory backlog. One of its project dirs,
+`projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/`,
+holds 4 legitimate notes (`MEMORY.md`, `feedback_plain_directory_names.md`,
+`feedback_prose_vs_code_workflow.md`, and `project_gide_dosquet_discussion.md`
+— the last has unique content). They are keyed to a `/tmp/claude-1001/...`
+scratchpad path that will never recur: a future Oeconomia session runs from the
+real project dir, so memory retrieval keyed on the working-directory hash will
+never surface these notes. The memory is committed (backed up) but orphaned from
+future lookup.
+
+## Relevant files
+- `projects/-tmp-claude-1001--home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--2e29adca-1aad-47ad-807b-291b5fd3d56b-scratchpad-merge-odt/memory/` — the 4 orphaned notes
+- `projects/-home-haduong-CNRS-papiers-actif-Oeconomia---Joint-production--5-Juillet--discussion-HDM-PM/memory/` — the real Oeconomia project dir (candidate re-home target)
+
+## Actions
+1. Confirm the real, recurring Oeconomia project working-directory hash (the dir
+   a normal Oeconomia session resolves to).
+2. Merge the 4 scratchpad-keyed notes into that project's `memory/`, deduping
+   against existing notes (`project_gide_dosquet_discussion.md` is unique;
+   the two `feedback_*` and `MEMORY.md` may overlap — reconcile, don't clobber).
+3. Remove the throwaway `-tmp-claude-1001-...scratchpad-merge-odt` project dir
+   once its content is re-homed.
+
+## Invariants
+- No content loss: `project_gide_dosquet_discussion.md` unique content must
+  survive the move verbatim.
+- Don't clobber existing notes in the target dir on a name collision.
+
+## Exit criteria
+- The 4 notes live under the real Oeconomia project dir and are reachable by a
+  normal Oeconomia session's memory retrieval.
+- The throwaway scratchpad project dir is gone from the tree.
+- Author has arbitrated the re-home target dir (his call).

--- a/tickets/closed/0278-track-the-untracked-per-project-memory-b.erg
+++ b/tickets/closed/0278-track-the-untracked-per-project-memory-b.erg
@@ -2,11 +2,13 @@
 Title: Track the untracked per-project memory backlog across all projects
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #484
 
 --- log ---
 2026-07-11T11:08Z Minh Ha-Duong created
 
 2026-07-11T13:05Z claude note raid plan — inventory 103 files / 27 projects, zero credential exclusions (grep+eyeball done); all 27 MEMORY.md untracked; single PR, per-project commits; executor copies from primary tree; follow-up to file: re-home tmp-scratchpad-keyed Oeconomia memory
+2026-07-11T14:17Z Minh Ha-Duong closed — autoclosed — PR #484
 --- body ---
 ## Context
 The `.gitignore` top-level `*` catch-all + git's parent-exclusion rule silently


### PR DESCRIPTION
## What / why

The `.gitignore` top-level `*` catch-all silently ignored per-project memory
under `projects/<hash>/memory/`. The fixing PR (`track-project-memory-gitignore`)
added the re-inclusion rule and committed the climate-finance-het orphans as the
reviewed exemplar. This PR clears the remaining backlog: **103 untracked memory
notes across 27 project dirs** (note bodies + 25 `MEMORY.md` indexes; the harness
and lowercase `polycentric-activity` dirs had their index already tracked / absent).

Without this, new memory bodies are unbacked — a machine loss drops them.

The files exist only in the primary checkout's working tree; each was copied
**byte-identical** (`cp -p` + `cmp` verify) into this worktree and staged via the
explicit `projects/<dir>/memory/` directory path — never `git add -A` — so
transcripts and session files stay ignored and `.provenance.lock` stays untracked.

## Per-commit project map

| Commit | Project dir(s) | Notes |
|--------|----------------|-------|
| Fuzzy-Corpus | `-Fuzzy-Corpus` | 10 |
| chemin-de-voix | `-chemin-de-voix` | 8 |
| Cadens | `-Cadens` | 7 |
| harness | `-home-haduong--claude` | 7 |
| home root | `-home-haduong` | 7 |
| maiba | `-code-maiba` | 6 |
| Tracing-Kieu | `-Tracing-Kieu` | 5 |
| polycentric-activity | `-polycentric-activity` (lowercase) | 5 |
| Jussieu | `-cours-Jussieu` + `-Jussieu-Payment` | 5 + 2 |
| CIRED-digital | `-CIRED-digital` + `-CIRED-digital-cired-digital` | 5 + 4 |
| html | `-CNRS-html` + `-CNRS-html-src` | 4 + 3 |
| Polycentric (capital-P) | `-Polycentric-activity` + `-Polycentric-activity-conception` | 2 + 2, kept distinct |
| Oeconomia-adjacent | Vannes-Colloque + discussion-HDM-PM + tmp-scratchpad-merge-odt | 3 + 1 + 4 |
| remaining sweep | Djerba, secretariat, replicator, padme, activity-report-writer, git-erg, DOIfetch, livre-milliards-climat | 1+1+1+1+1+2+2+4 = 13 |

A 15th commit files the follow-up ticket 0279.

## Eyeball / credential verification

Every file was skimmed and run through a strict credential scan
(`sk-…{20,}`, `ghp_…`, `xox[baprs]-`, `AKIA…`, `-----BEGIN`, `Bearer …`) plus a
broader backstop (`api[_-]?key|secret|password|token[:=]|…`). **Zero exclusions.**
The odd files were read in full: the CIRED-digital `outer-repo-local-only-secrets`
and `r2r-embeddings-openai-billing` notes *discuss* secrets handling and hold only
the placeholder `sk-proj-...` (no real key); the Jussieu vacation-dossier note
references locations of personal documents but contains no ID numbers or
credentials; the HAL "bypass" note documents a public Solr-API technique. All
kept as legitimate project notes.

## Comm verification

After all commits, comparing this branch's tracked memory set against the
primary's on-disk set:

```
git ls-files 'projects/*/memory/*.md'   → 556
find projects -path '*/memory/*.md'     → 556
comm (on-disk NOT tracked)              → empty
comm (tracked NOT on-disk)              → empty
```

Every memory `.md` on disk (the 103 backlog + 453 previously tracked) is now
tracked; no misses, no branch-only files. `git status` in the worktree is clean
of untracked `projects/*/memory/*.md`, nothing staged outside `memory/` paths,
`.provenance.lock` not tracked. `make check` green (648 passed).

Related follow-up: tickets/0279-re-home-memory-keyed-to-throwaway-scratc.erg

**Ticket:** tickets/0278-track-the-untracked-per-project-memory-b.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
