### PR TITLE
ticket(0290): close wontfix — hardcoded-literal detector targets a defect our suites don't have

### DIFF
--- a/tickets/0290-hardcoded-output-literal-detector.erg
+++ b/tickets/0290-hardcoded-output-literal-detector.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-12T18:55Z claude created
 
+2026-07-13T07:01Z claude note wontfix evidence: inventoried both live suites (IDH tests/ 54 files, chemin-de-voix 33 files) for asserted-literal-without-derivation; zero HARDCODED instances found
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 2).
@@ -26,6 +27,21 @@ mechanically.
 2. Decide the home — a test-audit-llm lens vs a maw-audit pre-pass; prefer
    mechanical-first per the harness invariant; document the choice.
 3. Known-bad fixture (hardcoded expected value, no computation) as anchor.
+
+## Resolution — wontfix, not a real issue here
+
+Empirical inventory (2026-07-13) of both live test suites found zero
+instances of the target defect. IDH tests/ (54 files, ~13k lines): 0
+HARDCODED, 1 borderline mirror (test_trace_compact_audit.py), 1 golden
+ratchet with documented regeneration path. chemin-de-voix tests/ (33
+files, 146 literal-assert hits read): 0 HARDCODED — near-misses were
+documented canaries (test_voice_count.py) or deliberate threshold
+assertions on real data. Both suites already practice the antidotes:
+inline eyeball-able fixtures, expected values derived from live config,
+thresholds instead of pasted metrics. A detector would remediate a
+defect class these codebases do not exhibit; the paper's context
+(gating freshly LLM-generated tests) is a different, smaller tool to be
+ticketed if agent-written tests ever show the smell.
 
 ## Exit criteria
 

--- a/tickets/closed/0290-hardcoded-output-literal-detector.erg
+++ b/tickets/closed/0290-hardcoded-output-literal-detector.erg
@@ -2,11 +2,13 @@
 Title: Hardcoded-output-literal detector for the test-quality audit surface
 Created: 2026-07-12
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #514
 
 --- log ---
 2026-07-12T18:55Z claude created
 
 2026-07-13T07:01Z claude note wontfix evidence: inventoried both live suites (IDH tests/ 54 files, chemin-de-voix 33 files) for asserted-literal-without-derivation; zero HARDCODED instances found
+2026-07-13T07:56Z Minh Ha-Duong closed — autoclosed — PR #514
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 2).


### PR DESCRIPTION
**Ticket:** tickets/0290-hardcoded-output-literal-detector.erg

Closes 0290 as wontfix. Empirical inventory (2026-07-13) of both live test suites — IDH tests/ (54 files) and chemin-de-voix tests/ (33 files, 146 literal-assert hits read) — found **zero** instances of the hardcoded-expected-output defect the detector would hunt. Both suites already practice the antidotes: eyeball-able inline fixtures, expected values derived from live config at test time, threshold assertions on real data, documented canaries.

The ticket body records the evidence and the one honest narrower reframing (a gate on freshly agent-generated tests) for future re-filing if the smell ever appears. Parent tracker 0266 stays open per the tracking-ticket convention.

erg-pr-merge closes and archives the ticket at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)