### PR TITLE
fix(0297): guard-commit-on-main checks tree identity, not just branch name

### DIFF
--- a/scripts/guard-commit-on-main.sh
+++ b/scripts/guard-commit-on-main.sh
@@ -21,20 +21,28 @@ echo "$cmd" | grep -qP '\bgit\s+commit\b' || exit 0
 # branch-only check: a stray `git checkout -B` moved the primary off main, and
 # the guard then allowed commits on it. Consume `.cwd` from the hook JSON (the
 # same idiom as scripts/guard-cd-primary-repo.sh:21-40) and block when the cwd
-# worktree path resolves back to the primary root, whatever the branch.
+# resolves to the primary checkout, whatever the branch.
+#
+# Derive "primary root" from git plumbing, not from a path-string pattern:
+# `--git-common-dir` points at the shared .git of the primary checkout, so its
+# parent IS the primary root — for a bare primary cwd AND for any worktree,
+# registered or not. When the cwd's own toplevel equals that primary root, the
+# commit lands on the primary. A registered worktree has its own distinct
+# toplevel, so it falls through to layer 2. This is the same technique as
+# scripts/pretooluse-worktree-path-guard.sh:24-26 and needs no `.claude/worktrees`
+# naming convention — the earlier case-gated version silently no-op'd when the
+# primary was addressed as a bare root path (ticket 0297, round-1 gate finding).
 cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 if [ -n "$cwd" ]; then
-    case "$cwd" in
-        */.claude/worktrees/*)
-            # primary_root = the prefix before the worktree marker.
-            primary_root="${cwd%%/.claude/worktrees/*}"
-            toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
-            if [ -n "$toplevel" ] && [ "$toplevel" = "$primary_root" ]; then
-                echo "BLOCKED: cwd '$cwd' looks like a worktree but git resolves it to the PRIMARY checkout ($primary_root) — an unregistered/deregistered worktree falls through to the primary tree. Committing here lands on the primary. Create/enter a real worktree first." >&2
-                exit 2
-            fi
-            ;;
-    esac
+    toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+    git_common_dir=$(git -C "$cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+    if [ -n "$toplevel" ] && [ -n "$git_common_dir" ]; then
+        primary_root=$(dirname "$git_common_dir")
+        if [ "$toplevel" = "$primary_root" ]; then
+            echo "BLOCKED: cwd '$cwd' resolves to the PRIMARY checkout ($primary_root) — a bare primary root, or an unregistered/deregistered worktree that falls through to it. Committing here lands on the primary, whatever the branch. Create/enter a real worktree first." >&2
+            exit 2
+        fi
+    fi
 fi
 
 # Layer 2 — branch name. Use `git -C "$cwd"` when cwd is known; bare git

--- a/scripts/guard-commit-on-main.sh
+++ b/scripts/guard-commit-on-main.sh
@@ -16,8 +16,35 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // empty')
 # Only check git commit commands
 echo "$cmd" | grep -qP '\bgit\s+commit\b' || exit 0
 
-# Get current branch
-branch=$(git branch --show-current 2>/dev/null || true)
+# Layer 1 — tree identity. Branch name is a proxy; the material predicate is
+# "this commit lands on the PRIMARY checkout". Incident I1 defeated the
+# branch-only check: a stray `git checkout -B` moved the primary off main, and
+# the guard then allowed commits on it. Consume `.cwd` from the hook JSON (the
+# same idiom as scripts/guard-cd-primary-repo.sh:21-40) and block when the cwd
+# worktree path resolves back to the primary root, whatever the branch.
+cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+if [ -n "$cwd" ]; then
+    case "$cwd" in
+        */.claude/worktrees/*)
+            # primary_root = the prefix before the worktree marker.
+            primary_root="${cwd%%/.claude/worktrees/*}"
+            toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+            if [ -n "$toplevel" ] && [ "$toplevel" = "$primary_root" ]; then
+                echo "BLOCKED: cwd '$cwd' looks like a worktree but git resolves it to the PRIMARY checkout ($primary_root) — an unregistered/deregistered worktree falls through to the primary tree. Committing here lands on the primary. Create/enter a real worktree first." >&2
+                exit 2
+            fi
+            ;;
+    esac
+fi
+
+# Layer 2 — branch name. Use `git -C "$cwd"` when cwd is known; bare git
+# otherwise (preserves today's behaviour for payloads that carry no `.cwd`,
+# where layer 1 is silently skipped — a residual gap for cwd-less callers).
+if [ -n "$cwd" ]; then
+    branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
+else
+    branch=$(git branch --show-current 2>/dev/null || true)
+fi
 
 if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     echo "BLOCKED: committing directly to $branch. Create a branch first: git switch -c <branch-name>" >&2

--- a/tests/test_guard_commit_on_main.sh
+++ b/tests/test_guard_commit_on_main.sh
@@ -9,7 +9,7 @@ fail=0
 
 # Create a temp git repo so `git branch --show-current` behaves predictably.
 TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+trap 'rm -rf "$TMPDIR" "${PRIMARY2:-}"' EXIT
 
 git -C "$TMPDIR" init -q
 git -C "$TMPDIR" config user.email "test@example.com"
@@ -50,6 +50,42 @@ _assert_allowed() {
     fi
 }
 
+# cwd-aware runner: passes a `.cwd` field in the payload (like the sibling
+# guard-cd-primary-repo tests) AND runs the hook from that directory, so the
+# fixed script (reads `.cwd`) and the old script (reads its process cwd) both
+# see the same tree. Reuses the jq payload-construction pattern from
+# tests/test_guard_cd_primary_repo.sh:20-28.
+_run_at() {
+    local cmd="$1" cwd="$2"
+    printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
+        "$(printf '%s' "$cmd" | jq -Rs .)" \
+        "$(printf '%s' "$cwd" | jq -Rs .)" \
+        | (cd "$cwd" && bash "$HOOK" >/dev/null 2>&1)
+    echo $?
+}
+
+_assert_blocked_at() {
+    local label="$1" cmd="$2" cwd="$3"
+    local rc; rc=$(_run_at "$cmd" "$cwd")
+    if [[ "$rc" == "2" ]]; then
+        echo "PASS: blocks $label"
+    else
+        echo "FAIL: expected block (exit 2) for $label; got exit $rc — cmd: $cmd"
+        fail=1
+    fi
+}
+
+_assert_allowed_at() {
+    local label="$1" cmd="$2" cwd="$3"
+    local rc; rc=$(_run_at "$cmd" "$cwd")
+    if [[ "$rc" == "0" ]]; then
+        echo "PASS: allows $label"
+    else
+        echo "FAIL: expected allow (exit 0) for $label; got exit $rc — cmd: $cmd"
+        fail=1
+    fi
+}
+
 # --- on main: git commit must be blocked ---------------------------------
 _assert_blocked "git commit on main"          "git commit -m 'msg'"
 _assert_blocked "git commit --amend on main"  "git commit --amend --no-edit"
@@ -81,6 +117,34 @@ else
     echo "FAIL: expected allow for empty payload; got exit $rc"
     fail=1
 fi
+
+# --- I1 fall-through: primary checkout moved off main, tree identity check --
+# Simulate incident I1: a stray `git checkout -B feature` moves the PRIMARY
+# checkout off main. A PLAIN (unregistered) directory under .claude/worktrees/
+# makes git's toplevel walk-up land back on the primary repo. Because the
+# branch is 'feature' (not main), the old branch-only guard passed the commit
+# WRONGLY; the fix blocks on tree identity. The fall-through is organic — it
+# comes from git's rev-parse walk-up, not from a hardcoded path match.
+PRIMARY2=$(mktemp -d)
+git -C "$PRIMARY2" init -q
+git -C "$PRIMARY2" config user.email "test@example.com"
+git -C "$PRIMARY2" config user.name "Test"
+git -C "$PRIMARY2" commit --allow-empty -q -m "init"
+git -C "$PRIMARY2" branch -m main 2>/dev/null || true
+git -C "$PRIMARY2" checkout -B feature -q          # I1: primary now off main
+PLAINWT="$PRIMARY2/.claude/worktrees/t001"
+mkdir -p "$PLAINWT"                                 # NOT a `git worktree add`
+_assert_blocked_at "git commit on primary via plain worktree dir (I1)" \
+                   "git commit -m x" "$PLAINWT"
+
+# --- positive: a real registered worktree on a feature branch → allowed ----
+# `git worktree add` gives the dir its own toplevel, distinct from the primary
+# root, so the tree-identity check passes through and layer-2 (branch=feature)
+# allows the commit. No false positive on legitimate worktree commits.
+REALWT="$PRIMARY2/.claude/worktrees/t002"
+git -C "$PRIMARY2" worktree add -q -b feature-wt "$REALWT"
+_assert_allowed_at "git commit in real registered worktree on feature branch" \
+                   "git commit -m x" "$REALWT"
 
 if (( fail )); then
     exit 1

--- a/tests/test_guard_commit_on_main.sh
+++ b/tests/test_guard_commit_on_main.sh
@@ -19,18 +19,30 @@ git -C "$TMPDIR" commit --allow-empty -q -m "init"
 # Rename the default branch to main (handles repos where default is 'master').
 git -C "$TMPDIR" branch -m main 2>/dev/null || true
 
-# Run the hook from inside the temp repo so `git branch --show-current` sees it.
+# Run the hook from inside $TMPDIR, or an explicit cwd (2nd arg). When an
+# explicit cwd is passed, the payload also carries a `.cwd` field (like the
+# sibling guard-cd-primary-repo tests) — reuses the jq payload-construction
+# pattern from tests/test_guard_cd_primary_repo.sh:20-28. Omitting the 2nd
+# arg preserves the plain (no `.cwd`) payload shape used by the original
+# main/master/feature-branch assertions below.
 _run() {
-    local cmd="$1"
-    printf '{"tool_name":"Bash","tool_input":{"command":%s}}' \
-        "$(printf '%s' "$cmd" | jq -Rs .)" \
-        | (cd "$TMPDIR" && bash "$HOOK" >/dev/null 2>&1)
+    local cmd="$1" cwd="${2:-$TMPDIR}"
+    local payload
+    if [[ -n "${2:-}" ]]; then
+        payload=$(printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
+            "$(printf '%s' "$cmd" | jq -Rs .)" \
+            "$(printf '%s' "$cwd" | jq -Rs .)")
+    else
+        payload=$(printf '{"tool_name":"Bash","tool_input":{"command":%s}}' \
+            "$(printf '%s' "$cmd" | jq -Rs .)")
+    fi
+    printf '%s' "$payload" | (cd "$cwd" && bash "$HOOK" >/dev/null 2>&1)
     echo $?
 }
 
 _assert_blocked() {
-    local label="$1" cmd="$2"
-    local rc; rc=$(_run "$cmd")
+    local label="$1" cmd="$2" cwd="${3:-}"
+    local rc; rc=$(_run "$cmd" "$cwd")
     if [[ "$rc" == "2" ]]; then
         echo "PASS: blocks $label"
     else
@@ -40,44 +52,8 @@ _assert_blocked() {
 }
 
 _assert_allowed() {
-    local label="$1" cmd="$2"
-    local rc; rc=$(_run "$cmd")
-    if [[ "$rc" == "0" ]]; then
-        echo "PASS: allows $label"
-    else
-        echo "FAIL: expected allow (exit 0) for $label; got exit $rc — cmd: $cmd"
-        fail=1
-    fi
-}
-
-# cwd-aware runner: passes a `.cwd` field in the payload (like the sibling
-# guard-cd-primary-repo tests) AND runs the hook from that directory, so the
-# fixed script (reads `.cwd`) and the old script (reads its process cwd) both
-# see the same tree. Reuses the jq payload-construction pattern from
-# tests/test_guard_cd_primary_repo.sh:20-28.
-_run_at() {
-    local cmd="$1" cwd="$2"
-    printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
-        "$(printf '%s' "$cmd" | jq -Rs .)" \
-        "$(printf '%s' "$cwd" | jq -Rs .)" \
-        | (cd "$cwd" && bash "$HOOK" >/dev/null 2>&1)
-    echo $?
-}
-
-_assert_blocked_at() {
-    local label="$1" cmd="$2" cwd="$3"
-    local rc; rc=$(_run_at "$cmd" "$cwd")
-    if [[ "$rc" == "2" ]]; then
-        echo "PASS: blocks $label"
-    else
-        echo "FAIL: expected block (exit 2) for $label; got exit $rc — cmd: $cmd"
-        fail=1
-    fi
-}
-
-_assert_allowed_at() {
-    local label="$1" cmd="$2" cwd="$3"
-    local rc; rc=$(_run_at "$cmd" "$cwd")
+    local label="$1" cmd="$2" cwd="${3:-}"
+    local rc; rc=$(_run "$cmd" "$cwd")
     if [[ "$rc" == "0" ]]; then
         echo "PASS: allows $label"
     else
@@ -134,8 +110,8 @@ git -C "$PRIMARY2" branch -m main 2>/dev/null || true
 git -C "$PRIMARY2" checkout -B feature -q          # I1: primary now off main
 PLAINWT="$PRIMARY2/.claude/worktrees/t001"
 mkdir -p "$PLAINWT"                                 # NOT a `git worktree add`
-_assert_blocked_at "git commit on primary via plain worktree dir (I1)" \
-                   "git commit -m x" "$PLAINWT"
+_assert_blocked "git commit on primary via plain worktree dir (I1)" \
+                "git commit -m x" "$PLAINWT"
 
 # --- positive: a real registered worktree on a feature branch → allowed ----
 # `git worktree add` gives the dir its own toplevel, distinct from the primary
@@ -143,8 +119,8 @@ _assert_blocked_at "git commit on primary via plain worktree dir (I1)" \
 # allows the commit. No false positive on legitimate worktree commits.
 REALWT="$PRIMARY2/.claude/worktrees/t002"
 git -C "$PRIMARY2" worktree add -q -b feature-wt "$REALWT"
-_assert_allowed_at "git commit in real registered worktree on feature branch" \
-                   "git commit -m x" "$REALWT"
+_assert_allowed "git commit in real registered worktree on feature branch" \
+                "git commit -m x" "$REALWT"
 
 if (( fail )); then
     exit 1

--- a/tests/test_guard_commit_on_main.sh
+++ b/tests/test_guard_commit_on_main.sh
@@ -113,6 +113,15 @@ mkdir -p "$PLAINWT"                                 # NOT a `git worktree add`
 _assert_blocked "git commit on primary via plain worktree dir (I1)" \
                 "git commit -m x" "$PLAINWT"
 
+# --- bare primary root off main: tree-identity check must fire (0297) ------
+# Round-1 gate finding: the tree-identity check must block even when `.cwd` is
+# the PRIMARY checkout root addressed directly — no `.claude/worktrees/` marker
+# segment in the path. This is the exact scenario from the ticket's Context: a
+# stray `git checkout -B` moves the primary off main; the commit must be blocked
+# regardless of branch name, not just when the cwd is dressed as a worktree path.
+_assert_blocked "git commit on bare primary root off main (0297)" \
+                "git commit -m x" "$PRIMARY2"
+
 # --- positive: a real registered worktree on a feature branch → allowed ----
 # `git worktree add` gives the dir its own toplevel, distinct from the primary
 # root, so the tree-identity check passes through and layer-2 (branch=feature)

--- a/tickets/0297-guard-commit-on-main-false-negative.erg
+++ b/tickets/0297-guard-commit-on-main-false-negative.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (author ratified model A, 2026-07-13)
 
+2026-07-13T07:36Z verify-gate round 1: REROLL — Layer 1 tree-identity check no-ops when .cwd is bare primary root (not under .claude/worktrees/); ticket's own item 'blocked regardless of branch name' unmet — reproduced 4x (2 reviewers + orchestrator + this gate)
 --- body ---
 ## Context
 

--- a/tickets/closed/0297-guard-commit-on-main-false-negative.erg
+++ b/tickets/closed/0297-guard-commit-on-main-false-negative.erg
@@ -2,11 +2,13 @@
 Title: Fix guard-commit-on-main.sh false-negative: check tree identity, not branch name
 Created: 2026-07-13
 Author: claude
+Closed: autoclosed — PR #517
 
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (author ratified model A, 2026-07-13)
 
 2026-07-13T07:36Z verify-gate round 1: REROLL — Layer 1 tree-identity check no-ops when .cwd is bare primary root (not under .claude/worktrees/); ticket's own item 'blocked regardless of branch name' unmet — reproduced 4x (2 reviewers + orchestrator + this gate)
+2026-07-13T08:22Z Minh Ha-Duong closed — autoclosed — PR #517
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`scripts/guard-commit-on-main.sh` checked only `branch == main`. In incident I1 (from the 0252 worktree-ownership audit), a stray `git checkout -B` moved the PRIMARY checkout onto a feature branch, after which this guard happily allowed commits on the primary — its exact failure mode. The material predicate is "this commit lands on the primary checkout", not "the branch is named main".

## Fix

- **Layer 1 (new): tree identity.** Consume `.cwd` from the hook JSON (same idiom as `scripts/guard-cd-primary-repo.sh:21-40`). When the cwd worktree path resolves via `git -C "$cwd" rev-parse --show-toplevel` back to the primary root, block unconditionally regardless of branch. An unregistered/deregistered worktree makes git's toplevel walk-up land on the primary tree — this catches it.
- **Layer 2 (kept): branch name.** The existing `branch==main` check stays, now using `git -C "$cwd"` when cwd is present and bare git otherwise — preserving today's behaviour for payloads without `.cwd`, where layer 1 is silently skipped (a noted residual gap for cwd-less callers).
- Fail-closed jq handling and `set -euo pipefail` discipline preserved. No shared helper extracted (a dedup-consideration ticket is being filed by a sibling PR).

## RED proof

The new I1 test case — a primary repo moved onto a `feature` branch, an unregistered plain directory under `.claude/worktrees/` whose git toplevel walks back up to the primary — **passed wrongly against the pre-fix script** while every existing assertion stayed green:

```
FAIL: expected block (exit 2) for git commit on primary via plain worktree dir (I1); got exit 0 — cmd: git commit -m x
```

After the fix, all 9 cases pass (including a positive `git worktree add` fixture on a feature branch → commit allowed, confirming no false positive on legitimate worktree commits). `make check` green.

**Ticket:** tickets/0297-guard-commit-on-main-false-negative.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)