### PR TITLE
naming(0298): collision-resistant worktree names t{N}-{pid}

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -12,10 +12,12 @@ The hook handles worktree entry automatically. When naming the worktree (if prom
 | Context | Worktree name | Phase |
 |---------|---------------|-------|
 | Fresh conversation, no ticket | `explore-{topic}` | `[→ Imagine]` |
-| Ticket reference but no branch | `t{N}` | `[→ Plan]` |
-| `/hunt N` | `t{N}` | `[→ Execute]` |
-| Active feature branch + open MR | `t{N}` | `[→ Execute]` |
+| Ticket reference but no branch | `t{N}-{pid}` | `[→ Plan]` |
+| `/hunt N` | `t{N}-{pid}` | `[→ Execute]` |
+| Active feature branch + open MR | `t{N}-{pid}` | `[→ Execute]` |
 | MR review | `review-{N}` | `[→ Verify]` |
+
+The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel sessions on the same ticket land in distinct worktree paths; legacy bare `t{N}` names remain valid.
 
 After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→ Execute]`) so the user sees which Five-Claws claw is active.
 

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -25,8 +25,8 @@ argument-hint: <ticket-id>
      via review like any other change. Do not stop with an uncommitted-to-`main` or unpushed close.
 3. Enter the ticket's **own** worktree, or confirm the spawner already gave you one.
    A worktree is **owned** when either its basename is `t$ARGUMENTS` or begins with
-   `t$ARGUMENTS-` (the collision-resistant suffixed form, e.g. `t$ARGUMENTS-$$`), OR its
-   basename matches `agent-*` (the orchestrator created it for this agent session) AND
+   `t$ARGUMENTS-` (the collision-resistant suffixed form — see the `EnterWorktree`
+   call below), OR its basename matches `agent-*` (the orchestrator created it for this agent session) AND
    `git status --porcelain` prints nothing — the session started inside it and its tree
    is clean (that is what `Agent(isolation:"worktree")` produces). Both conditions must
    hold: an `agent-*` basename over a dirty tree is not proof of ownership. A shared or
@@ -35,7 +35,7 @@ argument-hint: <ticket-id>
    it does not own (2026-06-11: a hunt inherited an orchestration session's worktree,
    rebased its branch, and stranded in-progress test edits there). Resolve ownership
    before the first branch-mutating command:
-   - Already inside an owned worktree — basename `t$ARGUMENTS` or `t$ARGUMENTS-<pid>`, or an `agent-*`
+   - Already inside an owned worktree — basename `t$ARGUMENTS` or beginning with `t$ARGUMENTS-`, or an `agent-*`
      one from an `Agent(isolation:"worktree")` spawn whose `git status --porcelain` is
      empty — means you are isolation-confirmed; proceed to step 4. When such a spawned
      agent has its `EnterWorktree` rejected with "already in a worktree", that rejection

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -24,7 +24,8 @@ argument-hint: <ticket-id>
      merge request (step 10). Skip the test/implement steps (5–9); the merge request lands the close
      via review like any other change. Do not stop with an uncommitted-to-`main` or unpushed close.
 3. Enter the ticket's **own** worktree, or confirm the spawner already gave you one.
-   A worktree is **owned** when either its basename is exactly `t$ARGUMENTS`, OR its
+   A worktree is **owned** when either its basename is `t$ARGUMENTS` or begins with
+   `t$ARGUMENTS-` (the collision-resistant suffixed form, e.g. `t$ARGUMENTS-$$`), OR its
    basename matches `agent-*` (the orchestrator created it for this agent session) AND
    `git status --porcelain` prints nothing — the session started inside it and its tree
    is clean (that is what `Agent(isolation:"worktree")` produces). Both conditions must
@@ -34,17 +35,18 @@ argument-hint: <ticket-id>
    it does not own (2026-06-11: a hunt inherited an orchestration session's worktree,
    rebased its branch, and stranded in-progress test edits there). Resolve ownership
    before the first branch-mutating command:
-   - Already inside an owned worktree — basename `t$ARGUMENTS`, or an `agent-*`
+   - Already inside an owned worktree — basename `t$ARGUMENTS` or `t$ARGUMENTS-<pid>`, or an `agent-*`
      one from an `Agent(isolation:"worktree")` spawn whose `git status --porcelain` is
      empty — means you are isolation-confirmed; proceed to step 4. When such a spawned
      agent has its `EnterWorktree` rejected with "already in a worktree", that rejection
      **is** the confirmation only if the current tree passes the same clean `agent-*`
      check; a rejection over a dirty or non-`agent-*` tree means STOP — the worktree is
      not owned — not an error to proceed through.
-   - Otherwise call `EnterWorktree` with name `t$ARGUMENTS`, even if the session already
-     sits inside some other, unowned worktree.
-   Confirm with `basename "$(git rev-parse --show-toplevel)"`: it must be `t$ARGUMENTS`
-   or the `agent-*` worktree of this session (rules/git.md § anchor branch-mutating git
+   - Otherwise call `EnterWorktree` with name `t$ARGUMENTS-$$` (the `$$` session-PID
+     suffix keeps parallel sessions on the same ticket in distinct worktree paths),
+     even if the session already sits inside some other, unowned worktree.
+   Confirm with `basename "$(git rev-parse --show-toplevel)"`: it must be `t$ARGUMENTS`,
+   begin with `t$ARGUMENTS-`, or be the `agent-*` worktree of this session (rules/git.md § anchor branch-mutating git
    across a forked-skill boundary). Ad hoc orchestrators should not hand-type this
    ownership contract: spawn the hunt headlessly as `~/.claude/scripts/beat.py` does, with
    `claude -p "/hunt <id>"`, so the live SKILL.md text supplies the rule.

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -2473,3 +2473,20 @@ class TestSyncOriginMainSharedScript:
 
         got = _run_git("rev-parse", "refs/heads/main", cwd=clone).stdout.strip()
         assert got == new_sha
+
+
+class TestHarnessWorktreeRe:
+    """_HARNESS_WORKTREE_RE recognizes both legacy and suffixed `t{N}` names.
+
+    Regression lock, not a bugfix: the pattern is an unanchored prefix match
+    (`t\\d`), so a collision-resistant suffix (`t0296-1234a`, ticket 0298) is
+    already recognized with no beat.py edit. This test pins that behavior so a
+    future re-anchoring of the regex cannot silently drop the suffixed form and
+    strand its locked worktrees during housekeeping cleanup.
+    """
+
+    def test_matches_legacy_bare_ticket_name(self):
+        assert beat._HARNESS_WORKTREE_RE.match("t0296")
+
+    def test_matches_suffixed_ticket_name(self):
+        assert beat._HARNESS_WORKTREE_RE.match("t0296-1234a")

--- a/tickets/closed/0298-collision-resistant-worktree-naming.erg
+++ b/tickets/closed/0298-collision-resistant-worktree-naming.erg
@@ -2,11 +2,13 @@
 Title: Collision-resistant worktree naming (t{N}-{discriminator})
 Created: 2026-07-13
 Author: claude
+Closed: autoclosed — PR #529
 
 --- log ---
 2026-07-13T07:00Z claude created child of 0252 (author ratified model C, 2026-07-13); blocked by 0294 which reworks the hunt step 3 ownership predicate this change must compose with
 
 2026-07-13T07:19Z Minh Ha-Duong note blocker 0294 closed — Blocked-by removed.
+2026-07-13T09:00Z Minh Ha-Duong closed — autoclosed — PR #529
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

Collision-resistant worktree naming — `t{N}-{pid}` — so two sessions on the same ticket resolve to distinct worktree paths (incident I2, aedist 2026-06-11/12). Child of tracking ticket 0252 (model C, ratified 2026-07-13).

## Changes

- **rules/workflow.md** naming table: the three `t{N}` cells become `t{N}-{pid}`, plus one sentence naming the `$$` session discriminator. Legacy bare `t{N}` remains valid.
- **skills/hunt/SKILL.md** step 3: the ownership predicate accepts basename exactly `t$ARGUMENTS` (legacy) OR beginning with `t$ARGUMENTS-` (suffixed) at all four comparison points; the `EnterWorktree` request now uses `t$ARGUMENTS-$$`. The legacy exact-match branch is kept so the invariant "legacy `t{N}` worktrees remain recognized" holds.
- **tests/test_beat.py**: new `TestHarnessWorktreeRe` regression lock.

## beat.py needed no edit

`_HARNESS_WORKTREE_RE = re.compile(r"^(agent- |explore-|t\d|review-)")` is an unanchored prefix match, so it already matches `t0296-1234a`. The new test pins that behavior (matches both `t0296` and `t0296-1234a`) so a future re-anchoring cannot silently drop the suffixed form and strand its locked worktrees during housekeeping.

## Verification

- `tests/test_beat.py::TestHarnessWorktreeRe` + `tests/test_hunt_worktree_ownership.py` — 7 passed (ticket 0294's guard test unchanged and green).
- `make check-fast` and `make check` — pass.

**Ticket:** tickets/0298-collision-resistant-worktree-naming.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)