### PR TITLE
ticket(0284): sweep stale pre-reorg home paths outside the nightbeat registry

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -26,7 +26,7 @@ A reusable, science-backed personal harness for AI-assisted research: code and p
 - **0216 fan-out evidence**: criterion-2 proof accumulated 2026-07-11 — five substantive /gaze runs (#482 #483 #485 #487 #491) fanned out full reviewer batteries; append to the closed ticket, then drop this line
 - **2026-07-11 landings**: eager local-main sync everywhere (0276/0277 — closes the 2026-06-08 stale-checkout guard gap; beat delegates to sync-local-main.sh), dream data-quality wave (0241/0263/0270/0275/0278/0279/0282), memory backlog tracked, batch-decisions doctrine in workflow.md
 - **Verify-reviewer-panel cluster** (only open work left): 0206 (Copilot seat — needs forge config + ≥5-MR trial), 0217/0207 (OS-sandboxed agnostic seats), 0205 (panel contract + decorrelation evidence). 0227/0231/0232/0233/0234 closed this session; cadens now canonical (cadens PR #45)
-- **AEDIST maw-audit run**: unblocked (0226), author-deferred — launch from a session rooted in `~/aedist-technical-report`, no args, ~3-5M tokens; resolve untracked `census_bars.csv` first
+- **AEDIST maw-audit run**: unblocked (0226), author-deferred — launch from a session rooted in `~/CNRS/papiers/actif/AEDIST-technical-report`, no args, ~3-5M tokens; resolve untracked `census_bars.csv` first
 - **Harden 0217 seat-runner**: network isolation (drop `--network=host`), `fs/read` path-allowlist, credential denyRead, BASH_ENV-stripped minimal env — unblocks 0207
 - **0062 trigger**: re-open Firecracker isolation when IDH agents run against secret-bearing projects
 - Delete the disabled cloud raid routine (claude.ai/code/routines — API has no delete)

--- a/scripts/setup-claude-agent.sh
+++ b/scripts/setup-claude-agent.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 
 HARNESS="$HOME/.claude"
 PROJECTS=(
-    "$HOME/aedist-technical-report"
-    "$HOME/cadens"
-    "$HOME/Climate_finance"
-    "$HOME/fuzzy-corpus"
+    "$HOME/CNRS/papiers/actif/AEDIST-technical-report"
+    "$HOME/CNRS/papiers/actif/Cadens"
+    "$HOME/CNRS/projets/actifs/climate-finance-het"
+    "$HOME/CNRS/papiers/actif/Fuzzy Corpus"
 )
 
 echo "── 1. User + group ──────────────────────────────────────────────────────"

--- a/skills/maw-audit/SKILL.md
+++ b/skills/maw-audit/SKILL.md
@@ -107,7 +107,7 @@ empty set.
 > The Workflow tool cuts each agent's throwaway worktree from the *session's*
 > repository (probe-verified, ticket 0221). Launched from any other repo, every
 > agent lands in a tree without the configured sources and fails at baseline. To
-> audit `~/git-erg`, open the Claude session in `~/git-erg`.
+> audit `~/CNRS/code/git-erg`, open the Claude session in `~/CNRS/code/git-erg`.
 
 The workflow is a `Workflow`-tool script: `skills/maw-audit/maw-audit.js`.
 Phases:
@@ -209,10 +209,10 @@ blast-radius × change-frequency findings surface first.
 
 Because discovery derives the config by reading the repo, a non-Go run is
 **zero-prep**: no `.maw-audit.json`, no pairing table to author. The validated
-second-language target is **`~/aedist-technical-report`** (a `uv` Python project,
+second-language target is **`~/CNRS/papiers/actif/AEDIST-technical-report`** (a `uv` Python project,
 30+ test files). The exact launch procedure:
 
-1. Open a Claude session **rooted in `~/aedist-technical-report`** (the
+1. Open a Claude session **rooted in `~/CNRS/papiers/actif/AEDIST-technical-report`** (the
    hard requirement — Workflow agents cut their worktrees from the session repo;
    this run **cannot** be launched from a `~/.claude`-rooted session).
 2. Invoke `maw-audit` with **no args** (or pass `{ "RISK": {...} }` / a `GUARDS`

--- a/tickets/0284-home-reorg-stale-paths-sweep.erg
+++ b/tickets/0284-home-reorg-stale-paths-sweep.erg
@@ -5,6 +5,8 @@ Author: Minh Ha-Duong
 
 --- log ---
 2026-07-11T20:40Z Minh Ha-Duong created
+2026-07-11T21:05Z claude bump circuit-breaker — execute agent stalled (stream watchdog 600s), WIP salvaged, finisher relaunched
+2026-07-11T21:05Z claude note scry/SKILL.md verified clean — no pre-reorg paths found, no edit needed
 --- body ---
 ## Context
 

--- a/tickets/closed/0284-home-reorg-stale-paths-sweep.erg
+++ b/tickets/closed/0284-home-reorg-stale-paths-sweep.erg
@@ -2,11 +2,13 @@
 Title: home-reorg sweep: stale pre-reorg paths outside the nightbeat registry
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #497
 
 --- log ---
 2026-07-11T20:40Z Minh Ha-Duong created
 2026-07-11T21:05Z claude bump circuit-breaker — execute agent stalled (stream watchdog 600s), WIP salvaged, finisher relaunched
 2026-07-11T21:05Z claude note scry/SKILL.md verified clean — no pre-reorg paths found, no edit needed
+2026-07-11T22:28Z Minh Ha-Duong closed — autoclosed — PR #497
 --- body ---
 ## Context
 


### PR DESCRIPTION
Finish the home-reorg stale-path sweep (ticket 0284). The original execute
agent stalled (stream watchdog, 600s); its WIP was salvage-committed, then a
finisher was relaunched to complete the remaining scope.

## What the salvage contained (commit 8bad412)
- `scripts/setup-claude-agent.sh` — PROJECTS array re-pointed to post-reorg locations
- `skills/maw-audit/SKILL.md` — `~/git-erg`→`~/CNRS/code/git-erg` and `~/aedist-technical-report`→`~/CNRS/papiers/actif/AEDIST-technical-report`

## What the finisher added (commit f77435f)
- `STATE.md` — AEDIST maw-audit directive re-pointed to `~/CNRS/papiers/actif/AEDIST-technical-report`
- Ticket log — recorded circuit-breaker relaunch and scry/SKILL.md clean verification

`skills/scry/SKILL.md` verified clean (no pre-reorg paths, no edit needed).
`scripts/check-agnostic.sh` passes; `make check` passes. README.md untouched
(salvage did not regenerate it).

**Ticket:** tickets/0284-home-reorg-stale-paths-sweep.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)