### PR TITLE
merge(0301): erg-pr-merge in_worktree() tightened to identity predicate

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -22,8 +22,32 @@ set -euo pipefail
 
 die() { echo "erg-pr-merge: $*" >&2; exit 1; }
 
+# Identity predicate (tickets 0301/0296; incidents I1/I2). Do NOT regress to
+# `[ -f .git ]`: that matched ANY dir with a `.git` FILE — a submodule, or a
+# linked worktree outside the harness convention — and trusted the path blindly.
+# Instead require that (a) the cwd sits under a `.claude/worktrees/<name>`
+# segment AND (b) git's own toplevel is exactly that worktree: basename equals
+# <name> and the toplevel is not the enclosing repo before the marker. A plain
+# dir planted under the marker (git resolves to the enclosing repo, a different
+# basename) is correctly rejected. A PreToolUse hook fires once on the outer
+# script invocation and cannot front these internal git calls, so the check is
+# self-contained by design.
 in_worktree() {
-    [ -f .git ] && grep -q "gitdir:" .git 2>/dev/null
+    local cwd top name prefix
+    cwd=$(pwd -P)
+    case "$cwd" in
+        */.claude/worktrees/*) ;;
+        *) return 1 ;;
+    esac
+    prefix=${cwd%%/.claude/worktrees/*}   # enclosing path before the marker
+    name=${cwd#*/.claude/worktrees/}      # <name>[/subdir...]
+    name=${name%%/*}
+    [ -n "$name" ] || return 1
+    top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+    [ -n "$top" ] || return 1
+    [ "$(basename "$top")" = "$name" ] || return 1
+    [ "$top" != "$prefix" ] || return 1
+    return 0
 }
 
 # ── Step 0: resolve PR ────────────────────────────────────────────────────────

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -35,10 +35,10 @@ die() { echo "erg-pr-merge: $*" >&2; exit 1; }
 in_worktree() {
     local cwd top name prefix
     cwd=$(pwd -P)
-    case "$cwd" in
-        */.claude/worktrees/*) ;;
-        *) return 1 ;;
-    esac
+    # No case pre-check needed: when cwd has no `.claude/worktrees/` segment,
+    # both parameter expansions below leave `name` equal to `cwd` (absolute
+    # path, starts with "/"), which the trailing `${name%%/*}` collapses to
+    # the empty string — the `[ -n "$name" ]` guard already rejects it.
     prefix=${cwd%%/.claude/worktrees/*}   # enclosing path before the marker
     name=${cwd#*/.claude/worktrees/}      # <name>[/subdir...]
     name=${name%%/*}
@@ -291,7 +291,11 @@ sync_local_base() {
 }
 
 echo "Queueing merge for PR #${PR}..."
-if in_worktree; then
+# cwd cannot change between here and Step 4 (no `cd` on this path), so the
+# identity predicate's answer is invariant for the rest of the run — compute
+# it once instead of re-spawning `git rev-parse`/`basename` at each call site.
+if in_worktree; then IN_WORKTREE=1; else IN_WORKTREE=0; fi
+if [[ "$IN_WORKTREE" -eq 1 ]]; then
     MERGE_FLAGS=(--merge --auto)
 else
     MERGE_FLAGS=(--merge --auto --delete-branch)
@@ -314,7 +318,7 @@ else
     # allow_auto_merge. (ticket 0198)
     echo "Auto-merge unavailable — falling back to watch-then-merge..."  # harness-extension-point
     watch_checks_or_die
-    if in_worktree; then  # harness-extension-point
+    if [[ "$IN_WORKTREE" -eq 1 ]]; then  # harness-extension-point
         gh pr merge "$PR" --merge || merge_took_effect \
             || die "merge failed and PR is not merged — check 'gh pr view $PR'"  # harness-extension-point
     else  # harness-extension-point
@@ -328,7 +332,7 @@ fi
 
 # ── Step 4: return to base branch (skipped inside a worktree) ────────────────
 
-if in_worktree; then
+if [[ "$IN_WORKTREE" -eq 1 ]]; then
     echo "In git worktree — exit the worktree when done."
 elif [[ "${AUTO_QUEUED:-0}" -eq 1 ]]; then
     if [[ "${MERGE_LANDED:-0}" -eq 1 ]]; then

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -720,5 +720,31 @@ else
     echo "FAIL: erg-pr-merge exited non-zero from an off-marker worktree"; fail=1
 fi
 
+# ── Case 21: name-collision lookalike — the ONE case that pins the final
+# `[ "$top" != "$prefix" ]` guard as a genuine discriminator (round-1 /gaze
+# REROLL, ticket 0301). A plain dir under `.claude/worktrees/<name>` whose
+# <name> segment equals the enclosing repo's OWN basename. git resolves
+# --show-toplevel to the enclosing repo, so `basename "$top"` == <name> by
+# coincidence and the line-48 basename check ALONE would pass — only the
+# `top != prefix` guard (top == the enclosing repo == prefix here) rejects it.
+# Case 18 cannot exercise this line: its <name> differs from the repo basename,
+# so it is already rejected at line 48. Deleting only line 49 leaves every other
+# case green but flips THIS one: in_worktree() must be FALSE, so the script takes
+# the non-worktree branch and --delete-branch is present.
+seed_repo collide 0303                        # $REPO basename == "collide"
+MLOG21="$WORK/merge21.log"; : > "$MLOG21"
+mkdir -p "$REPO/.claude/worktrees/collide"    # <name> == "collide" == repo basename; NOT a registered worktree
+BODY21=$'Summary.\n\n**Ticket:** tickets/0303-fixture.erg\n'
+if STUB_MERGE_LOG="$MLOG21" \
+   run_merge_at "$REPO/.claude/worktrees/collide" "$BODY21" "ticket(0303): name-collision lookalike" >/dev/null 2>&1; then
+    if grep -q -- '--delete-branch' "$MLOG21"; then
+        echo "PASS: name-collision lookalike rejected by top!=prefix guard (--delete-branch present)"
+    else
+        echo "FAIL: name-collision lookalike wrongly detected as worktree (top!=prefix guard not enforced)"; fail=1
+    fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero from a name-collision lookalike path"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands, in_worktree() identity-tightened"
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands, in_worktree() identity-tightened (incl. name-collision guard)"

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -632,6 +632,11 @@ fi
 #
 # Runs the real script with cwd set to an arbitrary directory (not just $REPO).
 # ERG is resolved from that cwd so a worktree closes its OWN tickets/.
+add_worktree() {  # $1 target path -> frees $BRANCH from $REPO, adds a linked worktree at $1
+    git -C "$REPO" switch -q "$BASE"
+    git -C "$REPO" worktree add -q "$1" "$BRANCH"
+}
+
 run_merge_at() {  # $1 cwd, $2 body, $3 title
     ( cd "$1"
       PATH="$STUBDIR:$PATH" \
@@ -677,9 +682,8 @@ fi
 # gap: the worktree-true branch was never exercised by any prior case, and it
 # guards against an over-strict reimplementation that rejects a real worktree.
 seed_repo genuinewt 0301
-git -C "$REPO" switch -q "$BASE"          # free $BRANCH for the worktree
 WT19="$REPO/.claude/worktrees/wtgood"
-git -C "$REPO" worktree add -q "$WT19" "$BRANCH"
+add_worktree "$WT19"
 MLOG19="$WORK/merge19.log"; : > "$MLOG19"
 BODY19=$'Summary.\n\n**Ticket:** tickets/0301-fixture.erg\n'
 if out19=$(STUB_MERGE_LOG="$MLOG19" \
@@ -701,9 +705,8 @@ fi
 # 0252 family retires). The tightened predicate scopes to the harness worktree
 # convention: no marker segment → in_worktree() FALSE → --delete-branch present.
 seed_repo offmarker 0302
-git -C "$REPO" switch -q "$BASE"          # free $BRANCH for the worktree
 WT20="$WORK/offmarker-wt"                  # deliberately NOT under .claude/worktrees/
-git -C "$REPO" worktree add -q "$WT20" "$BRANCH"
+add_worktree "$WT20"
 MLOG20="$WORK/merge20.log"; : > "$MLOG20"
 BODY20=$'Summary.\n\n**Ticket:** tickets/0302-fixture.erg\n'
 if STUB_MERGE_LOG="$MLOG20" \

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -623,5 +623,99 @@ else
     echo "FAIL: erg-pr-merge exited non-zero when the queued merge had not landed"; fail=1
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# in_worktree() identity predicate (tickets 0301/0296, incidents I1/I2).
+# The old `[ -f .git ]` gated MERGE_FLAGS (--delete-branch omission) and the
+# post-merge base sync. It fired on ANY `.git`-file dir — a submodule or a
+# worktree outside the harness convention — and never verified the cwd path
+# claim against git's actual toplevel. These cases pin the tightened predicate.
+#
+# Runs the real script with cwd set to an arbitrary directory (not just $REPO).
+# ERG is resolved from that cwd so a worktree closes its OWN tickets/.
+run_merge_at() {  # $1 cwd, $2 body, $3 title
+    ( cd "$1"
+      PATH="$STUBDIR:$PATH" \
+      ERG="$1/tickets/erg" \
+      STUB_PR="42" STUB_BRANCH="$BRANCH" STUB_BASE="$BASE" \
+      STUB_BODY="$2" STUB_TITLE="$3" \
+      STUB_AUTO_FAILS=0 \
+      STUB_MERGE_LOG="${STUB_MERGE_LOG:-/dev/null}" \
+      STUB_CHECKS_LOG="${STUB_CHECKS_LOG:-/dev/null}" \
+      STUB_STATE=MERGED \
+      ERG_PR_MERGE_SYNC=/bin/true \
+      ERG_PR_MERGE_MERGED_POLL_TRIES=2 \
+      ERG_PR_MERGE_POLL_INTERVAL=0 \
+      bash "$SCRIPT" 42 )
+}
+
+# ── Case 18: lookalike path — plain dir under `.claude/worktrees/<name>` that
+# is NOT a registered worktree. git resolves --show-toplevel to the enclosing
+# repo (a different basename), so in_worktree() must be FALSE and the script
+# takes the non-worktree branch (--delete-branch present). This guards against
+# a naive path-only reimplementation that would match the marker segment alone.
+# (Under the OLD `[ -f .git ]` predicate this dir has no `.git` file, so old
+# also returned false — not a discriminator against old, a regression guard for
+# the new code. See Case 20 for the case that is RED against the old predicate.)
+seed_repo lookalike 0300
+MLOG18="$WORK/merge18.log"; : > "$MLOG18"
+mkdir -p "$REPO/.claude/worktrees/notaworktree"
+BODY18=$'Summary.\n\n**Ticket:** tickets/0300-fixture.erg\n'
+if STUB_MERGE_LOG="$MLOG18" \
+   run_merge_at "$REPO/.claude/worktrees/notaworktree" "$BODY18" "ticket(0300): lookalike" >/dev/null 2>&1; then
+    if grep -q -- '--delete-branch' "$MLOG18"; then
+        echo "PASS: lookalike path under marker is NOT a worktree (--delete-branch present)"
+    else
+        echo "FAIL: lookalike path wrongly detected as worktree (no --delete-branch)"; fail=1
+    fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero from a lookalike path"; fail=1
+fi
+
+# ── Case 19: genuine registered worktree under `.claude/worktrees/<name>`.
+# in_worktree() must be TRUE — no --delete-branch, Step 4 prints the worktree
+# message, and the ticket still closes. This closes the pre-existing coverage
+# gap: the worktree-true branch was never exercised by any prior case, and it
+# guards against an over-strict reimplementation that rejects a real worktree.
+seed_repo genuinewt 0301
+git -C "$REPO" switch -q "$BASE"          # free $BRANCH for the worktree
+WT19="$REPO/.claude/worktrees/wtgood"
+git -C "$REPO" worktree add -q "$WT19" "$BRANCH"
+MLOG19="$WORK/merge19.log"; : > "$MLOG19"
+BODY19=$'Summary.\n\n**Ticket:** tickets/0301-fixture.erg\n'
+if out19=$(STUB_MERGE_LOG="$MLOG19" \
+   run_merge_at "$WT19" "$BODY19" "ticket(0301): genuine worktree" 2>&1); then
+    g_miss=0
+    grep -q -- '--delete-branch' "$MLOG19" && { echo "  --delete-branch present in a real worktree"; g_miss=1; }
+    echo "$out19" | grep -qi 'in git worktree' || { echo "  Step 4 did not report the worktree"; g_miss=1; }
+    closed_has 0301 || { echo "  ticket 0301 not closed from the worktree"; g_miss=1; }
+    if (( g_miss )); then echo "FAIL: genuine worktree not detected / mishandled"; fail=1
+    else echo "PASS: genuine registered worktree detected (no --delete-branch, ticket closed)"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero from a genuine worktree"; fail=1
+fi
+
+# ── Case 20: a real linked worktree OUTSIDE the harness convention (not under
+# `.claude/worktrees/`). This is the RED case against the OLD predicate: it has
+# a `.git` FILE, so `[ -f .git ]` returned TRUE and omitted --delete-branch —
+# the same over-broad match that also fired on git submodules (the defect the
+# 0252 family retires). The tightened predicate scopes to the harness worktree
+# convention: no marker segment → in_worktree() FALSE → --delete-branch present.
+seed_repo offmarker 0302
+git -C "$REPO" switch -q "$BASE"          # free $BRANCH for the worktree
+WT20="$WORK/offmarker-wt"                  # deliberately NOT under .claude/worktrees/
+git -C "$REPO" worktree add -q "$WT20" "$BRANCH"
+MLOG20="$WORK/merge20.log"; : > "$MLOG20"
+BODY20=$'Summary.\n\n**Ticket:** tickets/0302-fixture.erg\n'
+if STUB_MERGE_LOG="$MLOG20" \
+   run_merge_at "$WT20" "$BODY20" "ticket(0302): off-marker worktree" >/dev/null 2>&1; then
+    if grep -q -- '--delete-branch' "$MLOG20"; then
+        echo "PASS: worktree outside .claude/worktrees/ no longer matched (--delete-branch present; RED vs old [ -f .git ])"
+    else
+        echo "FAIL: off-marker .git-file dir still matched by predicate (no --delete-branch) — old behavior not tightened"; fail=1
+    fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero from an off-marker worktree"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands"
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands, in_worktree() identity-tightened"

--- a/tickets/0301-erg-pr-merge-in-worktree-predicate.erg
+++ b/tickets/0301-erg-pr-merge-in-worktree-predicate.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (audit finding: `[ -f .git ]` is the weak predicate verbatim)
 
+2026-07-13T08:00Z bump verify-reroll — round 1: guard line `[ "$top" != "$prefix" ]` (skills/merge/erg-pr-merge:49) is load-bearing but untested by any of cases 18-20; add a case 21 pinning the same-basename-as-enclosing-repo lookalike (basename(top)==name AND top==prefix) before re-review
 --- body ---
 ## Context
 

--- a/tickets/closed/0301-erg-pr-merge-in-worktree-predicate.erg
+++ b/tickets/closed/0301-erg-pr-merge-in-worktree-predicate.erg
@@ -2,11 +2,13 @@
 Title: Tighten or justify erg-pr-merge in_worktree() weak predicate
 Created: 2026-07-13
 Author: claude
+Closed: autoclosed — PR #521
 
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (audit finding: `[ -f .git ]` is the weak predicate verbatim)
 
 2026-07-13T08:00Z bump verify-reroll — round 1: guard line `[ "$top" != "$prefix" ]` (skills/merge/erg-pr-merge:49) is load-bearing but untested by any of cases 18-20; add a case 21 pinning the same-basename-as-enclosing-repo lookalike (basename(top)==name AND top==prefix) before re-review
+2026-07-13T08:27Z Minh Ha-Duong closed — autoclosed — PR #521
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0301-erg-pr-merge-in-worktree-predicate.erg

## What changed

`erg-pr-merge`'s `in_worktree()` was `[ -f .git ] && grep -q "gitdir:" .git` — the weak predicate the 0252 family exists to retire. It matches ANY directory holding a `.git` FILE (git submodules, linked worktrees outside the harness `.claude/worktrees/` convention) and never verifies the cwd path claim against git's actual toplevel. It gates `MERGE_FLAGS` (the `--delete-branch` omission, ticket 0170) and the post-merge base-branch sync, so a false "in worktree" is costly.

Per the raid's imagine decision: **tighten, do not justify**. A PreToolUse hook fires once on the outer opaque script invocation and structurally cannot front the script's internal git/erg subprocess calls, so "the 0296 guard fronts this" is never valid. The fix is self-contained — it does not source or reference the parallel 0296 script.

New predicate: cwd must sit under a `.claude/worktrees/<name>` segment, `git rev-parse --show-toplevel` must resolve, its basename must equal `<name>`, and the toplevel must not be the enclosing repo before the marker. A one-line comment cites tickets 0301/0296 and incidents I1/I2 to block a future regression to `[ -f .git ]`.

Callers (MERGE_FLAGS, fallback merge, Step-4 base return) are unchanged: a session merging from a registered `.claude/worktrees/tNNNN` worktree — the normal `/merge` flow — is still detected as in-worktree, so behavior does not flip for the legitimate path.

## What the red case proved

Constructing a stale-`.git`-file case that (a) satisfies the old check, (b) makes `rev-parse` disagree, AND (c) still lets the script run to the merge step is not cleanly possible: git resolves `--show-toplevel` to the cwd for any valid `.git` file (basename matches → both predicates agree), and a broken `.git` file aborts the script before `in_worktree()` is reached. The achievable RED against the old predicate is a **linked worktree outside the marker** (Case 20): it has a `.git` file, so `[ -f .git ]` returned TRUE and omitted `--delete-branch` — the same over-broad match that also fired on submodules. Verified: the suite FAILS on the pre-fix predicate ("old behavior not tightened") and PASSES on the new one.

## New coverage

- **Case 19 (genuine registered worktree)** closes the pre-existing coverage gap — the worktree-true branch (`no --delete-branch`, Step-4 worktree message, ticket closed) was never exercised by any prior case; also guards an over-strict reimplementation.
- **Case 18 (lookalike plain dir under the marker)** guards against a naive path-only reimplementation that would match the segment alone.

## Verification

- `bash tests/test_erg_pr_merge.sh` — 24/24 pass (was 21).
- `make check-fast` — 694 passed.
- `make check` — 734 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)