### PR TITLE
tickets(0285): describe CI ticket checks that actually run, drop erg-github fiction

### DIFF
--- a/tickets/0285-tickets-agents-md-documents-erg-github-v.erg
+++ b/tickets/0285-tickets-agents-md-documents-erg-github-v.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-11T22:21Z Minh Ha-Duong created
 
+2026-07-12T17:24Z claude note git-erg DOES ship tickets/erg-github (asset AGENTS.md L41, dispatch src/go/main.go, test test_erg_github.sh); this repo does not vendor it. Vendoring is a separate author decision. Conservative fix applied: describe the validate-tickets CI job (erg check tickets/) and cross-pr-ticket-collision gate that actually run; close-in-same-PR guidance attributed to erg-pr-merge.
 --- body ---
 ## Context
 

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -39,7 +39,7 @@ Rules agents must know:
 - A CI gate catches this trap across *open PRs*: `scripts/check-cross-pr-ticket-collision.sh` (the `cross-pr-ticket-collision` job, `pull_request` events only) lists the ticket IDs a PR adds and fails if any is also added by another open PR, naming the colliding PR and suggesting the next free ID. Per-branch `erg check` cannot see this — each branch's IDs are unique within itself. On a failure, renumber as above (`git mv` + fix cross-references) before merging. The cross-PR enumeration is the only forge-specific part, isolated behind `# harness-extension-point` calls.
 - Artifacts a ticket consumes or produces (reports, data, generated files, scripts) live in their natural location in the project tree and are referenced from the body by path, not embedded wholesale, and not kept as a filename-twinned `0002-slug.md` sidecar the tooling cannot track.
 
-On GitHub, `tickets/erg-github` (a separate committed helper, not an `erg` subcommand) adds a `verify` check that fails a PR referencing a still-open ticket -- so close the ticket in the same PR (`erg close`).
+Ticket validation runs in CI: the `validate-tickets` job runs `erg check tickets/` on every push and PR, and the `cross-pr-ticket-collision` job (above) guards the optimistic-ID trap across open PRs. No forge helper fails a PR for referencing a still-open ticket; closing the ticket in the same PR is a convention, enforced at merge by `erg-pr-merge`, which runs `erg close` on the ticket named in the PR's `**Ticket:**` line.
 
 In doubt, run `erg spec` (file format) or `erg --help --all` / `erg COMMAND --help` for command documentation.
 

--- a/tickets/closed/0285-tickets-agents-md-documents-erg-github-v.erg
+++ b/tickets/closed/0285-tickets-agents-md-documents-erg-github-v.erg
@@ -2,11 +2,13 @@
 Title: tickets/AGENTS.md documents erg-github verify, a helper this repo does not ship
 Created: 2026-07-11
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #501
 
 --- log ---
 2026-07-11T22:21Z Minh Ha-Duong created
 
 2026-07-12T17:24Z claude note git-erg DOES ship tickets/erg-github (asset AGENTS.md L41, dispatch src/go/main.go, test test_erg_github.sh); this repo does not vendor it. Vendoring is a separate author decision. Conservative fix applied: describe the validate-tickets CI job (erg check tickets/) and cross-pr-ticket-collision gate that actually run; close-in-same-PR guidance attributed to erg-pr-merge.
+2026-07-12T17:29Z Minh Ha-Duong closed — autoclosed — PR #501
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`tickets/AGENTS.md` claimed that on GitHub `tickets/erg-github` adds a `verify` check failing a PR that references a still-open ticket. This repo ships no such helper. The sentence misled agents into designing around a boundary that is not there (it bit ticket 0262's original plan).

This rewrites the sentence to describe what actually runs on this repo:
- the `validate-tickets` CI job (`erg check tickets/`), and
- the `cross-pr-ticket-collision` gate (`scripts/check-cross-pr-ticket-collision.sh`, already documented just above).

The close-the-ticket-in-the-same-PR norm survives, now attributed to its real enforcer — `erg-pr-merge` running `erg close` on the ticket named in the PR's `**Ticket:**` line — not a phantom verify helper.

## git-erg investigation

The git-erg project **does** ship `tickets/erg-github` (asset `AGENTS.md` L41, dispatch in `src/go/main.go`, tested by `tests/test_erg_github.sh`). This repo does not vendor it. Vendoring it here and wiring a `verify` CI check is a **separate decision for the author** — not done in this PR, which only corrects the documentation to match the checks this repo actually runs.

## Test

`make check` passes (exit 0).

**Ticket:** tickets/0285-tickets-agents-md-documents-erg-github-v.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)