### PR TITLE
dream: promotion frequency gate counts canonical projects (0270)

### DIFF
--- a/memory/.project-aliases.json
+++ b/memory/.project-aliases.json
@@ -1,0 +1,3 @@
+{
+  "-home-haduong-aedist-technical-report": "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report"
+}

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -190,7 +190,7 @@ Output is JSON: entries seen in >=2 distinct projects that are not yet promoted.
 
 For each candidate, Claude evaluates inline:
 
-- **Frequency gate** (mechanical, already passed): entry appears in >=2 distinct project consolidations.
+- **Frequency gate** (mechanical, already passed): entry appears in >=2 distinct canonical project consolidations (path aliases collapsed — see `provenance.py` / `memory/.project-aliases.json`).
 - **Cost gate** (Claude judgment): would missing this entry cost >500 tokens to re-derive per session, OR does missing it risk correctness/security failures? If neither, the entry fails.
 - **Context-independence gate** (Claude judgment): apply the three-part test from the research note:
   1. Entity stripping: remove project-specific entities. Does the lesson retain meaning?

--- a/skills/dream/SKILL.md
+++ b/skills/dream/SKILL.md
@@ -184,7 +184,7 @@ Runs after consolidation. Evaluates whether any project-level entries have earne
 python3 ~/.claude/skills/dream/provenance.py candidates
 ```
 
-Output is JSON: entries seen in >=2 distinct projects that are not yet promoted. If empty, skip to step 13.
+Output is JSON: entries seen in >=2 distinct canonical projects (path aliases collapsed) that are not yet promoted. If empty, skip to step 13.
 
 **10. Evaluate each candidate against three gates (all required).**
 

--- a/skills/dream/provenance.py
+++ b/skills/dream/provenance.py
@@ -23,6 +23,7 @@ from pathlib import Path
 HARNESS_MEMORY = Path.home() / ".claude" / "memory"
 PROVENANCE_PATH = HARNESS_MEMORY / ".provenance.json"
 PROVENANCE_LOCK = HARNESS_MEMORY / ".provenance.lock"
+PROJECT_ALIASES_PATH = HARNESS_MEMORY / ".project-aliases.json"
 PROJECTS_BASE = Path.home() / ".claude" / "projects"
 DECAY_DAYS = 90
 
@@ -65,6 +66,25 @@ def _load_provenance() -> dict:
     if PROVENANCE_PATH.exists():
         return json.loads(PROVENANCE_PATH.read_text())
     return {"entries": {}}
+
+
+def _load_aliases() -> dict:
+    """Map alias project-slug -> canonical project-slug (empty when absent).
+
+    Project keys in the provenance store are Claude-Code directory *slugs*
+    (e.g. `-home-haduong-CNRS-papiers-actif-AEDIST-technical-report`), not
+    filesystem paths, so `os.path.realpath` cannot collapse aliases: slug->path
+    inversion is ambiguous and a relocated tree's old path no longer exists on
+    disk. Instead we keep an explicit, read-time alias table (ticket 0270). A
+    missing table is the common case — no aliases — and yields {}."""
+    if PROJECT_ALIASES_PATH.exists():
+        return json.loads(PROJECT_ALIASES_PATH.read_text())
+    return {}
+
+
+def _canonical_project(project: str, aliases: dict) -> str:
+    """Resolve an alias project-slug to its canonical slug; identity otherwise."""
+    return aliases.get(project, project)
 
 
 def _save_provenance(data: dict) -> None:
@@ -214,9 +234,14 @@ def confirm(args):
 def candidates(args):
     """List promotion candidates: entries seen in >=2 distinct projects, not yet promoted."""
     data = _load_provenance()
+    aliases = _load_aliases()
     result = []
     for slug, entry in data["entries"].items():
-        if len(entry["projects"]) >= 2 and not entry["promoted"]:
+        # Count distinct *canonical* projects: two path-spellings of one project
+        # (a relocated/symlinked tree registered under two slugs) must count once,
+        # else the frequency gate promotes a single-project note (ticket 0270).
+        canonical = {_canonical_project(p, aliases) for p in entry["projects"]}
+        if len(canonical) >= 2 and not entry["promoted"]:
             result.append({"slug": slug, **entry})
     json.dump(result, sys.stdout, indent=2)
     print()

--- a/skills/dream/provenance.py
+++ b/skills/dream/provenance.py
@@ -83,8 +83,21 @@ def _load_aliases() -> dict:
 
 
 def _canonical_project(project: str, aliases: dict) -> str:
-    """Resolve an alias project-slug to its canonical slug; identity otherwise."""
-    return aliases.get(project, project)
+    """Resolve an alias project-slug to its canonical slug; identity otherwise.
+
+    Follows chained aliases ({old->mid, mid->canonical}) to a fixpoint so a
+    multi-hop table collapses fully. A visited-set guards against a cyclic table
+    looping forever: on a cycle we stop and return the last resolved slug, which
+    keeps the result deterministic (ticket 0270 reroll)."""
+    seen = {project}
+    current = project
+    while current in aliases:
+        nxt = aliases[current]
+        if nxt in seen:
+            return current
+        seen.add(nxt)
+        current = nxt
+    return current
 
 
 def _save_provenance(data: dict) -> None:

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -377,6 +377,25 @@ def test_provenance_candidates_substring_key_still_distinct(provenance_env):
     assert [c["slug"] for c in candidates] == ["feedback_vim"]
 
 
+def test_provenance_candidates_chained_alias_not_candidate(provenance_env):
+    """A chained alias table {old->A, A->B} must resolve `old` all the way to B,
+    so a slug recorded under both `old` and `B` collapses to one canonical
+    project and is NOT a candidate. Single-level dict.get() stops at A and
+    wrongly counts {A, B} == 2 (ticket 0270 reroll)."""
+    _write_aliases(provenance_env, {
+        "-home-haduong-old-spelling": "-home-haduong-mid-spelling",
+        "-home-haduong-mid-spelling": "-home-haduong-canonical",
+    })
+    _seed_provenance(provenance_env, "feedback_vim", [
+        "-home-haduong-old-spelling",
+        "-home-haduong-canonical",
+    ])
+    result = _run_provenance("candidates", home=provenance_env)
+    assert result.returncode == 0, result.stderr
+    candidates = json.loads(result.stdout)
+    assert [c["slug"] for c in candidates] == []
+
+
 def test_provenance_decay_empty(provenance_env):
     result = _run_provenance("decay", home=provenance_env)
     assert result.returncode == 0

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -294,6 +294,89 @@ def test_provenance_remove_unknown_slug(provenance_env):
     assert "nonexistent" not in show["entries"]
 
 
+# --- Provenance canonical-project gate (ticket 0270: path aliases collapse) ---
+
+
+def _write_aliases(home, mapping):
+    """Write the read-time alias table to <HOME>/.claude/memory/.project-aliases.json."""
+    path = home / ".claude" / "memory" / ".project-aliases.json"
+    path.write_text(json.dumps(mapping))
+
+
+def _seed_provenance(home, slug, projects, promoted=False):
+    """Write .provenance.json directly with one entry under the given project keys.
+
+    Directory-slug project keys begin with `-` (e.g. `-home-haduong--claude`), which
+    argparse in the record CLI parses as `-h`; the decay tests already seed the store
+    directly for the same reason. We exercise candidates() in isolation here."""
+    path = home / ".claude" / "memory" / ".provenance.json"
+    now = "2026-07-11T00:00:00Z"
+    path.write_text(json.dumps({
+        "entries": {
+            slug: {
+                "projects": list(projects),
+                "first_seen": now,
+                "last_confirmed": now,
+                "promoted": promoted,
+            }
+        }
+    }))
+
+
+def test_provenance_candidates_alias_collapse_not_candidate(provenance_env):
+    """Two path-spellings of one project collapse to one canonical project, so a
+    slug recorded under both keys is NOT a promotion candidate (frequency < 2).
+
+    Directory-slug keys, not paths: the AEDIST report registered under both
+    `-home-haduong-aedist-technical-report` and its
+    `-home-haduong-CNRS-papiers-actif-AEDIST-technical-report` spelling. The gate
+    must count distinct *canonical* projects."""
+    _write_aliases(provenance_env, {
+        "-home-haduong-aedist-technical-report":
+            "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report",
+    })
+    _seed_provenance(provenance_env, "reference_zotero", [
+        "-home-haduong-aedist-technical-report",
+        "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report",
+    ])
+    result = _run_provenance("candidates", home=provenance_env)
+    assert result.returncode == 0, result.stderr
+    candidates = json.loads(result.stdout)
+    assert [c["slug"] for c in candidates] == []
+
+
+def test_provenance_candidates_true_distinct_still_candidate(provenance_env):
+    """Teeth-check: with the alias table present, a slug in two genuinely distinct
+    projects is still the sole candidate — the canonicalizer collapses only aliases."""
+    _write_aliases(provenance_env, {
+        "-home-haduong-aedist-technical-report":
+            "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report",
+    })
+    _run_provenance("record", "feedback_vim", "project-alpha", home=provenance_env)
+    _run_provenance("record", "feedback_vim", "project-beta", home=provenance_env)
+    result = _run_provenance("candidates", home=provenance_env)
+    assert result.returncode == 0, result.stderr
+    candidates = json.loads(result.stdout)
+    assert [c["slug"] for c in candidates] == ["feedback_vim"]
+
+
+def test_provenance_candidates_substring_key_still_distinct(provenance_env):
+    """A key that shares a substring with an aliased key but is not that key stays
+    distinct — guards against substring matching creeping in instead of dict.get()."""
+    _write_aliases(provenance_env, {
+        "-home-haduong-aedist-technical-report":
+            "-home-haduong-CNRS-papiers-actif-AEDIST-technical-report",
+    })
+    _seed_provenance(provenance_env, "feedback_vim", [
+        "-home-haduong-aedist-technical-report",
+        "-home-haduong-aedist-technical-report-notes",
+    ])
+    result = _run_provenance("candidates", home=provenance_env)
+    assert result.returncode == 0, result.stderr
+    candidates = json.loads(result.stdout)
+    assert [c["slug"] for c in candidates] == ["feedback_vim"]
+
+
 def test_provenance_decay_empty(provenance_env):
     result = _run_provenance("decay", home=provenance_env)
     assert result.returncode == 0

--- a/tickets/closed/0270-dream-promotion-frequency-gate-miscounts.erg
+++ b/tickets/closed/0270-dream-promotion-frequency-gate-miscounts.erg
@@ -2,11 +2,13 @@
 Title: dream promotion frequency gate miscounts path-aliased project as distinct
 Created: 2026-07-10
 Author: minh
+Closed: autoclosed — PR #485
 
 --- log ---
 2026-07-10T15:20Z minh created
 
 2026-07-11T13:05Z claude note raid plan — realpath inapplicable (keys are slugs; old path gone): read-time alias table memory/.project-aliases.json in candidates(); record/promote untouched; live reference_zotero checkbox vacuous (already promoted) — synthetic tests are the proof; wave 2 after 0241 merges
+2026-07-11T14:46Z Minh Ha-Duong closed — autoclosed — PR #485
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

The dream promotion frequency gate counts distinct projects by their
directory-slug key. When one project is reachable under two path spellings (a
relocated or symlinked tree), the same project registers two slugs and the
`>=2 distinct projects` gate passes on a single project — elevating a
project-specific note to the shared harness tier on a false count.

Fix: an explicit, read-time alias table `memory/.project-aliases.json`
(alias slug -> canonical slug). `candidates()` now counts distinct **canonical**
projects. `record()`, `promote()`, `confirm()`, `decay()`, `remove()` and the
stored project lists are untouched; read-time normalization also repairs
already-recorded aliases without a migration.

Seeded with the one real alias observed 2026-07-10:
`-home-haduong-aedist-technical-report` ->
`-home-haduong-CNRS-papiers-actif-AEDIST-technical-report`.

## Deviation rationale (records a raid-plan decision)

The ticket's Action 1 suggests `os.path.realpath`. That is inapplicable here:
the store's project keys are Claude-Code directory **slugs**, not filesystem
paths. Slug->path inversion is ambiguous, and the motivating alias's old path no
longer exists on disk, so `realpath` on a gone path is a lexical no-op. An
explicit alias table, applied at read time in `candidates()`, is the route that
actually collapses the two spellings.

## Vacuous-checkbox caveat

The ticket's live checkbox "reference_zotero no longer appears in candidates
output" is **vacuous today**: that entry is already promoted, and promoted
entries are unconditionally excluded from `candidates()` — so the box reads true
with or without this fix. The synthetic tests are the real verification.

Author's attention (no action here): the existing `reference_zotero` promotion
may itself have been made on a false frequency count (the exact bug this fixes).

Separate latent observation (out of scope, for the author): the `record` CLI
cannot store a project slug beginning with `-` — argparse parses e.g.
`-home-haduong--claude` as `-h`, prints help, and no-ops (exit 0). The live
store nonetheless contains such keys, so production populates them by some other
route. The new tests seed `.provenance.json` directly for dashed-key scenarios
(the pattern the decay tests already use) rather than depending on this.

## RED -> GREEN evidence

New tests in `tests/test_dream.py`:
- `test_provenance_candidates_alias_collapse_not_candidate` — two path-spellings
  of one project under an alias table; asserts the slug is NOT a candidate.
  **RED** on base (`['reference_zotero'] == []` failed), **GREEN** after fix.
- `test_provenance_candidates_true_distinct_still_candidate` — teeth-check: with
  the alias table present, two genuinely distinct projects still yield the sole
  candidate. Guards against a canonicalizer that collapses everything.
- `test_provenance_candidates_substring_key_still_distinct` — a slug sharing a
  substring with an aliased key stays distinct; guards against substring
  matching creeping in instead of `dict.get()`.

Gates: `make check` green; `make check-skills-drift` in sync;
`scripts/check-agnostic.sh skills tickets` clean.

**Ticket:** tickets/0270-dream-promotion-frequency-gate-miscounts.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
