### PR TITLE
setup-claude-agent: read project list from projects.json registry

### DIFF
--- a/scripts/setup-claude-agent.sh
+++ b/scripts/setup-claude-agent.sh
@@ -4,12 +4,33 @@
 set -euo pipefail
 
 HARNESS="$HOME/.claude"
-PROJECTS=(
-    "$HOME/CNRS/papiers/actif/AEDIST-technical-report"
-    "$HOME/CNRS/papiers/actif/Cadens"
-    "$HOME/CNRS/projets/actifs/climate-finance-het"
-    "$HOME/CNRS/papiers/actif/Fuzzy Corpus"
-)
+# Canonical project registry — the single source of truth also read by
+# beat.py, the nightbeat survey, and scry. Override for tests.
+REGISTRY="${PROJECTS_JSON:-$HARNESS/scripts/projects.json}"
+
+# Derive the project directories that get dev-projects group ownership.
+# Reads the registry, expands a leading ~ to $HOME (as the Python consumers do
+# via expanduser), and excludes the harness itself: ~/.claude receives
+# read-only ACL access in steps 4-5, so granting it group write here would
+# contradict that design and expose the config tree. Every other registry
+# entry is a project the overnight agent works on and needs write access to.
+derive_project_dirs() {
+    local name path
+    while IFS=$'\t' read -r name path; do
+        path="${path/#\~/$HOME}"          # expand leading ~ only
+        [ "$path" = "$HARNESS" ] && continue
+        printf '%s\n' "$path"
+    done < <(jq -r '.[] | [.name, .path] | @tsv' "$REGISTRY")
+}
+
+# `--list` prints the derived dirs and exits — the testable, side-effect-free
+# entry point. Everything below it mutates the system and needs sudo.
+if [ "${1:-}" = "--list" ]; then
+    derive_project_dirs
+    exit 0
+fi
+
+mapfile -t PROJECTS < <(derive_project_dirs)
 
 echo "── 1. User + group ──────────────────────────────────────────────────────"
 sudo groupadd -f dev-projects

--- a/scripts/setup-claude-agent.sh
+++ b/scripts/setup-claude-agent.sh
@@ -15,12 +15,25 @@ REGISTRY="${PROJECTS_JSON:-$HARNESS/scripts/projects.json}"
 # contradict that design and expose the config tree. Every other registry
 # entry is a project the overnight agent works on and needs write access to.
 derive_project_dirs() {
-    local name path
+    local name path tsv
+    # Capture jq's output into a variable BEFORE the loop so its exit status is
+    # observable under `set -e`. A `< <(jq …)` process substitution hides jq's
+    # failure — `set -e` only reacts to a pipeline's status under `pipefail`,
+    # and process substitution is neither — so a missing or malformed registry
+    # would silently yield an empty list and exit 0, and the ownership loop
+    # would run zero iterations while the script still printed "Done." A valid
+    # but empty registry (`[]`) yields empty output with jq exit 0, which is a
+    # legitimate degenerate state and must NOT abort.
+    tsv="$(jq -r '.[] | [.name, .path] | @tsv' "$REGISTRY")" \
+        || { echo "derive_project_dirs: failed to read registry $REGISTRY" >&2; exit 1; }
+    # Empty registry (`[]`) → empty $tsv. A here-string of "" still feeds one
+    # blank line, so guard it to avoid emitting a spurious empty project dir.
+    [ -z "$tsv" ] && return 0
     while IFS=$'\t' read -r name path; do
         path="${path/#\~/$HOME}"          # expand leading ~ only
         [ "$path" = "$HARNESS" ] && continue
         printf '%s\n' "$path"
-    done < <(jq -r '.[] | [.name, .path] | @tsv' "$REGISTRY")
+    done <<< "$tsv"
 }
 
 # `--list` prints the derived dirs and exits — the testable, side-effect-free

--- a/scripts/setup-claude-agent.sh
+++ b/scripts/setup-claude-agent.sh
@@ -43,7 +43,19 @@ if [ "${1:-}" = "--list" ]; then
     exit 0
 fi
 
-mapfile -t PROJECTS < <(derive_project_dirs)
+# Capture first: inside `< <(…)` the function's `exit 1` dies in the child
+# and mapfile sees only closed stdin — a bad registry would yield an empty
+# PROJECTS and a clean "Done." (the exact bug fixed inside the function,
+# recurring at its call site). A top-level command-substitution assignment
+# propagates the failure under `set -e`. Empty output (registry `[]`, or
+# every entry filtered) is legitimate: guard it so a here-string's single
+# blank line does not become one empty project dir.
+derived="$(derive_project_dirs)"
+if [ -z "$derived" ]; then
+    PROJECTS=()
+else
+    mapfile -t PROJECTS <<< "$derived"
+fi
 
 echo "── 1. User + group ──────────────────────────────────────────────────────"
 sudo groupadd -f dev-projects

--- a/tests/test_setup_claude_agent_projects.sh
+++ b/tests/test_setup_claude_agent_projects.sh
@@ -77,6 +77,52 @@ else
     fail=1
 fi
 
+# --- a missing registry fails loudly, not silently empty ------------------
+# set -e does NOT observe jq failing inside `< <(...)` process substitution,
+# so a missing/malformed registry once yielded an empty list and exit 0 —
+# the ownership loop then ran zero iterations while the script reported "Done".
+if missing_out="$(HOME="$FAKE_HOME" PROJECTS_JSON="$TMP/does-not-exist.json" bash "$SCRIPT" --list 2>/dev/null)"; then
+    missing_rc=0
+else
+    missing_rc=$?
+fi
+if (( missing_rc != 0 )) && [ -z "$missing_out" ]; then
+    echo "PASS: missing registry exits non-zero with no derived dirs"
+else
+    echo "FAIL: missing registry should exit non-zero (got rc=$missing_rc, out=[$missing_out])"
+    fail=1
+fi
+
+# --- a malformed-JSON registry also fails loudly --------------------------
+BAD_REG="$TMP/malformed.json"
+printf 'not valid json {[' > "$BAD_REG"
+if malformed_out="$(HOME="$FAKE_HOME" PROJECTS_JSON="$BAD_REG" bash "$SCRIPT" --list 2>/dev/null)"; then
+    malformed_rc=0
+else
+    malformed_rc=$?
+fi
+if (( malformed_rc != 0 )) && [ -z "$malformed_out" ]; then
+    echo "PASS: malformed registry exits non-zero with no derived dirs"
+else
+    echo "FAIL: malformed registry should exit non-zero (got rc=$malformed_rc, out=[$malformed_out])"
+    fail=1
+fi
+
+# --- a valid but empty registry [] is legitimate, not an error ------------
+EMPTY_REG="$TMP/empty.json"
+printf '[]' > "$EMPTY_REG"
+if empty_out="$(HOME="$FAKE_HOME" PROJECTS_JSON="$EMPTY_REG" bash "$SCRIPT" --list 2>/dev/null)"; then
+    empty_rc=0
+else
+    empty_rc=$?
+fi
+if (( empty_rc == 0 )) && [ -z "$empty_out" ]; then
+    echo "PASS: empty registry [] exits 0 with no derived dirs"
+else
+    echo "FAIL: empty registry [] should exit 0 with empty output (got rc=$empty_rc, out=[$empty_out])"
+    fail=1
+fi
+
 if (( fail )); then
     exit 1
 fi

--- a/tests/test_setup_claude_agent_projects.sh
+++ b/tests/test_setup_claude_agent_projects.sh
@@ -123,6 +123,43 @@ else
     fail=1
 fi
 
+# --- the MUTATING entry point (no --list) aborts on a bad registry --------
+# Round-2 gate finding on PR #500: the fix inside derive_project_dirs was
+# swallowed again at the call site `mapfile -t PROJECTS < <(derive_project_dirs)`
+# — the child's exit 1 never reaches the parent, PROJECTS goes empty, and the
+# ownership step no-ops behind a clean "Done." Run the real path with a stub
+# sudo first on PATH (never touch the system; on CI sudo is passwordless, so an
+# unstubbed run would REALLY mutate) and assert: non-zero exit, the derive
+# error on stderr, and zero sudo invocations.
+STUBDIR="$TMP/bin"
+mkdir -p "$STUBDIR"
+SUDO_LOG="$TMP/sudo-calls.log"
+: > "$SUDO_LOG"
+cat > "$STUBDIR/sudo" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "$SUDO_LOG"
+exit 99
+STUB
+chmod +x "$STUBDIR/sudo"
+
+set +e
+mutate_err="$(PATH="$STUBDIR:$PATH" HOME="$FAKE_HOME" \
+    PROJECTS_JSON="$TMP/does-not-exist.json" bash "$SCRIPT" 2>&1 >/dev/null)"
+mutate_rc=$?
+set -e
+mutate_ok=1
+(( mutate_rc != 0 )) || { echo "  mutating path exited 0 on a bad registry"; mutate_ok=0; }
+grep -q "failed to read registry" <<< "$mutate_err" \
+    || { echo "  no derive error on stderr: [$mutate_err]"; mutate_ok=0; }
+[ ! -s "$SUDO_LOG" ] \
+    || { echo "  sudo was invoked despite the bad registry:"; cat "$SUDO_LOG"; mutate_ok=0; }
+if (( mutate_ok )); then
+    echo "PASS: mutating entry point aborts on a bad registry before any sudo"
+else
+    echo "FAIL: bad registry must abort the mutating path before any sudo"
+    fail=1
+fi
+
 if (( fail )); then
     exit 1
 fi

--- a/tests/test_setup_claude_agent_projects.sh
+++ b/tests/test_setup_claude_agent_projects.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Tests for scripts/setup-claude-agent.sh --list: the project-dir derivation
+# must read scripts/projects.json (the canonical registry), expand a leading
+# ~ to $HOME, keep paths with spaces intact, and exclude the harness itself
+# (it gets read-only ACL treatment, not group ownership).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+SCRIPT="$PWD/scripts/setup-claude-agent.sh"
+fail=0
+
+# Build a throwaway HOME + fixture registry, run `--list`, capture stdout.
+_derive() {
+    local home="$1" registry="$2"
+    HOME="$home" PROJECTS_JSON="$registry" bash "$SCRIPT" --list
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAKE_HOME="$TMP/home"
+mkdir -p "$FAKE_HOME"
+REG="$TMP/projects.json"
+cat > "$REG" <<'JSON'
+[
+  { "name": "harness", "path": "~/.claude" },
+  { "name": "plain", "path": "~/CNRS/code/plain" },
+  { "name": "spaced", "path": "~/CNRS/papiers/actif/Fuzzy Corpus" }
+]
+JSON
+
+mapfile -t OUT < <(_derive "$FAKE_HOME" "$REG")
+
+# --- harness (~/.claude) is excluded --------------------------------------
+if printf '%s\n' "${OUT[@]}" | grep -qx "$FAKE_HOME/.claude"; then
+    echo "FAIL: harness path should be excluded from the group-ownership list"
+    fail=1
+else
+    echo "PASS: harness path excluded"
+fi
+
+# --- leading ~ expanded to \$HOME -----------------------------------------
+if printf '%s\n' "${OUT[@]}" | grep -qx "$FAKE_HOME/CNRS/code/plain"; then
+    echo "PASS: leading ~ expanded to \$HOME"
+else
+    echo "FAIL: expected expanded path $FAKE_HOME/CNRS/code/plain in output:"
+    printf '  %s\n' "${OUT[@]}"
+    fail=1
+fi
+# no unexpanded tilde survives
+if printf '%s\n' "${OUT[@]}" | grep -q '~'; then
+    echo "FAIL: an unexpanded ~ leaked into the output"
+    fail=1
+else
+    echo "PASS: no unexpanded ~ in output"
+fi
+
+# --- path with a space stays a single intact element ----------------------
+found_spaced=0
+for p in "${OUT[@]}"; do
+    if [[ "$p" == "$FAKE_HOME/CNRS/papiers/actif/Fuzzy Corpus" ]]; then
+        found_spaced=1
+    fi
+done
+if (( found_spaced )); then
+    echo "PASS: spaced path preserved as one element"
+else
+    echo "FAIL: spaced path was split or lost; output was:"
+    printf '  [%s]\n' "${OUT[@]}"
+    fail=1
+fi
+
+# --- exactly the two non-harness entries, no more, no fewer ---------------
+if (( ${#OUT[@]} == 2 )); then
+    echo "PASS: derived exactly the 2 non-harness project dirs"
+else
+    echo "FAIL: expected 2 derived dirs, got ${#OUT[@]}"
+    fail=1
+fi
+
+if (( fail )); then
+    exit 1
+fi
+echo "PASS: setup-claude-agent.sh --list derives expanded, intact project dirs"

--- a/tickets/closed/0286-setup-claude-agent-sh-projects-array-dup.erg
+++ b/tickets/closed/0286-setup-claude-agent-sh-projects-array-dup.erg
@@ -2,10 +2,12 @@
 Title: setup-claude-agent.sh PROJECTS array duplicates projects.json — read the registry instead
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #500
 
 --- log ---
 2026-07-11T22:30Z Minh Ha-Duong created
 
+2026-07-12T17:48Z Minh Ha-Duong closed — autoclosed — PR #500
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`scripts/setup-claude-agent.sh` hardcoded a 4-project `PROJECTS` array that
duplicated `scripts/projects.json` — the same 2026-07 home reorg fact had to be
edited in both places (PR #493 and PR #497). This makes the script read the
canonical registry via `jq`, so the next path change lands in one place.

## Semantic decision: full registry minus the harness

The old array listed only 4 of the 8 registry entries. Step 2 of the script
chowns each project dir to `haduong:dev-projects` with setgid so the overnight
`claude-agent` can write to it. Every registry project is such a dir, so all of
them belong — the old 4 were an incomplete snapshot that silently omitted
`git-erg`, `chemin-de-voix`, and `padme`. The one principled exclusion is the
harness (`~/.claude`): steps 4-5 grant it read-only ACL access, and chowning it
to the group with `g+rwX` would contradict that design. `derive_project_dirs`
therefore emits every registry entry except the harness — the original 4 keep
identical treatment, the 3 previously-missing projects are now covered, and a
registry edit propagates without touching the script.

## Robustness

- Tilde expansion mirrors the Python consumers' `expanduser` via `${path/#\~/$HOME}` (leading `~` only).
- Paths flow through `jq @tsv` → `read -r` loop → `mapfile`, so `Fuzzy Corpus` and any future spaced path survive as single elements (no word-splitting).
- New `--list` mode prints the derived dirs and exits before any sudo — a side-effect-free, testable entry point.

## Test (RED → GREEN)

`tests/test_setup_claude_agent_projects.sh` drives `--list` against a fixture
registry and asserts: harness excluded, `~` expanded to `$HOME`, no tilde leaks,
spaced path stays one element, exact count. Auto-discovered by
`test_bash_suites.py`. `make check`: 686 passed.

## Other hardcoded copies

Swept `scripts/` and `skills/`: no other list existed. Remaining grep hits are
incidental single-project-name mentions in skill docs/examples, not a copy of
the project list.

**Ticket:** tickets/0286-setup-claude-agent-sh-projects-array-dup.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)