### PR TITLE
hunt(step 11): invoke review-pr mechanically, not 'according to' prose

### DIFF
--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -69,6 +69,12 @@ argument-hint: <ticket-id>
      - Otherwise → STOP. Do not open the PR. Escalate with the adherence report and the blocker list.
    - Circuit breaker: if `/verify-adherence` itself errors, times out, or returns an unparseable result → ESCALATE. Do not open the PR and do not silently skip the gate.
 10. Push the branch and open a merge request.
-11. Review according to `/review-pr`.
+11. Review the merge request. This action is mechanical — invoke the review-pr
+    skill with the PR number:
+    ```
+    Skill(skill: "review-pr", args: <pr-number>)
+    ```
+    Follow the contract the skill loader returns; do not paraphrase or inline its
+    steps (mirrors raid Phase 5's mechanical `Skill(hunt)` invocation, ticket 0293).
 12. Fix all comments regardless of severity.
 13. Repeat 11–12 up to 3 times. If still not clean, escalate (see workflow rules).

--- a/tests/test_hunt_invokes_review_pr.py
+++ b/tests/test_hunt_invokes_review_pr.py
@@ -1,0 +1,43 @@
+"""Guard: hunt step 11 must invoke /review-pr mechanically, not paraphrase it.
+
+Child of ticket 0307 (roar sweep after the 0251 raid). Ticket 0293 replaced
+raid Phase 5's "follows /hunt workflow" paraphrase with a mechanical
+Skill(hunt) invocation, because paraphrases drift. The same shape survived in
+skills/hunt/SKILL.md step 11 — "Review according to /review-pr" — which an
+executing agent may paraphrase instead of invoking the skill. review-pr sets
+disable-model-invocation: false, so the mechanical call works. Text-grep only
+→ fast tier, no marker.
+"""
+
+from pathlib import Path
+
+HUNT = Path(__file__).resolve().parent.parent / "skills" / "hunt" / "SKILL.md"
+
+
+def test_step11_invokes_review_pr_mechanically():
+    """The imperative Skill-invocation string must be present in hunt."""
+    text = HUNT.read_text()
+    assert 'Skill(skill: "review-pr", args:' in text, (
+        "hunt step 11 must invoke the mechanical "
+        'Skill(skill: "review-pr", args: <pr-number>), not a paraphrase'
+    )
+
+
+def test_step11_does_not_paraphrase_review_pr():
+    """The prose paraphrase must be gone — the skill loader is the contract."""
+    text = HUNT.read_text()
+    assert "Review according to `/review-pr`" not in text, (
+        "hunt step 11 still paraphrases review-pr ('Review according to "
+        "`/review-pr`'); the agent prompt must invoke the skill, not describe it"
+    )
+
+
+def test_review_pr_is_model_invocable():
+    """The mandated Skill(review-pr) call only works if model invocation is on."""
+    review_pr = HUNT.parent.parent / "review-pr" / "SKILL.md"
+    frontmatter = review_pr.read_text().split("---")[1]
+    assert "disable-model-invocation: false" in frontmatter, (
+        "skills/review-pr/SKILL.md must set disable-model-invocation: false — "
+        "hunt step 11 mandates Skill(review-pr), which the Skill tool refuses "
+        "while model invocation is disabled"
+    )

--- a/tickets/closed/0307-hunt-step-11-invoke-review-pr-mechanical.erg
+++ b/tickets/closed/0307-hunt-step-11-invoke-review-pr-mechanical.erg
@@ -2,10 +2,12 @@
 Title: hunt step 11: invoke /review-pr mechanically, not 'according to' prose
 Created: 2026-07-13
 Author: claude
+Closed: autoclosed — PR #539
 
 --- log ---
 2026-07-13T07:59Z claude created from roar sweep after 0251 raid
 
+2026-07-13T11:49Z Minh Ha-Duong closed — autoclosed — PR #539
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Reword hunt step 11 from the paraphrase "Review according to `/review-pr`" to a
mechanical, greppable invocation `Skill(skill: "review-pr", args: <pr-number>)`,
mirroring what ticket 0293 did for raid Phase 5. Paraphrases drift; a
skill-invokes-skill call keeps the review procedure pinned to the live
`skills/review-pr/SKILL.md` contract. Steps 12-13 are unchanged.

A sibling guard test (`tests/test_hunt_invokes_review_pr.py`) pins the phrasing
red-first: asserts the invocation string is present, the old paraphrase is gone,
and `review-pr` sets `disable-model-invocation: false` (so the mandated call
works at runtime).

## Verification
- New guard: 3 tests, RED before the reword, GREEN after.
- `make check`: 757 passed.
- Pre-PR `/verify-adherence`: PASS (no rules file touched; rule is mechanized by the new grep test).

**Ticket:** tickets/0307-hunt-step-11-invoke-review-pr-mechanical.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)