### PR TITLE
memory: complete the reference_zotero promotion (0281)

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -4,4 +4,4 @@
 
 ## Entries
 
-(No entries yet. Entries are promoted from project-level memory when they meet all three gates: frequency across >=2 projects, material cost, and context-independence.)
+- [Zotero library](reference_zotero.md) — userID 95318, API keys in ~/.claude/.env (RO + RW scopes), collection T4X7ZNQL, endpoints

--- a/memory/reference_zotero.md
+++ b/memory/reference_zotero.md
@@ -1,0 +1,17 @@
+---
+name: Zotero library
+description: Zotero user ID, API-key locations and scopes, main collection for Vietnamese energy decisions, endpoints
+type: reference
+---
+
+Zotero userID: **95318**, username: `haduong`, display name: Minh Ha-Duong.
+
+API keys stored in `~/.claude/.env` (loaded by the SessionStart hook):
+- `ZOTERO_API_KEY` — read-only (library + files + notes; groups read-only)
+- `ZOTERO_RW_API_KEY` — read-write
+
+Main collection for Vietnamese energy policy decisions: `T4X7ZNQL`.
+
+Endpoints: items `https://api.zotero.org/users/95318/items`; file download
+`https://api.zotero.org/users/95318/items/{itemKey}/file`; web library
+https://www.zotero.org/haduong/library.

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/MEMORY.md
@@ -69,7 +69,6 @@
 - API key: `~/.claude/.env` has ANTHROPIC_API_KEY, repo `.env` has OPENROUTER_API_KEY
 - [Autonomous Claude on Padme](reference_autonomous_padme.md) — nohup recipe for ticket-driven autonomous work
 - [Interactive Claude on Padme via tmux](reference_tmux_padme.md) — named tmux session recipe (claude1, claude2, …) for live driving
-- [Zotero library](reference_zotero.md) — userID 95318, API keys in ~/.claude/.env, collection T4X7ZNQL
 - [Worktrees not stash](feedback_worktree_not_stash.md) — use git worktree for cross-branch work, never stash+checkout
 - [evaluate-all record quality](feedback_evaluate_all_quality.md) — spot-check for absolute paths and -runN in model names
 - [Ollama num_ctx](feedback_ollama_num_ctx.md) — /v1/ ignores num_ctx, must use native /api/chat

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/reference_zotero.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/reference_zotero.md
@@ -1,13 +1,3 @@
----
-name: Zotero library
-description: Zotero user ID, API keys location, and main collection for Vietnamese energy decisions
-type: reference
----
-
-Zotero userID: **95318**, username: `haduong`, display name: Minh Ha-Duong.
-
-API keys stored in `~/.claude/.env`:
-- `ZOTERO_API_KEY` — read-only (library + files + notes; groups read-only)
-- `ZOTERO_RW_API_KEY` — read-write
-
-Main collection for Vietnamese energy policy decisions: `T4X7ZNQL`.
+# PROMOTED 2026-07-11T16:03:29Z: Zotero library
+# Now at: ~/.claude/memory/reference_zotero.md
+# Original content preserved in git history.

--- a/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
@@ -44,7 +44,6 @@
 - [Ticket line in PR](feedback_ticket_line_in_pr.md) — only put **Ticket:** in PR body when that ticket will actually be closed; admin PRs omit it
 - [Permutation test power](feedback_permutation_test_power.md) — min attainable p = 1/2^n; with n=4 subjects p<0.05 is unreachable; check before writing threshold
 - [Compute before figure](feedback_compute_before_figure.md) — run throwaway data script first; catches prose claim errors and N-count surprises before writing plot code
-- [Zotero API access](reference_zotero.md) — user ID 95318, API key for downloading PDFs from haduong's library
 - [API keys location](reference_api_keys_location.md) — project `.env` has OPENROUTER_API_KEY; use `UV_ENV_FILE=.env` for experiment scripts, not `~/.claude/.env`
 - [Econom'IA 2026 venue](reference_econom_ia_2026.md) — conference URL and abstract location
 - [Padme local AI infra](project_padme_local_infra.md) — GROBID, Ollama, GPUs; user prefers local-first pipelines

--- a/projects/-home-haduong-aedist-technical-report/memory/reference_zotero.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/reference_zotero.md
@@ -1,12 +1,3 @@
----
-name: Zotero API access
-description: Zotero API key and user ID for downloading PDFs from haduong's library
-type: reference
----
-
-Zotero public API for user `haduong`:
-- User ID: `95318`
-- API key stored in `~/.claude/.env` as `ZOTERO_API_KEY` (user-scoped, loaded by SessionStart hook)
-- Endpoint: `https://api.zotero.org/users/95318/items`
-- File download: `https://api.zotero.org/users/95318/items/{itemKey}/file`
-- Library URL: https://www.zotero.org/haduong/library
+# PROMOTED 2026-07-11T16:03:29Z: Zotero API access
+# Now at: ~/.claude/memory/reference_zotero.md
+# Original content preserved in git history.

--- a/tickets/0281-review-reference-zotero-harness-promotio.erg
+++ b/tickets/0281-review-reference-zotero-harness-promotio.erg
@@ -7,6 +7,7 @@ Label: needs-human
 --- log ---
 2026-07-11T14:47Z Minh Ha-Duong created
 
+2026-07-11T16:05Z Minh Ha-Duong note author decision: complete the promotion — content is user-level (zotero-import skill, multi-project use); false count was mechanism, not merit
 --- body ---
 ## Context
 Ticket 0270 (closed by PR #485) fixed the dream promotion frequency gate: the

--- a/tickets/closed/0281-review-reference-zotero-harness-promotio.erg
+++ b/tickets/closed/0281-review-reference-zotero-harness-promotio.erg
@@ -3,11 +3,13 @@ Title: Review reference_zotero harness promotion — may rest on false frequency
 Created: 2026-07-11
 Author: Minh Ha-Duong
 Label: needs-human
+Closed: autoclosed — PR #488
 
 --- log ---
 2026-07-11T14:47Z Minh Ha-Duong created
 
 2026-07-11T16:05Z Minh Ha-Duong note author decision: complete the promotion — content is user-level (zotero-import skill, multi-project use); false count was mechanism, not merit
+2026-07-11T16:05Z Minh Ha-Duong closed — autoclosed — PR #488
 --- body ---
 ## Context
 Ticket 0270 (closed by PR #485) fixed the dream promotion frequency gate: the


### PR DESCRIPTION
## What

Resolves the half-promoted state ticket 0281 flagged: provenance had `promoted: true` (2026-06-24) yet no harness-level entry existed and neither project copy was tombstoned.

Author decision (recorded in the ticket log): **complete the promotion** — the content is user-level reference (Zotero userID, API-key env names and scopes, main collection, endpoints), consumed by the zotero-import skill and multiple paper projects. Ticket 0270's finding was that the *gate mechanism* miscounted; this entry earns harness tier on merit regardless.

- `memory/reference_zotero.md` — new harness entry (newer AEDIST version + the older version's endpoint URLs)
- `memory/MEMORY.md` — first real index entry replaces the placeholder
- both AEDIST project copies → standard `# PROMOTED` tombstones; their index lines dropped
- provenance already carries the promoted flag — unchanged

## Verification
- [x] `make check` green
- [x] `erg validate` PASS on the decision-logged ticket

**Ticket:** tickets/0281-review-reference-zotero-harness-promotio.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)