### PR TITLE
rules(workflow): batch decisions, then run to the end (author doctrine)

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Batch decisions, then run to the end](feedback_batch_decisions_run_to_end.md) — author doctrine: one frontloaded question round with defaults, then autonomous through verify/merge/cleanup to a single report; spinners are not deliverables. Promoted to rules/workflow.md (2026-07-11)
 - [Sync main: check the primary checkout's branch first](feedback_sync_main_check_primary_branch_first.md) — the primary checkout may sit on a feature branch; ff-merging origin/main there advances THAT branch. Update by ref (`fetch origin main:main`); preserve dirty overlapping files by backup + re-apply, never discard or bare-stash (2026-07-11)
 - [R&R intake is laborious](feedback_rr_intake_is_laborious.md) — Ingesting an editor decision + reviewer comments has no skill; done by hand it burns turns (Gmail re-search, comment recount, coverage verified 2-3×). Check `release/` not Gmail, archive to a known path, verify coverage once. Fix ticketed IDH 0265 (2026-06-18)
 - [No ruff ping-pong](feedback_no_ruff_ping_pong.md) — PostToolUse ruff hook fires after EVERY Edit; batch related edits so no intermediate state has unused imports; write new files complete in one Write

--- a/projects/-home-haduong--claude/memory/feedback_batch_decisions_run_to_end.md
+++ b/projects/-home-haduong--claude/memory/feedback_batch_decisions_run_to_end.md
@@ -1,0 +1,24 @@
+---
+name: batch-decisions-run-to-end
+description: Author doctrine — frontload all interactive questions in one batched round, then run autonomously through verify/merge/cleanup to a single final report; never make the author watch a spinner
+metadata:
+  type: feedback
+---
+
+Author doctrine (2026-07-11, stated twice in one session and promoted to
+rules/workflow.md § Autonomous Action Rules "Batch the decisions, then run to
+the end"): with long-run-capable agents, the preferred interaction mode is to
+collect as much feasible work as possible up front — one dense
+question round with recommended defaults — then work autonomously to
+completion. Watching a spinner is not a good use of the author's time.
+
+**Why:** the author's attention is the scarcest resource; sequential
+questions and progress check-ins each burn a context switch, while the
+autonomous tail (gaze, merges, cleanup) needs none of them.
+
+**How to apply:** before starting a multi-step task with known decision
+points, enumerate them and ask ALL of them in one AskUserQuestion round (up
+to 4 questions); delegate waits to background agents instead of holding the
+conversation; return mid-run only for genuinely new scope or irreversible
+actions the batch did not cover; end with one consolidated report. The rule
+text is authoritative; this entry records the origin.

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -148,6 +148,21 @@ When compacting, preserve the list of modified files, test commands, and current
 
 # Autonomous Action Rules
 
+**Batch the decisions, then run to the end.** The author's attention is the
+scarcest resource in the loop; a spinner is not a deliverable. This is the
+interactive counterpart of the supervisor doctrine (autonomous mode trades
+supervision for time): interactive mode trades a single dense question round
+for a long autonomous tail. When work needs author input, collect every
+foreseeable decision into ONE batched question round — frontload the whole
+set, up to the tool's limit, with a recommended default per question — then
+execute through verification, merge, and cleanup without returning between
+steps, delegating waits to background agents, and deliver one report at the
+end. Never ask sequentially what could be asked together; never park the
+conversation on a wait a background agent could hold. Mid-run returns to the
+author are for genuinely NEW scope or destructive/irreversible actions the
+batched decisions did not cover — not for progress, not for permission to
+continue (author doctrine, 2026-07-11).
+
 **Sweep results are decisions.** When a skill sweep (roar step 3, healthcheck, etc.) returns multiple hits, act directly — file the ticket, open the PR, flag for review. Don't prompt the user to confirm. The data is the decision. Silent no-op if the sweep is empty.
 
 **Loophole found → offer to plug it.** When a gap or loophole is identified (audit, review, user-reported check), don't just report it — immediately offer a concrete fix. Propose either implementing it now or opening a ticket. Reporting without offering leaves the user to ask the obvious follow-up.


### PR DESCRIPTION
## What

New bullet in § Autonomous Action Rules: the author's attention is the scarcest resource — frontload every foreseeable decision into one batched question round (with recommended defaults), then execute autonomously through verification, merge, and cleanup, delegating waits to background agents, one report at the end. Mid-run returns only for genuinely new scope or irreversible actions the batch didn't cover. Matching memory entry records the origin (author, 2026-07-11, stated twice); the rule text is authoritative.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)