### PR TITLE
guard(0311): CI job against 3+-field tab-delimited read

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -189,6 +189,45 @@ jobs:
           fi
           echo "OK: guard passes clean script"
 
+  tab-ifs-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No IFS=$'\t' read with 3+ fields in shell scripts
+        # Tab is IFS *whitespace*: consecutive tabs collapse, so an empty
+        # middle field silently shifts later fields left (bit reviewers.sh
+        # roster parsing, 2026-07-13). Two-field reads are safe (an empty
+        # field can only be last); three or more need a non-whitespace
+        # delimiter like | or ;. See rules/coding-bash.md.
+        run: |
+          violations=$(grep -Pn "IFS=\\\$'\\\\t'\\s+read\\s+(-\\w+\\s+)*(\\w+\\s+){2,}\\w+" scripts/*.sh skills/*/*.sh 2>/dev/null || true)
+          if [ -n "$violations" ]; then
+            echo "FAIL: tab-delimited read with 3+ fields — empty middle fields collapse; use IFS='|' (rules/coding-bash.md):"
+            echo "$violations"
+            exit 1
+          fi
+          echo "OK: no 3+-field tab-delimited reads found"
+      - name: Self-test — guard must catch a deliberate violation
+        run: |
+          tmp=$(mktemp --suffix=.sh)
+          printf '%s\n' '#!/bin/bash' "while IFS=\$'\\t' read -r a b c; do :; done < f" > "$tmp"
+          violations=$(grep -Pn "IFS=\\\$'\\\\t'\\s+read\\s+(-\\w+\\s+)*(\\w+\\s+){2,}\\w+" "$tmp" 2>/dev/null || true)
+          if [ -z "$violations" ]; then
+            echo "FAIL: guard did not catch 3-field tab read"
+            exit 1
+          fi
+          echo "OK: deliberate violation caught"
+      - name: Self-test — guard must pass 2-field and pipe-delimited reads
+        run: |
+          tmp=$(mktemp --suffix=.sh)
+          printf '%s\n' '#!/bin/bash' "while IFS=\$'\\t' read -r name path; do :; done < f" "while IFS='|' read -r a b c d; do :; done < g" > "$tmp"
+          violations=$(grep -Pn "IFS=\\\$'\\\\t'\\s+read\\s+(-\\w+\\s+)*(\\w+\\s+){2,}\\w+" "$tmp" 2>/dev/null || true)
+          if [ -n "$violations" ]; then
+            echo "FAIL: guard false-positived on safe reads"
+            exit 1
+          fi
+          echo "OK: guard passes safe reads"
+
   pytest-guard:
     runs-on: ubuntu-latest
     steps:

--- a/tickets/0311-tab-ifs-guard-ci-job.erg
+++ b/tickets/0311-tab-ifs-guard-ci-job.erg
@@ -1,0 +1,47 @@
+%erg 0.1
+Title: CI guard against 3+-field tab-delimited read (empty-field collapse)
+Created: 2026-07-13
+Author: fable
+
+--- log ---
+2026-07-13T13:10Z fable created
+
+--- body ---
+## Context
+
+Tab is IFS whitespace, so `IFS=$'\t' read` collapses consecutive tabs: an
+empty middle field silently shifts every later field left. This bit
+reviewers.sh roster parsing on 2026-07-13 (a seat kind with no
+endpoint/model put the trial-ticket in the wrong variable); the fix
+(IFS='|') and the rule (rules/coding-bash.md § Tab-delimited records) are
+landed. The class has no standing guard: nothing stops the next 3+-field
+tab read from entering scripts/ or skills/.
+
+Fleet sweep 2026-07-13: two tab-IFS sites remain
+(`scripts/setup-claude-agent.sh:32`, `scripts/check-cross-pr-ticket-collision.sh:97`),
+both 2-field with a schema-guaranteed non-empty first field — the safe
+shape the rule carves out.
+
+## Relevant files
+- `.github/workflows/CI.yml` — guard job family (pipefail-guard, grep-e-guard)
+- `rules/coding-bash.md` — the documented rule this guard mechanizes
+
+## Actions
+1. Add a `tab-ifs-guard` CI job: flag `IFS=$'\t' read` with 3+ variables in
+   `scripts/*.sh` and `skills/*/*.sh`; 2-field reads stay allowed.
+2. Self-tests in the job: catch a deliberate 3-field violation; pass 2-field
+   tab and multi-field pipe-delimited reads.
+
+## Test
+- Guard RED on a synthetic `IFS=$'\t' read -r a b c` script.
+- Guard GREEN on the current tree and on the safe forms.
+
+## Verification
+- [ ] CI job green on this PR (self-tests prove both directions)
+- [ ] Current 2-field sites not flagged
+
+## Invariants
+- Existing guard jobs unchanged; CI.yml stays valid YAML.
+
+## Exit criteria
+- A 3+-field tab-delimited read cannot merge without failing CI.

--- a/tickets/closed/0311-tab-ifs-guard-ci-job.erg
+++ b/tickets/closed/0311-tab-ifs-guard-ci-job.erg
@@ -2,10 +2,12 @@
 Title: CI guard against 3+-field tab-delimited read (empty-field collapse)
 Created: 2026-07-13
 Author: fable
+Closed: autoclosed — PR #534
 
 --- log ---
 2026-07-13T13:10Z fable created
 
+2026-07-13T10:15Z Minh Ha-Duong closed — autoclosed — PR #534
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0311-tab-ifs-guard-ci-job.erg

## What

New `tab-ifs-guard` CI job in the existing guard family (pipefail-guard, grep-e-guard): fails when any `scripts/*.sh` or `skills/*/*.sh` contains `IFS=$'\t' read` with 3+ variables. Tab is IFS whitespace — consecutive tabs collapse, so an empty middle field silently shifts later fields left (bit reviewers.sh roster parsing 2026-07-13; rule documented in `rules/coding-bash.md`). Two-field reads stay allowed: an empty field can only be last, the safe shape.

## Investigation (fleet sweep 2026-07-13)

- `skills/reviewers/reviewers.sh` — the bitten instance, already fixed to `IFS='|'` on main.
- `scripts/setup-claude-agent.sh:32`, `scripts/check-cross-pr-ticket-collision.sh:97` — 2-field reads from jq `@tsv` with schema-guaranteed non-empty first field: safe, not flagged.

## Verification

Pattern proven locally with the exact CI string: GREEN on the current tree, RED on a synthetic `read -r a b c` violation, no false positive on 2-field tab or pipe-delimited reads. In-job self-tests pin both directions; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)