### PR TITLE
trace-stats: six-way tool taxonomy with per-category char volume (0292)

### DIFF
--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -11,6 +11,11 @@ multiple JSONL rows — one per content block — each repeating the same
 harness-injected and carry no API cost: excluded from $ and token sums,
 counted in `synthetic_messages`.
 
+Ticket 0292: each tool call is also placed in a six-way category (execution,
+reading, navigation, search, writing, other; arXiv:2604.21965 §5.2, App. B.2),
+with per-category call count and per-category tool_result char volume reported
+as `cat_<category>_calls` / `cat_<category>_chars` columns.
+
 Emits JSON summary: {window, files, sessions, totals, skipped_lines, rollup}
 """
 
@@ -60,6 +65,19 @@ PRICING = {
 }
 
 WRITE_TOOLS = {"Edit", "Write", "NotebookEdit"}
+
+# Ticket 0292: six-way tool-call taxonomy (arXiv:2604.21965 §5.2, App. B.2),
+# mapped onto this harness's tool set. Categories are disjoint and total.
+TOOL_CATEGORIES = ("execution", "reading", "navigation", "search", "writing", "other")
+READ_TOOLS = {"Read", "NotebookRead", "WebFetch"}
+SEARCH_TOOLS = {"Grep", "Glob", "WebSearch", "ToolSearch"}
+NAV_TOOLS = {"EnterWorktree", "ExitWorktree"}
+# Bash read-vs-execute rule: classify a Bash call by its leading command token.
+# A known read-only content reader is reading; a known search/filter tool is
+# search; an orientation command (cd/ls/pwd, git status|log|branch) is
+# navigation (see NAV_COMMAND_RE); everything else is execution.
+BASH_READ_RE = re.compile(r"^\s*(?:cat|head|tail|less|more|bat)\b")
+BASH_SEARCH_RE = re.compile(r"^\s*(?:grep|egrep|fgrep|rg|ag|ack|find|fd)\b")
 
 # Built-in CLI commands that appear as <command-name> but are not entry skills.
 BUILTIN_COMMANDS = {
@@ -116,8 +134,34 @@ MANDATED_SKILLS = {"roar", "lair", "dream", "molt", "memory", "housekeeping"}
 PATH_TOOLS = {"Read", "Edit", "Write", "NotebookEdit"}
 
 
+def categorize_tool(name: str, tool_input: dict) -> str:
+    """Six-way tool-call category: execution, reading, navigation, search,
+    writing, other (ticket 0292). Total over every tool the harness emits."""
+    if name == "Bash":
+        cmd = str(tool_input.get("command", ""))
+        if NAV_COMMAND_RE.search(cmd):
+            return "navigation"
+        if BASH_READ_RE.search(cmd):
+            return "reading"
+        if BASH_SEARCH_RE.search(cmd):
+            return "search"
+        return "execution"
+    if name in READ_TOOLS:
+        return "reading"
+    if name in SEARCH_TOOLS:
+        return "search"
+    if name in WRITE_TOOLS:
+        return "writing"
+    if name in NAV_TOOLS:
+        return "navigation"
+    return "other"
+
+
 def _is_nav_tool(name: str, tool_input: dict) -> bool:
-    return name == "Bash" and bool(NAV_COMMAND_RE.search(str(tool_input.get("command", ""))))
+    # Bash-only navigation, expressed via the six-way classifier so the two
+    # never drift (categorize_tool maps a Bash orientation command to
+    # "navigation" iff NAV_COMMAND_RE matches — the pre-0292 contract).
+    return name == "Bash" and categorize_tool(name, tool_input) == "navigation"
 
 
 def _is_mandated_tool(name: str, tool_input: dict) -> bool:
@@ -187,6 +231,9 @@ def parse_trace_file(path: Path) -> dict:
     total_lines = 0
     models: Counter = Counter()
     tool_counts: Counter = Counter()
+    category_calls: Counter = Counter()  # ticket 0292: six-way category counts
+    category_chars: Counter = Counter()  # per-category tool_result char volume
+    tool_use_category: dict[str, str] = {}  # block_id -> category, for the join
     read_paths: Counter = Counter()
     bash_commands: Counter = Counter()
     ask_user = 0
@@ -269,6 +316,10 @@ def parse_trace_file(path: Path) -> dict:
                         name = block.get("name", "?")
                         tool_counts[name] += 1
                         tool_input = block.get("input") or {}
+                        category = categorize_tool(name, tool_input)
+                        category_calls[category] += 1
+                        if block_id:
+                            tool_use_category[block_id] = category
                         turn_idx = msg_turn_index.get(msg.get("id") or "")
                         if turn_idx is not None:
                             turn_tool_kinds[turn_idx].append(
@@ -299,6 +350,11 @@ def parse_trace_file(path: Path) -> dict:
                             except (TypeError, ValueError):
                                 continue
                             tool_result_bytes += len(result_text)
+                            # Ticket 0292: charge these chars to the category of
+                            # the tool_use that produced them; unmatched results
+                            # fall to "other" so the buckets partition the total.
+                            cat = tool_use_category.get(block.get("tool_use_id"), "other")
+                            category_chars[cat] += len(result_text)
                             if MERGE_MARKER_RE.search(result_text):
                                 if merge_marker_turn is None:
                                     merge_marker_turn = len(turn_tool_kinds)
@@ -368,6 +424,8 @@ def parse_trace_file(path: Path) -> dict:
         "total_lines": total_lines,
         "models": models,
         "tool_counts": tool_counts,
+        "category_calls": category_calls,
+        "category_chars": category_chars,
         "tool_result_bytes": tool_result_bytes,
         "max_read_repeat": max(read_paths.values(), default=0),
         "max_bash_repeat": max(bash_commands.values(), default=0),
@@ -410,6 +468,7 @@ CSV_COLUMNS = [
     "total_lines",
     "tool_histogram",
     "tool_result_bytes",
+    *[f"cat_{c}_{m}" for c in TOOL_CATEGORIES for m in ("calls", "chars")],
     "max_read_repeat",
     "max_bash_repeat",
     "read_only",
@@ -438,7 +497,14 @@ CSV_COLUMNS = [
 
 def build_row(project: str, session_id: str, agent_id: str, path: Path, stats: dict) -> dict:
     dominant_model = stats["models"].most_common(1)
+    category_cols = {
+        f"cat_{c}_calls": stats["category_calls"].get(c, 0) for c in TOOL_CATEGORIES
+    }
+    category_cols.update(
+        {f"cat_{c}_chars": stats["category_chars"].get(c, 0) for c in TOOL_CATEGORIES}
+    )
     return {
+        **category_cols,
         "project": project,
         "session_id": session_id,
         "agent_id": agent_id,

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -323,7 +323,9 @@ def parse_trace_file(path: Path) -> dict:
                         turn_idx = msg_turn_index.get(msg.get("id") or "")
                         if turn_idx is not None:
                             turn_tool_kinds[turn_idx].append(
-                                "nav" if _is_nav_tool(name, tool_input) else "work"
+                                "nav"
+                                if name == "Bash" and category == "navigation"
+                                else "work"
                             )
                             if _is_mandated_tool(name, tool_input):
                                 turn_mandated[turn_idx] = True
@@ -498,11 +500,10 @@ CSV_COLUMNS = [
 def build_row(project: str, session_id: str, agent_id: str, path: Path, stats: dict) -> dict:
     dominant_model = stats["models"].most_common(1)
     category_cols = {
-        f"cat_{c}_calls": stats["category_calls"].get(c, 0) for c in TOOL_CATEGORIES
+        f"cat_{c}_{m}": stats[f"category_{m}"].get(c, 0)
+        for c in TOOL_CATEGORIES
+        for m in ("calls", "chars")
     }
-    category_cols.update(
-        {f"cat_{c}_chars": stats["category_chars"].get(c, 0) for c in TOOL_CATEGORIES}
-    )
     return {
         **category_cols,
         "project": project,

--- a/scripts/trace-stats.py
+++ b/scripts/trace-stats.py
@@ -76,8 +76,8 @@ NAV_TOOLS = {"EnterWorktree", "ExitWorktree"}
 # A known read-only content reader is reading; a known search/filter tool is
 # search; an orientation command (cd/ls/pwd, git status|log|branch) is
 # navigation (see NAV_COMMAND_RE); everything else is execution.
-BASH_READ_RE = re.compile(r"^\s*(?:cat|head|tail|less|more|bat)\b")
-BASH_SEARCH_RE = re.compile(r"^\s*(?:grep|egrep|fgrep|rg|ag|ack|find|fd)\b")
+BASH_READ_RE = re.compile(r"^\s*(?:cat|head|tail|less|more|bat)(?=\s|$|[;&|])")
+BASH_SEARCH_RE = re.compile(r"^\s*(?:grep|egrep|fgrep|rg|ag|ack|find|fd)(?=\s|$|[;&|])")
 
 # Built-in CLI commands that appear as <command-name> but are not entry skills.
 BUILTIN_COMMANDS = {

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -454,6 +454,24 @@ def test_categorize_bash_ambiguous_read_vs_execute():
     assert ts.categorize_tool("Bash", {"command": "ls -la"}) == "navigation"
 
 
+def test_categorize_bash_hyphen_boundary_not_a_reader():
+    """A distinct binary that merely shares a reader/searcher prefix up to a
+    hyphen or word char is execution, not reading/search (ticket 0292 gate
+    round 1: \\b fires at the t->- transition, leaking cat-fetch-tool as a
+    reader and find-orphans.sh as a searcher)."""
+    # hyphen boundary: single distinct binaries, not cat/find
+    assert ts.categorize_tool("Bash", {"command": "cat-fetch-tool foo"}) == "execution"
+    assert ts.categorize_tool("Bash", {"command": "find-orphans.sh"}) == "execution"
+    # word-char boundary: catfoo / finder are not cat / find
+    assert ts.categorize_tool("Bash", {"command": "catfoo"}) == "execution"
+    assert ts.categorize_tool("Bash", {"command": "finder x"}) == "execution"
+    # legitimate cases still classify correctly
+    assert ts.categorize_tool("Bash", {"command": "cat foo.py"}) == "reading"
+    assert ts.categorize_tool("Bash", {"command": "grep -n x y"}) == "search"
+    assert ts.categorize_tool("Bash", {"command": "find"}) == "search"
+    assert ts.categorize_tool("Bash", {"command": "find; ls"}) == "search"
+
+
 def test_is_nav_tool_unchanged_by_six_way():
     # regression: _is_nav_tool keeps its exact contract
     assert ts._is_nav_tool("Bash", {"command": "cd /tmp"}) is True

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -403,3 +403,142 @@ def test_bucket_csv_columns_declared():
         "pr_numbers",
     ):
         assert col in ts.CSV_COLUMNS, f"missing CSV column {col}"
+
+
+# --- ticket 0292: six-way tool-call taxonomy + per-category char volume ---
+#
+# Categories (arXiv:2604.21965 §5.2, App. B.2 applied to this harness):
+# execution, reading, navigation, search, writing, other.
+# Bash read-vs-execute rule: a Bash call is classified by its leading command
+# token — a known read-only reader (cat/head/tail/less/more/bat) is reading, a
+# known search tool (grep/rg/find/fd/ag/ack) is search, an orientation command
+# (cd/ls/pwd, git status|log|branch|show-current — the pre-existing nav set) is
+# navigation, and everything else is execution. `ls` stays navigation to keep
+# _is_nav_tool byte-identical (documented, defensible: ls is directory
+# orientation, not content reading).
+
+
+def _result_for(tool_use_id, text):
+    return {
+        "type": "user",
+        "timestamp": "2026-06-09T10:02:00.000Z",
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": tool_use_id, "content": text}
+            ],
+        },
+    }
+
+
+def test_categorize_tool_one_per_category():
+    c = ts.categorize_tool
+    # execution
+    assert c("Bash", {"command": "uv run pytest -q"}) == "execution"
+    # reading
+    assert c("Read", {"file_path": "/a.md"}) == "reading"
+    assert c("Bash", {"command": "cat /etc/hosts"}) == "reading"
+    # navigation
+    assert c("Bash", {"command": "cd /tmp"}) == "navigation"
+    assert c("Bash", {"command": "git status"}) == "navigation"
+    assert c("EnterWorktree", {}) == "navigation"
+    # search
+    assert c("Grep", {"pattern": "foo"}) == "search"
+    assert c("Glob", {"pattern": "*.py"}) == "search"
+    assert c("Bash", {"command": "grep -r foo ."}) == "search"
+    assert c("WebSearch", {"query": "x"}) == "search"
+    # writing
+    assert c("Edit", {"file_path": "/a.py"}) == "writing"
+    assert c("Write", {"file_path": "/a.py"}) == "writing"
+    assert c("NotebookEdit", {"notebook_path": "/a.ipynb"}) == "writing"
+    # other
+    assert c("Skill", {"skill": "roar"}) == "other"
+    assert c("AskUserQuestion", {}) == "other"
+    assert c("TodoWrite", {}) == "other"
+
+
+def test_categorize_bash_ambiguous_read_vs_execute():
+    """Pins the documented Bash rule: a read-only command prefix is reading,
+    otherwise the Bash call is execution. `ls` stays navigation."""
+    assert ts.categorize_tool("Bash", {"command": "cat report.md"}) == "reading"
+    assert ts.categorize_tool("Bash", {"command": "python deploy.py"}) == "execution"
+    assert ts.categorize_tool("Bash", {"command": "ls -la"}) == "navigation"
+
+
+def test_is_nav_tool_unchanged_by_six_way():
+    # regression: _is_nav_tool keeps its exact contract
+    assert ts._is_nav_tool("Bash", {"command": "cd /tmp"}) is True
+    assert ts._is_nav_tool("Bash", {"command": "git status"}) is True
+    assert ts._is_nav_tool("Bash", {"command": "uv run pytest"}) is False
+    # non-Bash navigation tools are NOT nav_tool (Bash-only contract preserved)
+    assert ts._is_nav_tool("EnterWorktree", {}) is False
+
+
+def test_category_call_counts(tmp_path):
+    read_use = {"type": "tool_use", "id": "tu_r", "name": "Read", "input": {"file_path": "/a"}}
+    exec_use = {
+        "type": "tool_use",
+        "id": "tu_e",
+        "name": "Bash",
+        "input": {"command": "uv run pytest"},
+    }
+    search_use = {"type": "tool_use", "id": "tu_s", "name": "Grep", "input": {"pattern": "x"}}
+    rows = [
+        _assistant_row("m1", "claude-opus-4-8", USAGE, read_use),
+        _assistant_row("m2", "claude-opus-4-8", USAGE, exec_use),
+        _assistant_row("m3", "claude-opus-4-8", USAGE, search_use),
+    ]
+    stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
+    assert stats["category_calls"]["reading"] == 1
+    assert stats["category_calls"]["execution"] == 1
+    assert stats["category_calls"]["search"] == 1
+
+
+def test_category_char_volume_joins_result_to_tooluse(tmp_path):
+    read_use = {"type": "tool_use", "id": "tu_r", "name": "Read", "input": {"file_path": "/a"}}
+    exec_use = {
+        "type": "tool_use",
+        "id": "tu_e",
+        "name": "Bash",
+        "input": {"command": "uv run pytest"},
+    }
+    rows = [
+        _assistant_row("m1", "claude-opus-4-8", USAGE, read_use),
+        _result_for("tu_r", "READCONTENT"),
+        _assistant_row("m2", "claude-opus-4-8", USAGE, exec_use),
+        _result_for("tu_e", "EXEC-OUTPUT-IS-LONGER"),
+    ]
+    stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
+    assert stats["category_chars"]["reading"] == len(json.dumps("READCONTENT"))
+    assert stats["category_chars"]["execution"] == len(json.dumps("EXEC-OUTPUT-IS-LONGER"))
+    # invariant: per-category char volumes partition tool_result_bytes
+    assert sum(stats["category_chars"].values()) == stats["tool_result_bytes"]
+
+
+def test_unmatched_result_charged_to_other(tmp_path):
+    """A tool_result whose tool_use_id matches no tool_use lands in 'other',
+    preserving the sum(category_chars) == tool_result_bytes invariant."""
+    rows = [_result_for("no_such_id", "ORPHAN")]
+    stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
+    assert stats["category_chars"]["other"] == len(json.dumps("ORPHAN"))
+    assert sum(stats["category_chars"].values()) == stats["tool_result_bytes"]
+
+
+def test_category_csv_columns_declared():
+    for cat in ("execution", "reading", "navigation", "search", "writing", "other"):
+        for metric in ("calls", "chars"):
+            col = f"cat_{cat}_{metric}"
+            assert col in ts.CSV_COLUMNS, f"missing CSV column {col}"
+
+
+def test_category_columns_populated_in_row(tmp_path):
+    read_use = {"type": "tool_use", "id": "tu_r", "name": "Read", "input": {"file_path": "/a"}}
+    rows = [
+        _assistant_row("m1", "claude-opus-4-8", USAGE, read_use),
+        _result_for("tu_r", "HELLO"),
+    ]
+    stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
+    row = ts.build_row("proj", "sess", "main", Path("/x.jsonl"), stats)
+    assert row["cat_reading_calls"] == 1
+    assert row["cat_reading_chars"] == len(json.dumps("HELLO"))
+    assert row["cat_execution_calls"] == 0

--- a/tests/test_trace_stats.py
+++ b/tests/test_trace_stats.py
@@ -188,13 +188,15 @@ def _tool_row(msg_id, name, tool_input, ts_str="2026-06-09T10:00:00.000Z"):
     return _assistant_row(msg_id, "claude-opus-4-8", USAGE, block, ts_str=ts_str)
 
 
-def _result_row(text):
+def _result_row(text, tool_use_id="x"):
     return {
         "type": "user",
         "timestamp": "2026-06-09T10:02:00.000Z",
         "message": {
             "role": "user",
-            "content": [{"type": "tool_result", "tool_use_id": "x", "content": text}],
+            "content": [
+                {"type": "tool_result", "tool_use_id": tool_use_id, "content": text}
+            ],
         },
     }
 
@@ -418,19 +420,6 @@ def test_bucket_csv_columns_declared():
 # orientation, not content reading).
 
 
-def _result_for(tool_use_id, text):
-    return {
-        "type": "user",
-        "timestamp": "2026-06-09T10:02:00.000Z",
-        "message": {
-            "role": "user",
-            "content": [
-                {"type": "tool_result", "tool_use_id": tool_use_id, "content": text}
-            ],
-        },
-    }
-
-
 def test_categorize_tool_one_per_category():
     c = ts.categorize_tool
     # execution
@@ -504,9 +493,9 @@ def test_category_char_volume_joins_result_to_tooluse(tmp_path):
     }
     rows = [
         _assistant_row("m1", "claude-opus-4-8", USAGE, read_use),
-        _result_for("tu_r", "READCONTENT"),
+        _result_row("READCONTENT", "tu_r"),
         _assistant_row("m2", "claude-opus-4-8", USAGE, exec_use),
-        _result_for("tu_e", "EXEC-OUTPUT-IS-LONGER"),
+        _result_row("EXEC-OUTPUT-IS-LONGER", "tu_e"),
     ]
     stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
     assert stats["category_chars"]["reading"] == len(json.dumps("READCONTENT"))
@@ -518,7 +507,7 @@ def test_category_char_volume_joins_result_to_tooluse(tmp_path):
 def test_unmatched_result_charged_to_other(tmp_path):
     """A tool_result whose tool_use_id matches no tool_use lands in 'other',
     preserving the sum(category_chars) == tool_result_bytes invariant."""
-    rows = [_result_for("no_such_id", "ORPHAN")]
+    rows = [_result_row("ORPHAN", "no_such_id")]
     stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
     assert stats["category_chars"]["other"] == len(json.dumps("ORPHAN"))
     assert sum(stats["category_chars"].values()) == stats["tool_result_bytes"]
@@ -535,7 +524,7 @@ def test_category_columns_populated_in_row(tmp_path):
     read_use = {"type": "tool_use", "id": "tu_r", "name": "Read", "input": {"file_path": "/a"}}
     rows = [
         _assistant_row("m1", "claude-opus-4-8", USAGE, read_use),
-        _result_for("tu_r", "HELLO"),
+        _result_row("HELLO", "tu_r"),
     ]
     stats = ts.parse_trace_file(_write_rows(tmp_path, rows))
     row = ts.build_row("proj", "sess", "main", Path("/x.jsonl"), stats)

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -121,6 +121,8 @@ Children:
 - 0244 — phase 4 counterfactual accounting (closed)
 - 0245 — phase 5 targeted A/B: model right-sizing of long mains +
   verification convergence, quality-guarded
+- 0292 — six-way tool-call taxonomy + per-category char volume for
+  trace-stats (from the 0266 pillage manifest, technique 5)
 
 Not owned by any child (integration-review checklist):
 - `trace-doctor` skill assembly (the tracker's deliverable)
@@ -136,7 +138,3 @@ Not owned by any child (integration-review checklist):
 - [ ] At least one cost-saving measure validated (phase 3 or 4) and
       either adopted in a skill/prompt or explicitly rejected with
       measured evidence
-
-## Child (2026-07-12)
-
-- 0292 six-way tool-call taxonomy + per-category char volume for trace-stats (from the 0266 pillage manifest, technique 5)

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -11,6 +11,7 @@ Author: claude
 2026-06-10T15:23Z claude note phase 3 complete (0243, PR #374) — report docs/trace-hypotheses-2026-06.md: 13/13 hypotheses resolved, ranked $/week list; H4/H5/quality routed to phase 4; phase 4-5 filing unblocked
 2026-06-10T16:40Z claude note 0244 executed: addressable $2356/28d exact; H10 confound confirmed (~4x); H12/H5 dissolved; phase-5 shortlist fixed
 2026-06-10T20:09Z claude note 0245 filed (phase 5 A/B); remaining beyond children: trace-doctor skill assembly + phase-4 adopt items #1/#3
+2026-07-12T22:31Z child 0292 delivered: six-way tool taxonomy + per-category char volume in scripts/trace-stats.py (PR pending)
 --- body ---
 ## Context
 

--- a/tickets/0292-trace-stats-six-way-tool-taxonomy.erg
+++ b/tickets/0292-trace-stats-six-way-tool-taxonomy.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-12T18:55Z claude created
 
+2026-07-12T22:31Z impl landed: categorize_tool six-way + per-category calls/chars columns; tests RED->GREEN, make check green
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 5); serves

--- a/tickets/closed/0292-trace-stats-six-way-tool-taxonomy.erg
+++ b/tickets/closed/0292-trace-stats-six-way-tool-taxonomy.erg
@@ -2,11 +2,13 @@
 Title: trace-stats: six-way tool-call taxonomy with per-category char volume
 Created: 2026-07-12
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #506
 
 --- log ---
 2026-07-12T18:55Z claude created
 
 2026-07-12T22:31Z impl landed: categorize_tool six-way + per-category calls/chars columns; tests RED->GREEN, make check green
+2026-07-12T22:57Z Minh Ha-Duong closed — autoclosed — PR #506
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 5); serves


### PR DESCRIPTION
## What

Extends `scripts/trace-stats.py` (the trace-doctor census, tracker 0236)
with a six-way tool-call taxonomy and per-category character volume, per
the paper's taxonomy (arXiv:2604.21965 §5.2, App. B.2) applied to this
harness's tool set.

- New `categorize_tool(name, input)` -> one of execution, reading,
  navigation, search, writing, other. Disjoint and total.
- Bash read-vs-execute rule: classify by the leading command token — a
  read-only reader (`cat`/`head`/`tail`/`less`/`more`/`bat`) is reading,
  a search tool (`grep`/`rg`/`find`/`fd`/`ag`/`ack`) is search, the
  pre-existing orientation set (`cd`/`ls`/`pwd`, `git status|log|branch|
  show-current`) is navigation, everything else is execution. `ls` stays
  navigation to keep `_is_nav_tool` byte-identical.
- `_is_nav_tool` is re-expressed via `categorize_tool` so the 0243
  binary classifier and the six-way one cannot drift; its Bash-only
  contract is preserved (regression-tested).
- Per-category call count and per-category `tool_result` char volume,
  joined result->tool_use by `tool_use_id` (unmatched -> "other", so the
  buckets partition `tool_result_bytes`). Reported as
  `cat_<category>_{calls,chars}` CSV columns on the existing
  project/session/agent row key.

## Test

Tests written first (RED, 5 failing -> GREEN): one assertion per
category, the ambiguous Bash read-vs-execute case pinned to the
documented rule, the char-volume result->tool_use join, and the
`sum(category_chars) == tool_result_bytes` partition invariant. Full
`make check` passes; verified end-to-end on the live 28-day corpus (393
rows, partition invariant holds on real data).

**Ticket:** tickets/0292-trace-stats-six-way-tool-taxonomy.erg
Ticket-ref: tickets/0236-trace-doctor-session-trace-economics-aud.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)