### PR TITLE
skill(0287): ingest-decision-letter — R&R intake ledger + coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/healthcheck` | Repo healthcheck — git hygiene, test status, and deep freshness verification of status/directive docs. Gracefully degrades when project-specific conventions (git-erg tickets, STATE.md, etc.) are absent. |
 | `/housekeeping` | Alias of /molt — repo housekeeping with git sync, healthcheck, and eager fix-now repairs. |
 | `/hunt` | Begin work on a ticket — creates a worktree and writes the first test. |
+| `/ingest-decision-letter` | Ingest a journal decision letter and reviewer comments into a structured remark ledger, archive the sources, and run a coverage check that maps every remark to a ticket. Turns Revise-and-Resubmit intake into one deterministic pass instead of a manual re-count. |
 | `/lair` | End-of-day session wrap-up. Runs housekeeping, pushes branches, runs tests, refreshes STATE, offers autonomous session. |
 | `/maw-audit` | "Mutation-testing audit of test-suite quality — verifies each test detects defects, tolerates safe refactors, and guards the whole defect class. EXPENSIVE — invoke deliberately. Auto-discovers config." |
 | `/memory` | Write, update, or sweep persistent memory. Enforces list caps, TTLs, and staleness criteria. |

--- a/skills/ingest-decision-letter/SKILL.md
+++ b/skills/ingest-decision-letter/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: ingest-decision-letter
+description: Ingest a journal decision letter and reviewer comments into a structured remark ledger, archive the sources, and run a coverage check that maps every remark to a ticket. Turns Revise-and-Resubmit intake into one deterministic pass instead of a manual re-count.
+user-invocable: true
+disable-model-invocation: false
+argument-hint: <decision-letter> <reviewer-comments>... [--release-dir <paper-repo>/release/<date>]
+---
+
+# Ingest decision letter $ARGUMENTS
+
+Take a journal's **Revise-and-Resubmit** decision letter plus each reviewer's
+comments, archive them where they will not be lost, parse them into a structured
+**remark ledger**, and produce a **coverage check** that maps every remark to the
+ticket(s) addressing it — flagging uncovered remarks and orphan tickets. This is
+the *inverse* of `external-peer-review` / `review-pr-prose`: those review **our**
+manuscript; this ingests **the journal's** review of it.
+
+The bundled helper is `~/.claude/skills/ingest-decision-letter/ingest_letter.py`.
+It is pure I/O — it never calls a model. You (the model) read the extracted text
+and assign categories and ticket mappings; the script does the deterministic,
+re-runnable work: extract, archive, segment, dedupe, coverage.
+
+## Sources
+
+Accept the letter and comments as **file paths** — a text file or a PDF (the
+helper extracts PDF text via `pdftotext`). The comments may also arrive as an
+**email thread**: if the project exposes a mail-reading capability, fetch the
+thread and save its text to a file first, then proceed exactly as for a text
+file. Do not build the intake around any one mail tool — the archived text file
+is the interface.
+
+Once located, **archive first** (next step): the 2026-06-18 intake wasted a whole
+search re-hunting comments that had already been filed. The archive is the
+single source of truth; never send the author back to a mailbox to re-find them.
+
+## Steps
+
+1. **Locate the sources.** Resolve each path argument. If a source is missing and
+   it lived in an email thread, fetch the thread with whatever mail capability the
+   project offers and write it to a text file. If you cannot find a source, stop
+   and ask the author for the path — do not guess.
+
+2. **Archive to `release/<date>/`.** Paper repos keep an immutable, append-only
+   `release/<date description>/` per submission; editorial replies file into the
+   release subdir they answer, as tracked text. Copy the sources there:
+   ```
+   ~/.claude/skills/ingest-decision-letter/ingest_letter.py archive \
+       decision.pdf reviewer1.txt reviewer2.txt \
+       --into <paper-repo>/release/<date>/
+   ```
+   PDFs are copied verbatim and a `.txt` sidecar of their text is written beside
+   them, so the archive stays greppable. A `manifest.json` records what landed.
+   Commit the archived text in the paper repo (it is durable tracked state).
+
+3. **Segment each reviewer into a candidate ledger.** Run `segment` once per
+   reviewer — it splits the comments into candidate remarks with **stable ids**
+   (`R1-01`, `R1-02`, …) and source line locations. Re-running on the same input
+   yields the same ids, so the ledger is a stable anchor.
+   ```
+   ~/.claude/skills/ingest-decision-letter/ingest_letter.py segment \
+       reviewer1.txt --reviewer R1 >  ledger.jsonl
+   ~/.claude/skills/ingest-decision-letter/ingest_letter.py segment \
+       reviewer2.txt --reviewer R2 >> ledger.jsonl
+   ```
+   The segmenter is a deterministic first pass (it splits on enumeration markers,
+   or on paragraphs when the reviewer did not number anything). **Then read the
+   extracted text yourself** and refine each record: set `category` (framing /
+   method / data / literature / typo / …), fix any remark the segmenter split or
+   merged wrongly, and keep the `text` verbatim. This is the one judgment step;
+   everything around it is mechanical.
+
+4. **Dedupe atomic-vs-remark.** A reviewer's numbered points often restate one
+   underlying remark (the 2026-06-18 letter reconciled 60 atomic comments down to
+   56 remarks). `dedupe` folds duplicates and any record you tagged with
+   `atomic_of` into its parent, so the distinct-remark count is deterministic:
+   ```
+   ~/.claude/skills/ingest-decision-letter/ingest_letter.py dedupe \
+       ledger.jsonl > ledger.dedup.jsonl
+   ```
+   Distinct remarks are the records whose `atomic_of` is null; folded atomics
+   inherit their parent's coverage.
+
+5. **Create tickets, then map remarks to them.** Group the distinct remarks into
+   thematic tickets (one theme per ticket). Record the mapping **in the ledger**:
+   set each remark's `tickets` field to the list of ticket ids that address it.
+   Leave it `[]` for anything not yet ticketed — the coverage check will catch it.
+
+6. **Coverage check — one deterministic pass.** Cross-check the ledger against the
+   tickets that exist for this round:
+   ```
+   ~/.claude/skills/ingest-decision-letter/ingest_letter.py coverage \
+       ledger.dedup.jsonl --tickets-dir tickets/
+   ```
+   The report lists, and the command exits non-zero on, any of:
+   - **uncovered_remarks** — a remark no ticket addresses.
+   - **orphan_tickets** — a ticket in the universe that addresses no remark.
+   - **unknown_ticket_refs** — a ticket a remark points at that does not exist.
+
+   Iterate — add tickets, fix mappings — until the report is clean. That clean
+   pass replaces the two-or-three manual re-counts the old intake needed.
+
+## Ledger schema
+
+One JSON object per line (JSONL):
+
+| Field | Meaning |
+|-------|---------|
+| `id` | stable `<reviewer>-<NN>`, document order |
+| `reviewer` | reviewer label, e.g. `R1` |
+| `category` | you assign: framing / method / data / literature / typo / … |
+| `text` | verbatim remark text |
+| `source` | `<file>:<line>` where the remark starts |
+| `tickets` | list of ticket ids addressing this remark (`[]` = uncovered) |
+| `atomic_of` | parent remark id when this folds into another (`null` = distinct) |
+
+## Notes
+
+- **Pure I/O helper.** The script never calls a model; the one judgment step
+  (categories, mapping, fixing a mis-split remark) is yours.
+- **Tool-agnostic.** The email-thread path is a capability, not a fixed tool —
+  the archived text file is the interface, so any mail reader works.
+- **Stable ids** make the ledger a durable anchor: re-segmenting the same source
+  does not renumber remarks, so ticket references stay valid.
+- Companion skill `track-changes-pdf` (tracker 0265) closes the loop by rendering
+  a revision-marked PDF grouped by ticket; it lands separately.

--- a/skills/ingest-decision-letter/ingest_letter.py
+++ b/skills/ingest-decision-letter/ingest_letter.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Ingest a journal decision letter + reviewer comments into a remark ledger.
+
+Pure I/O helper for the ``ingest-decision-letter`` skill. It never calls an
+LLM API — the model reads extracted text and refines categories/tickets; this
+script does the deterministic, testable, mechanical work:
+
+  extract   read text from a text file, or a PDF via ``pdftotext``.
+  archive   copy source documents into a paper repo's ``release/<date>/``
+            convention, as tracked text, with a manifest.
+  segment   first-pass split of a reviewer's comments into candidate remarks
+            with STABLE ids and source line locations.
+  dedupe    collapse duplicate / atomic sub-comments into distinct remarks.
+  coverage  cross-check a ledger against the tickets that address it — flag
+            uncovered remarks and orphan tickets in one deterministic pass.
+
+Ledger record (JSONL, one object per line):
+    id        stable, ``<reviewer>-<NN>`` (document order, zero-padded)
+    reviewer  reviewer label, e.g. ``R1``
+    category  free text; empty until the model fills it
+    text      verbatim remark text
+    source    ``<file>:<line>`` where the remark starts
+    tickets   list of ticket ids that address this remark ([] = uncovered)
+    atomic_of parent remark id when this record folds into another ([]-> null)
+
+Example:
+    ingest_letter.py segment reviewer1.txt --reviewer R1 > ledger.jsonl
+    ingest_letter.py dedupe ledger.jsonl > ledger.dedup.jsonl
+    ingest_letter.py coverage ledger.dedup.jsonl --tickets-dir tickets/
+"""
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# A line that opens a new atomic comment: "1.", "2)", "Comment 3:", "R1.4",
+# "Point 2 -", "- ", "* ". Kept deliberately permissive; the model refines.
+_ENUM_MARKER = re.compile(
+    r"""^\s*
+    (?:
+        (?:comment|point|remark|item|question|major|minor)\s*\#?\s*\d+   # Comment 3
+      | \d+[.)]                                                          # 1.  2)
+      | [-*•]\s                                                     # bullet
+      | [A-Z]?\d+\.\d+                                                   # R1.4 / 2.3
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Fields every ledger record carries, with their defaults.
+_LEDGER_FIELDS = {
+    "id": "",
+    "reviewer": "",
+    "category": "",
+    "text": "",
+    "source": "",
+    "tickets": list,
+    "atomic_of": None,
+}
+
+
+def _normalize_record(rec: dict) -> dict:
+    """Fill missing ledger fields with defaults; leave present ones intact."""
+    out = {}
+    for field, default in _LEDGER_FIELDS.items():
+        if field in rec and rec[field] is not None:
+            out[field] = rec[field]
+        else:
+            out[field] = default() if callable(default) else default
+    return out
+
+
+def read_ledger(path: Path) -> list[dict]:
+    """Read a JSONL ledger; skip blank lines; normalize each record."""
+    records = []
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError as e:
+            raise SystemExit(f"{path}:{lineno}: invalid JSON: {e}") from e
+        records.append(_normalize_record(rec))
+    return records
+
+
+def write_ledger(records: list[dict], out) -> None:
+    """Write records as JSONL to an open text stream."""
+    for rec in records:
+        out.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# extract
+# --------------------------------------------------------------------------- #
+def extract_text(path: Path) -> str:
+    """Return the text of a document: read text files, pdftotext for PDFs."""
+    if path.suffix.lower() == ".pdf":
+        if shutil.which("pdftotext") is None:
+            raise SystemExit(
+                "pdftotext not found — install poppler-utils to extract PDF "
+                "text, or pass a text file instead."
+            )
+        result = subprocess.run(
+            ["pdftotext", "-layout", str(path), "-"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+    return path.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# archive
+# --------------------------------------------------------------------------- #
+def archive(sources: list[Path], into: Path) -> dict:
+    """Copy source documents into ``into`` (a release/<date>/ dir).
+
+    PDFs are copied verbatim AND a ``.txt`` sidecar of their extracted text is
+    written beside them, so the archive is greppable tracked text. Returns a
+    manifest describing what was written.
+    """
+    into.mkdir(parents=True, exist_ok=True)
+    entries = []
+    for src in sources:
+        if not src.exists():
+            raise SystemExit(f"source not found: {src}")
+        dest = into / src.name
+        shutil.copy2(src, dest)
+        entry = {"source": str(src), "archived": str(dest)}
+        if src.suffix.lower() == ".pdf":
+            sidecar = dest.with_suffix(".txt")
+            sidecar.write_text(extract_text(src), encoding="utf-8")
+            entry["text_sidecar"] = str(sidecar)
+        entries.append(entry)
+        log.info("archived %s -> %s", src, dest)
+    manifest = {"into": str(into), "entries": entries}
+    (into / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return manifest
+
+
+# --------------------------------------------------------------------------- #
+# segment
+# --------------------------------------------------------------------------- #
+def segment(text: str, reviewer: str, source_name: str) -> list[dict]:
+    """Split a reviewer's comment text into candidate remarks.
+
+    Deterministic first pass: an enumeration marker (``1.``, ``Comment 2:``,
+    a bullet, ``R1.3``) opens a new remark; lines until the next marker are its
+    body. With no markers at all, blank-line-separated paragraphs each become a
+    remark. Ids are ``<reviewer>-<NN>`` in document order, so re-running on the
+    same input yields the same ids.
+    """
+    lines = text.splitlines()
+    # Locate marker lines (non-empty, matching the enumeration pattern).
+    marker_idx = [
+        i for i, ln in enumerate(lines) if ln.strip() and _ENUM_MARKER.match(ln)
+    ]
+
+    spans: list[tuple[int, list[str]]] = []
+    if marker_idx:
+        for k, start in enumerate(marker_idx):
+            end = marker_idx[k + 1] if k + 1 < len(marker_idx) else len(lines)
+            body = [ln for ln in lines[start:end]]
+            spans.append((start, body))
+    else:
+        # Paragraph fallback: split on blank lines.
+        start = None
+        buf: list[str] = []
+        for i, ln in enumerate(lines):
+            if ln.strip():
+                if start is None:
+                    start = i
+                buf.append(ln)
+            elif buf:
+                spans.append((start, buf))
+                start, buf = None, []
+        if buf:
+            spans.append((start, buf))
+
+    records = []
+    for n, (start, body) in enumerate(spans, 1):
+        remark_text = "\n".join(body).strip()
+        if not remark_text:
+            continue
+        records.append(
+            _normalize_record(
+                {
+                    "id": f"{reviewer}-{n:02d}",
+                    "reviewer": reviewer,
+                    "text": remark_text,
+                    "source": f"{source_name}:{start + 1}",
+                }
+            )
+        )
+    return records
+
+
+def _norm_text(text: str) -> str:
+    """Normalize remark text for duplicate detection.
+
+    Strips a leading enumeration marker so two verbatim-identical comments that
+    differ only in their reviewer numbering (``1.`` vs ``3.``) still collapse.
+    """
+    stripped = _ENUM_MARKER.sub("", text.strip(), count=1)
+    return re.sub(r"\s+", " ", stripped.lower()).strip().rstrip(".;:,")
+
+
+# --------------------------------------------------------------------------- #
+# dedupe
+# --------------------------------------------------------------------------- #
+def dedupe(records: list[dict]) -> tuple[list[dict], dict]:
+    """Collapse atomic sub-comments and duplicates into distinct remarks.
+
+    Two folding rules:
+      - explicit: a record whose ``atomic_of`` names another record's id is
+        folded into that parent.
+      - implicit: records with identical normalized text collapse; the first
+        in document order is canonical, the rest fold into it.
+    Returns (ledger, summary). The ledger keeps every input record, with folded
+    ones carrying ``atomic_of`` set to their canonical id. Distinct remarks are
+    the records whose ``atomic_of`` is null.
+    """
+    by_id = {r["id"]: r for r in records if r["id"]}
+    canonical_by_text: dict[str, str] = {}
+    out = []
+    for rec in records:
+        rec = dict(rec)
+        # Respect an explicit atomic_of that points at a known record.
+        if rec.get("atomic_of") and rec["atomic_of"] in by_id:
+            out.append(rec)
+            continue
+        key = _norm_text(rec["text"])
+        if key in canonical_by_text:
+            rec["atomic_of"] = canonical_by_text[key]
+        else:
+            canonical_by_text[key] = rec["id"]
+            rec["atomic_of"] = None
+        out.append(rec)
+
+    remarks = [r for r in out if r["atomic_of"] is None]
+    atomics = [r for r in out if r["atomic_of"] is not None]
+    summary = {
+        "input": len(records),
+        "remarks": len(remarks),
+        "atomics": len(atomics),
+    }
+    return out, summary
+
+
+# --------------------------------------------------------------------------- #
+# coverage
+# --------------------------------------------------------------------------- #
+def _ticket_ids_from_dir(tickets_dir: Path) -> set[str]:
+    """Collect ticket ids from ``NNNN-*.erg`` filenames (open + closed)."""
+    ids = set()
+    for erg in tickets_dir.rglob("*.erg"):
+        m = re.match(r"(\d{3,})", erg.name)
+        if m:
+            ids.add(m.group(1))
+    return ids
+
+
+def coverage(records: list[dict], universe: set[str]) -> dict:
+    """Cross-check remark-to-ticket mapping against a ticket universe.
+
+    A remark is a record whose ``atomic_of`` is null. Atomic sub-comments
+    inherit their parent's coverage and are not counted separately.
+
+    Flags:
+      uncovered_remarks    remarks addressed by no ticket.
+      orphan_tickets       tickets in the universe that address no remark.
+      unknown_ticket_refs  ticket ids a remark references but not in the universe.
+    """
+    remarks = [r for r in records if r["atomic_of"] is None]
+    mapping = {r["id"]: list(r.get("tickets") or []) for r in remarks}
+
+    uncovered = sorted(rid for rid, tks in mapping.items() if not tks)
+    referenced = {t for tks in mapping.values() for t in tks}
+    orphan = sorted(universe - referenced)
+    unknown = sorted(referenced - universe)
+
+    return {
+        "remark_count": len(remarks),
+        "covered": len(remarks) - len(uncovered),
+        "uncovered_remarks": uncovered,
+        "orphan_tickets": orphan,
+        "unknown_ticket_refs": unknown,
+        "map": mapping,
+    }
+
+
+def coverage_ok(report: dict) -> bool:
+    """A clean coverage report has no uncovered, orphan, or unknown items."""
+    return not (
+        report["uncovered_remarks"]
+        or report["orphan_tickets"]
+        or report["unknown_ticket_refs"]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _cmd_extract(args) -> int:
+    sys.stdout.write(extract_text(args.path))
+    return 0
+
+
+def _cmd_archive(args) -> int:
+    manifest = archive(args.sources, args.into)
+    json.dump(manifest, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_segment(args) -> int:
+    text = extract_text(args.path)
+    source_name = args.source_name or args.path.name
+    records = segment(text, args.reviewer, source_name)
+    write_ledger(records, sys.stdout)
+    log.info("segmented %d candidate remark(s) for %s", len(records), args.reviewer)
+    return 0
+
+
+def _cmd_dedupe(args) -> int:
+    records = read_ledger(args.ledger)
+    out, summary = dedupe(records)
+    write_ledger(out, sys.stdout)
+    log.info(
+        "dedupe: %d input -> %d remark(s), %d atomic(s)",
+        summary["input"],
+        summary["remarks"],
+        summary["atomics"],
+    )
+    return 0
+
+
+def _cmd_coverage(args) -> int:
+    records = read_ledger(args.ledger)
+    universe: set[str] = set()
+    if args.tickets:
+        universe |= {t.strip() for t in args.tickets.split(",") if t.strip()}
+    if args.tickets_dir:
+        universe |= _ticket_ids_from_dir(args.tickets_dir)
+    report = coverage(records, universe)
+    json.dump(report, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0 if coverage_ok(report) else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pe = sub.add_parser("extract", help="print a document's text to stdout")
+    pe.add_argument("path", type=Path)
+    pe.set_defaults(func=_cmd_extract)
+
+    pa = sub.add_parser("archive", help="copy sources into a release/<date>/ dir")
+    pa.add_argument("sources", type=Path, nargs="+")
+    pa.add_argument("--into", type=Path, required=True,
+                    help="destination dir, e.g. <paper-repo>/release/<date>/")
+    pa.set_defaults(func=_cmd_archive)
+
+    ps = sub.add_parser("segment", help="first-pass split into candidate remarks")
+    ps.add_argument("path", type=Path)
+    ps.add_argument("--reviewer", required=True,
+                    help="reviewer label used in the id prefix, e.g. R1")
+    ps.add_argument("--source-name", default=None,
+                    help="name used in the source field (default: file name)")
+    ps.set_defaults(func=_cmd_segment)
+
+    pd = sub.add_parser("dedupe", help="fold atomic/duplicate comments into remarks")
+    pd.add_argument("ledger", type=Path)
+    pd.set_defaults(func=_cmd_dedupe)
+
+    pc = sub.add_parser("coverage", help="cross-check remark-to-ticket coverage")
+    pc.add_argument("ledger", type=Path)
+    pc.add_argument("--tickets", default=None,
+                    help="comma-separated ticket ids in the universe")
+    pc.add_argument("--tickets-dir", type=Path, default=None,
+                    help="dir of NNNN-*.erg tickets to build the universe from")
+    pc.set_defaults(func=_cmd_coverage)
+
+    return p
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ingest-decision-letter/ingest_letter.py
+++ b/skills/ingest-decision-letter/ingest_letter.py
@@ -21,7 +21,7 @@ Ledger record (JSONL, one object per line):
     text      verbatim remark text
     source    ``<file>:<line>`` where the remark starts
     tickets   list of ticket ids that address this remark ([] = uncovered)
-    atomic_of parent remark id when this record folds into another ([]-> null)
+    atomic_of parent remark id when this record folds into another (null = distinct)
 
 Example:
     ingest_letter.py segment reviewer1.txt --reviewer R1 > ledger.jsonl
@@ -106,19 +106,49 @@ def extract_text(path: Path) -> str:
                 "pdftotext not found — install poppler-utils to extract PDF "
                 "text, or pass a text file instead."
             )
-        result = subprocess.run(
-            ["pdftotext", "-layout", str(path), "-"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        try:
+            result = subprocess.run(
+                ["pdftotext", "-layout", str(path), "-"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise SystemExit(
+                f"pdftotext failed on {path}: {e.stderr.strip() or e}. "
+                "The file may be malformed or not a valid PDF."
+            ) from e
         return result.stdout
-    return path.read_text(encoding="utf-8")
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise SystemExit(
+            f"{path} is not valid UTF-8 text: {e}. Re-save it as UTF-8, or pass "
+            "the PDF and let pdftotext extract it."
+        ) from e
 
 
 # --------------------------------------------------------------------------- #
 # archive
 # --------------------------------------------------------------------------- #
+def _unique_dest(into: Path, name: str, used: set[str]) -> Path:
+    """Return a destination path in ``into`` that collides with nothing.
+
+    Appends ``-2``, ``-3``, … before the extension when the basename is already
+    taken — by an earlier source in this archive run or a file already on disk —
+    so two same-named sources from different directories both survive instead of
+    the second silently clobbering the first.
+    """
+    stem, suffix = Path(name).stem, Path(name).suffix
+    candidate = name
+    i = 2
+    while candidate in used or (into / candidate).exists():
+        candidate = f"{stem}-{i}{suffix}"
+        i += 1
+    used.add(candidate)
+    return into / candidate
+
+
 def archive(sources: list[Path], into: Path) -> dict:
     """Copy source documents into ``into`` (a release/<date>/ dir).
 
@@ -128,14 +158,15 @@ def archive(sources: list[Path], into: Path) -> dict:
     """
     into.mkdir(parents=True, exist_ok=True)
     entries = []
+    used: set[str] = set()
     for src in sources:
         if not src.exists():
             raise SystemExit(f"source not found: {src}")
-        dest = into / src.name
+        dest = _unique_dest(into, src.name, used)
         shutil.copy2(src, dest)
         entry = {"source": str(src), "archived": str(dest)}
         if src.suffix.lower() == ".pdf":
-            sidecar = dest.with_suffix(".txt")
+            sidecar = _unique_dest(into, dest.stem + ".txt", used)
             sidecar.write_text(extract_text(src), encoding="utf-8")
             entry["text_sidecar"] = str(sidecar)
         entries.append(entry)
@@ -230,11 +261,20 @@ def dedupe(records: list[dict]) -> tuple[list[dict], dict]:
     """
     known_ids = {r["id"] for r in records if r["id"]}
     canonical_by_text: dict[str, str] = {}
+    unknown_refs: list[str] = []
     out = []
     for rec in records:
         rec = dict(rec)
-        # Respect an explicit atomic_of that points at a known record.
-        if rec.get("atomic_of") and rec["atomic_of"] in known_ids:
+        ref = rec.get("atomic_of")
+        if ref:
+            if ref in known_ids:
+                # Respect an explicit atomic_of that points at a known record.
+                out.append(rec)
+                continue
+            # Dangling atomic_of — likely a typo from the hand-edit step. Surface
+            # it and keep the record's stated (dangling) parent, rather than
+            # silently falling through and treating it as a distinct remark.
+            unknown_refs.append(rec["id"])
             out.append(rec)
             continue
         key = _norm_text(rec["text"])
@@ -251,6 +291,7 @@ def dedupe(records: list[dict]) -> tuple[list[dict], dict]:
         "input": len(records),
         "remarks": len(remarks),
         "atomics": len(atomics),
+        "unknown_atomic_refs": sorted(unknown_refs),
     }
     return out, summary
 
@@ -271,16 +312,24 @@ def _ticket_ids_from_dir(tickets_dir: Path) -> set[str]:
 def coverage(records: list[dict], universe: set[str]) -> dict:
     """Cross-check remark-to-ticket mapping against a ticket universe.
 
-    A remark is a record whose ``atomic_of`` is null. Atomic sub-comments
-    inherit their parent's coverage and are not counted separately.
+    A remark is a record whose ``atomic_of`` is null. Atomic sub-comments are
+    folded into their parent and excluded from the count entirely.
 
     Flags:
       uncovered_remarks    remarks addressed by no ticket.
       orphan_tickets       tickets in the universe that address no remark.
       unknown_ticket_refs  ticket ids a remark references but not in the universe.
+      duplicate_ids        remark ids that occur more than once (a re-run/concat
+                           collision that would otherwise silently drop a mapping).
     """
     remarks = [r for r in records if r["atomic_of"] is None]
-    mapping = {r["id"]: list(r.get("tickets") or []) for r in remarks}
+    mapping: dict[str, list[str]] = {}
+    duplicate: set[str] = set()
+    for r in remarks:
+        rid = r["id"]
+        if rid in mapping:
+            duplicate.add(rid)
+        mapping[rid] = list(r.get("tickets") or [])
 
     uncovered = sorted(rid for rid, tks in mapping.items() if not tks)
     referenced = {t for tks in mapping.values() for t in tks}
@@ -293,16 +342,18 @@ def coverage(records: list[dict], universe: set[str]) -> dict:
         "uncovered_remarks": uncovered,
         "orphan_tickets": orphan,
         "unknown_ticket_refs": unknown,
+        "duplicate_ids": sorted(duplicate),
         "map": mapping,
     }
 
 
 def coverage_ok(report: dict) -> bool:
-    """A clean coverage report has no uncovered, orphan, or unknown items."""
+    """A clean coverage report has no uncovered, orphan, unknown, or duplicate items."""
     return not (
         report["uncovered_remarks"]
         or report["orphan_tickets"]
         or report["unknown_ticket_refs"]
+        or report["duplicate_ids"]
     )
 
 

--- a/skills/ingest-decision-letter/ingest_letter.py
+++ b/skills/ingest-decision-letter/ingest_letter.py
@@ -54,27 +54,18 @@ _ENUM_MARKER = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
-# Fields every ledger record carries, with their defaults.
-_LEDGER_FIELDS = {
-    "id": "",
-    "reviewer": "",
-    "category": "",
-    "text": "",
-    "source": "",
-    "tickets": list,
-    "atomic_of": None,
-}
-
 
 def _normalize_record(rec: dict) -> dict:
     """Fill missing ledger fields with defaults; leave present ones intact."""
-    out = {}
-    for field, default in _LEDGER_FIELDS.items():
-        if field in rec and rec[field] is not None:
-            out[field] = rec[field]
-        else:
-            out[field] = default() if callable(default) else default
-    return out
+    return {
+        "id": rec.get("id") or "",
+        "reviewer": rec.get("reviewer") or "",
+        "category": rec.get("category") or "",
+        "text": rec.get("text") or "",
+        "source": rec.get("source") or "",
+        "tickets": rec.get("tickets") or [],
+        "atomic_of": rec.get("atomic_of"),
+    }
 
 
 def read_ledger(path: Path) -> list[dict]:
@@ -96,6 +87,12 @@ def write_ledger(records: list[dict], out) -> None:
     """Write records as JSONL to an open text stream."""
     for rec in records:
         out.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def _print_json(obj: dict) -> None:
+    """Pretty-print a JSON object to stdout, newline-terminated."""
+    json.dump(obj, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
 
 
 # --------------------------------------------------------------------------- #
@@ -172,8 +169,7 @@ def segment(text: str, reviewer: str, source_name: str) -> list[dict]:
     if marker_idx:
         for k, start in enumerate(marker_idx):
             end = marker_idx[k + 1] if k + 1 < len(marker_idx) else len(lines)
-            body = [ln for ln in lines[start:end]]
-            spans.append((start, body))
+            spans.append((start, lines[start:end]))
     else:
         # Paragraph fallback: split on blank lines.
         start = None
@@ -232,13 +228,13 @@ def dedupe(records: list[dict]) -> tuple[list[dict], dict]:
     ones carrying ``atomic_of`` set to their canonical id. Distinct remarks are
     the records whose ``atomic_of`` is null.
     """
-    by_id = {r["id"]: r for r in records if r["id"]}
+    known_ids = {r["id"] for r in records if r["id"]}
     canonical_by_text: dict[str, str] = {}
     out = []
     for rec in records:
         rec = dict(rec)
         # Respect an explicit atomic_of that points at a known record.
-        if rec.get("atomic_of") and rec["atomic_of"] in by_id:
+        if rec.get("atomic_of") and rec["atomic_of"] in known_ids:
             out.append(rec)
             continue
         key = _norm_text(rec["text"])
@@ -320,8 +316,7 @@ def _cmd_extract(args) -> int:
 
 def _cmd_archive(args) -> int:
     manifest = archive(args.sources, args.into)
-    json.dump(manifest, sys.stdout, indent=2, ensure_ascii=False)
-    sys.stdout.write("\n")
+    _print_json(manifest)
     return 0
 
 
@@ -355,8 +350,7 @@ def _cmd_coverage(args) -> int:
     if args.tickets_dir:
         universe |= _ticket_ids_from_dir(args.tickets_dir)
     report = coverage(records, universe)
-    json.dump(report, sys.stdout, indent=2, ensure_ascii=False)
-    sys.stdout.write("\n")
+    _print_json(report)
     return 0 if coverage_ok(report) else 1
 
 

--- a/tests/fixtures/decision-letter/decision.txt
+++ b/tests/fixtures/decision-letter/decision.txt
@@ -1,0 +1,12 @@
+From: Editor, Journal of Fictional Econometrics
+To: The Authors
+Subject: Decision on manuscript JFE-9999 — Major Revision
+
+Dear Authors,
+
+Your manuscript "A Toy Estimator for Imaginary Panels" has been reviewed by two
+referees. Both see merit but raise substantive concerns. I invite a major
+revision. Please respond point by point to every reviewer comment below.
+
+Sincerely,
+The Editor

--- a/tests/fixtures/decision-letter/reviewer1.txt
+++ b/tests/fixtures/decision-letter/reviewer1.txt
@@ -1,0 +1,10 @@
+Reviewer 1
+
+1. The introduction overstates the novelty of the proposed estimator. Please
+   temper the claims and cite the prior work of Imaginary and Panels (2019).
+
+2. The sample size used in the Section 3 simulation is never stated. Report N
+   and the number of replications.
+
+3. The introduction overstates the novelty of the proposed estimator. Please
+   temper the claims and cite the prior work of Imaginary and Panels (2019).

--- a/tests/fixtures/decision-letter/reviewer2.txt
+++ b/tests/fixtures/decision-letter/reviewer2.txt
@@ -1,0 +1,9 @@
+Reviewer 2
+
+Comment 1: Figure 2 is illegible at print size; please increase the font and
+export it as a vector graphic.
+
+Comment 2: The discussion does not engage with the recent literature on robust
+standard errors for short panels.
+
+Comment 3: Typo on page 7: "recieve" should read "receive".

--- a/tests/test_ingest_decision_letter.py
+++ b/tests/test_ingest_decision_letter.py
@@ -86,7 +86,12 @@ def test_dedupe_folds_identical_duplicate():
     text = (FIX / "reviewer1.txt").read_text()
     recs = il.segment(text, "R1", "reviewer1.txt")
     out, summary = il.dedupe(recs)
-    assert summary == {"input": 3, "remarks": 2, "atomics": 1}
+    assert summary == {
+        "input": 3,
+        "remarks": 2,
+        "atomics": 1,
+        "unknown_atomic_refs": [],
+    }
     folded = [r for r in out if r["atomic_of"] is not None]
     assert len(folded) == 1
     assert folded[0]["id"] == "R1-03"
@@ -104,6 +109,21 @@ def test_dedupe_respects_explicit_atomic_of():
     out, summary = il.dedupe(recs)
     assert summary["remarks"] == 2 and summary["atomics"] == 1
     assert [r for r in out if r["id"] == "R1-02"][0]["atomic_of"] == "R1-01"
+
+
+def test_dedupe_flags_dangling_atomic_of():
+    """A dangling atomic_of (typo from the hand-edit step) is surfaced, not silently
+    rewritten to a distinct remark."""
+    recs = [
+        il._normalize_record({"id": "R1-01", "text": "Parent remark."}),
+        il._normalize_record(
+            {"id": "R1-02", "text": "A sub-point.", "atomic_of": "R9-99"}
+        ),
+    ]
+    out, summary = il.dedupe(recs)
+    assert summary["unknown_atomic_refs"] == ["R1-02"]
+    child = [r for r in out if r["id"] == "R1-02"][0]
+    assert child["atomic_of"] == "R9-99", "dangling ref must not become distinct"
 
 
 def test_dedupe_full_ledger_counts():
@@ -140,6 +160,18 @@ def test_coverage_flags_uncovered_and_orphan_together():
     assert report["uncovered_remarks"] == ["R2-03"]
     assert report["orphan_tickets"] == ["0399"]
     assert report["unknown_ticket_refs"] == []
+    assert not il.coverage_ok(report)
+
+
+def test_coverage_flags_duplicate_remark_id():
+    """Two remarks sharing an id (e.g. re-run segment + concat) are surfaced, not
+    silently collapsed into one mapping."""
+    ledger = [
+        il._normalize_record({"id": "R1-01", "text": "a", "tickets": ["0301"]}),
+        il._normalize_record({"id": "R1-01", "text": "dup", "tickets": ["0302"]}),
+    ]
+    report = il.coverage(ledger, {"0301", "0302"})
+    assert report["duplicate_ids"] == ["R1-01"]
     assert not il.coverage_ok(report)
 
 
@@ -180,6 +212,21 @@ def test_archive_copies_sources_and_writes_manifest(tmp_path):
     assert (into / "reviewer1.txt").exists()
     assert (into / "manifest.json").exists()
     assert len(manifest["entries"]) == 2
+
+
+def test_archive_disambiguates_same_basename_from_different_dirs(tmp_path):
+    d1 = tmp_path / "d1"
+    d2 = tmp_path / "d2"
+    d1.mkdir()
+    d2.mkdir()
+    (d1 / "review.txt").write_text("from dir one")
+    (d2 / "review.txt").write_text("from dir two")
+    into = tmp_path / "release" / "2026-07-12"
+    manifest = il.archive([d1 / "review.txt", d2 / "review.txt"], into)
+    archived = [Path(e["archived"]).name for e in manifest["entries"]]
+    assert len(set(archived)) == 2, "both sources must survive with distinct names"
+    contents = {(into / name).read_text() for name in archived}
+    assert contents == {"from dir one", "from dir two"}, "no source clobbered"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_ingest_decision_letter.py
+++ b/tests/test_ingest_decision_letter.py
@@ -1,0 +1,247 @@
+"""ingest-decision-letter: remark-ledger parse, dedupe, and coverage check.
+
+The skill ingests a journal decision letter + reviewer comments into a stable
+remark ledger and cross-checks remark-to-ticket coverage in one deterministic
+pass. These fast tests pin the helper's mechanical contract; the skill-text
+ratchets pin the documented invariants (pure I/O, tool-agnostic sources).
+
+Fixtures under tests/fixtures/decision-letter/ are SYNTHESIZED fiction — no real
+editorial content is stored in this repo.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO / "skills" / "ingest-decision-letter"
+SCRIPT = SKILL_DIR / "ingest_letter.py"
+SKILL = SKILL_DIR / "SKILL.md"
+FIX = REPO / "tests" / "fixtures" / "decision-letter"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ingest_letter", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+il = _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# segment — parse into a candidate ledger with stable ids
+# --------------------------------------------------------------------------- #
+def test_segment_numbered_reviewer_counts():
+    text = (FIX / "reviewer1.txt").read_text()
+    recs = il.segment(text, "R1", "reviewer1.txt")
+    assert len(recs) == 3, "three numbered comments -> three candidate remarks"
+    assert [r["id"] for r in recs] == ["R1-01", "R1-02", "R1-03"]
+    assert all(r["reviewer"] == "R1" for r in recs)
+
+
+def test_segment_comment_prefixed_reviewer_counts():
+    text = (FIX / "reviewer2.txt").read_text()
+    recs = il.segment(text, "R2", "reviewer2.txt")
+    assert len(recs) == 3, "three 'Comment N:' items -> three remarks"
+    assert [r["id"] for r in recs] == ["R2-01", "R2-02", "R2-03"]
+
+
+def test_segment_ids_are_stable_across_runs():
+    text = (FIX / "reviewer1.txt").read_text()
+    a = il.segment(text, "R1", "reviewer1.txt")
+    b = il.segment(text, "R1", "reviewer1.txt")
+    assert [r["id"] for r in a] == [r["id"] for r in b]
+    assert [r["text"] for r in a] == [r["text"] for r in b]
+
+
+def test_segment_records_source_location():
+    text = (FIX / "reviewer2.txt").read_text()
+    recs = il.segment(text, "R2", "reviewer2.txt")
+    for r in recs:
+        assert r["source"].startswith("reviewer2.txt:")
+        assert int(r["source"].split(":")[1]) >= 1
+
+
+def test_segment_verbatim_text_preserved():
+    text = (FIX / "reviewer2.txt").read_text()
+    recs = il.segment(text, "R2", "reviewer2.txt")
+    assert "recieve" in recs[2]["text"], "verbatim typo must survive segmentation"
+
+
+def test_segment_paragraph_fallback_when_unnumbered():
+    text = "First standalone concern here.\n\nA second, separate concern.\n"
+    recs = il.segment(text, "R3", "r3.txt")
+    assert len(recs) == 2, "blank-line paragraphs each become a remark"
+
+
+# --------------------------------------------------------------------------- #
+# dedupe — fold atomic / duplicate comments into distinct remarks
+# --------------------------------------------------------------------------- #
+def test_dedupe_folds_identical_duplicate():
+    text = (FIX / "reviewer1.txt").read_text()
+    recs = il.segment(text, "R1", "reviewer1.txt")
+    out, summary = il.dedupe(recs)
+    assert summary == {"input": 3, "remarks": 2, "atomics": 1}
+    folded = [r for r in out if r["atomic_of"] is not None]
+    assert len(folded) == 1
+    assert folded[0]["id"] == "R1-03"
+    assert folded[0]["atomic_of"] == "R1-01", "duplicate folds into the first"
+
+
+def test_dedupe_respects_explicit_atomic_of():
+    recs = [
+        il._normalize_record({"id": "R1-01", "text": "Parent remark."}),
+        il._normalize_record(
+            {"id": "R1-02", "text": "A distinct sub-point.", "atomic_of": "R1-01"}
+        ),
+        il._normalize_record({"id": "R1-03", "text": "Another remark."}),
+    ]
+    out, summary = il.dedupe(recs)
+    assert summary["remarks"] == 2 and summary["atomics"] == 1
+    assert [r for r in out if r["id"] == "R1-02"][0]["atomic_of"] == "R1-01"
+
+
+def test_dedupe_full_ledger_counts():
+    combined = il.segment((FIX / "reviewer1.txt").read_text(), "R1", "reviewer1.txt")
+    combined += il.segment((FIX / "reviewer2.txt").read_text(), "R2", "reviewer2.txt")
+    out, summary = il.dedupe(combined)
+    assert summary["input"] == 6
+    assert summary["remarks"] == 5, "60->56 in miniature: one duplicate folds"
+    assert summary["atomics"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# coverage — flag uncovered remarks AND orphan tickets in one pass
+# --------------------------------------------------------------------------- #
+def _mapped_ledger():
+    return [
+        il._normalize_record({"id": "R1-01", "text": "a", "tickets": ["0301"]}),
+        il._normalize_record({"id": "R1-02", "text": "b", "tickets": ["0302"]}),
+        il._normalize_record({"id": "R2-01", "text": "c", "tickets": ["0303"]}),
+        il._normalize_record({"id": "R2-02", "text": "d", "tickets": ["0304"]}),
+        il._normalize_record({"id": "R2-03", "text": "e", "tickets": []}),
+        # a folded atomic inherits coverage; must not count as a remark
+        il._normalize_record(
+            {"id": "R1-03", "text": "a", "tickets": [], "atomic_of": "R1-01"}
+        ),
+    ]
+
+
+def test_coverage_flags_uncovered_and_orphan_together():
+    ledger = _mapped_ledger()
+    universe = {"0301", "0302", "0303", "0304", "0399"}
+    report = il.coverage(ledger, universe)
+    assert report["remark_count"] == 5, "the folded atomic is not counted"
+    assert report["uncovered_remarks"] == ["R2-03"]
+    assert report["orphan_tickets"] == ["0399"]
+    assert report["unknown_ticket_refs"] == []
+    assert not il.coverage_ok(report)
+
+
+def test_coverage_flags_unknown_ticket_reference():
+    ledger = [il._normalize_record({"id": "R1-01", "text": "a", "tickets": ["0999"]})]
+    report = il.coverage(ledger, {"0301"})
+    assert report["unknown_ticket_refs"] == ["0999"]
+    assert report["orphan_tickets"] == ["0301"]
+    assert not il.coverage_ok(report)
+
+
+def test_coverage_clean_when_every_remark_mapped():
+    ledger = [
+        il._normalize_record({"id": "R1-01", "text": "a", "tickets": ["0301"]}),
+        il._normalize_record({"id": "R1-02", "text": "b", "tickets": ["0301", "0302"]}),
+    ]
+    report = il.coverage(ledger, {"0301", "0302"})
+    assert report["uncovered_remarks"] == []
+    assert report["orphan_tickets"] == []
+    assert report["unknown_ticket_refs"] == []
+    assert il.coverage_ok(report)
+
+
+def test_ticket_ids_from_dir_reads_erg_filenames(tmp_path):
+    (tmp_path / "0301-foo.erg").write_text("x")
+    (tmp_path / "0302-bar.erg").write_text("x")
+    (tmp_path / "notes.txt").write_text("x")
+    assert il._ticket_ids_from_dir(tmp_path) == {"0301", "0302"}
+
+
+# --------------------------------------------------------------------------- #
+# archive — copy sources into a release/<date>/ dir with a manifest
+# --------------------------------------------------------------------------- #
+def test_archive_copies_sources_and_writes_manifest(tmp_path):
+    into = tmp_path / "release" / "2026-07-12-r1"
+    manifest = il.archive([FIX / "decision.txt", FIX / "reviewer1.txt"], into)
+    assert (into / "decision.txt").exists()
+    assert (into / "reviewer1.txt").exists()
+    assert (into / "manifest.json").exists()
+    assert len(manifest["entries"]) == 2
+
+
+# --------------------------------------------------------------------------- #
+# skill-text + script ratchets (documented contract)
+# --------------------------------------------------------------------------- #
+def test_bundled_script_exists():
+    assert SCRIPT.exists(), "skill must bundle ingest_letter.py"
+
+
+def test_first_sentence_is_plain_and_searchable():
+    first = SKILL.read_text().split("description:", 1)[1].split("\n", 1)[0].lower()
+    for kw in ("decision letter", "reviewer", "ledger", "coverage"):
+        assert kw in first, f"first sentence should mention {kw!r}"
+
+
+def test_skill_documents_ledger_and_coverage():
+    text = SKILL.read_text().lower()
+    for term in ("remark ledger", "coverage", "atomic", "release/"):
+        assert term in text, f"skill must document {term!r}"
+
+
+def test_script_is_pure_io_no_llm_api():
+    src = SCRIPT.read_text().lower()
+    for banned in ("import anthropic", "import openai", "anthropic(", "openai("):
+        assert banned not in src, "helper must not call an LLM API (pure I/O)"
+
+
+def test_source_is_tool_agnostic():
+    """The email-thread path is a capability, not a hardcoded mail tool."""
+    text = SKILL.read_text()
+    assert "capability" in text.lower()
+    assert "gmail" not in text.lower(), "no hardcoded mail tool in prescriptive steps"
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring (subprocess -> integration tier)
+# --------------------------------------------------------------------------- #
+@pytest.mark.integration
+def test_cli_end_to_end_segment_dedupe_coverage(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    with ledger.open("w") as fh:
+        for rev, src in [("R1", "reviewer1.txt"), ("R2", "reviewer2.txt")]:
+            out = subprocess.run(
+                [sys.executable, str(SCRIPT), "segment", str(FIX / src),
+                 "--reviewer", rev],
+                capture_output=True, text=True, check=True,
+            )
+            fh.write(out.stdout)
+
+    dd = subprocess.run(
+        [sys.executable, str(SCRIPT), "dedupe", str(ledger)],
+        capture_output=True, text=True, check=True,
+    )
+    dedup = tmp_path / "ledger.dedup.jsonl"
+    dedup.write_text(dd.stdout)
+    assert len(dd.stdout.strip().splitlines()) == 6
+
+    # No tickets mapped yet -> coverage must exit non-zero (all uncovered).
+    cov = subprocess.run(
+        [sys.executable, str(SCRIPT), "coverage", str(dedup),
+         "--tickets", "0301,0302"],
+        capture_output=True, text=True,
+    )
+    assert cov.returncode == 1, "unmapped ledger is not covered"
+    assert '"orphan_tickets"' in cov.stdout

--- a/tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg
+++ b/tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg
@@ -6,6 +6,7 @@ Author: minh
 --- log ---
 2026-06-18T13:46Z minh created
 
+2026-07-12T18:08Z note child 0287 (ingest-decision-letter) landed
 --- body ---
 ## Context
 A full day (2026-06-18, ~12 sessions on the Oeconomia — Climate finance

--- a/tickets/0287-ingest-decision-letter-skill.erg
+++ b/tickets/0287-ingest-decision-letter-skill.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: Build the ingest-decision-letter skill
+Created: 2026-07-12
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-12T17:23Z claude created
+
+--- body ---
+Child of tracker 0265.
+
+## Context
+Journal Revise-and-Resubmit *intake* has no harness tooling: a full day
+(2026-06-18, Oeconomia manuscript) was spent by hand extracting the editor
+decision and reviewer comments from PDFs, hunting for already-archived files in
+Gmail, reconciling "60 atomic comments" down to "56 remarks" with no parser, and
+re-verifying two or three times that the created tickets covered every remark
+because no remark-to-ticket ledger existed.
+
+This ticket builds the first of the two skills in tracker 0265:
+`ingest-decision-letter`. It takes a decision letter plus reviewer comments
+(PDF or text; email-thread source is a documented, tool-agnostic capability),
+archives them to the paper repo's `release/<date>/` convention as tracked text,
+parses them into a structured remark ledger (id, reviewer, category, verbatim
+text, source location), dedupes atomic sub-comments against distinct remarks,
+and emits a coverage check that maps remarks to tickets and flags uncovered
+remarks and orphan tickets — turning verification into one deterministic pass.
+
+The second skill (`track-changes-pdf`) is out of scope here; it lands under its
+own child ticket.
+
+## Relevant files
+- `skills/external-peer-review/` — closest sibling (sends our PDF out); reuse
+  its PDF/text plumbing style and persona-free structure.
+- `skills/related-work-note/`, `skills/zotero-import/` — structure-extraction
+  precedents.
+- `README.md` — skills catalog, regenerated via `make skills-catalog`.
+- `tests/test_skill_descriptions.py` — discoverability-first description gate.
+
+## Actions
+1. Spec the remark-ledger JSONL schema (id, reviewer, category, verbatim text,
+   source location, mapped tickets, atomic-of) — the contract the ledger and the
+   coverage check share.
+2. Build `skills/ingest-decision-letter/SKILL.md` + a stdlib-only helper:
+   text/PDF extraction, archive to `release/<date>/`, deterministic first-pass
+   segmentation into a candidate ledger, dedupe, and a coverage report.
+3. Keep the skill tool-agnostic: the email-thread source is named as a
+   capability, not hardcoded tooling; helpers are pure I/O, never call an LLM API.
+4. Regenerate the skills catalog (`make skills-catalog`) and commit the README.
+5. Add `tests/test_ingest_decision_letter.py` with synthesized fictional
+   fixtures (no real editorial content copied in): ledger parse, dedupe, and a
+   coverage check that flags an orphan ticket and an uncovered remark.
+
+## Exit criteria
+- [ ] `ingest-decision-letter` skill exists (SKILL.md + helper), extracts +
+      archives + emits a structured remark ledger from text/PDF sources.
+- [ ] Coverage check reports remark-to-ticket mapping, orphan tickets, and
+      uncovered remarks in one deterministic pass.
+- [ ] Skill listed in `README.md` catalog; `make check-skills-drift` clean.
+- [ ] Description-discoverability and skill-contract tests pass.
+- [ ] `make check` passes; `tickets/erg validate` clean.

--- a/tickets/0287-ingest-decision-letter-skill.erg
+++ b/tickets/0287-ingest-decision-letter-skill.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-12T17:23Z claude created
 
+2026-07-12T18:04Z bump verify-reroll — round 1: 3 blocking findings unresolved (archive() basename-collision silent overwrite ingest_letter.py:132; coverage() duplicate-id dict-comprehension silently drops ticket mapping ingest_letter.py:283; dedupe() silently discards atomic_of pointing at nonexistent id ingest_letter.py:236) + 6 verifiable: minors unresolved from posted panel review (pullrequestreview-4680504924); simplify commit 9fce88c was quality-only, did not touch any of these lines behaviorally
 --- body ---
 Child of tracker 0265.
 
@@ -26,8 +27,8 @@ text, source location), dedupes atomic sub-comments against distinct remarks,
 and emits a coverage check that maps remarks to tickets and flags uncovered
 remarks and orphan tickets — turning verification into one deterministic pass.
 
-The second skill (`track-changes-pdf`) is out of scope here; it lands under its
-own child ticket.
+The second skill (`track-changes-pdf`) is out of scope here; it will land under
+its own child ticket.
 
 ## Relevant files
 - `skills/external-peer-review/` — closest sibling (sends our PDF out); reuse

--- a/tickets/closed/0287-ingest-decision-letter-skill.erg
+++ b/tickets/closed/0287-ingest-decision-letter-skill.erg
@@ -2,11 +2,13 @@
 Title: Build the ingest-decision-letter skill
 Created: 2026-07-12
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #503
 
 --- log ---
 2026-07-12T17:23Z claude created
 
 2026-07-12T18:04Z bump verify-reroll — round 1: 3 blocking findings unresolved (archive() basename-collision silent overwrite ingest_letter.py:132; coverage() duplicate-id dict-comprehension silently drops ticket mapping ingest_letter.py:283; dedupe() silently discards atomic_of pointing at nonexistent id ingest_letter.py:236) + 6 verifiable: minors unresolved from posted panel review (pullrequestreview-4680504924); simplify commit 9fce88c was quality-only, did not touch any of these lines behaviorally
+2026-07-12T18:16Z Minh Ha-Duong closed — autoclosed — PR #503
 --- body ---
 Child of tracker 0265.
 


### PR DESCRIPTION
## Summary

Builds the `ingest-decision-letter` skill — the first of the two R&R-intake
skills specced in tracker 0265. It ingests a journal decision letter + reviewer
comments, archives them to the paper repo's `release/<date>/` convention as
tracked text, parses them into a structured **remark ledger**, dedupes atomic
sub-comments against distinct remarks, and emits a **coverage check** mapping
remarks to tickets with uncovered remarks and orphan tickets flagged — one
deterministic pass instead of the manual re-counting the 2026-06-18 Oeconomia
intake needed.

## Surface

- `skills/ingest-decision-letter/SKILL.md` — workflow; tool-agnostic source
  handling (email-thread is a documented capability, the archived text file is
  the interface); pure-I/O helper contract.
- `skills/ingest-decision-letter/ingest_letter.py` — stdlib-only helper, never
  calls a model. Subcommands: `extract` (text/PDF via pdftotext), `archive`
  (copy to `release/<date>/` + manifest), `segment` (stable `<reviewer>-NN`
  ids + source locations), `dedupe` (fold atomic/duplicate → distinct remarks),
  `coverage` (uncovered / orphan / unknown-ref, exit 1 on any).
- `tests/test_ingest_decision_letter.py` + `tests/fixtures/decision-letter/`
  (synthesized fiction — no real editorial content). 20 tests: parse/stable-ids,
  dedupe (60→56 in miniature), coverage flags uncovered + orphan together, plus
  skill-contract ratchets. One integration CLI end-to-end test.
- `README.md` — regenerated skills catalog.

## Ledger schema (JSONL)

`id` (stable `<reviewer>-NN`) · `reviewer` · `category` (model fills) ·
`text` (verbatim) · `source` (`file:line`) · `tickets` (`[]` = uncovered) ·
`atomic_of` (`null` = distinct remark).

## Test evidence

`make check` — 705 passed. `tickets/erg validate` clean.

## Not in scope

- `track-changes-pdf` (the second 0265 skill) — lands under its own child ticket.
- Gmail/mail MCP wiring is intentionally not hardcoded; the skill treats the
  email-thread source as a capability writing to a text file.

**Ticket:** tickets/0287-ingest-decision-letter-skill.erg
**Ticket-ref:** tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)