### PR TITLE
memory(climate-finance-het): adopt orphaned ln-autostage note

### DIFF
--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
@@ -65,6 +65,7 @@
 - [feedback_branch_before_edit.md](feedback_branch_before_edit.md) — always checkout target branch before editing files; never edit on main then move
 - [feedback_make_corpus.md](feedback_make_corpus.md) — never suggest bare `dvc repro`; always use `make corpus` (padme) or `make corpus-sync` (doudou)
 - [feedback_no_rebase_dvc.md](feedback_no_rebase_dvc.md) — never rebase when DVC symlinks are dirty; use merge + stash/pop
+- [feedback_ln_into_existing_dir_autostage.md](feedback_ln_into_existing_dir_autostage.md) — ln -s into an existing dir lands the link INSIDE it; dvc autostage commits the loop symlink (0252 guard: test_no_committed_symlink_under_data)
 - [feedback_simplest_fix.md](feedback_simplest_fix.md) — don't add hooks/exceptions; restructure the operation to work within existing rules (ff merge vs --no-ff)
 - [feedback_ssh_padme.md](feedback_ssh_padme.md) — can SSH doudou→padme; always prepend PATH=$HOME/.local/bin (uv not in non-interactive PATH)
 - [feedback_weekend_boundary.md](feedback_weekend_boundary.md) — no project work on weekends; mental health is non-negotiable

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ln_into_existing_dir_autostage.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_ln_into_existing_dir_autostage.md
@@ -1,0 +1,25 @@
+---
+name: feedback_ln_into_existing_dir_autostage
+description: ln -s into an existing dir drops the link INSIDE it; dvc autostage + broad git add then commits the machine-specific loop symlink
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a3584f5c-bfd3-4b93-b0bb-06c5d1a89788
+---
+
+`ln -s <primary>/data/catalogs data/catalogs` when `data/catalogs` already
+exists creates `data/catalogs/catalogs` — a self-looping, absolute,
+machine-specific symlink. With `.dvc/config` `autostage = true`, a later broad
+`git add` sweeps it into an unrelated commit (431af0ce, 0240 epic close); it
+then loops every recursive traversal (`glob('**')`, `find -L`) in every
+checkout. Caught and fixed in ticket 0252, PR #1038.
+
+**Why:** the worktree data-sharing idiom ([[feedback_verify_datadep_worktree_symlink]])
+uses exactly this `ln -s` shape, so the trap re-arms every time a worktree
+needs contract data.
+
+**How to apply:** use `ln -sfn <target> <linkname>` only when the linkname does
+not yet exist as a directory — or symlink individual contract *files*, never
+the directory onto itself. Guard exists: adherence test
+`test_phase_layout.py::test_no_committed_symlink_under_data` fails any tracked
+mode-120000 entry under `data/`.


### PR DESCRIPTION
Adopts an orphaned memory write left uncommitted by a parallel session in the primary checkout's working tree: `feedback_ln_into_existing_dir_autostage.md` (climate-finance-het project memory) plus its matching MEMORY.md index line, byte-identical to the primary's untracked file and staged diff — no other diff hunks were present in the primary's MEMORY.md, so nothing else was adopted.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>