### PR TITLE
fix(0246): forge-join blank-row retry, mandated-regex anchor, report nit

### DIFF
--- a/docs/trace-counterfactuals-2026-06.md
+++ b/docs/trace-counterfactuals-2026-06.md
@@ -81,5 +81,5 @@ the operative guardrail metrics (merged-rate is saturated at 100%).
   needs the A/B, not traces.
 - Whether Sonnet mains deliver gaze-APPROVED PRs at Opus rates — the
   census never observes the counterfactual model.
-- H4 beyond medians — 34 joined sessions is too thin for a regression;
+- H4 beyond medians — 33 joined sessions is too thin for a regression;
   the join cache will accumulate across monthly runs.

--- a/scripts/trace-pr-join.py
+++ b/scripts/trace-pr-join.py
@@ -87,11 +87,15 @@ def gh_fetch_pr(owner: str, repo: str, n: int) -> dict:
 
 def build_join(pairs: list[tuple[str, int]], cache: dict, fetcher) -> dict:
     """Resolve every pair from cache, then fetcher; fetch failures yield a
-    blank row (merged='') so the join never silently drops a PR."""
+    blank row (merged='') so the join never silently drops a PR.
+
+    A cached row left blank by a prior failed fetch (merged in (None, ''))
+    is re-fetched on this run and overwritten; a resolved row is kept as is."""
     out = dict(cache)
     for repo, n in pairs:
-        if (repo, n) in out:
-            continue
+        cached = out.get((repo, n))
+        if cached is not None and cached.get("merged") not in (None, ""):
+            continue  # resolved row — keep, never re-fetch
         try:
             out[(repo, n)] = fetcher(repo, n)
         except Exception as e:  # noqa: BLE001 — any fetch failure is non-fatal

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -109,7 +109,9 @@ PR_NUMBER_RE = re.compile(r"(?:PR\s*#|pulls/)(\d+)")
 # Ticket 0244 (H10'): harness-mandated wrap-up work — memory/STATE writes,
 # branch hygiene, wrap-up skills. Used only to classify tail turns.
 MANDATED_PATH_RE = re.compile(r"/memory/|MEMORY\.md|STATE\.md")
-MANDATED_BASH_RE = re.compile(r"\bgit\s+(?:branch|worktree|fetch\s+--prune)|\berg\s+close\b")
+MANDATED_BASH_RE = re.compile(
+    r"(?:^|&&|;|\|)\s*(?:git\s+(?:branch|worktree|fetch\s+--prune)|erg\s+close)\b"
+)
 MANDATED_SKILLS = {"roar", "lair", "dream", "molt", "memory", "housekeeping"}
 PATH_TOOLS = {"Read", "Edit", "Write", "NotebookEdit"}
 

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -109,7 +109,7 @@ PR_NUMBER_RE = re.compile(r"(?:PR\s*#|pulls/)(\d+)")
 # Ticket 0244 (H10'): harness-mandated wrap-up work — memory/STATE writes,
 # branch hygiene, wrap-up skills. Used only to classify tail turns.
 MANDATED_PATH_RE = re.compile(r"/memory/|MEMORY\.md|STATE\.md")
-MANDATED_BASH_RE = re.compile(r"^\s*git\s+(?:branch|worktree|fetch\s+--prune)|erg\s+close")
+MANDATED_BASH_RE = re.compile(r"\bgit\s+(?:branch|worktree|fetch\s+--prune)|\berg\s+close\b")
 MANDATED_SKILLS = {"roar", "lair", "dream", "molt", "memory", "housekeeping"}
 PATH_TOOLS = {"Read", "Edit", "Write", "NotebookEdit"}
 

--- a/tests/test_trace_pr_join.py
+++ b/tests/test_trace_pr_join.py
@@ -56,6 +56,32 @@ def test_fetcher_failure_recorded_not_fatal():
     assert out[("r", 9)]["merged"] == ""  # row present, marked unfetched
 
 
+def test_build_join_refetches_blank_cached_rows(tmp_path):
+    """Ticket 0246 action 1: a cached row left blank by a prior failed fetch
+    (merged in (None, "")) must be re-fetched on a networked run and
+    overwritten; a resolved cached row is never re-fetched."""
+    cached = {
+        # resolved — must be left untouched, no fetch
+        ("r", 1): {"repo": "r", "pr": 1, "additions": 10, "deletions": 2,
+                   "merged": True, "reroll_mentions": 0, "escalate_mentions": 0},
+        # blank — a prior fetch failed; must be re-fetched and overwritten
+        ("r", 2): {"repo": "r", "pr": 2, "additions": "", "deletions": "",
+                   "merged": "", "reroll_mentions": "", "escalate_mentions": ""},
+    }
+    calls = []
+
+    def fetcher(repo, n):
+        calls.append((repo, n))
+        return {"repo": repo, "pr": n, "additions": 7, "deletions": 3,
+                "merged": True, "reroll_mentions": 2, "escalate_mentions": 0}
+
+    out = tpj.build_join([("r", 1), ("r", 2)], cached, fetcher)
+    assert calls == [("r", 2)], "only the blank pair is re-fetched"
+    assert out[("r", 1)]["additions"] == 10, "resolved row untouched"
+    assert out[("r", 2)]["merged"] is True, "blank row overwritten by fetch"
+    assert out[("r", 2)]["additions"] == 7
+
+
 def test_cli_flags_present():
     src = (SCRIPTS / "trace-pr-join.py").read_text()
     for flag in ("--census", "--cache", "--owner", "--no-network"):

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -367,6 +367,27 @@ def test_mandated_regex_matches_compound_commands():
     assert ts._is_mandated_tool("Bash", {"command": "uv run pytest -q"}) is False
 
 
+def test_mandated_regex_does_not_match_mentions_in_prose():
+    """/gaze simplify follow-up (PR 494): dropping the `^\\s*` anchor entirely
+    made MANDATED_BASH_RE match the keywords anywhere in the command string,
+    including inside quoted/echoed text that never invokes the command. The
+    regex must require the match sit at true command position — start of
+    string or right after a `&&`/`;`/`|` separator — not merely present
+    somewhere in the string."""
+    assert ts._is_mandated_tool(
+        "Bash", {"command": 'echo "see: run git branch -D to clean up"'}
+    ) is False
+    assert ts._is_mandated_tool(
+        "Bash", {"command": 'git commit -m "mentions erg close in the message"'}
+    ) is False
+    assert ts._is_mandated_tool("Bash", {"command": "erg closed 0246"}) is False
+    # semicolon and pipe separators still count as command position
+    assert ts._is_mandated_tool("Bash", {"command": "somecmd; git branch -D foo"}) is True
+    assert ts._is_mandated_tool(
+        "Bash", {"command": "git branch --list | grep foo"}
+    ) is True
+
+
 def test_bucket_csv_columns_declared():
     for col in (
         "merge_markers",

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -354,6 +354,19 @@ def test_first_turn_cache_write_and_excess_reads(tmp_path):
     assert stats["excess_file_reads"] == 1  # /a.md read twice
 
 
+def test_mandated_regex_matches_compound_commands():
+    """Ticket 0246 action 2: the anchor bound only the first alternative, so a
+    compound command like `cd x && git worktree prune` did NOT count as
+    mandated while `cd x && erg close` DID. Both must count now."""
+    assert ts._is_mandated_tool("Bash", {"command": "cd x && git worktree prune"}) is True
+    assert ts._is_mandated_tool("Bash", {"command": "cd x && erg close 0246"}) is True
+    # regression: leading git-branch/fetch still match unchanged
+    assert ts._is_mandated_tool("Bash", {"command": "git branch -D foo"}) is True
+    assert ts._is_mandated_tool("Bash", {"command": "git fetch --prune"}) is True
+    # a non-mandated command still does not match
+    assert ts._is_mandated_tool("Bash", {"command": "uv run pytest -q"}) is False
+
+
 def test_bucket_csv_columns_declared():
     for col in (
         "merge_markers",

--- a/tickets/closed/0246-review-378-follow-up-forge-join-blank-ro.erg
+++ b/tickets/closed/0246-review-378-follow-up-forge-join-blank-ro.erg
@@ -2,11 +2,13 @@
 Title: review-378 follow-up: forge-join blank-row retry, mandated-regex anchor, report nits
 Created: 2026-06-10
 Author: claude
+Closed: autoclosed — PR #494
 
 --- log ---
 2026-06-10T20:32Z claude created
 
 2026-06-10T21:55Z claude note action 4 already done by PR #380 (merged 2026-06-10): both 0236 placeholders removed when filing 0245; remaining scope is actions 1-3
+2026-07-11T21:16Z Minh Ha-Duong closed — autoclosed — PR #494
 --- body ---
 ## Context
 


### PR DESCRIPTION
Post-merge review of PR #378 (ticket 0244, trace-doctor phase 4) found four
defects; action 4 already landed via PR #380. This closes out actions 1-3.

## Defect 1 — `build_join` never re-fetched blank cached rows
`scripts/trace-pr-join.py` skipped every pair already keyed in the cache, so a
row left blank by a prior failed fetch (`merged` in `None`/`""`) stayed blank
forever. Now only *resolved* rows are skipped; blank rows are re-fetched and
overwritten. **The 5 currently-stuck blank CSV rows (`-claude-projects` 67/366,
`git-erg` 309, `padme` 321/322) are left as-is: they resolve on the author's
next networked join run, which is the intended design** — this PR does not
re-run the networked join and does not touch `docs/trace-pr-join-2026-06.csv`.

## Defect 2 — mandated-regex anchor was asymmetric
`MANDATED_BASH_RE` bound the `^\s*` anchor only to the first alternative, so
`cd x && git worktree prune` did NOT count as mandated while `cd x && erg close`
DID. Replaced the line anchor with word boundaries on both alternatives;
compound commands now count as mandated.

## Defect 3 — stale joined-session count in the report
`docs/trace-counterfactuals-2026-06.md`: the final "what accounting could not
settle" line still said `34`; every other section says `33`. Commit c2b9f0f
fixed two of three occurrences and missed this one. Corrected to `33` (the
recomputed post-fix value from trace-hypotheses H4r).

## Tests (RED-first)
- `test_build_join_refetches_blank_cached_rows` — cache with one resolved + one
  blank pair, stubbed fetcher; asserts only the blank pair is re-fetched and its
  row overwritten, resolved row untouched.
- `test_mandated_regex_matches_compound_commands` — `cd x && git worktree prune`
  is now True (was False), plus regression on `erg close`, leading
  git-branch/fetch, and a non-mandated command.

Both were confirmed failing before the fix; `make check` passes.

**Ticket:** tickets/0246-review-378-follow-up-forge-join-blank-ro.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
