### PR TITLE
provenance CLI robustness: leading-dash slugs + corrupt alias table (0282)

### DIFF
--- a/skills/dream/provenance.py
+++ b/skills/dream/provenance.py
@@ -76,9 +76,19 @@ def _load_aliases() -> dict:
     filesystem paths, so `os.path.realpath` cannot collapse aliases: slug->path
     inversion is ambiguous and a relocated tree's old path no longer exists on
     disk. Instead we keep an explicit, read-time alias table (ticket 0270). A
-    missing table is the common case — no aliases — and yields {}."""
+    missing table is the common case — no aliases — and yields {}. A corrupt
+    table degrades to 'no aliases' with a stderr warning rather than crashing
+    the caller (ticket 0282): candidates then gates on raw keys, which can
+    only over-count — it never wrongly suppresses a candidate."""
     if PROJECT_ALIASES_PATH.exists():
-        return json.loads(PROJECT_ALIASES_PATH.read_text())
+        try:
+            return json.loads(PROJECT_ALIASES_PATH.read_text())
+        except json.JSONDecodeError as e:
+            print(
+                f"Warning: malformed alias table {PROJECT_ALIASES_PATH}: {e} — "
+                "treating as empty",
+                file=sys.stderr,
+            )
     return {}
 
 
@@ -344,7 +354,18 @@ def main():
     show_p = sub.add_parser("show", help="Show full provenance data.")
     show_p.set_defaults(func=show)
 
-    args = parser.parse_args()
+    # Production project keys are directory slugs that begin with '-'
+    # (e.g. -home-haduong-CNRS-...). Without a '--' separator argparse
+    # clusters '-home-…' into '-h' and help-exits 0 — a silent no-op on a
+    # mutating call (ticket 0282). No subcommand takes options, so insert
+    # the separator after the subcommand unless the caller already did, or
+    # is asking for help at either level.
+    tokens = sys.argv[1:]
+    wants_help = any(t in ("-h", "--help") for t in tokens)
+    if len(tokens) > 1 and "--" not in tokens and not wants_help:
+        tokens = [tokens[0], "--"] + tokens[1:]
+
+    args = parser.parse_args(tokens)
     args.func(args)
 
 

--- a/skills/dream/provenance.py
+++ b/skills/dream/provenance.py
@@ -363,7 +363,7 @@ def main():
     tokens = sys.argv[1:]
     wants_help = any(t in ("-h", "--help") for t in tokens)
     if len(tokens) > 1 and "--" not in tokens and not wants_help:
-        tokens = [tokens[0], "--"] + tokens[1:]
+        tokens.insert(1, "--")
 
     args = parser.parse_args(tokens)
     args.func(args)

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -574,3 +574,58 @@ def test_provenance_read_during_write_never_torn(provenance_env):
     # The reader must see a complete document: the old entry is always present
     # (the new entry may or may not have landed, depending on old-or-new).
     assert "slug_old" in data["entries"], "reader lost the pre-existing entry"
+
+
+# ── Provenance CLI robustness (ticket 0282) ────────────────────────────────────
+
+
+def test_provenance_record_leading_dash_project(provenance_env):
+    """Ticket 0282: production project keys are directory slugs that begin
+    with '-' (e.g. -home-haduong-...). argparse clusters '-home-…' into '-h'
+    and help-exits 0 — a silent no-op on a mutating call. The CLI must accept
+    them directly."""
+    result = _run_provenance(
+        "record", "feedback_vim", "-home-haduong-some-project", home=provenance_env
+    )
+    assert result.returncode == 0, result.stderr
+    show = _run_provenance("show", home=provenance_env)
+    data = json.loads(show.stdout)
+    assert "feedback_vim" in data["entries"], "record silently no-opped"
+    assert data["entries"]["feedback_vim"]["projects"] == [
+        "-home-haduong-some-project"
+    ]
+
+
+def test_provenance_remove_leading_dash_project(provenance_env):
+    """Same defect on the remove verb (SKILL.md step 5 calls it per DELETE)."""
+    _run_provenance(
+        "record", "feedback_vim", "-home-haduong-some-project", home=provenance_env
+    )
+    result = _run_provenance(
+        "remove", "feedback_vim", "-home-haduong-some-project", home=provenance_env
+    )
+    assert result.returncode == 0, result.stderr
+    show = _run_provenance("show", home=provenance_env)
+    assert "feedback_vim" not in json.loads(show.stdout)["entries"]
+
+
+def test_provenance_help_still_works(provenance_env):
+    """The separator auto-insert must not eat -h/--help, top-level or per-verb."""
+    top = _run_provenance("--help", home=provenance_env)
+    assert top.returncode == 0 and "record" in top.stdout
+    sub = _run_provenance("record", "-h", home=provenance_env)
+    assert sub.returncode == 0 and "slug" in sub.stdout
+
+
+def test_provenance_candidates_survives_malformed_alias_table(provenance_env):
+    """Ticket 0282: a corrupt .project-aliases.json must degrade to 'no
+    aliases' with a stderr warning, not crash candidates."""
+    aliases_path = provenance_env / ".claude" / "memory" / ".project-aliases.json"
+    aliases_path.write_text("{not json")
+    _run_provenance("record", "feedback_vim", "project-alpha", home=provenance_env)
+    _run_provenance("record", "feedback_vim", "project-beta", home=provenance_env)
+    result = _run_provenance("candidates", home=provenance_env)
+    assert result.returncode == 0, result.stderr
+    assert "alias" in result.stderr.lower()  # warned, not silent
+    slugs = [c["slug"] for c in json.loads(result.stdout)]
+    assert slugs == ["feedback_vim"]  # gate still works, aliases treated empty

--- a/tickets/0282-provenance-cli-robustness-leading-dash-s.erg
+++ b/tickets/0282-provenance-cli-robustness-leading-dash-s.erg
@@ -1,0 +1,34 @@
+%erg 0.1
+Title: provenance CLI robustness: leading-dash slugs no-op silently; malformed alias table crashes candidates
+Created: 2026-07-11
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-11T14:49Z Minh Ha-Duong created
+
+--- body ---
+## Context
+Two robustness gaps surfaced during the 2026-07-11 dream-sync raid:
+1. The 0270 execute agent found `provenance.py record <slug> -home-...`
+   silently no-ops: argparse clusters the leading-dash project slug into
+   `-h`, prints help, exits 0 — yet production project keys ARE
+   leading-dash directory slugs, and SKILL.md steps 5/7 call record/remove
+   with them unconditionally.
+2. The 0270 gaze verdict noted `_load_aliases()` crashes `candidates` on a
+   malformed `memory/.project-aliases.json`.
+
+## Actions
+1. Auto-insert the `--` separator after the subcommand in `main()` when
+   arguments follow and no help flag is present — leading-dash slugs then
+   parse as positionals; zero-arg verbs (show/candidates/decay) unaffected.
+2. `_load_aliases()` catches JSONDecodeError: stderr warning, degrade to
+   no-aliases (candidates then over-counts at worst, never suppresses).
+
+## Test
+- record/remove with a leading-dash project actually mutate the store
+  (RED: silent no-op at exit 0); -h/--help preserved at both levels;
+  candidates survives a corrupt alias table with a warning (RED: crash).
+
+## Exit criteria
+- The documented SKILL.md invocations work verbatim with real slugs
+- `make check` green

--- a/tickets/closed/0282-provenance-cli-robustness-leading-dash-s.erg
+++ b/tickets/closed/0282-provenance-cli-robustness-leading-dash-s.erg
@@ -2,10 +2,12 @@
 Title: provenance CLI robustness: leading-dash slugs no-op silently; malformed alias table crashes candidates
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #487
 
 --- log ---
 2026-07-11T14:49Z Minh Ha-Duong created
 
+2026-07-11T15:07Z Minh Ha-Duong closed — autoclosed — PR #487
 --- body ---
 ## Context
 Two robustness gaps surfaced during the 2026-07-11 dream-sync raid:


### PR DESCRIPTION
## What

1. `main()` auto-inserts the `--` separator after the subcommand when arguments follow (and no help flag): `record <slug> -home-...` previously clustered the leading-dash slug into `-h` and help-exited 0 — a **silent no-op on a mutating call** that SKILL.md steps 5/7 mandate with exactly such slugs. Zero-arg verbs are untouched; `-h/--help` preserved at both levels.
2. `_load_aliases()` catches `JSONDecodeError`: stderr warning, degrades to no-aliases — `candidates` keeps working and can only over-count, never wrongly suppress.

Both defects surfaced in the dream-sync raid: the first by the 0270 execute agent (the live store contains leading-dash keys the documented CLI path could not have written), the second in the 0270 gaze verdict.

## Verification

- [x] TDD: RED confirmed — record with a real slug no-opped at exit 0; corrupt alias table crashed candidates. GREEN after: 4 new tests (leading-dash record/remove, help preservation, malformed-table survival)
- [x] `make check` — 676 passed
- [x] First-cut defect caught by the suite itself: appending `--` to bare `show` broke 22 tests; fixed to insert only when arguments follow

**Ticket:** tickets/0282-provenance-cli-robustness-leading-dash-s.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)