### PR TITLE
skill(track-changes-pdf): revision-marked PDF via latexdiff between two refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/smoke` | Agent environment smoke test — reports runtime identity, auth method, and harness context. |
 | `/start-ticket` | Deprecated — renamed to /hunt. Warns, then delegates to the new name. |
 | `/test-audit-llm` | "Read-and-judge audit of test quality across four lenses: faithfulness, intent legibility, negative-space coverage, change-detector smell. Runs nothing — advisory only; findings feed ticket creation." |
+| `/track-changes-pdf` | Render a revision-marked PDF of a LaTeX manuscript between two git refs, highlighting insertions and deletions via latexdiff. Closes the annotate-reply-apply loop for journal revise-and-resubmit rounds. |
 | `/update-publist` | Add or update a publication on the personal page and deposit on HAL via SWORD. Gated on user payload review before any outward API call. |
 | `/verify` | Deprecated — renamed to /gaze. Warns, then delegates to the new name. |
 | `/verify-adherence` | Check a branch's diff against project rules. Mechanical-first — runs hygiene tests + grep ratchet before falling back to LLM. |

--- a/skills/track-changes-pdf/SKILL.md
+++ b/skills/track-changes-pdf/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: track-changes-pdf
+description: Render a revision-marked PDF of a LaTeX manuscript between two git refs, highlighting insertions and deletions via latexdiff. Closes the annotate-reply-apply loop for journal revise-and-resubmit rounds.
+user-invocable: true
+disable-model-invocation: false
+argument-hint: --old-ref <tag/branch/commit> [--new-ref HEAD] --main-tex <path/to/main.tex> --output <marked.pdf> [--repo .]
+---
+
+# Track-changes PDF $ARGUMENTS
+
+Render a revision-marked PDF of a LaTeX manuscript: insertions and deletions
+between two git refs highlighted, so the author (or a journal editor) can read
+and annotate exactly what changed. This mechanizes the review doctrine "the
+review interface for prose is the recompiled PDF and latexdiff between tags" —
+the diff is authored from the git history, never marked up by hand.
+
+The bundled script is `~/.claude/skills/track-changes-pdf/track_changes_pdf.py`.
+
+## When to use it
+
+- A journal revise-and-resubmit asks for a change-marked version of the
+  manuscript alongside the clean one.
+- The author wants to review, in one pass, everything that moved between the
+  submitted version and the current draft before replying to reviewers.
+
+## How it works
+
+1. `git archive` extracts the whole tree at the old ref and at the new ref into
+   two temp directories (the full tree, so figures, `.bib`, and class files
+   resolve).
+2. `latexdiff --flatten` compares the two main-tex sources — `--flatten`
+   inlines `\input`/`\include` so a multi-file manuscript diffs correctly — and
+   writes a marked-up `*-diff.tex` into the new tree.
+3. A LaTeX compiler (`latexmk` preferred, `pdflatex` fallback) builds the diff
+   `.tex` to PDF, which is copied to `--output`.
+
+## Steps
+
+1. **Resolve the refs.** The old ref is the baseline — typically the tag or
+   commit of the submitted manuscript (e.g. a `v1-submitted` tag). The new ref
+   defaults to `HEAD`. Confirm both resolve in the target repository.
+
+2. **Locate the main tex.** `--main-tex` is the manuscript's root `.tex` file,
+   given relative to the repository root. If the manuscript splits across
+   `\input` files, still point at the root — `--flatten` handles the rest.
+
+3. **Run the helper.**
+   ```
+   python ~/.claude/skills/track-changes-pdf/track_changes_pdf.py \
+       --repo . --old-ref v1-submitted --new-ref HEAD \
+       --main-tex manuscript/main.tex --output revision-marked.pdf
+   ```
+
+4. **Toolchain check.** The helper needs `latexdiff` and a LaTeX compiler
+   (`latexmk` or `pdflatex`). If either is absent it stops with an actionable
+   install message — relay it to the author rather than retrying. On
+   Debian/Ubuntu: `texlive-extra-utils` provides latexdiff, `texlive-latex-extra`
+   plus `latexmk` the compiler.
+
+5. **Hand off the PDF.** Report the output path and offer to open it for
+   annotation. The marked PDF is an author artifact, never a CI gate.
+
+## Scope note (v1)
+
+Grouping insertions and deletions **by ticket or reviewer remark** is out of
+scope for v1. latexdiff diffs two source trees and has no per-remark concept —
+it cannot know which ticket authored which change. The whole-revision diff
+ships first because it is exact and needs no bookkeeping. The future hook for
+per-remark grouping is either to drive latexdiff once per ticket (one diff over
+each ticket's commit range, then merge the marked outputs) or to tag changes in
+the source with a `\ticket{N}{...}` macro and colour by tag. Tracked in ticket
+0288 (child of the R&R intake tracker 0265).
+
+## Notes
+
+- Forge-agnostic: the skill reads a git repository via refs; it opens no merge
+  request and touches no forge.
+- The helper is pure I/O — `git`, `latexdiff`, and a LaTeX compiler. No network,
+  no model calls.
+- Determinism: the diff is a function of the two refs' sources. Re-running with
+  the same refs reproduces the same markup (compiler timestamps aside).

--- a/skills/track-changes-pdf/track_changes_pdf.py
+++ b/skills/track-changes-pdf/track_changes_pdf.py
@@ -31,11 +31,6 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
-# latexdiff marks insertions with \DIFadd and deletions with \DIFdel; the
-# preamble it injects defines these. Presence of the markup in the diff .tex
-# is the machine-checkable signal that a diff was produced.
-DIFF_MARKERS = ("\\DIFadd", "\\DIFdel")
-
 
 class ToolchainError(SystemExit):
     """Raised (as SystemExit) when a required external tool is missing."""
@@ -173,8 +168,9 @@ def render(repo: Path, old_ref: str, new_ref: str, main_tex: str, output: Path,
     compiler = resolve_compiler()
 
     repo = repo.resolve()
-    if not (repo / ".git").exists() and not repo.joinpath(".git").is_file():
-        # A worktree has a .git file, a normal checkout a .git dir; either is fine.
+    if not (repo / ".git").exists():
+        # Path.exists() covers both a normal checkout's .git dir and a
+        # worktree's .git file — either is fine, so a single check suffices.
         # Only warn — git archive will give the authoritative error if truly not a repo.
         log.warning("%s does not look like a git repository root", repo)
 

--- a/skills/track-changes-pdf/track_changes_pdf.py
+++ b/skills/track-changes-pdf/track_changes_pdf.py
@@ -78,6 +78,60 @@ def resolve_compiler() -> list[str]:
     )
 
 
+def resolve_ref(git: str, repo: Path, ref: str) -> str:
+    """Resolve a user-supplied ref to a full commit SHA, rejecting option-like values.
+
+    ``git archive`` (and git plumbing generally) parse a leading-dash argument as
+    an option, not a tree-ish — ``git archive --format=tar -o/path HEAD`` writes an
+    arbitrary file with exit 0. A crafted ``--old-ref``/``--new-ref`` value such as
+    ``-o/path`` or ``--remote=<url>`` could redirect the archive write or trigger
+    network access, so reject any option-like ref *before* it reaches a subprocess,
+    then resolve it to a concrete SHA. Downstream callers thus only ever see a
+    40-hex-char commit id, which can never start with ``-``.
+    """
+    if ref.startswith("-"):
+        raise SystemExit(
+            f"refusing ref {ref!r}: a value starting with '-' is parsed as a git "
+            "option, not a commit. Pass a tag, branch, or commit SHA."
+        )
+    result = subprocess.run(
+        [git, "-C", str(repo), "rev-parse", "--verify", "--end-of-options",
+         f"{ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"could not resolve ref {ref!r} in {repo} to a commit:\n"
+            f"{result.stderr.strip() or '(no stderr)'}"
+        )
+    return result.stdout.strip()
+
+
+def contained_join(base: Path, rel_str: str) -> Path:
+    """Join ``rel_str`` under ``base``, rejecting absolute paths and ``..`` traversal.
+
+    ``pathlib``'s ``/`` silently discards the left operand when the right is
+    absolute (``Path('/a') / '/etc/passwd' == Path('/etc/passwd')``), and a ``..``
+    component escapes the extracted tree. Either lets latexdiff or the compiler
+    read arbitrary local files, so validate before returning the joined path.
+    """
+    rel = Path(rel_str)
+    if rel.is_absolute():
+        raise SystemExit(
+            f"--main-tex must be relative to the repository root, got absolute {rel_str!r}"
+        )
+    base_resolved = base.resolve()
+    joined = (base / rel).resolve()
+    if not joined.is_relative_to(base_resolved):
+        raise SystemExit(
+            f"--main-tex {rel_str!r} escapes the extracted tree "
+            f"({joined} is outside {base_resolved})"
+        )
+    return joined
+
+
 def extract_ref(git: str, repo: Path, ref: str, dest: Path) -> None:
     """Extract the whole tree at ``ref`` into ``dest`` via ``git archive``.
 
@@ -174,6 +228,11 @@ def render(repo: Path, old_ref: str, new_ref: str, main_tex: str, output: Path,
         # Only warn — git archive will give the authoritative error if truly not a repo.
         log.warning("%s does not look like a git repository root", repo)
 
+    # Reject option-like refs and pin each ref to a concrete commit SHA before it
+    # reaches git archive (argument-injection guard).
+    old_ref = resolve_ref(git, repo, old_ref)
+    new_ref = resolve_ref(git, repo, new_ref)
+
     managed_tmp = None
     if workdir is None:
         managed_tmp = tempfile.mkdtemp(prefix="track-changes-pdf-")
@@ -186,11 +245,11 @@ def render(repo: Path, old_ref: str, new_ref: str, main_tex: str, output: Path,
         extract_ref(git, repo, old_ref, old_dir)
         extract_ref(git, repo, new_ref, new_dir)
 
-        rel = Path(main_tex)
-        old_tex = old_dir / rel
-        new_tex = new_dir / rel
+        # Keep --main-tex inside the extracted tree (absolute/.. traversal guard).
+        old_tex = contained_join(old_dir, main_tex)
+        new_tex = contained_join(new_dir, main_tex)
         # Write the diff into the new tree so figures/.bib/class files resolve.
-        diff_tex = new_tex.with_name(f"{rel.stem}-diff.tex")
+        diff_tex = new_tex.with_name(f"{Path(main_tex).stem}-diff.tex")
         run_latexdiff(latexdiff, old_tex, new_tex, diff_tex)
 
         pdf = compile_pdf(compiler, diff_tex.parent, diff_tex)

--- a/skills/track-changes-pdf/track_changes_pdf.py
+++ b/skills/track-changes-pdf/track_changes_pdf.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Render a revision-marked PDF of a LaTeX manuscript between two git refs.
+
+Extracts the manuscript source at ``--old-ref`` and ``--new-ref``, runs
+``latexdiff --flatten`` to produce a diff ``.tex`` (insertions and deletions
+marked up), then compiles it to a PDF. This mechanizes the review doctrine
+"the review interface for prose is the recompiled PDF and latexdiff between
+tags" — the diff is authored from the git history, not by hand.
+
+The helper is pure I/O: it shells out to ``git``, ``latexdiff``, and a LaTeX
+compiler (``latexmk`` preferred, else ``pdflatex``). It makes no network or
+model calls. It hardcodes no paths — repo, refs, main tex, and output are all
+command-line arguments.
+
+If ``latexdiff`` or the LaTeX compiler is absent, the helper exits with a
+clear, actionable message rather than a stack trace.
+
+Example:
+    python track_changes_pdf.py \\
+        --repo . --old-ref v1-submitted --new-ref HEAD \\
+        --main-tex manuscript/main.tex --output revision-marked.pdf
+"""
+
+import argparse
+import logging
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# latexdiff marks insertions with \DIFadd and deletions with \DIFdel; the
+# preamble it injects defines these. Presence of the markup in the diff .tex
+# is the machine-checkable signal that a diff was produced.
+DIFF_MARKERS = ("\\DIFadd", "\\DIFdel")
+
+
+class ToolchainError(SystemExit):
+    """Raised (as SystemExit) when a required external tool is missing."""
+
+
+def require_git() -> str:
+    """Return the git executable path, or exit with an actionable message."""
+    git = shutil.which("git")
+    if git is None:
+        raise ToolchainError("git not found on PATH — this helper diffs a git repository.")
+    return git
+
+
+def require_latexdiff() -> str:
+    """Return the latexdiff path, or exit with an install hint."""
+    latexdiff = shutil.which("latexdiff")
+    if latexdiff is None:
+        raise ToolchainError(
+            "latexdiff not found on PATH. Install it to render a revision-marked "
+            "PDF:\n"
+            "  Debian/Ubuntu:  sudo apt-get install texlive-extra-utils\n"
+            "  macOS (MacTeX):  tlmgr install latexdiff\n"
+            "  Fedora:          sudo dnf install texlive-latexdiff\n"
+            "latexdiff ships with most full TeX Live installations."
+        )
+    return latexdiff
+
+
+def resolve_compiler() -> list[str]:
+    """Return the compile command prefix, or exit if no compiler is present.
+
+    Prefers ``latexmk`` (handles multi-pass runs and the bibliography), falls
+    back to a two-pass ``pdflatex`` invocation handled by the caller.
+    """
+    if shutil.which("latexmk"):
+        return ["latexmk", "-pdf", "-interaction=nonstopmode", "-halt-on-error"]
+    if shutil.which("pdflatex"):
+        return ["pdflatex", "-interaction=nonstopmode", "-halt-on-error"]
+    raise ToolchainError(
+        "no LaTeX compiler found on PATH (looked for latexmk and pdflatex). "
+        "Install a TeX distribution:\n"
+        "  Debian/Ubuntu:  sudo apt-get install texlive-latex-extra latexmk\n"
+        "  macOS:           install MacTeX\n"
+        "  Fedora:          sudo dnf install texlive-scheme-medium latexmk"
+    )
+
+
+def extract_ref(git: str, repo: Path, ref: str, dest: Path) -> None:
+    """Extract the whole tree at ``ref`` into ``dest`` via ``git archive``.
+
+    Extracting the full tree (not just the main tex) lets latexdiff --flatten
+    resolve \\input/\\include and lets the compiler find figures, .bib, and
+    class files.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    # git archive <ref> | tar -x -C dest, without a shell pipe.
+    archive = subprocess.run(
+        [git, "-C", str(repo), "archive", "--format=tar", ref],
+        capture_output=True,
+        check=False,
+    )
+    if archive.returncode != 0:
+        raise SystemExit(
+            f"git archive failed for ref {ref!r} in {repo}:\n"
+            f"{archive.stderr.decode(errors='replace').strip()}"
+        )
+    tar = subprocess.run(
+        ["tar", "-x", "-C", str(dest)],
+        input=archive.stdout,
+        capture_output=True,
+        check=False,
+    )
+    if tar.returncode != 0:
+        raise SystemExit(
+            f"extracting the tree for ref {ref!r} failed:\n"
+            f"{tar.stderr.decode(errors='replace').strip()}"
+        )
+
+
+def run_latexdiff(latexdiff: str, old_tex: Path, new_tex: Path, diff_tex: Path) -> None:
+    """Run latexdiff --flatten and write the marked-up diff to ``diff_tex``."""
+    if not old_tex.exists():
+        raise SystemExit(f"main tex not found at old ref: {old_tex}")
+    if not new_tex.exists():
+        raise SystemExit(f"main tex not found at new ref: {new_tex}")
+    result = subprocess.run(
+        [latexdiff, "--flatten", str(old_tex), str(new_tex)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "latexdiff failed:\n" + (result.stderr.strip() or "(no stderr)")
+        )
+    diff_tex.write_text(result.stdout)
+
+
+def compile_pdf(compiler: list[str], workdir: Path, diff_tex: Path) -> Path:
+    """Compile ``diff_tex`` in ``workdir``; return the produced PDF path.
+
+    latexmk resolves multi-pass and bibliography automatically. For the
+    pdflatex fallback, run twice so cross-references settle.
+    """
+    stem = diff_tex.stem
+    if compiler[0] == "latexmk":
+        runs = [compiler + [diff_tex.name]]
+    else:
+        runs = [compiler + [diff_tex.name], compiler + [diff_tex.name]]
+    for cmd in runs:
+        result = subprocess.run(
+            cmd, cwd=str(workdir), capture_output=True, text=True, check=False
+        )
+        if result.returncode != 0:
+            tail = "\n".join(result.stdout.splitlines()[-25:])
+            raise SystemExit(
+                f"LaTeX compilation failed ({cmd[0]}). Last lines of the log:\n{tail}"
+            )
+    pdf = workdir / f"{stem}.pdf"
+    if not pdf.exists():
+        raise SystemExit(f"compiler reported success but produced no PDF at {pdf}")
+    return pdf
+
+
+def render(repo: Path, old_ref: str, new_ref: str, main_tex: str, output: Path,
+           workdir: Path | None = None) -> Path:
+    """Render the revision-marked PDF; return the output path.
+
+    ``main_tex`` is the manuscript path relative to the repository root.
+    ``workdir`` lets tests inspect intermediates; when None a temp dir is used
+    and cleaned up.
+    """
+    git = require_git()
+    latexdiff = require_latexdiff()
+    compiler = resolve_compiler()
+
+    repo = repo.resolve()
+    if not (repo / ".git").exists() and not repo.joinpath(".git").is_file():
+        # A worktree has a .git file, a normal checkout a .git dir; either is fine.
+        # Only warn — git archive will give the authoritative error if truly not a repo.
+        log.warning("%s does not look like a git repository root", repo)
+
+    managed_tmp = None
+    if workdir is None:
+        managed_tmp = tempfile.mkdtemp(prefix="track-changes-pdf-")
+        workdir = Path(managed_tmp)
+    workdir = Path(workdir)
+
+    try:
+        old_dir = workdir / "old"
+        new_dir = workdir / "new"
+        extract_ref(git, repo, old_ref, old_dir)
+        extract_ref(git, repo, new_ref, new_dir)
+
+        rel = Path(main_tex)
+        old_tex = old_dir / rel
+        new_tex = new_dir / rel
+        # Write the diff into the new tree so figures/.bib/class files resolve.
+        diff_tex = new_tex.with_name(f"{rel.stem}-diff.tex")
+        run_latexdiff(latexdiff, old_tex, new_tex, diff_tex)
+
+        pdf = compile_pdf(compiler, diff_tex.parent, diff_tex)
+
+        output = output.resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(pdf, output)
+        log.info("wrote revision-marked PDF to %s", output)
+        return output
+    finally:
+        if managed_tmp is not None:
+            shutil.rmtree(managed_tmp, ignore_errors=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render a revision-marked PDF between two git refs via latexdiff.",
+    )
+    parser.add_argument("--repo", type=Path, default=Path("."),
+                        help="Path to the git repository (default: current dir).")
+    parser.add_argument("--old-ref", required=True,
+                        help="Baseline git ref (tag/branch/commit), e.g. the submitted version.")
+    parser.add_argument("--new-ref", default="HEAD",
+                        help="Revised git ref (default: HEAD).")
+    parser.add_argument("--main-tex", required=True,
+                        help="Main .tex file, relative to the repository root.")
+    parser.add_argument("--output", type=Path, required=True,
+                        help="Path to write the revision-marked PDF.")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Verbose logging.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+    render(
+        repo=args.repo,
+        old_ref=args.old_ref,
+        new_ref=args.new_ref,
+        main_tex=args.main_tex,
+        output=args.output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_track_changes_pdf.py
+++ b/tests/test_track_changes_pdf.py
@@ -98,7 +98,67 @@ def test_compiler_prefers_latexmk(monkeypatch):
     assert mod.resolve_compiler()[0] == "latexmk"
 
 
+# --- Input-validation guards (fast, no LaTeX / no git needed) -----------------
+
+def test_resolve_ref_rejects_option_like_ref(tmp_path):
+    """A ref starting with '-' is a git-archive argument-injection vector.
+
+    ``git archive --format=tar -o/path HEAD`` writes an arbitrary file with exit
+    0, so an option-like ref must be rejected before it reaches any subprocess —
+    and must never create a file.
+    """
+    mod = load_helper()
+    git = shutil.which("git") or "git"
+    bad_target = tmp_path / "pwned.tar"
+    bad_ref = f"-o{bad_target}"
+    with pytest.raises(SystemExit) as exc:
+        mod.resolve_ref(git, tmp_path, bad_ref)
+    assert bad_ref in str(exc.value), "error must name the offending ref"
+    assert not bad_target.exists(), "option-like ref must never reach a subprocess"
+
+
+def test_contained_join_rejects_absolute_main_tex(tmp_path):
+    """An absolute --main-tex silently escapes the extracted tree via pathlib '/'."""
+    mod = load_helper()
+    with pytest.raises(SystemExit) as exc:
+        mod.contained_join(tmp_path, "/etc/passwd")
+    assert "absolute" in str(exc.value).lower()
+
+
+def test_contained_join_rejects_traversal_main_tex(tmp_path):
+    """A '..' --main-tex escapes the extracted tree."""
+    mod = load_helper()
+    base = tmp_path / "old"
+    base.mkdir()
+    with pytest.raises(SystemExit) as exc:
+        mod.contained_join(base, "../../../etc/passwd")
+    msg = str(exc.value).lower()
+    assert "escape" in msg or "outside" in msg
+
+
 # --- Real end-to-end (integration + slow) ------------------------------------
+
+
+@pytest.mark.integration
+def test_resolve_ref_resolves_to_full_sha(tmp_path):
+    """A valid ref resolves to a 40-hex-char commit SHA (which can't start '-')."""
+    mod = load_helper()
+    repo = tmp_path / "manuscript"
+    _make_two_ref_repo(repo)
+    git = shutil.which("git")
+    sha = mod.resolve_ref(git, repo, "v1-submitted")
+    assert len(sha) == 40 and all(c in "0123456789abcdef" for c in sha)
+
+
+@pytest.mark.integration
+def test_resolve_ref_bad_ref_errors(tmp_path):
+    mod = load_helper()
+    repo = tmp_path / "manuscript"
+    _make_two_ref_repo(repo)
+    git = shutil.which("git")
+    with pytest.raises(SystemExit) as exc:
+        mod.resolve_ref(git, repo, "no-such-ref")
+    assert "no-such-ref" in str(exc.value)
 
 def _toolchain_present() -> bool:
     return bool(shutil.which("latexdiff")) and bool(

--- a/tests/test_track_changes_pdf.py
+++ b/tests/test_track_changes_pdf.py
@@ -1,0 +1,190 @@
+"""track-changes-pdf renders a revision-marked PDF via latexdiff between refs.
+
+Two layers of coverage:
+
+- **Contract ratchets + toolchain-absent behaviour** (fast tier, no LaTeX):
+  the skill bundles its helper, documents the toolchain and the deferred
+  per-ticket-grouping scope, and the helper degrades with a clear, actionable
+  message when latexdiff or a compiler is missing.
+- **Real end-to-end** (integration + slow): on a synthetic two-ref git repo,
+  the helper runs latexdiff + compile, produces a PDF, and the intermediate
+  diff .tex carries latexdiff markup. Skipped when the toolchain is absent.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO / "skills" / "track-changes-pdf"
+SKILL = SKILL_DIR / "SKILL.md"
+SCRIPT = SKILL_DIR / "track_changes_pdf.py"
+
+
+def load_helper():
+    """Import the bundled helper by path (it is not an installed package)."""
+    spec = importlib.util.spec_from_file_location("track_changes_pdf", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def skill_text() -> str:
+    return SKILL.read_text()
+
+
+# --- Contract ratchets (fast) -------------------------------------------------
+
+def test_bundled_script_exists():
+    assert SCRIPT.exists(), "track-changes-pdf must bundle track_changes_pdf.py"
+
+
+def test_first_sentence_is_searchable():
+    """Discoverability: plain keywords in the opening description sentence."""
+    first = skill_text().split("description:", 1)[1].split("\n", 1)[0].lower()
+    for kw in ("revision-marked", "latexdiff", "git"):
+        assert kw in first, f"first sentence should mention {kw!r}"
+
+
+def test_documents_toolchain_requirements():
+    text = skill_text().lower()
+    assert "latexdiff" in text
+    assert "latexmk" in text or "pdflatex" in text
+
+
+def test_documents_deferred_grouping_scope():
+    text = skill_text().lower()
+    assert "scope" in text and "ticket" in text, (
+        "must record that per-ticket/remark grouping is deferred in v1"
+    )
+
+
+def test_helper_is_pure_io_no_model_calls():
+    src = SCRIPT.read_text()
+    assert "anthropic" not in src.lower(), "helper must make no Anthropic API calls"
+    for flag in ("--repo", "--old-ref", "--new-ref", "--main-tex", "--output"):
+        assert flag in src, f"helper must expose {flag} (no hardcoded paths)"
+
+
+# --- Toolchain-absent degrade path (fast, no LaTeX needed) --------------------
+
+def test_latexdiff_absent_gives_actionable_error(monkeypatch):
+    mod = load_helper()
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    with pytest.raises(SystemExit) as exc:
+        mod.require_latexdiff()
+    msg = str(exc.value)
+    assert "latexdiff not found" in msg
+    assert "install" in msg.lower(), "error must tell the user how to install it"
+
+
+def test_no_compiler_gives_actionable_error(monkeypatch):
+    mod = load_helper()
+    monkeypatch.setattr(mod.shutil, "which", lambda name: None)
+    with pytest.raises(SystemExit) as exc:
+        mod.resolve_compiler()
+    msg = str(exc.value).lower()
+    assert "latexmk" in msg and "pdflatex" in msg
+    assert "install" in msg
+
+
+def test_compiler_prefers_latexmk(monkeypatch):
+    mod = load_helper()
+    monkeypatch.setattr(mod.shutil, "which",
+                        lambda name: f"/usr/bin/{name}" if name in {"latexmk", "pdflatex"} else None)
+    assert mod.resolve_compiler()[0] == "latexmk"
+
+
+# --- Real end-to-end (integration + slow) ------------------------------------
+
+def _toolchain_present() -> bool:
+    return bool(shutil.which("latexdiff")) and bool(
+        shutil.which("latexmk") or shutil.which("pdflatex")
+    )
+
+
+def _make_two_ref_repo(root: Path) -> None:
+    """A tiny LaTeX manuscript committed at two refs, one sentence changed."""
+    def git(*args):
+        subprocess.run(["git", "-C", str(root), *args], check=True,
+                       capture_output=True, text=True)
+
+    root.mkdir(parents=True, exist_ok=True)
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    tex = root / "main.tex"
+    tex.write_text(
+        "\\documentclass{article}\n"
+        "\\begin{document}\n"
+        "The original climate finance estimate was ten billion dollars.\n"
+        "\\end{document}\n"
+    )
+    git("add", "main.tex")
+    git("commit", "-q", "-m", "v1")
+    git("tag", "v1-submitted")
+    tex.write_text(
+        "\\documentclass{article}\n"
+        "\\begin{document}\n"
+        "The revised climate finance estimate was twenty billion dollars.\n"
+        "\\end{document}\n"
+    )
+    git("add", "main.tex")
+    git("commit", "-q", "-m", "v2")
+
+
+@pytest.mark.integration
+def test_extract_ref_pulls_each_refs_content(tmp_path):
+    """Real git-archive plumbing: each ref extracts its own tree (no latexdiff)."""
+    mod = load_helper()
+    repo = tmp_path / "manuscript"
+    _make_two_ref_repo(repo)
+    git = shutil.which("git")
+
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    mod.extract_ref(git, repo, "v1-submitted", old_dir)
+    mod.extract_ref(git, repo, "HEAD", new_dir)
+
+    assert "original" in (old_dir / "main.tex").read_text()
+    assert "twenty billion" in (new_dir / "main.tex").read_text()
+
+
+@pytest.mark.integration
+def test_extract_ref_bad_ref_errors(tmp_path):
+    mod = load_helper()
+    repo = tmp_path / "manuscript"
+    _make_two_ref_repo(repo)
+    git = shutil.which("git")
+    with pytest.raises(SystemExit) as exc:
+        mod.extract_ref(git, repo, "no-such-ref", tmp_path / "out")
+    assert "no-such-ref" in str(exc.value)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_render_end_to_end(tmp_path):
+    if not _toolchain_present():
+        pytest.skip("latexdiff and/or a LaTeX compiler not installed")
+    mod = load_helper()
+    repo = tmp_path / "manuscript"
+    _make_two_ref_repo(repo)
+    workdir = tmp_path / "work"
+    output = tmp_path / "revision-marked.pdf"
+
+    result = mod.render(
+        repo=repo, old_ref="v1-submitted", new_ref="HEAD",
+        main_tex="main.tex", output=output, workdir=workdir,
+    )
+
+    assert result == output.resolve()
+    assert output.exists() and output.stat().st_size > 0, "no PDF produced"
+
+    diff_tex = workdir / "new" / "main-diff.tex"
+    assert diff_tex.exists(), "latexdiff should have written the diff .tex"
+    diff_src = diff_tex.read_text()
+    assert "\\DIFadd" in diff_src, "insertions should be marked with \\DIFadd"
+    assert "\\DIFdel" in diff_src, "deletions should be marked with \\DIFdel"

--- a/tickets/0288-track-changes-pdf-skill.erg
+++ b/tickets/0288-track-changes-pdf-skill.erg
@@ -1,0 +1,77 @@
+%erg 0.1
+Title: track-changes-pdf skill — revision-marked PDF via latexdiff between two refs
+Created: 2026-07-12
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-12T17:22Z claude created
+
+--- body ---
+Child of tracker 0265.
+
+## Context
+Tracker 0265 (R&R intake skill chain) specifies two skills. This is skill 2 of
+2: `track-changes-pdf`. During the 2026-06-18 Oeconomia R&R day a track-changes
+PDF was requested ("do 140 with track-change mode, open it for me to annotate")
+and never delivered — ~14 tool calls were spent assessing feasibility, then the
+work was abandoned because no skill existed.
+
+The repo's review doctrine already names the mechanism: rules/git.md says "the
+review interface for prose is the recompiled PDF and latexdiff between tags".
+This skill mechanizes exactly that — render a revision-marked PDF (insertions
+and deletions highlighted) from a LaTeX manuscript between two git refs, by
+running latexdiff on the refs' sources and then compiling.
+
+## Relevant files
+- `skills/track-changes-pdf/SKILL.md` — the skill entry point.
+- `skills/track-changes-pdf/track_changes_pdf.py` — helper: extract each ref's
+  tree, run latexdiff --flatten, compile the diff .tex to PDF.
+- `skills/external-peer-review/` — sibling precedent for a skill + pure-I/O
+  Python helper with argparse and graceful toolchain degradation.
+- `tests/test_track_changes_pdf.py` — fixture-driven suite.
+- `README.md` — skills catalog, regenerated via `make skills-catalog`.
+
+## Actions
+1. Build the helper: `--repo --old-ref --new-ref --main-tex --output`
+   (argparse, no hardcoded paths). Extract both refs' trees with `git archive`,
+   run `latexdiff --flatten OLD NEW > diff.tex`, compile with latexmk/pdflatex,
+   copy the PDF to `--output`.
+2. Degrade gracefully: if latexdiff or the LaTeX compiler is absent, exit with a
+   clear, actionable install message rather than a stack trace.
+3. Write SKILL.md with a plain, search-findable first sentence and
+   forge-/stack-agnostic prescriptive language.
+4. Regenerate the skills catalog (`make skills-catalog`) and commit README.md.
+5. Tests: a tiny synthetic 2-ref LaTeX repo fixture. Real latexdiff+compile
+   end-to-end when the toolchain is present (integration/slow tier); the
+   toolchain-absent clear-error path in the fast tier.
+
+## Deferred (out of scope for v1)
+- Grouping insertions/deletions by ticket or remark (from tracker 0265) is NOT
+  implemented. latexdiff has no per-remark concept — it diffs two source trees
+  and knows nothing about which ticket authored a change. The future hook is to
+  drive latexdiff per-ticket (one diff per ticket's commit range) and merge the
+  marked outputs, or to tag changes with `\ticket{N}{...}` macros in the source
+  and colour by tag. Recorded here so v1 ships the byte-accurate whole-revision
+  diff first; per-ticket grouping is a follow-up.
+
+## Test
+- Fixture: a temp git repo with a one-sentence LaTeX manuscript, committed at
+  two refs with one sentence changed between them.
+- Toolchain present: run the helper end-to-end, assert the output PDF exists and
+  the intermediate diff .tex carries latexdiff markup (`\DIFadd` / `\DIFdel`).
+  Mark integration (subprocess + compile) / slow.
+- Toolchain absent: force latexdiff missing, assert a clear SystemExit whose
+  message names latexdiff and how to install it. Fast tier, no LaTeX needed.
+
+## Invariants
+- Skill is SKILL.md + a pure-I/O helper; no Anthropic API calls in the helper.
+- Forge-/stack-agnostic skill text (no hardcoded `gh`, no absolute home paths);
+  `make check-agnostic-skills` stays clean.
+- `make check-skills-drift` clean after catalog regeneration.
+- Description first sentence is unthemed (`tests/test_skill_descriptions.py`).
+
+## Exit criteria
+- `skills/track-changes-pdf/` exists (SKILL.md + helper), catalogued in
+  README.md, with a passing fixture-driven test suite.
+- `make check` passes; `tickets/erg validate` accepts this ticket.
+- Per-ticket grouping is recorded as deferred, not silently dropped.

--- a/tickets/closed/0288-track-changes-pdf-skill.erg
+++ b/tickets/closed/0288-track-changes-pdf-skill.erg
@@ -2,10 +2,12 @@
 Title: track-changes-pdf skill — revision-marked PDF via latexdiff between two refs
 Created: 2026-07-12
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #504
 
 --- log ---
 2026-07-12T17:22Z claude created
 
+2026-07-12T18:37Z Minh Ha-Duong closed — autoclosed — PR #504
 --- body ---
 Child of tracker 0265.
 


### PR DESCRIPTION
## Summary

Adds the `track-changes-pdf` skill — skill 2 of tracker 0265's R&R intake chain. It renders a revision-marked PDF (insertions/deletions highlighted) of a LaTeX manuscript between two git refs, by running `latexdiff --flatten` on the refs' extracted sources and compiling. This mechanizes the repo's existing review doctrine (rules/git.md: "the review interface for prose is the recompiled PDF and latexdiff between tags").

A track-changes PDF was requested during the 2026-06-18 Oeconomia R&R day and never delivered because no skill existed (~14 tool calls spent assessing feasibility, then abandoned).

## What's included
- `skills/track-changes-pdf/SKILL.md` — plain, search-findable first sentence; forge-/stack-agnostic prescriptive language.
- `skills/track-changes-pdf/track_changes_pdf.py` — pure-I/O helper: `--repo --old-ref --new-ref --main-tex --output` (argparse, no hardcoded paths). Extracts each ref's whole tree via `git archive`, runs `latexdiff --flatten` (so multi-file `\input` manuscripts diff correctly), compiles with `latexmk` (pdflatex fallback). Missing `latexdiff` or compiler exits with an actionable install message, not a stack trace.
- `tests/test_track_changes_pdf.py` — synthetic two-ref LaTeX repo fixture. Fast tier: toolchain-absent clear-error path + documented contract. Integration tier: real git-archive plumbing. The full latexdiff+compile end-to-end is integration+slow and skips when the toolchain is absent.
- `README.md` — skills catalog regenerated (`make skills-catalog`).

## Deferred (v1 scope)
Grouping changes by ticket/remark (from tracker 0265) is out of scope: latexdiff has no per-remark concept. Recorded in SKILL.md and ticket 0288; the future hook (per-ticket commit-range diffs, or `\ticket{}` source tags) is noted.

## Verification
- `make check` passes: 695 passed, 1 skipped (the latexdiff end-to-end, correctly skipped — latexdiff is not installed on this host; pdflatex/latexmk are).
- `check-skills-drift`, `check-agnostic-skills`, description tests all clean.

**Ticket:** tickets/0288-track-changes-pdf-skill.erg
**Ticket-ref:** tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)