### PR TITLE
feat(0206): on-demand Copilot reviewer request + gaze gate clause

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -370,6 +370,18 @@ panel comment (only verifiable-class may bounce). The full panel-extension
 contract is ticket 0205's deliverable; seat execution is the 0217
 seat-runner. See `skills/reviewers/SKILL.md`.
 
+**Forge automated reviewer** (ticket 0206): the gate's comment-validation
+step includes the forge's automated reviewer (e.g. a requested Copilot
+review), when present — its findings are dispositioned like any panel
+comment: correctness-class only may bounce, style is noted-not-blocking.
+The seat is **on-demand**: a PR nobody requested it on is simply a PR
+without that seat — no warning, no wait. Only when a request WAS made
+(the bot appears in the PR's requested or completed reviewers) and its
+review is still pending while everything else is ready: bounded wait of a
+few minutes, then proceed with a logged WARN — fail-open.
+<!-- harness-extension-point: requested-reviewer detection is
+`gh pr view <pr> --json reviewRequests,reviews` on GitHub. -->
+
 ## Output shape
 
 Post a single top-level PR comment at end of skill. Two sections,

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -372,13 +372,13 @@ seat-runner. See `skills/reviewers/SKILL.md`.
 
 **Forge automated reviewer** (ticket 0206): the gate's comment-validation
 step includes the forge's automated reviewer (e.g. a requested Copilot
-review), when present — its findings are dispositioned like any panel
+review), when present. Its findings are dispositioned like any panel
 comment: correctness-class only may bounce, style is noted-not-blocking.
 The seat is **on-demand**: a PR nobody requested it on is simply a PR
-without that seat — no warning, no wait. Only when a request WAS made
-(the bot appears in the PR's requested or completed reviewers) and its
-review is still pending while everything else is ready: bounded wait of a
-few minutes, then proceed with a logged WARN — fail-open.
+without that seat, with no warning and no wait. Only when a request WAS
+made (the bot appears in the PR's requested or completed reviewers) and
+its review is still pending while everything else is ready: bounded wait
+of a few minutes, then proceed with a logged WARN — fail-open.
 <!-- harness-extension-point: requested-reviewer detection is
 `gh pr view <pr> --json reviewRequests,reviews` on GitHub. -->
 

--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -29,8 +29,15 @@ diff (the branch is resolved from the PR, or passed explicitly):
 - **cli-agent / local-model**: the seat-runner launches the agnostic CLI
   reviewer inside an OS sandbox over an OpenAI-compatible endpoint
   (OpenRouter or local llama-server), writing per-seat findings.
-- **forge-bot**: requested via the forge's review API.
-  <!-- harness-extension-point -->
+- **forge-bot**: requested via the forge's reviewer-request API, using the
+  seat's `login` from the roster (on GitHub: <!-- harness-extension-point -->
+  `gh api --method POST repos/{owner}/{repo}/pulls/<pr>/requested_reviewers
+  -f 'reviewers[]=<login>'`).
+  **On-demand only** (ticket 0206): the seat fires when this subcommand is
+  invoked on a specific merge request — no repo-wide auto-request, so
+  trivial PRs stay unreviewed. Its findings surface as review comments on
+  the merge request itself (not as `harvest` findings files); the gate
+  dispositions them like any panel comment.
 
 **Per-seat fail-open**: a seat that errors or hangs WARNs and the others
 proceed — one seat never blocks the verdict (0205). Empty roster → no-op,

--- a/skills/reviewers/panel.yml
+++ b/skills/reviewers/panel.yml
@@ -19,7 +19,9 @@
 # `/reviewers request <pr>` is invoked on a specific merge request — there
 # is no repo-wide auto-request lever, so trivial PRs stay unreviewed.
 #
-# Default: empty roster → /reviewers is a no-op until seats are configured.
+# The shipped roster below is inert until explicitly invoked: no seat fires
+# without `/reviewers request <pr>`. An empty roster (`reviewers: []`) makes
+# /reviewers a no-op entirely.
 # Example cli/model seat (commented; uncomment + adjust to enable):
 #
 #   - name: local-qwen

--- a/skills/reviewers/panel.yml
+++ b/skills/reviewers/panel.yml
@@ -12,11 +12,16 @@
 #     # cli-agent / local-model seats also carry:
 #     endpoint:     OpenAI-compatible base URL (e.g. http://127.0.0.1:8012/v1)
 #     model:        model id passed to the seat-runner
+#     # forge-bot seats also carry:
+#     login:        the bot's forge login, passed to the reviewer-request API
+#
+# A forge-bot seat is ON-DEMAND (ticket 0206): it fires only when
+# `/reviewers request <pr>` is invoked on a specific merge request — there
+# is no repo-wide auto-request lever, so trivial PRs stay unreviewed.
 #
 # Default: empty roster → /reviewers is a no-op until seats are configured.
-# Example (commented; uncomment + adjust to enable):
+# Example cli/model seat (commented; uncomment + adjust to enable):
 #
-# reviewers:
 #   - name: local-qwen
 #     kind: local-model
 #     status: advisory
@@ -24,4 +29,9 @@
 #     endpoint: http://127.0.0.1:8012/v1
 #     model: openai/qwen3.6-35b-a3b
 
-reviewers: []
+reviewers:
+  - name: copilot
+    kind: forge-bot
+    status: advisory
+    login: copilot-pull-request-reviewer[bot]
+    trial-ticket: tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -33,24 +33,26 @@ EOF
 }
 
 # ── roster parsing ───────────────────────────────────────────────────────────
-# Emit one TAB-separated record per seat: name kind status endpoint model
-# trial-ticket. Minimal block parser for the flat panel.yml schema; comment
-# and blank lines are ignored, and an explicit `reviewers: []` yields nothing.
+# Emit one pipe-separated record per seat: name kind status endpoint model
+# login trial-ticket. Minimal block parser for the flat panel.yml schema;
+# comment and blank lines are ignored, and an explicit `reviewers: []` yields
+# nothing.
 roster_records() {
     awk '
         /^[[:space:]]*#/        { next }
         /^reviewers:[[:space:]]*\[\][[:space:]]*$/ { exit }
         /^[[:space:]]*-[[:space:]]*name:/ {
-            if (have) print rec(); have=1; name=val($0); kind=st=ep=mo=tt=""; next
+            if (have) print rec(); have=1; name=val($0); kind=st=ep=mo=lg=tt=""; next
         }
         /^[[:space:]]+kind:/          { kind=val($0) }
         /^[[:space:]]+status:/        { st=val($0) }
         /^[[:space:]]+endpoint:/      { ep=val($0) }
         /^[[:space:]]+model:/         { mo=val($0) }
+        /^[[:space:]]+login:/         { lg=val($0) }
         /^[[:space:]]+trial-ticket:/  { tt=val($0) }
         END { if (have) print rec() }
         function val(line,  v) { sub(/^[^:]*:[[:space:]]*/, "", line); gsub(/^[[:space:]]+|[[:space:]]+$/, "", line); return line }
-        function rec() { return name"\t"kind"\t"st"\t"ep"\t"mo"\t"tt }
+        function rec() { return name"|"kind"|"st"|"ep"|"mo"|"lg"|"tt }
     ' "$PANEL" 2>/dev/null
 }
 
@@ -69,7 +71,7 @@ case "$subcmd" in
     list)
         if panel_is_empty; then echo "no reviewers configured"; exit 0; fi
         printf '%-18s %-12s %-9s %s\n' NAME KIND STATUS TRIAL-TICKET
-        while IFS=$'\t' read -r name kind st ep mo tt; do
+        while IFS='|' read -r name kind st ep mo lg tt; do
             printf '%-18s %-12s %-9s %s\n' "$name" "$kind" "${st:-advisory}" "$tt"
         done < <(roster_records)
         ;;
@@ -81,11 +83,25 @@ case "$subcmd" in
         [ -n "$branch" ] || { echo "error: could not resolve branch for MR #${pr}" >&2; exit 1; }
         dest="${FINDINGS_DIR}/${pr}"; mkdir -p "$dest"
         ran=0
-        while IFS=$'\t' read -r name kind st ep mo tt; do
+        while IFS='|' read -r name kind st ep mo lg tt; do
             case "$kind" in
                 forge-bot)
-                    # Server-side reviewer; requested via the forge API.
-                    echo "request: forge-bot seat '${name}' — request via forge review API" >&2  # harness-extension-point
+                    # Server-side reviewer, requested on demand — nothing
+                    # fires without this explicit request (0206: no repo-wide
+                    # auto-request lever). Fail-open like every other seat.
+                    if [ -z "$lg" ]; then
+                        echo "request: WARN forge-bot seat '${name}' has no login — skipped" >&2
+                        continue
+                    fi
+                    # GitHub review-request API — swap this call for
+                    # another forge's reviewer request. harness-extension-point
+                    if gh api --method POST \
+                        "repos/{owner}/{repo}/pulls/${pr}/requested_reviewers" \
+                        -f "reviewers[]=${lg}" >/dev/null 2>&1; then
+                        echo "request: forge-bot seat '${name}' requested (${lg}) on MR #${pr}" >&2
+                    else
+                        echo "request: WARN forge-bot seat '${name}' request failed (fail-open)" >&2
+                    fi
                     ;;
                 cli-agent|local-model)
                     # Per-seat fail-open: a seat that errors WARNs and the
@@ -150,7 +166,7 @@ case "$subcmd" in
         [ -n "$pr" ] && [ -n "$seat" ] && [ -n "$verdict" ] || { echo "error: scorecard requires <pr> <seat> <verdict-summary>" >&2; exit 1; }
         # Resolve the seat's trial ticket from the roster.
         tt=""
-        while IFS=$'\t' read -r n k s e m t; do [ "$n" = "$seat" ] && tt="$t"; done < <(roster_records)
+        while IFS='|' read -r n k s e m l t; do [ "$n" = "$seat" ] && tt="$t"; done < <(roster_records)
         [ -n "$tt" ] || { echo "error: seat '${seat}' not in roster (no trial-ticket)" >&2; exit 1; }
         tid=$(sed -n 's#.*/\([0-9]\{4\}\)-.*#\1#p' <<<"$tt")
         # Fixed schema so 0205's integration review is evidence-based, not vibes.

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -65,6 +65,14 @@ pr_branch() {  # $1 pr; honor an explicit override first
     gh pr view "$pr" --json headRefName --jq '.headRefName'  # harness-extension-point
 }
 
+# ── Forge reviewer request (forge-specific; swap for another forge) ──────────
+request_forge_reviewer() {  # $1 pr, $2 bot login
+    local pr="$1" login="$2"
+    gh api --method POST \
+        "repos/{owner}/{repo}/pulls/${pr}/requested_reviewers" \
+        -f "reviewers[]=${login}" >/dev/null 2>&1  # harness-extension-point
+}
+
 subcmd="${1:-}"; shift || true
 
 case "$subcmd" in
@@ -93,11 +101,7 @@ case "$subcmd" in
                         echo "request: WARN forge-bot seat '${name}' has no login — skipped" >&2
                         continue
                     fi
-                    # GitHub review-request API — swap this call for
-                    # another forge's reviewer request. harness-extension-point
-                    if gh api --method POST \
-                        "repos/{owner}/{repo}/pulls/${pr}/requested_reviewers" \
-                        -f "reviewers[]=${lg}" >/dev/null 2>&1; then
+                    if request_forge_reviewer "$pr" "$lg"; then
                         echo "request: forge-bot seat '${name}' requested (${lg}) on MR #${pr}" >&2
                     else
                         echo "request: WARN forge-bot seat '${name}' request failed (fail-open)" >&2

--- a/tests/test_reviewers.sh
+++ b/tests/test_reviewers.sh
@@ -152,6 +152,59 @@ else
     echo "SKIP: erg binary absent — scorecard erg-integration test"
 fi
 
+# ── forge-bot seat: on-demand request via the forge review API (0206) ────────
+# A forge-bot seat has no seat-runner; `request` asks the forge to run its
+# server-side reviewer on the PR. Stub `gh` to capture the call.
+GHBOT="$WORK/ghbin"; mkdir -p "$GHBOT"
+cat > "$GHBOT/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$GH_CALL_LOG"
+[ -n "${GH_FAIL:-}" ] && exit 1
+exit 0
+GHSTUB
+chmod +x "$GHBOT/gh"
+
+BOTROSTER="$WORK/bot.yml"
+cat > "$BOTROSTER" <<'YAML'
+reviewers:
+  - name: copilot
+    kind: forge-bot
+    status: advisory
+    login: copilot-pull-request-reviewer[bot]
+    trial-ticket: tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
+YAML
+
+GHLOG="$WORK/gh-calls.log"; : > "$GHLOG"
+bot_err=$(PATH="$GHBOT:$PATH" GH_CALL_LOG="$GHLOG" \
+          REVIEWERS_PANEL="$BOTROSTER" REVIEWERS_PR_BRANCH="some-branch" \
+          "$REVIEWERS" request 42 2>&1 >/dev/null)
+assert_contains "request: forge-bot seat requested" "forge-bot seat 'copilot' requested" "$bot_err"
+assert_contains "request: forge API call carries the login" "copilot-pull-request-reviewer[bot]" "$(cat "$GHLOG")"
+assert_contains "request: forge API call targets the PR" "pulls/42/requested_reviewers" "$(cat "$GHLOG")"
+
+# Forge API failure → WARN, fail-open (exit 0).
+bot_fail_err=$(PATH="$GHBOT:$PATH" GH_CALL_LOG="$GHLOG" GH_FAIL=1 \
+               REVIEWERS_PANEL="$BOTROSTER" REVIEWERS_PR_BRANCH="some-branch" \
+               "$REVIEWERS" request 42 2>&1 >/dev/null)
+assert_contains "request: forge-bot failure fail-open WARN" "WARN forge-bot seat 'copilot'" "$bot_fail_err"
+assert_exit_0 "request: forge-bot failure exits 0" env PATH="$GHBOT:$PATH" GH_CALL_LOG="$GHLOG" GH_FAIL=1 \
+    REVIEWERS_PANEL="$BOTROSTER" REVIEWERS_PR_BRANCH="some-branch" "$REVIEWERS" request 42
+
+# A forge-bot seat with no login → WARN, skipped, others unaffected.
+NOLOGIN="$WORK/nologin.yml"
+cat > "$NOLOGIN" <<'YAML'
+reviewers:
+  - name: mystery-bot
+    kind: forge-bot
+    status: advisory
+    trial-ticket: tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
+YAML
+nologin_err=$(PATH="$GHBOT:$PATH" GH_CALL_LOG="$GHLOG" \
+              REVIEWERS_PANEL="$NOLOGIN" REVIEWERS_PR_BRANCH="some-branch" \
+              "$REVIEWERS" request 42 2>&1 >/dev/null)
+assert_contains "request: forge-bot without login WARNs" "WARN forge-bot seat 'mystery-bot' has no login" "$nologin_err"
+
 # ── arg validation ───────────────────────────────────────────────────────────
 if "$REVIEWERS" request >/dev/null 2>&1; then echo "FAIL: request missing arg should fail"; FAIL=$((FAIL+1)); else echo "PASS: request missing arg fails"; PASS=$((PASS+1)); fi
 

--- a/tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
+++ b/tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
@@ -13,6 +13,8 @@ Author: MinhHaDuong
 2026-06-05T06:55Z claude note format correction: the 2026-06-04T08:52Z line above has no actor token (spec is {ts} {actor} {verb} {detail}); the unblocking action was performed by claude. Appending here per append-only rule rather than editing the original
 
 2026-07-13T08:50Z MinhHaDuong note design change: auto-request on every MR is too much — some PRs are trivial. Switch to on-demand: the review is requested per-PR when warranted, never enabled repo-wide. Body rewritten accordingly by claude
+
+2026-07-13T09:30Z claude note lever documented: /reviewers request <pr> runs the forge-bot seat via `gh api --method POST repos/{owner}/{repo}/pulls/<pr>/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'` (login from panel.yml); gate clause added to skills/gaze/SKILL.md (absent seat silent, requested-but-pending bounded fail-open wait). Exit criteria 1-2 delivered; trial (criteria 3-4) remains
 --- body ---
 ## Context
 
@@ -61,8 +63,8 @@ dispositioned in the gate verdict's evidence table.
 
 ## Exit criteria
 
-- [ ] On-demand request path live; exact forge call documented
-- [ ] Gate clause merged (absent seat is silent; requested-but-pending
+- [x] On-demand request path live; exact forge call documented
+- [x] Gate clause merged (absent seat is silent; requested-but-pending
       gets fail-open bounded wait)
 - [ ] Trial scorecard: ≥5 non-trivial MRs, ≥3 projects, logged here
 - [ ] Promote/drop recommendation recorded for 0205's integration review


### PR DESCRIPTION
Implements exit criteria 1–2 of ticket 0206 (on-demand respec merged in #515).

**What**
- `/reviewers request <pr>` now runs forge-bot seats for real: it requests the seat's bot on the named PR via the forge reviewer-request API (GitHub: `POST pulls/<pr>/requested_reviewers` with the roster `login`), fail-open, behind a `harness-extension-point` marker. Nothing fires without an explicit request — no repo-wide auto-request lever exists.
- `panel.yml` gains a `login:` field for forge-bot seats and enables the `copilot` seat (advisory), trial-ticketed to 0206.
- Roster records switch from tab to pipe delimiters: tab is IFS whitespace, so `read` collapses empty mid-record fields — a latent parser bug the login field exposed (forge-bot seats have no endpoint/model).
- gaze SKILL.md gains the gate clause: the forge's automated reviewer, when present, is dispositioned like any panel comment; an unrequested seat is silent; requested-but-pending gets a bounded fail-open wait.

**Tests**: 5 new cases in `tests/test_reviewers.sh` (forge-bot request call shape, fail-open on API failure, login-missing WARN) — RED on the stub, GREEN now; suite 25/25. `make check` exits 0.

**Adherence**: /verify-adherence PASS (one em-dash nit, fixed in the second commit) — /gaze may skip the mechanical phase.

The ticket stays open for the advisory trial (exit criteria 3–4: ≥5 non-trivial MRs, ≥3 projects, scorecards).

Ticket-ref: tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)