### PR TITLE
ticket(0265): close R&R intake tracker — latexdiff verified live

### DIFF
--- a/tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg
+++ b/tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg
@@ -6,7 +6,9 @@ Author: minh
 --- log ---
 2026-06-18T13:46Z minh created
 
-2026-07-12T18:08Z note child 0287 (ingest-decision-letter) landed2026-07-12T20:55Z claude note integration review (both children merged): 0287 PR #503 and 0288 PR #504 landed gaze-APPROVED; merged-main suite 724 passed; live fixture chain verified by the supervisor — archive -> segment (3+3) -> dedupe (6->5+1 atomic) -> coverage (uncovered remark + orphan ticket flagged, exit 1; clean map exit 0). Tracker stays open: the exit criterion's final link (track-changes PDF render) is blocked on latexdiff, absent on doudou — install texlive-extra-utils or run at the next real R&R to close.
+2026-07-12T18:08Z claude note child 0287 (ingest-decision-letter) landed
+2026-07-12T20:55Z claude note integration review (both children merged): 0287 PR #503 and 0288 PR #504 landed gaze-APPROVED; merged-main suite 724 passed; live fixture chain verified by the supervisor — archive -> segment (3+3) -> dedupe (6->5+1 atomic) -> coverage (uncovered remark + orphan ticket flagged, exit 1; clean map exit 0). Tracker stays open: the exit criterion's final link (track-changes PDF render) is blocked on latexdiff, absent on doudou — install texlive-extra-utils or run at the next real R&R to close.
+2026-07-13T06:51Z claude note latexdiff unblocked: on this distro latexdiff is its own package, split out of texlive-extra-utils; author installed latexdiff 1.3.2. test_render_end_to_end now runs live (git archive -> latexdiff -> compiled PDF, no skip) and passes, 16/16 in the module — the final exit-criterion link is verified on doudou. Tracker ready to close.
 
 --- body ---
 ## Context

--- a/tickets/closed/0265-r-r-intake-skill-chain-ingest-decision-l.erg
+++ b/tickets/closed/0265-r-r-intake-skill-chain-ingest-decision-l.erg
@@ -2,6 +2,7 @@
 Title: R&R intake skill chain: ingest-decision-letter + track-changes-pdf
 Created: 2026-06-18
 Author: minh
+Closed: autoclosed — PR #508
 
 --- log ---
 2026-06-18T13:46Z minh created
@@ -10,6 +11,7 @@ Author: minh
 2026-07-12T20:55Z claude note integration review (both children merged): 0287 PR #503 and 0288 PR #504 landed gaze-APPROVED; merged-main suite 724 passed; live fixture chain verified by the supervisor — archive -> segment (3+3) -> dedupe (6->5+1 atomic) -> coverage (uncovered remark + orphan ticket flagged, exit 1; clean map exit 0). Tracker stays open: the exit criterion's final link (track-changes PDF render) is blocked on latexdiff, absent on doudou — install texlive-extra-utils or run at the next real R&R to close.
 2026-07-13T06:51Z claude note latexdiff unblocked: on this distro latexdiff is its own package, split out of texlive-extra-utils; author installed latexdiff 1.3.2. test_render_end_to_end now runs live (git archive -> latexdiff -> compiled PDF, no skip) and passes, 16/16 in the module — the final exit-criterion link is verified on doudou. Tracker ready to close.
 
+2026-07-13T06:56Z Minh Ha-Duong closed — autoclosed — PR #508
 --- body ---
 ## Context
 A full day (2026-06-18, ~12 sessions on the Oeconomia — Climate finance


### PR DESCRIPTION
**Ticket:** tickets/0265-r-r-intake-skill-chain-ingest-decision-l.erg

Closes the 0265 tracking ticket. Both children merged gaze-APPROVED (0287 PR #503, 0288 PR #504), the integration review was recorded on 2026-07-12, and the sole remaining exit-criterion link — a live track-changes PDF render — is now verified: the author installed latexdiff 1.3.2 (packaged separately from texlive-extra-utils on this distro), and `test_render_end_to_end` runs the real git-archive → latexdiff → compiled-PDF path and passes (16/16 in the module).

This PR only appends the verification note to the ticket log (and unjams two concatenated log lines); `erg-pr-merge` closes and archives the ticket at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)