### PR TITLE
roar(0206): bash tab-IFS rule + shared-worktree contention memory

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Shared-worktree live-session contention](feedback_shared_worktree_live_session_contention.md) — a live session can switch branches under a background job between Bash calls; assert branch and commit in ONE compound in any worktree you didn't create; recover misplaced commits by cherry-pick from a fresh worktree, never by resetting the other branch (2026-07-13)
 - [Skill invocation flag gates Skill(X) mandates](feedback_skill_invocation_flag_gates_mandates.md) — a mandated Skill(X) call fails at runtime when X's frontmatter has disable-model-invocation: true; check the target's flag in the same pass and pin the pair with a guard test (raid 0293, 2026-07-13)
 - [Local-evidence gate for pillaged techniques](feedback_local_evidence_gate_for_pillaged_techniques.md) — inventory the local codebase for the target defect class before implementing a paper-pillaged detector; 0290 closed wontfix on a zero-instance two-suite audit (2026-07-13)
 - [Batch decisions, then run to the end](feedback_batch_decisions_run_to_end.md) — author doctrine: one frontloaded question round with defaults, then autonomous through verify/merge/cleanup to a single report; spinners are not deliverables. Promoted to rules/workflow.md (2026-07-11)

--- a/projects/-home-haduong--claude/memory/feedback_shared_worktree_live_session_contention.md
+++ b/projects/-home-haduong--claude/memory/feedback_shared_worktree_live_session_contention.md
@@ -1,0 +1,27 @@
+---
+name: shared-worktree-live-session-contention
+description: A live session can share your worktree and switch branches between your commands — verify the branch in the same compound as every commit
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 8ce49305-98bf-405f-af7f-6e3e79fefdeb
+---
+
+A background job's checkout can be shared by a live interactive session that
+switches branches at any moment. On 2026-07-13 the `explore-session` worktree
+changed branches under a background job three times: one commit landed on a
+foreign branch (`t0268-state-guard`), and a recovery `git reset HEAD~1` then
+uncommitted the *other session's* newer commit because HEAD had moved again
+between inspection and reset.
+
+**Why:** `git switch` mutates shared state; separate Bash calls are not
+atomic, so any branch check in an earlier call is stale by the commit call.
+
+**How to apply:** In any worktree you did not create this session (basename
+not `t<id>` or `agent-*`), anchor branch state and mutation in ONE compound:
+`git branch --show-current` (assert expected) `&& git commit …`. On a
+misplaced commit, capture the SHA, verify by `git show --stat` whose commit
+HEAD actually is before any reset, and prefer moving *your* commit out
+(cherry-pick from a fresh `git worktree add`) over resetting *their* branch.
+Related: [[feedback_parallel_execute_branch_contamination]],
+[[feedback_verify_agents_dirty_main_repo]].

--- a/rules/coding-bash.md
+++ b/rules/coding-bash.md
@@ -35,6 +35,25 @@ if [ -z "${_TIMER_UNITS[$stem]:-}" ]; then ...
 
 Always use `${arr[$key]:-}` (or `${arr[$key]:-default}`) when the key may not exist.
 
+## Tab-delimited records drop empty fields in `read`
+
+Tab is IFS *whitespace*, so `IFS=$'\t' read` collapses consecutive tabs: an
+empty mid-record field silently shifts every later field left (bit
+reviewers.sh roster parsing, 2026-07-13 — a seat kind with no endpoint/model
+put the trial-ticket in the wrong variable).
+
+```bash
+# WRONG — l gets "g", t gets "" (the empty field vanished)
+printf 'a\tb\t\tg\n' | while IFS=$'\t' read -r k v l t; do ...
+
+# CORRECT — pipe is not IFS whitespace; empty fields survive
+printf 'a|b||g\n' | while IFS='|' read -r k v l t; do ...
+```
+
+Records with possibly-empty middle fields need a non-whitespace delimiter
+(`|`, `;`) or a placeholder value. Tab-delimited `read` is safe only when
+every field is guaranteed non-empty or the empty field is last.
+
 ## General `set -euo pipefail` discipline
 
 - Every script starts with `set -euo pipefail` unless there is an explicit reason not to.


### PR DESCRIPTION
Post-task wrap-up of the 0206 hunt (PRs #515, #528).

- `rules/coding-bash.md`: new section — `IFS=$'\t' read` collapses consecutive tabs, so empty mid-record fields shift later fields; use a non-whitespace delimiter. Discovered fixing the reviewers.sh roster parser.
- Memory: a live session can switch a shared worktree's branch between a background job's Bash calls; assert branch and commit in one compound, recover misplaced commits by cherry-pick from a fresh worktree.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)