### PR TITLE
fix(collision-gate): don't flag a ticket rename as a base-tip collision

### DIFF
--- a/scripts/check-cross-pr-ticket-collision.sh
+++ b/scripts/check-cross-pr-ticket-collision.sh
@@ -42,11 +42,22 @@ ticket_ids_from_paths() {  # reads filenames on stdin, prints 4-digit IDs
 }
 
 # ── this PR's newly-added ticket files (local git, no forge call) ─────────────
+# --no-renames pins a rename to delete(old)+add(new) regardless of git's
+# similarity detection, so classification never depends on how much the
+# rename edited the body.
 OWN_PATHS=$(
-    git diff --diff-filter=A --name-only "${BASE_REF}...HEAD" -- tickets/ \
+    git diff --no-renames --diff-filter=A --name-only "${BASE_REF}...HEAD" -- tickets/ \
         | grep -E '^tickets/[0-9]{4}-.*\.erg$'
 ) || true
 OWN_IDS=$(ticket_ids_from_paths <<< "$OWN_PATHS") || true
+
+# Ticket files this PR deletes. A rename (slug fix) is delete(old)+add(new)
+# with the same ID: the old path still on the base tip is this PR's own file,
+# not a rival claim, and must not trip the base-tip check below.
+OWN_DELETED=$(
+    git diff --no-renames --diff-filter=D --name-only "${BASE_REF}...HEAD" -- tickets/ \
+        | grep -E '^tickets/[0-9]{4}-.*\.erg$'
+) || true
 
 if [[ -z "$OWN_IDS" ]]; then
     echo "cross-pr-collision: this PR adds no ticket files — nothing to check."
@@ -62,13 +73,18 @@ collision=0
 # after this branch diverged, and a merged claimant is invisible to the open-PR
 # scan below. Compare added IDs against the base tip directly. A same-path hit
 # is this PR's own file already landed (not a rival claim), so only a different
-# filename carrying the same ID counts.
+# filename carrying the same ID counts — and among those, a path this PR
+# deletes is its own rename, not a rival.
 BASE_TICKETS=$(git ls-tree -r --name-only "$BASE_REF" -- tickets/ \
     | grep -E '^tickets/[0-9]{4}-.*\.erg$' || true)
 while IFS= read -r own_path; do
     [[ -z "$own_path" ]] && continue
     id=$(sed -E 's|^tickets/([0-9]{4})-.*|\1|' <<< "$own_path")
     rivals=$(grep -E "^tickets/${id}-" <<< "$BASE_TICKETS" | grep -vxF "$own_path" || true)
+    if [[ -n "$rivals" && -n "$OWN_DELETED" ]]; then
+        # drop base-tip paths this PR itself deletes (rename, not a rival)
+        rivals=$(comm -23 <(sort <<< "$rivals") <(sort <<< "$OWN_DELETED") || true)
+    fi
     [[ -z "$rivals" ]] && continue
     echo "COLLISION: ticket ID ${id} already exists on ${BASE_REF} as $(tr '\n' ' ' <<< "$rivals")(landed after this branch diverged)." >&2
     collision=$((collision + 1))

--- a/tests/test_check_cross_pr_ticket_collision.sh
+++ b/tests/test_check_cross_pr_ticket_collision.sh
@@ -23,6 +23,9 @@
 #       the merge-base diff and the open-PR scan are both blind to this one.
 #   (f) the PR's own file (same path) already sits on the base tip -> exit 0;
 #       a same-path hit is not a rival claim.
+#   (g) the PR RENAMES a base ticket (delete old slug + add new slug, same ID)
+#       -> exit 0; the old path on the base tip is the PR's own file, not a
+#       rival claimant.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -244,5 +247,39 @@ else
     echo "FAIL: same-path base hit wrongly flagged as a collision"; echo "$out"; fail=1
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# Case (g): the PR renames a base ticket (same ID, new slug) -> exit 0
+# ════════════════════════════════════════════════════════════════════════════
+seed_repo rename                # branch adds no new ticket; it renames one
+git -C "$REPO" mv tickets/0001-base.erg tickets/0001-renamed.erg
+# Rewrite the body so git's similarity detection does NOT pair the two paths
+# (the real-world trigger: a respec that renames the slug AND rewrites the
+# body shows up as delete(old)+add(new), not R).
+cat > "$REPO/tickets/0001-renamed.erg" <<'ERG'
+%erg 0.1
+Title: Base ticket, respecified beyond similarity recognition
+Created: 2026-06-18
+Author: test
+
+--- log ---
+2026-06-18T00:00Z test created
+2026-06-18T01:00Z test note respecified: new slug, new body
+
+--- body ---
+## Context
+Entirely rewritten so the rename is not detected as one: different sections,
+different wording, different length. The ID is the only thing that survives.
+
+## Exit criteria
+- [ ] nothing in common with the original body
+ERG
+git -C "$REPO" add tickets/0001-renamed.erg
+git -C "$REPO" commit -q -m "rename slug + respec body"
+if out=$(SELF_PR_NUMBER=99 STUB_PR_LIST='[]' run_check 2>&1); then
+    echo "PASS: same-ID rename is not flagged (exit 0)"
+else
+    echo "FAIL: rename wrongly flagged as a base-tip collision"; echo "$out"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: cross-PR ticket-ID collision gate — collisions fail with a named PR, distinct IDs pass, no-ticket PRs skip the forge call, fetch failures warn, base-tip claims are caught"
+echo "PASS: cross-PR ticket-ID collision gate — collisions fail with a named PR, distinct IDs pass, no-ticket PRs skip the forge call, fetch failures warn, base-tip claims are caught, renames pass"


### PR DESCRIPTION
Ticket: none

Retitled 2026-07-13: shared-worktree branch contention force-pushed this collision-gate fix (d218034, authored by a parallel live session) over the `t0268-state-guard` branch, replacing the 0268 guard commit this PR originally carried. The guard work now lives in #524 (self-contained, based on main, closes 0268 + 0304). Title/body updated to match the actual diff so the stale `**Ticket:** 0268` close claim cannot fire on merge; the authoring session should adjust the ticket line if this fix has its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)