### PR TITLE
guard(0296): live worktree-identity preflight for mutating git/erg commands

### DIFF
--- a/scripts/guard-worktree-identity.sh
+++ b/scripts/guard-worktree-identity.sh
@@ -39,20 +39,63 @@ case "$cwd" in
     *) exit 0 ;;
 esac
 
+# Normalize away shell quote characters before matching. A quoted verb token
+# (`git "commit"`) otherwise breaks the git↔verb adjacency the regex relies on
+# and slips through. Stripping quotes also splits a semicolon/ampersand that was
+# hiding inside a quoted argument into its own segment below, which only makes
+# the guard MORE conservative (it errs toward the identity check, never away).
+# Two indirections stay opaque to any static command-string scan and are OUT OF
+# SCOPE here: command substitution (`git $(echo commit)`) and git aliases
+# (`git ci` for commit) — a regex cannot see through either without invoking git
+# itself. See ticket 0302 if closing the alias gap ever becomes necessary.
+norm=${cmd//\"/}
+norm=${norm//\'/}
+
+# Mutating-verb patterns, reused by the fast path and the per-segment scan.
+# The git list adds the destructive verbs the original allowlist missed
+# (cherry-pick/revert/apply/am/restore/filter-branch/gc/pull/clean, worktree
+# remove|move|prune|add, branch|tag with a delete/force/move short flag, config,
+# fetch --prune). Dual-mode verbs (branch/tag) are gated only in their
+# destructive flag form so read-only listing (`git branch -vv`) still passes.
+# Long-form flags (`git branch --delete`) are a known residual gap.
+GIT_MUT='\bgit\s+(commit|checkout|switch|merge|rebase|push|reset|add|mv|rm|stash|cherry-pick|revert|apply|am|restore|filter-branch|gc|pull|clean|worktree\s+(remove|move|prune|add)|(branch|tag)\s+-[a-zA-Z]*[dDfFmM]|config|fetch\s+--prune)\b'
+ERG_MUT='\berg\s+(new|close|log|label|unlabel|archive|rm|migrate|init|install|update)\b'
+
 # Fast path 2 (pure string, no git call yet): command carries no mutating verb →
 # read-only git (status/log/diff) and everything else pass untouched.
 # erg's install/update/init also mutate on-disk state (skills/molt calls
 # `erg update` to replace the installed binary), so they are gated too.
-echo "$cmd" | grep -qP '\bgit\s+(commit|checkout|switch|merge|rebase|push|reset|add|mv|rm|stash)\b' \
-  || echo "$cmd" | grep -qP '\berg\s+(new|close|log|label|unlabel|archive|rm|migrate|init|install|update)\b' \
+echo "$norm" | grep -qP "$GIT_MUT" \
+  || echo "$norm" | grep -qP "$ERG_MUT" \
   || exit 0
 
-# Whitelist: an explicit `git -C <path>` names its target tree, so the cwd
-# identity is irrelevant — that idiom is the sanctioned way to mutate another
-# tree on purpose (rules/git.md).
-if echo "$cmd" | grep -qP '\bgit\s+-C\s'; then
-    exit 0
-fi
+# Whitelist, re-checked PER SEGMENT (ticket 0302 reroll). An explicit
+# `git -C <path>` names its target tree, so the cwd identity is irrelevant —
+# the sanctioned cross-tree idiom (rules/git.md). But the exemption is sound
+# ONLY for the segment that carries the -C: a compound like
+# `git -C X status && git commit -m y` must NOT let the leading `git -C` whitelist
+# its trailing BARE `git commit`, which mutates whatever bare git resolves to.
+# The old guard tested the literal substring `git -C ` over the WHOLE command and
+# waved the entire chain through — the I1 fall-through this guard exists to close.
+# Fix: split on shell separators (&&, ||, ;, |, &) and require every MUTATING
+# segment to name -C in ITSELF; any mutating segment without its own -C forces
+# the identity check below. (Note: printf adds a trailing newline so `read`
+# does not drop the final, separator-less segment.)
+needs_check=0
+while IFS= read -r seg; do
+    if echo "$seg" | grep -qP "$GIT_MUT"; then
+        if echo "$seg" | grep -qP '\bgit\s+-C\s'; then
+            continue
+        fi
+        needs_check=1
+        break
+    fi
+    if echo "$seg" | grep -qP "$ERG_MUT"; then
+        needs_check=1
+        break
+    fi
+done < <(printf '%s\n' "$norm" | tr ';&|' '\n')
+[ "$needs_check" -eq 0 ] && exit 0
 
 # cwd = .../.claude/worktrees/<name>/...  →  extract <name> and the primary root.
 worktree_rest="${cwd#*/.claude/worktrees/}"

--- a/scripts/guard-worktree-identity.sh
+++ b/scripts/guard-worktree-identity.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+# PreToolUse hook: block a mutating git/erg command when the cwd CLAIMS a harness
+# worktree (`.../.claude/worktrees/<name>/`) but `git rev-parse --show-toplevel`
+# resolves somewhere else — the live worktree-identity preflight (ticket 0296).
+#
+# Incident I1 (aedist, 2026-06-11/12): a session's worktree was deregistered
+# mid-session; the directory lingered, so bare git fell through to the PRIMARY
+# repo and a `git checkout -B` moved the primary checkout off main. Every
+# existing guard checks only the weak predicate ("cwd is *some* worktree"); this
+# one re-derives ownership per command — does rev-parse still match the name the
+# cwd claims — on the hot path. Overhead: one rev-parse (~5-20 ms), and only
+# after two pure-string fast-paths reject the common case.
+#
+# Exit 0 = allow, exit 2 = block with a stderr message.
+#
+# Fail-CLOSED when jq is missing (contrast guard-cd-primary-repo.sh, which is a
+# narrow advisory and fails open): this guard protects the primary-checkout
+# integrity invariant, so a missing parser must block, not wave a mutation
+# through unchecked.
+
+input=$(cat)
+
+if ! command -v jq &>/dev/null; then
+    echo "BLOCKED: jq not found — guard-worktree-identity.sh cannot parse tool input." >&2
+    exit 2
+fi
+
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
+[ -z "$cwd" ] && exit 0  # fail-safe: cannot tell which tree this session owns
+
+# Fast path 1 (pure string, no subprocess): cwd not under a harness worktree →
+# primary-checkout work is governed by other guards.
+case "$cwd" in
+    */.claude/worktrees/*) ;;
+    *) exit 0 ;;
+esac
+
+# Fast path 2 (pure string, no git call yet): command carries no mutating verb →
+# read-only git (status/log/diff) and everything else pass untouched.
+# erg's install/update/init also mutate on-disk state (skills/molt calls
+# `erg update` to replace the installed binary), so they are gated too.
+echo "$cmd" | grep -qP '\bgit\s+(commit|checkout|switch|merge|rebase|push|reset|add|mv|rm|stash)\b' \
+  || echo "$cmd" | grep -qP '\berg\s+(new|close|log|label|unlabel|archive|rm|migrate|init|install|update)\b' \
+  || exit 0
+
+# Whitelist: an explicit `git -C <path>` names its target tree, so the cwd
+# identity is irrelevant — that idiom is the sanctioned way to mutate another
+# tree on purpose (rules/git.md).
+if echo "$cmd" | grep -qP '\bgit\s+-C\s'; then
+    exit 0
+fi
+
+# cwd = .../.claude/worktrees/<name>/...  →  extract <name> and the primary root.
+worktree_rest="${cwd#*/.claude/worktrees/}"
+worktree_name="${worktree_rest%%/*}"
+primary_root="${cwd%%/.claude/worktrees/*}"
+
+# The only git call: resolve the real toplevel FROM THE CWD explicitly (-C),
+# never the ambient shell cwd. Empty = cwd was deleted / not in a repo →
+# fail-safe allow (nothing to compare against; other guards cover the rest).
+toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+[ -z "$toplevel" ] && exit 0
+
+# Identity mismatch: the tree git resolves is not the worktree the cwd claims,
+# or it is the primary root itself (the I1 fall-through). Block.
+if [ "$(basename "$toplevel")" != "$worktree_name" ] || [ "$toplevel" = "$primary_root" ]; then
+    echo "BLOCKED: worktree identity mismatch. cwd claims worktree '$worktree_name' but git resolves to '$toplevel'." >&2
+    echo "This is the I1 fall-through: a deregistered/moved worktree lets bare git mutate the wrong tree (e.g. the primary checkout)." >&2
+    echo "Re-enter the correct worktree, or for intentional cross-tree work name the target explicitly: git -C <path> ..." >&2
+    exit 2
+fi
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -133,6 +133,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/scripts/guard-worktree-identity.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash(git commit*)",
         "hooks": [
           {

--- a/tests/test_guard_worktree_identity.sh
+++ b/tests/test_guard_worktree_identity.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for scripts/guard-worktree-identity.sh — the PreToolUse Bash hook that
+# blocks a mutating git/erg command when the cwd claims a harness worktree
+# (`.../.claude/worktrees/<name>/`) but `git rev-parse --show-toplevel` resolves
+# elsewhere (exit 2 = deny, exit 0 = allow). See ticket 0296 / incident I1:
+# a deregistered worktree whose directory lingers, so bare git falls through to
+# the PRIMARY repo and mutates the wrong tree.
+#
+# The guard is driven purely via the JSON payload's .cwd (worktree detection +
+# the -C target for rev-parse) and .tool_input.command. Fixtures are REAL git
+# repos — rev-parse is never mocked, so the test exercises the actual walk-up.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HOOK="$PWD/scripts/guard-worktree-identity.sh"
+fail=0
+
+# --- real git fixtures ----------------------------------------------------
+FIX=$(mktemp -d)
+trap 'rm -rf "$FIX"' EXIT
+
+PRIMARY="$FIX/primary"
+mkdir -p "$PRIMARY"
+git -C "$PRIMARY" init -q
+git -C "$PRIMARY" config user.email t@e.st
+git -C "$PRIMARY" config user.name tester
+git -C "$PRIMARY" commit -q --allow-empty -m init
+
+# Case (a) fixture: a PLAIN directory under .claude/worktrees/ — NOT a
+# registered worktree. rev-parse from here walks up to $PRIMARY.
+BROKEN="$PRIMARY/.claude/worktrees/t001"
+mkdir -p "$BROKEN"
+
+# Case (b) fixture: a REAL registered worktree at the same layout shape.
+GOOD="$PRIMARY/.claude/worktrees/t002"
+git -C "$PRIMARY" worktree add -q -b wt002 "$GOOD"
+
+# Feed a Bash tool-input payload (with cwd) to the hook; print "<rc>\t<stderr>".
+_run() {
+    local cmd="$1" cwd="$2"
+    local err rc
+    err=$(printf '{"tool_name":"Bash","tool_input":{"command":%s},"cwd":%s}' \
+            "$(printf '%s' "$cmd" | jq -Rs .)" \
+            "$(printf '%s' "$cwd" | jq -Rs .)" \
+            | bash "$HOOK" 2>&1 1>/dev/null) && rc=0 || rc=$?
+    printf '%s\t%s' "$rc" "$err"
+}
+
+_rc() {
+    local out; out=$(_run "$1" "$2")
+    printf '%s' "${out%%$'\t'*}"
+}
+
+_assert_blocked() {
+    local label="$1" cmd="$2" cwd="$3"
+    local rc; rc=$(_rc "$cmd" "$cwd")
+    if [[ "$rc" == "2" ]]; then
+        echo "PASS: blocks $label"
+    else
+        echo "FAIL: expected block (exit 2) for $label; got exit $rc — cmd: $cmd"
+        fail=1
+    fi
+}
+
+_assert_allowed() {
+    local label="$1" cmd="$2" cwd="$3"
+    local rc; rc=$(_rc "$cmd" "$cwd")
+    if [[ "$rc" == "0" ]]; then
+        echo "PASS: allows $label"
+    else
+        echo "FAIL: expected allow (exit 0) for $label; got exit $rc — cmd: $cmd"
+        fail=1
+    fi
+}
+
+# --- (a) I1 replay: mutating git in a deregistered worktree → BLOCK --------
+_assert_blocked "I1 git commit in deregistered worktree" \
+                "git commit -m x" "$BROKEN"
+_assert_blocked "I1 git checkout -B off main" \
+                "git checkout -B main" "$BROKEN"
+_assert_blocked "I1 erg close in deregistered worktree" \
+                "erg close 123 done" "$BROKEN"
+
+# --- (b) false-positive path: real registered worktree → ALLOW -------------
+_assert_allowed "mutating git in a real registered worktree" \
+                "git commit -m x" "$GOOD"
+_assert_allowed "erg new in a real registered worktree" \
+                "erg new 'a title'" "$GOOD"
+
+# --- (c) explicit git -C anywhere → ALLOW regardless of cwd ----------------
+_assert_allowed "git -C whitelist in the broken worktree" \
+                "git -C $PRIMARY commit -m x" "$BROKEN"
+
+# --- (d) read-only git in the broken worktree → ALLOW (verb fast-path) -----
+_assert_allowed "git status in the broken worktree" "git status" "$BROKEN"
+_assert_allowed "git log in the broken worktree"    "git log -1"  "$BROKEN"
+_assert_allowed "git diff in the broken worktree"   "git diff"    "$BROKEN"
+
+# --- fast path: cwd not a harness worktree → ALLOW ------------------------
+_assert_allowed "mutating git in the primary root (not a worktree)" \
+                "git commit -m x" "$PRIMARY"
+
+# --- fail-safe: cwd deleted (rev-parse empty) → ALLOW ---------------------
+GONE="$PRIMARY/.claude/worktrees/t999-deleted"
+_assert_allowed "cwd does not exist (rev-parse empty) → fail-safe allow" \
+                "git commit -m x" "$GONE"
+
+# --- payload without .cwd → fail-safe allow -------------------------------
+rc=$(printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}' \
+        | bash "$HOOK" >/dev/null 2>&1; echo $?)
+if [[ "$rc" == "0" ]]; then
+    echo "PASS: allows payload with no .cwd (fail-safe)"
+else
+    echo "FAIL: expected allow for payload with no .cwd; got exit $rc"
+    fail=1
+fi
+
+# --- jq missing → FAIL-CLOSED (exit 2): this guard protects primary-checkout
+# integrity, so a missing parser must block, not wave through. ---------------
+_tmpbin=$(mktemp -d)
+ln -s "$(type -P cat)" "$_tmpbin/cat"
+_real_bash="$(type -P bash)"
+rc=$(printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"},"cwd":"%s"}' "$BROKEN" \
+        | env PATH="$_tmpbin" "$_real_bash" "$HOOK" >/dev/null 2>&1; echo $?)
+rm -rf "$_tmpbin"
+if [[ "$rc" == "2" ]]; then
+    echo "PASS: fails closed (exit 2) when jq is missing"
+else
+    echo "FAIL: expected fail-closed (exit 2) without jq; got exit $rc"
+    fail=1
+fi
+
+if (( fail )); then
+    exit 1
+fi
+echo "PASS: guard-worktree-identity blocks mutations when cwd worktree identity mismatches git"

--- a/tests/test_guard_worktree_identity.sh
+++ b/tests/test_guard_worktree_identity.sh
@@ -91,6 +91,37 @@ _assert_allowed "erg new in a real registered worktree" \
 _assert_allowed "git -C whitelist in the broken worktree" \
                 "git -C $PRIMARY commit -m x" "$BROKEN"
 
+# --- (c2) COMPOUND-command whitelist bypass (ticket 0302 reroll) -----------
+# A leading `git -C <path>` in a chained command must NOT whitelist a trailing
+# BARE mutating git/erg that resolves to the wrong tree. Regression for the
+# substring-match bypass: the old guard tested `git -C ` over the whole string.
+_assert_blocked "compound: git -C status && bare git commit" \
+                "git -C $PRIMARY status && git commit -m x" "$BROKEN"
+_assert_blocked "compound: read-only git ; bare erg close" \
+                "git status ; erg close 1 done" "$BROKEN"
+# Two self-contained git -C segments (each names its target) stay whitelisted.
+_assert_allowed "compound: two git -C segments stay whitelisted" \
+                "git -C $PRIMARY status && git -C $PRIMARY commit -m x" "$BROKEN"
+
+# --- newly-gated destructive verbs → BLOCK in the deregistered worktree -----
+_assert_blocked "git cherry-pick in deregistered worktree" \
+                "git cherry-pick abc123" "$BROKEN"
+_assert_blocked "git branch -D in deregistered worktree" \
+                "git branch -D somebranch" "$BROKEN"
+_assert_blocked "git worktree remove in deregistered worktree" \
+                "git worktree remove foo" "$BROKEN"
+_assert_blocked "git config in deregistered worktree" \
+                "git config user.email x@y.z" "$BROKEN"
+_assert_blocked "git pull in deregistered worktree" \
+                "git pull" "$BROKEN"
+# Dual-mode verbs stay allowed in their read-only form (no destructive flag).
+_assert_allowed "git branch -vv (read-only listing) in broken worktree" \
+                "git branch -vv" "$BROKEN"
+
+# --- quoting evasion: git \"commit\" must not slip the verb match -----------
+_assert_blocked "quoted verb git \"commit\" in deregistered worktree" \
+                'git "commit" -m x' "$BROKEN"
+
 # --- (d) read-only git in the broken worktree → ALLOW (verb fast-path) -----
 _assert_allowed "git status in the broken worktree" "git status" "$BROKEN"
 _assert_allowed "git log in the broken worktree"    "git log -1"  "$BROKEN"

--- a/tickets/0296-live-worktree-identity-guard.erg
+++ b/tickets/0296-live-worktree-identity-guard.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (author ratified model A, 2026-07-13)
 
+2026-07-13T07:34Z bump verify-reroll — round 1: git -C whitelist is a substring match over the whole command, allowing a compound command to bypass the mutating-verb block (I1 fall-through unfixed for chained commands)
 --- body ---
 ## Context
 

--- a/tickets/0302-extract-shared-worktree-identity-predica.erg
+++ b/tickets/0302-extract-shared-worktree-identity-predica.erg
@@ -1,0 +1,53 @@
+%erg 0.1
+Title: Extract shared worktree-identity predicate helper — or record why three inline copies stay
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T07:18Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+The 0252 audit fixes land the same worktree-identity predicate — "does
+`git rev-parse --show-toplevel` still match the worktree the cwd claims, and
+is it not the primary root" — inline in three places:
+
+- `scripts/guard-worktree-identity.sh` (0296, this wave)
+- `scripts/guard-commit-on-main.sh` (0297: tree-identity check replaces the
+  branch-name check that I1 defeats)
+- `skills/merge/erg-pr-merge` `in_worktree()` (0301: `[ -f .git ]` weak
+  predicate tightened)
+
+Three copies drift. This ticket decides: extract one shared helper, or record
+why the duplication is deliberate.
+
+## Actions
+
+1. After 0296/0297/0301 have all merged, diff the three implementations and
+   confirm they share the same predicate (they may differ in fail-open vs
+   fail-closed and in what they read — hook JSON `.cwd` vs shell cwd).
+2. Decide: extract a `scripts/lib/worktree-identity.sh` sourced by all three,
+   or document the choice to keep them inline.
+
+## Invariants
+
+- The extraction must not change any of the three call sites' fail-open /
+  fail-closed semantics — those differ by design (advisory vs
+  integrity-protecting guard).
+
+## Exit criteria
+
+- [ ] Either a shared helper is extracted and all three sites use it, OR a
+      short rationale is recorded (in this ticket or a code comment) for why
+      three inline copies stay.
+
+## Note — YAGNI counter-argument
+
+The three scripts are tiny, each a few lines of string-munging plus one
+`rev-parse`, and they intentionally diverge on failure semantics (fail-open for
+the advisory `cd` guard, fail-closed for the integrity guards; JSON `.cwd`
+versus live shell cwd as the input). A shared helper couples three hook scripts'
+failure behaviour into one file, so a change for one site risks the other two —
+which may cost more than the duplication saves. "Record why they stay separate"
+is a legitimate, possibly preferred, outcome of this ticket.

--- a/tickets/closed/0296-live-worktree-identity-guard.erg
+++ b/tickets/closed/0296-live-worktree-identity-guard.erg
@@ -2,11 +2,13 @@
 Title: Live worktree-identity preflight guard for mutating git/erg commands
 Created: 2026-07-13
 Author: claude
+Closed: autoclosed — PR #519
 
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (author ratified model A, 2026-07-13)
 
 2026-07-13T07:34Z bump verify-reroll — round 1: git -C whitelist is a substring match over the whole command, allowing a compound command to bypass the mutating-verb block (I1 fall-through unfixed for chained commands)
+2026-07-13T08:25Z Minh Ha-Duong closed — autoclosed — PR #519
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

New PreToolUse Bash guard `scripts/guard-worktree-identity.sh` that blocks a mutating git/erg command when the cwd claims a harness worktree (`.../.claude/worktrees/<name>/`) but `git rev-parse --show-toplevel` resolves elsewhere. This closes incident I1 from the 0252 audit: a session's worktree is deregistered mid-session, the directory lingers, so bare git falls through to the PRIMARY repo and a `git checkout -B` moves the primary checkout off main. Every existing guard checks only the weak predicate "cwd is some worktree"; this one re-derives ownership per command.

### Guard logic
- Two pure-string fast-paths run before any subprocess: cwd not under `.claude/worktrees/` → allow; command carries no mutating verb → allow.
- Mutating verbs: git (commit|checkout|switch|merge|rebase|push|reset|add|mv|rm|stash), erg (new|close|log|label|unlabel|archive|rm|migrate|init|install|update) — install/update/init gated because `skills/molt` calls `erg update` to replace the binary.
- Whitelist: `git -C <path>` names its target tree, so cwd identity is irrelevant — the sanctioned cross-tree idiom passes.
- One `git -C "$cwd" rev-parse --show-toplevel` (never ambient cwd). Empty (cwd deleted) → fail-safe allow.
- Block (exit 2, explanatory stderr) when `basename $toplevel != worktree_name` OR `$toplevel == primary_root`.
- Fails CLOSED when jq is missing (unlike the advisory guard-cd-primary-repo.sh) — this guard protects primary-checkout integrity.

### Tests
`tests/test_guard_worktree_identity.sh`, auto-discovered by `test_bash_suites.py`, uses REAL git fixtures (no mocked rev-parse):
- (a) I1 replay — plain unregistered dir under `.claude/worktrees/` → BLOCKED (rev-parse walks up to primary).
- (b) false-positive path — real `git worktree add` → ALLOWED.
- (c) `git -C <path>` anywhere → ALLOWED regardless of cwd.
- (d) read-only git (status/log/diff) in the broken worktree → ALLOWED (verb fast-path).
- Plus: primary-root cwd, deleted cwd, missing `.cwd`, and jq-missing fail-closed.

`make check` passes.

**Ticket:** tickets/0296-live-worktree-identity-guard.erg

Related follow-up: tickets/0302-extract-shared-worktree-identity-predica.erg (dedup the predicate across the three 0296/0297/0301 sites, or record why they stay inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)