### PR TITLE
roar(0252): close worktree-ownership tracker — integration review + sweep tickets

### DIFF
--- a/tickets/0252-audit-worktree-ownership-vs-isolation.erg
+++ b/tickets/0252-audit-worktree-ownership-vs-isolation.erg
@@ -9,6 +9,7 @@ Author: HDMX-coding-agent
 
 2026-07-13T06:59Z note Author ratified A + C, deferred B to design (2026-07-13). Children filed: 0296 (A guard), 0297 (guard-commit-on-main fix), 0298 (C naming, blocked-by 0294), 0299 (B design), 0300 (gaze /tmp worktrees), 0301 (erg-pr-merge predicate). Now a tracking ticket; stays open until all children close.
 2026-07-13T07:02Z note 0299 closed wontfix pre-merge (author, 2026-07-13): B claim-binding design not pursued; retained model is A (0296/0297) + C (0298) with 0300/0301 hygiene
+2026-07-13T09:05Z note Integration review at raid wrap-up (2026-07-13): all six children closed (0296 PR#519, 0297 PR#517, 0298 PR#529, 0299 wontfix PR#511, 0300 PR#518, 0301 PR#521); make check green on main at 89ca9b0; union sweep found zero /tmp/review or exact-match t{N} residuals; weak-predicate residuals in two sibling guards ticketed as 0308; EnterWorktree PID-resolution doc gap ticketed as 0309; follow-ups 0302/0303 remain open. Exit criteria verified — closing via PR.
 --- body ---
 ## Context
 

--- a/tickets/0308-retire-the-weak-f-git-predicate-in-preto.erg
+++ b/tickets/0308-retire-the-weak-f-git-predicate-in-preto.erg
@@ -1,0 +1,32 @@
+%erg 0.1
+Title: Retire the weak [ -f .git ] predicate in pretooluse-worktree-path-guard.sh and block-pr-merge-in-worktree.sh
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T09:04Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Found during the 0252 raid wrap-up sweep (2026-07-13). Ticket 0301 retired
+the weak worktree predicate `[ -f .git ]` in erg-pr-merge, and gaze's PR #521
+review flagged that two sibling guards still carry the exact same predicate:
+
+- `scripts/pretooluse-worktree-path-guard.sh`
+- `scripts/block-pr-merge-in-worktree.sh`
+
+Neither is owned by any 0252 child. Same class, same fix shape as 0301:
+compare the cwd's worktree-name segment against
+`basename $(git rev-parse --show-toplevel)` (see `scripts/guard-worktree-identity.sh`
+and `in_worktree()` in `skills/merge/erg-pr-merge` for the two reference
+implementations), or record a justification comment where the weak check is
+genuinely sufficient.
+
+Related: 0302 (extract shared predicate helper — if 0302 lands first, use the
+helper; if this lands first, it becomes a third copy for 0302 to unify).
+
+## Exit criteria
+- [ ] Both scripts either use the identity predicate or carry a written justification
+- [ ] Tests cover the changed behavior (red-first where the predicate tightens)
+- [ ] `make check` passes

--- a/tickets/0309-hunt-step-3-spell-out-how-to-obtain-the.erg
+++ b/tickets/0309-hunt-step-3-spell-out-how-to-obtain-the.erg
@@ -1,0 +1,22 @@
+%erg 0.1
+Title: hunt step 3: spell out how to obtain the session PID for the t{N}-{pid} worktree name
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T09:04Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Found during the 0252 raid wrap-up sweep (2026-07-13). PR #529 (ticket 0298)
+instructs hunt step 3 to request the worktree name `t$ARGUMENTS-$$`, but the
+EnterWorktree name schema rejects `$` characters and nothing tells the model
+how to resolve `$$` first. The gaze verdict on #529 ruled it non-blocking
+(failure mode is a loud InputValidationError, not a silent collision) and
+recommended this documentation fast-follow: spell out obtaining the PID via
+`bash -c 'echo $$'` (or equivalent) before the EnterWorktree call.
+
+## Exit criteria
+- [ ] hunt step 3 shows a literal, executable way to obtain the discriminator
+- [ ] `make check` passes (test_hunt_worktree_ownership.py still green)

--- a/tickets/closed/0252-audit-worktree-ownership-vs-isolation.erg
+++ b/tickets/closed/0252-audit-worktree-ownership-vs-isolation.erg
@@ -2,6 +2,7 @@
 Title: Audit harness isolation practices: "be in a worktree" vs "be in YOUR worktree"
 Created: 2026-06-12
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #530
 
 --- log ---
 2026-06-12T10:55Z orchestrator created from aedist orchestration-night incidents (2026-06-11/12)
@@ -10,6 +11,7 @@ Author: HDMX-coding-agent
 2026-07-13T06:59Z note Author ratified A + C, deferred B to design (2026-07-13). Children filed: 0296 (A guard), 0297 (guard-commit-on-main fix), 0298 (C naming, blocked-by 0294), 0299 (B design), 0300 (gaze /tmp worktrees), 0301 (erg-pr-merge predicate). Now a tracking ticket; stays open until all children close.
 2026-07-13T07:02Z note 0299 closed wontfix pre-merge (author, 2026-07-13): B claim-binding design not pursued; retained model is A (0296/0297) + C (0298) with 0300/0301 hygiene
 2026-07-13T09:05Z note Integration review at raid wrap-up (2026-07-13): all six children closed (0296 PR#519, 0297 PR#517, 0298 PR#529, 0299 wontfix PR#511, 0300 PR#518, 0301 PR#521); make check green on main at 89ca9b0; union sweep found zero /tmp/review or exact-match t{N} residuals; weak-predicate residuals in two sibling guards ticketed as 0308; EnterWorktree PID-resolution doc gap ticketed as 0309; follow-ups 0302/0303 remain open. Exit criteria verified — closing via PR.
+2026-07-13T09:05Z Minh Ha-Duong closed — autoclosed — PR #530
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0252-audit-worktree-ownership-vs-isolation.erg

Closes the 0252 tracking ticket after the raid delivered its whole family: 0296 (#519), 0297 (#517), 0298 (#529), 0300 (#518), 0301 (#521), and 0299 closed wontfix (#511). Integration review recorded on the ticket log: full suite green on main, union sweep clean except two residuals filed as tickets in this PR:

- tickets/0308 — retire the weak `[ -f .git ]` predicate in the two remaining sibling guards
- tickets/0309 — hunt step 3: spell out PID resolution for the t{N}-{pid} worktree name

Related follow-ups already open: tickets/0302 (shared predicate helper), tickets/0303 (maw-audit /tmp worktrees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)