### PR TITLE
ticket(0249): soften merge-prohibition wording misleading the permission classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/dream` | Autonomous nightly memory consolidation for one project. |
 | `/end-session` | Deprecated — renamed to /lair. Warns, then delegates to the new name. |
 | `/external-peer-review` | Send a manuscript PDF to external frontier models (OpenAI + Mistral via OpenRouter) for peer review; synthesize convergent findings into one verdict. |
-| `/gaze` | Run the full per-PR verification loop (adherence + review + review-pr + simplify), then gate through /verify-gate. Bounces the PR for at most one retry. Never merges. |
+| `/gaze` | Run the full per-PR verification loop (adherence + review + review-pr + simplify), then gate through /verify-gate. Bounces the PR for at most one retry. Does not merge — the merge decision belongs to the caller. |
 | `/healthcheck` | Repo healthcheck — git hygiene, test status, and deep freshness verification of status/directive docs. Gracefully degrades when project-specific conventions (git-erg tickets, STATE.md, etc.) are absent. |
 | `/housekeeping` | Alias of /molt — repo housekeeping with git sync, healthcheck, and eager fix-now repairs. |
 | `/hunt` | Begin work on a ticket — creates a worktree and writes the first test. |
@@ -114,7 +114,7 @@ Skills are available as `/roar`, `/gaze`, `/molt`, etc. Hooks fire automatically
 | `/update-publist` | Add or update a publication on the personal page and deposit on HAL via SWORD. Gated on user payload review before any outward API call. |
 | `/verify` | Deprecated — renamed to /gaze. Warns, then delegates to the new name. |
 | `/verify-adherence` | Check a branch's diff against project rules. Mechanical-first — runs hygiene tests + grep ratchet before falling back to LLM. |
-| `/verify-gate` | Anti-rubber-stamp merge gate. Validates every ticket exit criterion and every review comment against the actual diff. Emits APPROVED / REROLL / ESCALATE with explicit evidence. Never merges. |
+| `/verify-gate` | Anti-rubber-stamp merge gate. Validates every ticket exit criterion and every review comment against the actual diff. Emits APPROVED / REROLL / ESCALATE with explicit evidence. Does not merge — the merge decision belongs to the caller. |
 | `/zotero-import` | Import one or more PDFs into Zotero — extract metadata, resolve identifiers online, dedupe against the local library, and write a RIS file for import. |
 
 <!-- skills:end -->

--- a/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_review_before_merge.md
+++ b/projects/-home-haduong-CNRS-papiers-actif-AEDIST-technical-report/memory/feedback_review_before_merge.md
@@ -1,11 +1,11 @@
 ---
 name: Wait for review before merging
-description: Never merge a PR before the review agents have returned their results
+description: Merge a PR only after the review agents have returned their results
 type: feedback
 ---
 
-Always wait for review results before merging a PR, even for "trivial" renames.
+Wait for review results before merging a PR, even for "trivial" renames.
 
 **Why:** Review exists to catch bugs before they land on main. Merging before reviewers return defeats the purpose. Low-risk is not zero-risk.
 
-**How to apply:** After creating a PR and launching review, wait for all review agents to complete and report back. Only then proceed to merge — and only if findings are clean or non-blocking.
+**How to apply:** After creating a PR and launching review, wait for all review agents to complete and report back. Then merge, provided findings are clean or non-blocking. This is a sequencing rule, not a merge prohibition: once the review is in and a standing authorization covers the merge (e.g. the [[merge-review-merge-cadence]] grant), merging without a fresh confirmation is the intended behavior.

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gaze
-description: Run the full per-PR verification loop (adherence + review + review-pr + simplify), then gate through /verify-gate. Bounces the PR for at most one retry. Never merges.
+description: Run the full per-PR verification loop (adherence + review + review-pr + simplify), then gate through /verify-gate. Bounces the PR for at most one retry. Does not merge — the merge decision belongs to the caller.
 disable-model-invocation: false
 user-invocable: true
 argument-hint: <pr-number>
@@ -16,8 +16,8 @@ context: fork
 > environment (worktree name, git status snapshot, ticket files, or the shared
 > task list).
 
-One skill, one PR, one decision: APPROVED / REROLL / ESCALATE. **Never merges.**
-Merge is always the human's or the raid's call.
+One skill, one PR, one decision: APPROVED / REROLL / ESCALATE. **Does not
+merge** — the merge decision belongs to the caller (the human or the raid).
 
 ## When to use
 
@@ -29,7 +29,7 @@ Merge is always the human's or the raid's call.
 
 - Runs on exactly one PR.
 - Two gate rounds maximum. Third round is forbidden — escalate instead.
-- Never merges. The verdict is structured output; the caller decides.
+- Does not merge. The verdict is structured output; the merge decision belongs to the caller.
 - The fix loop between rounds makes commits on the PR branch; no changes to other branches.
 - `--force-approve` is supported for explicit human override; it is logged loudly in the
   PR comments and the skill transcript.

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -33,6 +33,12 @@ The script reads close intent from the PR **body** only — never the title:
 
 Report stdout/stderr verbatim. If the script exits non-zero, stop and show the error.
 
+A killed or failed `erg-pr-merge` run (non-zero exit after its rebase) can
+leave the PR-branch worktree with a stale pre-rebase index: staged diffs that
+appear to re-open closed tickets and revert prose. That is not WIP — run
+`git reset --hard HEAD` in that worktree before any salvage or gc decision
+(ticket 0249 incident, aedist PR #979).
+
 Merge is queued via auto-merge; it lands when required checks pass (falls back to watch-then-merge where auto-merge is disabled). A **draft** PR (roar/raid sweeps file bootstrap PRs as draft) is marked ready automatically before merging — invoking `/merge` is explicit intent to merge.
 
 ## After the merge lands

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-gate
-description: Anti-rubber-stamp merge gate. Validates every ticket exit criterion and every review comment against the actual diff. Emits APPROVED / REROLL / ESCALATE with explicit evidence. Never merges.
+description: Anti-rubber-stamp merge gate. Validates every ticket exit criterion and every review comment against the actual diff. Emits APPROVED / REROLL / ESCALATE with explicit evidence. Does not merge — the merge decision belongs to the caller.
 disable-model-invocation: false
 user-invocable: true
 argument-hint: <pr-number>
@@ -215,6 +215,6 @@ current round = count + 1.
 
 ## Not in scope
 
-- **Merging.** The gate never merges.
+- **Merging.** The gate does not merge; that decision belongs to the caller.
 - **Re-running tests.** The gate reads results; phase 1 of `/verify-adherence` runs them.
 - **Acting on scope overflow.** The gate detects and reports; the caller tickets and annotates.

--- a/tickets/0249-autonomous-raid-merge-step-classifier-re.erg
+++ b/tickets/0249-autonomous-raid-merge-step-classifier-re.erg
@@ -5,6 +5,7 @@ Author: Integration Test
 
 --- log ---
 2026-06-11T20:54Z Integration Test created
+2026-07-13T10:00Z claude note Resolution: reworded the merge prohibitions the classifier can see (gaze + verify-gate "Never merges" -> "does not merge, decision belongs to the caller"; aedist memory review-before-merge recast as a sequencing rule) and documented the stale pre-rebase index pitfall in skills/merge. Author closes to test the fix by experience.
 
 --- body ---
 ## Context

--- a/tickets/0268-refresh-state-clobbers-custom-status-section.erg
+++ b/tickets/0268-refresh-state-clobbers-custom-status-section.erg
@@ -6,6 +6,7 @@ Label: needs-human
 
 --- log ---
 2026-06-19T11:35Z HDMX-coding-agent created
+2026-07-13T10:40Z fable note author decided: abort on customized heading (action 1); no opt-out marker — fleet audit 2026-07-13 found all active repos converged to the machine template, only dormant Cadens + Fuzzy Corpus diverge (safe append path)
 
 --- body ---
 ## Context

--- a/tickets/closed/0249-autonomous-raid-merge-step-classifier-re.erg
+++ b/tickets/closed/0249-autonomous-raid-merge-step-classifier-re.erg
@@ -2,11 +2,13 @@
 Title: Autonomous raid merge step: classifier rejects STATE standing authorization
 Created: 2026-06-11
 Author: Integration Test
+Closed: autoclosed — PR #527
 
 --- log ---
 2026-06-11T20:54Z Integration Test created
 2026-07-13T10:00Z claude note Resolution: reworded the merge prohibitions the classifier can see (gaze + verify-gate "Never merges" -> "does not merge, decision belongs to the caller"; aedist memory review-before-merge recast as a sequencing rule) and documented the stale pre-rebase index pitfall in skills/merge. Author closes to test the fix by experience.
 
+2026-07-13T08:03Z Minh Ha-Duong closed — autoclosed — PR #527
 --- body ---
 ## Context
 Raid Phase 7 stalls in unattended sessions: the auto-mode permission


### PR DESCRIPTION
**Ticket:** tickets/0249-autonomous-raid-merge-step-classifier-re.erg

## What

The auto-mode permission classifier denied an autonomous `erg-pr-merge` (aedist PR #979, 2026-06-11) citing a rule — "never close merge requests without explicit user confirmation" — that exists nowhere verbatim. It was paraphrased from prohibition-flavored texts the classifier can see, while the STATE.md standing authorization stayed invisible. This PR rewords the sources we control so scope survives paraphrase:

- `skills/gaze/SKILL.md`, `skills/verify-gate/SKILL.md`: "Never merges" → "Does not merge — the merge decision belongs to the caller" (same contract, no free-floating absolute).
- aedist memory `feedback_review_before_merge.md`: description recast in positive form ("Merge a PR only after…") and the body now states explicitly that it is a sequencing rule, not a merge prohibition, and that a standing authorization covers the merge without fresh confirmation.
- `skills/merge/SKILL.md`: documents the stale pre-rebase index left by a killed `erg-pr-merge` run (exit criterion 2 of the ticket).
- `README.md`: regenerated skills catalog (descriptions changed).

## Why close now

Author decision 2026-07-13: apply the cheap wording fix (ticket option 2 territory) instead of a settings grant (options 1/3), close 0249, and judge effectiveness by experience in future autonomous raids. The system-prompt-level "never merge" remains outside our control and is accepted residual risk.

## Test plan

- `erg check tickets/` passes (298 tickets).
- `make check-skills-drift` covered by CI (catalog regenerated in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)