### PR TITLE
ticket(0267): deny EnterWorktree from a parked (git-ignored) base cwd

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -43,6 +43,8 @@ For everything else (source code, data files): if `git branch --show-current` is
 
 The same trap exists on the Bash surface: prefixing a command with `cd <primary-repo-root> &&` silently lands `git`/`erg` mutations on the primary checkout (on main) instead of the worktree branch. A PreToolUse guard blocks `cd <primary-repo-root> && <mutating git/erg>` during worktree sessions; read-only inspection (`git status`, `git log`) is not penalised, and an intentional primary-repo mutation should use `git -C <path>` rather than a `cd`.
 
+**Parked-cwd trap: `EnterWorktree` resolves the repo from the session base cwd.** `EnterWorktree` (and cwd-dependent skills) target the repo enclosing the *session base cwd* — never wherever the last `cd` landed, since a `cd` inside a Bash call resets after that call. If the base cwd is parked off-project (e.g. left at `~/.claude/projects` by an earlier step or an `ExitWorktree`), the worktree is silently created in the nearest enclosing repo — on 2026-06-19 this put a project worktree inside the harness repo. A PreToolUse guard (`scripts/guard-enterworktree-parked-cwd.sh`) denies `EnterWorktree` when the base cwd sits in a git-ignored runtime directory. After any `EnterWorktree`, run the ownership check: `basename "$(git rev-parse --show-toplevel)"` must match the expected worktree/project name. If the resolved repo is wrong, fall back to manual isolation in the correct repo — `git -C <project> worktree add <project>/.claude/worktrees/<name> -b <branch>` — and drive everything with absolute paths and `git -C`. See ticket 0267.
+
 # Escalation Protocol
 
 When stuck, escalate progressively:

--- a/scripts/guard-enterworktree-parked-cwd.sh
+++ b/scripts/guard-enterworktree-parked-cwd.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+# PreToolUse hook: deny EnterWorktree when the session base cwd is parked in a
+# git-ignored runtime directory (e.g. ~/.claude/projects, ~/.claude/jobs) —
+# EnterWorktree resolves the target repo from the session base cwd, so a parked
+# cwd silently creates the worktree in the nearest enclosing repo, not the
+# intended project. Exit 0 = allow, Exit 2 = deny. See ticket 0267.
+#
+# A `cd` inside a Bash call never moves the session base cwd — it resets after
+# every call — so the only reliable signal is the .cwd field of the hook JSON.
+
+input=$(cat)
+
+command -v jq &>/dev/null || exit 0
+command -v git &>/dev/null || exit 0
+
+cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+[ -z "$cwd" ] && exit 0
+[ -d "$cwd" ] || exit 0
+
+# Not inside a git repo: EnterWorktree fails on its own (or hook-delegated
+# VCS-agnostic mode handles it) — nothing for this guard to judge.
+toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# At the repo root, or in a tracked subdirectory: repo resolution is correct.
+[ "$cwd" = "$toplevel" ] && exit 0
+git -C "$cwd" check-ignore -q "$cwd" 2>/dev/null || exit 0
+
+# Parked cwd: a git-ignored runtime directory inside some repo. EnterWorktree
+# would target that repo, which is almost never the intended project.
+cat >&2 <<EOF
+Blocked: the session base cwd is parked in a git-ignored runtime directory:
+  cwd:  $cwd
+  repo: $toplevel
+EnterWorktree resolves the target repo from the session base cwd, so it would
+create the worktree inside '$toplevel' — likely not the intended project. A
+'cd' in a Bash call does not move the base cwd (it resets after every call).
+
+If '$toplevel' IS the intended repo, run EnterWorktree from its root instead.
+Otherwise fall back to manual isolation in the correct repo:
+  git -C <project> worktree add <project>/.claude/worktrees/<name> -b <branch>
+then drive all work with absolute paths and 'git -C'. After any EnterWorktree,
+verify ownership: basename "\$(git rev-parse --show-toplevel)" must match the
+expected worktree/project name. See ticket 0267.
+EOF
+exit 2

--- a/settings.json
+++ b/settings.json
@@ -153,6 +153,16 @@
         ]
       },
       {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/scripts/guard-enterworktree-parked-cwd.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash(git worktree remove*)",
         "hooks": [
           {

--- a/tests/test_guard_enterworktree_parked_cwd.sh
+++ b/tests/test_guard_enterworktree_parked_cwd.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Tests for scripts/guard-enterworktree-parked-cwd.sh — the PreToolUse
+# EnterWorktree hook that denies (exit 2) when the session base cwd is parked
+# in a git-ignored runtime directory, so EnterWorktree would create the
+# worktree in the wrong repo. See ticket 0267.
+#
+# The guard is driven purely by the JSON payload's .cwd field against real
+# directories, so the tests build a throwaway git repo in a temp dir.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HOOK="$PWD/scripts/guard-enterworktree-parked-cwd.sh"
+RULES="$HOME/.claude/rules/workflow.md"
+fail=0
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# A repo with a tracked subdir and a git-ignored runtime dir.
+REPO="$TMP/repo"
+git init -q "$REPO"
+mkdir -p "$REPO/src" "$REPO/projects/session-x"
+echo "projects/" > "$REPO/.gitignore"
+touch "$REPO/src/keep"
+git -C "$REPO" add -A
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -qm init
+
+# A plain non-repo directory.
+NOREPO="$TMP/norepo"
+mkdir -p "$NOREPO"
+
+_rc() {
+    local cwd="$1"
+    printf '{"tool_name":"EnterWorktree","tool_input":{},"cwd":%s}' \
+        "$(printf '%s' "$cwd" | jq -Rs .)" \
+        | bash "$HOOK" >/dev/null 2>&1 && echo 0 || echo $?
+}
+
+_assert() {
+    local expected="$1" label="$2" cwd="$3"
+    local rc; rc=$(_rc "$cwd")
+    if [[ "$rc" == "$expected" ]]; then
+        echo "PASS: $label (exit $rc)"
+    else
+        echo "FAIL: $label — expected exit $expected, got $rc (cwd: $cwd)"
+        fail=1
+    fi
+}
+
+# --- DENY: cwd parked in a git-ignored runtime dir --------------------------
+_assert 2 "denies cwd in git-ignored dir"        "$REPO/projects"
+_assert 2 "denies cwd deep in git-ignored dir"   "$REPO/projects/session-x"
+
+# --- ALLOW -------------------------------------------------------------------
+_assert 0 "allows cwd at repo root"              "$REPO"
+_assert 0 "allows cwd in tracked subdir"         "$REPO/src"
+_assert 0 "allows cwd outside any repo"          "$NOREPO"
+_assert 0 "allows nonexistent cwd (fail-safe)"   "$TMP/does-not-exist"
+
+# --- Payload without .cwd → fail-safe allow ---------------------------------
+rc=$(printf '{"tool_name":"EnterWorktree","tool_input":{}}' \
+        | bash "$HOOK" >/dev/null 2>&1; echo $?)
+if [[ "$rc" == "0" ]]; then
+    echo "PASS: allows payload with no .cwd (fail-safe)"
+else
+    echo "FAIL: expected allow for payload with no .cwd; got exit $rc"
+    fail=1
+fi
+
+# --- Deny message names the resolved repo and the fallback recipe -----------
+err=$(printf '{"tool_name":"EnterWorktree","tool_input":{},"cwd":%s}' \
+        "$(printf '%s' "$REPO/projects" | jq -Rs .)" \
+        | bash "$HOOK" 2>&1 1>/dev/null) || true
+for needle in "worktree add" "show-toplevel" "0267"; do
+    if grep -qF "$needle" <<< "$err"; then
+        echo "PASS: deny message mentions '$needle'"
+    else
+        echo "FAIL: deny message missing '$needle'"
+        fail=1
+    fi
+done
+
+# --- jq missing → fail-open --------------------------------------------------
+_tmpbin=$(mktemp -d)
+ln -s "$(type -P cat)" "$_tmpbin/cat"
+ln -s "$(type -P git)" "$_tmpbin/git"
+_real_bash="$(type -P bash)"
+rc=$(printf '{"tool_name":"EnterWorktree","tool_input":{},"cwd":"%s"}' "$REPO/projects" \
+        | env PATH="$_tmpbin" "$_real_bash" "$HOOK" >/dev/null 2>&1; echo $?)
+rm -rf "$_tmpbin"
+if [[ "$rc" == "0" ]]; then
+    echo "PASS: fails open (exit 0) when jq is missing"
+else
+    echo "FAIL: expected fail-open (exit 0) without jq; got exit $rc"
+    fail=1
+fi
+
+# --- Doc ratchet: rules/workflow.md documents the parked-cwd trap ------------
+# Use the checked-out copy when running from a branch/worktree, so the ratchet
+# tests THIS revision, not whatever the primary checkout has.
+[ -f "$PWD/rules/workflow.md" ] && RULES="$PWD/rules/workflow.md"
+for needle in "parked" "show-toplevel" "worktree add"; do
+    if grep -qF "$needle" "$RULES"; then
+        echo "PASS: workflow.md documents '$needle'"
+    else
+        echo "FAIL: workflow.md missing '$needle' (parked-cwd trap undocumented)"
+        fail=1
+    fi
+done
+
+# --- Wiring ratchet: settings.json routes EnterWorktree through the guard ----
+if jq -e '.hooks.PreToolUse[] | select(.matcher == "EnterWorktree")
+          | .hooks[].command | test("guard-enterworktree-parked-cwd")' \
+        settings.json >/dev/null 2>&1; then
+    echo "PASS: settings.json wires the EnterWorktree guard"
+else
+    echo "FAIL: settings.json has no EnterWorktree PreToolUse hook for the guard"
+    fail=1
+fi
+
+if (( fail )); then
+    exit 1
+fi
+echo "PASS: guard-enterworktree-parked-cwd denies parked-cwd EnterWorktree calls"

--- a/tickets/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg
+++ b/tickets/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg
@@ -6,6 +6,7 @@ Label: needs-human
 
 --- log ---
 2026-06-19T11:35Z HDMX-coding-agent created
+2026-07-13T12:00Z claude note author ratified the bug; landed guard-enterworktree-parked-cwd.sh (PreToolUse deny on git-ignored base cwd), workflow.md trap doc, and test suite with doc+wiring ratchets
 
 --- body ---
 ## Context
@@ -50,9 +51,9 @@ isolated worktree in an unrelated repository.
   and asserting it refuses / warns rather than silently picking the harness repo.
 
 ## Verification
-- [ ] `rules/workflow.md` documents the parked-cwd trap + ownership check + fallback
-- [ ] (if action 2) EnterWorktree warns/aborts on an unexpected resolved repo
-- [ ] A test guards whichever action lands
+- [x] `rules/workflow.md` documents the parked-cwd trap + ownership check + fallback
+- [x] (if action 2) EnterWorktree warns/aborts on an unexpected resolved repo — PreToolUse guard `scripts/guard-enterworktree-parked-cwd.sh` denies when the base cwd is git-ignored
+- [x] A test guards whichever action lands — `tests/test_guard_enterworktree_parked_cwd.sh` (guard behaviour + doc ratchet + settings wiring)
 
 ## Invariants
 - Do not break the normal in-project EnterWorktree happy path.

--- a/tickets/closed/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg
+++ b/tickets/closed/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg
@@ -3,11 +3,13 @@ Title: EnterWorktree (and cwd-skills) resolve the wrong repo when the session ba
 Created: 2026-06-19
 Author: HDMX-coding-agent
 Label: needs-human
+Closed: autoclosed — PR #516
 
 --- log ---
 2026-06-19T11:35Z HDMX-coding-agent created
 2026-07-13T12:00Z claude note author ratified the bug; landed guard-enterworktree-parked-cwd.sh (PreToolUse deny on git-ignored base cwd), workflow.md trap doc, and test suite with doc+wiring ratchets
 
+2026-07-13T07:54Z Minh Ha-Duong closed — autoclosed — PR #516
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0267-enterworktree-resolves-wrong-repo-on-parked-cwd.erg

## What

Fixes the ratified wrong-repo footgun: `EnterWorktree` resolves the target repo from the session base cwd, so a cwd parked in a git-ignored runtime dir (e.g. `~/.claude/projects`) silently creates the worktree in the nearest enclosing repo instead of the intended project (incident 2026-06-19).

- `scripts/guard-enterworktree-parked-cwd.sh` — new PreToolUse hook on the `EnterWorktree` matcher; denies (exit 2) when the base cwd is git-ignored by its own enclosing repo, with a message naming the resolved repo, the ownership check, and the manual `git -C … worktree add` fallback. Fails open without jq/git or `.cwd`.
- `settings.json` — wires the matcher.
- `rules/workflow.md` — documents the parked-cwd trap, the post-EnterWorktree ownership check, and the fallback recipe.
- `tests/test_guard_enterworktree_parked_cwd.sh` — guard behaviour against a throwaway repo, plus doc and settings-wiring ratchets. Auto-discovered by `test_bash_suites.py`.

## Why the git-ignored discriminator

Every observed parked location (`projects/`, `jobs/`) is runtime data its repo ignores; every legitimate launch point (repo root, tracked subdir) is not. No hardcoded dir list, no happy-path false positives.

## Verification

- New suite: all PASS (deny, allow, fail-open, message content, both ratchets)
- Neighbour guard suites (`cd-primary`, `worktree-path`): PASS
- `make check-fast`: 694 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)