### PR TITLE
chore: untrack memory/.provenance.lock; file promotion-review ticket (0280)

### DIFF
--- a/tickets/0280-untrack-memory-provenance-lock-tracked-d.erg
+++ b/tickets/0280-untrack-memory-provenance-lock-tracked-d.erg
@@ -1,0 +1,23 @@
+%erg 0.1
+Title: Untrack memory/.provenance.lock (tracked despite gitignore)
+Created: 2026-07-11
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-11T14:47Z Minh Ha-Duong created
+
+--- body ---
+## Context
+The wave-1 integration review of the 2026-07-11 dream-sync raid found
+`memory/.provenance.lock` is git-TRACKED despite `.gitignore:24` ignoring it —
+force-added once in commit ebe6614 (dream consolidation, 2026-06-06). A tracked
+lock file churns on every dream run and defeats the ignore rule's intent
+(mirrored for projects/*/memory/.provenance.lock by PR #480, which stays
+untracked correctly).
+
+## Actions
+1. `git rm --cached memory/.provenance.lock` (keep the working-tree file).
+
+## Exit criteria
+- `git ls-files memory/.provenance.lock` empty; the file remains on disk and
+  ignored.

--- a/tickets/0281-review-reference-zotero-harness-promotio.erg
+++ b/tickets/0281-review-reference-zotero-harness-promotio.erg
@@ -1,0 +1,28 @@
+%erg 0.1
+Title: Review reference_zotero harness promotion — may rest on false frequency count
+Created: 2026-07-11
+Author: Minh Ha-Duong
+Label: needs-human
+
+--- log ---
+2026-07-11T14:47Z Minh Ha-Duong created
+
+--- body ---
+## Context
+Ticket 0270 (closed by PR #485) fixed the dream promotion frequency gate: the
+AEDIST project registered under two path-aliased slugs, so `reference_zotero`
+passed the >=2-distinct-projects gate on a single real project. The entry was
+promoted to harness tier on 2026-06-24 — BEFORE the fix — so the existing
+promotion may rest on that false count. Promotion is one-way by design;
+demoting (or confirming) a promoted entry is the author's call, not an
+autonomous action.
+
+## Actions
+1. Author reviews `memory/` for the promoted reference_zotero entry and its
+   provenance record (`provenance.py show`).
+2. Decide: keep at harness tier (useful regardless of provenance) or demote
+   back to the AEDIST project memory.
+
+## Exit criteria
+- A recorded decision (keep or demote) in this ticket's log; the memory store
+  reflects it.

--- a/tickets/closed/0280-untrack-memory-provenance-lock-tracked-d.erg
+++ b/tickets/closed/0280-untrack-memory-provenance-lock-tracked-d.erg
@@ -2,10 +2,12 @@
 Title: Untrack memory/.provenance.lock (tracked despite gitignore)
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #486
 
 --- log ---
 2026-07-11T14:47Z Minh Ha-Duong created
 
+2026-07-11T14:48Z Minh Ha-Duong closed — autoclosed — PR #486
 --- body ---
 ## Context
 The wave-1 integration review of the 2026-07-11 dream-sync raid found


### PR DESCRIPTION
## What

1. `git rm --cached memory/.provenance.lock` — the file was force-added in ebe6614 (2026-06-06) despite `.gitignore` ignoring it, so it churned as tracked state on every dream run. Working-tree file kept; `projects/*/memory/.provenance.lock` was already handled correctly by PR #480.
2. Files ticket 0281 (needs-human): review the `reference_zotero` harness promotion, which ticket 0270's fix (PR #485) showed was granted on a false >=2-projects frequency count (AEDIST under two path-aliased slugs). Demote-or-keep is the author's call.

Both findings come from the 2026-07-11 dream-sync raid (wave-1 integration review; 0270 gaze verdict).

**Ticket:** tickets/0280-untrack-memory-provenance-lock-tracked-d.erg
Ticket-ref: tickets/0281-review-reference-zotero-harness-promotio.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)