### PR TITLE
hunt step 3: spell out obtaining the session PID for the worktree name

### DIFF
--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -42,9 +42,13 @@ argument-hint: <ticket-id>
      **is** the confirmation only if the current tree passes the same clean `agent-*`
      check; a rejection over a dirty or non-`agent-*` tree means STOP — the worktree is
      not owned — not an error to proceed through.
-   - Otherwise call `EnterWorktree` with name `t$ARGUMENTS-$$` (the `$$` session-PID
-     suffix keeps parallel sessions on the same ticket in distinct worktree paths),
-     even if the session already sits inside some other, unowned worktree.
+   - Otherwise call `EnterWorktree` with name `t$ARGUMENTS-<pid>`, where `<pid>`
+     is the session PID — a discriminator that keeps parallel sessions on the same
+     ticket in distinct worktree paths. Resolve it to a literal first (the
+     `EnterWorktree` name schema rejects `$` characters): run `bash -c 'echo $$'`
+     and substitute the number, e.g. pass `t$ARGUMENTS-12345`, not the raw
+     `t$ARGUMENTS-$$`. Call `EnterWorktree` even if the session already sits inside
+     some other, unowned worktree.
    Confirm with `basename "$(git rev-parse --show-toplevel)"`: it must be `t$ARGUMENTS`,
    begin with `t$ARGUMENTS-`, or be the `agent-*` worktree of this session (rules/git.md § anchor branch-mutating git
    across a forked-skill boundary). Ad hoc orchestrators should not hand-type this

--- a/tests/test_hunt_worktree_ownership.py
+++ b/tests/test_hunt_worktree_ownership.py
@@ -77,6 +77,21 @@ def test_rejection_as_confirmation_documented():
     )
 
 
+def test_pid_discriminator_obtainable():
+    """Step 3 spells out a literal, executable way to obtain the `$$` discriminator.
+
+    Ticket 0309: `EnterWorktree`'s name schema rejects `$` characters, so the
+    model must resolve the session PID to a literal before the call. Step 3 must
+    show how (e.g. `bash -c 'echo $$'`), not just reference the bare `$$` token.
+    """
+    step3 = step3_text()
+    assert "bash -c 'echo $$'" in step3, (
+        "step 3 must show a literal, executable way to obtain the session-PID "
+        "discriminator (e.g. `bash -c 'echo $$'`) before the EnterWorktree call, "
+        "since the name schema rejects `$` characters (ticket 0309)"
+    )
+
+
 def test_headless_pattern_pointer_present():
     """One sentence points ad hoc orchestrators at the beat.py headless pattern."""
     step3 = step3_text()

--- a/tickets/0309-hunt-step-3-spell-out-how-to-obtain-the.erg
+++ b/tickets/0309-hunt-step-3-spell-out-how-to-obtain-the.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T09:04Z Minh Ha-Duong created
 
+2026-07-13T11:24Z note hunt step 3 shows bash -c echo-PID to resolve discriminator before EnterWorktree; test_pid_discriminator_obtainable added
 --- body ---
 ## Context
 

--- a/tickets/closed/0309-hunt-step-3-spell-out-how-to-obtain-the.erg
+++ b/tickets/closed/0309-hunt-step-3-spell-out-how-to-obtain-the.erg
@@ -2,11 +2,13 @@
 Title: hunt step 3: spell out how to obtain the session PID for the t{N}-{pid} worktree name
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #538
 
 --- log ---
 2026-07-13T09:04Z Minh Ha-Duong created
 
 2026-07-13T11:24Z note hunt step 3 shows bash -c echo-PID to resolve discriminator before EnterWorktree; test_pid_discriminator_obtainable added
+2026-07-13T11:33Z Minh Ha-Duong closed — autoclosed — PR #538
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

Hunt step 3 named the fresh worktree `t$ARGUMENTS-$$` but never said how to resolve `$$`. `EnterWorktree`'s name schema rejects `$` characters, so the model would pass a literal `$` and hit a loud `InputValidationError`. This spells out resolving the session PID with `bash -c 'echo $$'` and substituting the number (e.g. `t$ARGUMENTS-12345`) before the call.

Documentation fast-follow recommended by the #529 gaze verdict (which ruled the gap non-blocking: loud error, not a silent collision).

## Changes

- `skills/hunt/SKILL.md` — step 3 `EnterWorktree` bullet now shows the literal PID-resolution command.
- `tests/test_hunt_worktree_ownership.py` — adds `test_pid_discriminator_obtainable` asserting step 3 shows `bash -c 'echo $$'`.
- ticket log line.

## Verification

- `make check` exits 0 (754 passed).
- Pre-PR `/verify-adherence`: PASS (all phases clean).

**Ticket:** tickets/0309-hunt-step-3-spell-out-how-to-obtain-the.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)