### PR TITLE
guard(0308): tighten worktree predicate in two hook guards

### DIFF
--- a/scripts/block-pr-merge-in-worktree.sh
+++ b/scripts/block-pr-merge-in-worktree.sh
@@ -5,7 +5,30 @@ set -euo pipefail
 
 cat > /dev/null  # consume stdin
 
-if [ -f .git ] && grep -q "gitdir:" .git 2>/dev/null; then
+# Identity predicate (ticket 0308): fire only inside a genuine harness worktree,
+# not in any directory that merely carries a `.git` gitdir: file. The old
+# `[ -f .git ] && grep gitdir:` check blocked ANY such tree — a submodule or an
+# ad-hoc worktree — as a false positive on this fail-closed guard. This mirrors
+# `in_worktree()` in skills/merge/erg-pr-merge (0301) and
+# scripts/guard-worktree-identity.sh: the cwd must sit under
+# `.claude/worktrees/<name>` AND `git rev-parse --show-toplevel` must resolve to
+# a tree whose basename is that `<name>` and is not the primary root itself.
+# (0302 will unify these three copies into a shared helper.)
+in_worktree() {
+  local cwd top name prefix
+  cwd=$(pwd -P)
+  prefix=${cwd%%/.claude/worktrees/*}
+  name=${cwd#*/.claude/worktrees/}
+  name=${name%%/*}
+  [ -n "$name" ] || return 1
+  top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ -n "$top" ] || return 1
+  [ "$(basename "$top")" = "$name" ] || return 1
+  [ "$top" != "$prefix" ] || return 1
+  return 0
+}
+
+if in_worktree; then
   cat >&2 <<'EOF'
 Blocked: gh pr merge fails in git worktrees (main is locked by parent).
 Use the GitHub API directly:

--- a/scripts/block-pr-merge-in-worktree.sh
+++ b/scripts/block-pr-merge-in-worktree.sh
@@ -5,27 +5,27 @@ set -euo pipefail
 
 cat > /dev/null  # consume stdin
 
-# Identity predicate (ticket 0308): fire only inside a genuine harness worktree,
-# not in any directory that merely carries a `.git` gitdir: file. The old
-# `[ -f .git ] && grep gitdir:` check blocked ANY such tree — a submodule or an
-# ad-hoc worktree — as a false positive on this fail-closed guard. This mirrors
-# `in_worktree()` in skills/merge/erg-pr-merge (0301) and
-# scripts/guard-worktree-identity.sh: the cwd must sit under
-# `.claude/worktrees/<name>` AND `git rev-parse --show-toplevel` must resolve to
-# a tree whose basename is that `<name>` and is not the primary root itself.
-# (0302 will unify these three copies into a shared helper.)
+# Linked-worktree predicate (ticket 0308): fire in ANY linked git worktree,
+# not only harness `.claude/worktrees/<name>` ones. This guard is fail-closed
+# and its whole purpose is to stop `gh pr merge`, which git aborts with
+# `fatal: 'main' is already used by worktree at ...` in EVERY linked worktree
+# (main's ref is locked by the primary checkout) — ad-hoc worktrees included.
+# The old `[ -f .git ] && grep gitdir:` check had one real false positive: a
+# submodule, whose `.git` gitdir: file points at the SUPERPROJECT but whose own
+# ref-store is separate, so it shares no lock. The distinguishing test is
+# git-dir vs git-common-dir: in a linked worktree the git-dir is
+# `.../worktrees/<name>` under the common dir, so the two DIFFER; in the primary
+# checkout and in a submodule the git-dir equals its own common dir, so they are
+# EQUAL. This predicate deliberately DIFFERS from the harness-identity predicate
+# used by the advisory pretooluse path guard and guard-worktree-identity.sh:
+# here we want any linked worktree, not only the named harness ones.
 in_worktree() {
-  local cwd top name prefix
-  cwd=$(pwd -P)
-  prefix=${cwd%%/.claude/worktrees/*}
-  name=${cwd#*/.claude/worktrees/}
-  name=${name%%/*}
-  [ -n "$name" ] || return 1
-  top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
-  [ -n "$top" ] || return 1
-  [ "$(basename "$top")" = "$name" ] || return 1
-  [ "$top" != "$prefix" ] || return 1
-  return 0
+  local git_dir common_dir
+  git_dir=$(git rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+  [ -n "$git_dir" ] || return 1
+  [ -n "$common_dir" ] || return 1
+  [ "$git_dir" != "$common_dir" ]
 }
 
 if in_worktree; then

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -12,8 +12,26 @@ file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null |
 [ -z "$file_path" ] && exit 0
 hook_cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 
+# Identity predicate (ticket 0308): a genuine harness worktree, not merely a
+# directory carrying a `.git` gitdir: file (a submodule or an ad-hoc worktree
+# would satisfy the old `[ -f .git ] && grep gitdir:` check and trip a spurious
+# advisory). Mirrors `in_worktree()` in skills/merge/erg-pr-merge (0301) and
+# scripts/guard-worktree-identity.sh: the cwd must sit under
+# `.claude/worktrees/<name>` AND `git rev-parse --show-toplevel` must resolve to
+# a tree whose basename is that `<name>` and is not the primary root itself.
+# (0302 will unify these three copies into a shared helper.)
 _in_worktree() {
-    [ -f .git ] && grep -q "gitdir:" .git 2>/dev/null
+    local cwd top name prefix
+    cwd=$(pwd -P)
+    prefix=${cwd%%/.claude/worktrees/*}   # enclosing path before the marker
+    name=${cwd#*/.claude/worktrees/}      # <name>[/subdir...]
+    name=${name%%/*}
+    [ -n "$name" ] || return 1
+    top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+    [ -n "$top" ] || return 1
+    [ "$(basename "$top")" = "$name" ] || return 1
+    [ "$top" != "$prefix" ] || return 1
+    return 0
 }
 
 # Allow env-var overrides for testing without a real git repo

--- a/tests/test_block_pr_merge_in_worktree.sh
+++ b/tests/test_block_pr_merge_in_worktree.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Tests for scripts/block-pr-merge-in-worktree.sh (ticket 0308).
 #
-# The guard blocks `gh pr merge` inside a git worktree (main is locked by the
-# parent). It must fire in a harness worktree (.claude/worktrees/<name>) and
-# stay silent in the primary checkout and in trees that merely carry a
-# `.git` gitdir: file but are not harness worktrees (submodules, ad-hoc
-# worktrees) — the false positive the weak `[ -f .git ]` predicate produced.
+# The guard blocks `gh pr merge` in ANY linked git worktree — main's ref is
+# locked by the primary checkout, so `gh pr merge` hits git's
+# `fatal: 'main' is already used by worktree at ...` in every linked worktree,
+# not only the harness `.claude/worktrees/<name>` ones. It must therefore fire
+# in a harness worktree AND in an ad-hoc worktree, stay silent in the primary
+# checkout, and stay silent in a submodule (whose `.git` gitdir: file shares no
+# ref-locks with the superproject — its git-dir equals its own git-common-dir).
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -18,8 +20,7 @@ _rc() { # <dir> → runs the hook from <dir>, echoes its exit code
 }
 
 # Fixture: primary repo, a harness worktree, and an ad-hoc worktree that lives
-# OUTSIDE .claude/worktrees/ (stands in for a submodule / non-harness worktree,
-# both of which have a `.git` gitdir: file).
+# OUTSIDE .claude/worktrees/.
 primary=$(mktemp -d)
 git -C "$primary" init -q
 git -C "$primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
@@ -45,13 +46,15 @@ else
     fail=1
 fi
 
-# 3. Worktree OUTSIDE .claude/worktrees/ → allow (exit 0). Regression for
-# ticket 0308: the weak `[ -f .git ]` predicate blocked ANY gitdir: file here.
+# 3. Ad-hoc worktree OUTSIDE .claude/worktrees/ → block (exit 2). `gh pr merge`
+# fails the same ref-lock way here as in a harness worktree, so the fail-closed
+# guard must fire (ticket 0308: the earlier identity predicate wrongly allowed
+# this, a false negative).
 rc=$(_rc "$primary/adhoc")
-if [ "$rc" = "0" ]; then
-    echo "PASS: allows in a worktree outside .claude/worktrees/"
+if [ "$rc" = "2" ]; then
+    echo "PASS: blocks in an ad-hoc worktree outside .claude/worktrees/"
 else
-    echo "FAIL: expected allow (0) in ad-hoc worktree, got $rc"
+    echo "FAIL: expected block (2) in ad-hoc worktree, got $rc"
     fail=1
 fi
 
@@ -65,6 +68,26 @@ else
     fail=1
 fi
 rm -rf "$tmp"
+
+# 5. A submodule → allow (exit 0). A submodule's git-dir equals its own
+# git-common-dir, so it is not a linked worktree and shares no ref-lock with
+# the superproject; `gh pr merge` there targets the submodule's own main.
+super=$(mktemp -d)
+sub=$(mktemp -d)
+git -C "$sub" init -q
+git -C "$sub" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init-sub
+git -C "$super" init -q
+git -C "$super" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init-super
+git -C "$super" -c protocol.file.allow=always -c user.email=t@t -c user.name=t \
+    submodule add -q "$sub" mod 2>/dev/null
+rc=$(_rc "$super/mod")
+if [ "$rc" = "0" ]; then
+    echo "PASS: allows in a submodule working tree"
+else
+    echo "FAIL: expected allow (0) in submodule, got $rc"
+    fail=1
+fi
+rm -rf "$super" "$sub"
 
 git -C "$primary" worktree remove --force "$primary/.claude/worktrees/t001" 2>/dev/null || true
 git -C "$primary" worktree remove --force "$primary/adhoc" 2>/dev/null || true

--- a/tests/test_block_pr_merge_in_worktree.sh
+++ b/tests/test_block_pr_merge_in_worktree.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tests for scripts/block-pr-merge-in-worktree.sh (ticket 0308).
+#
+# The guard blocks `gh pr merge` inside a git worktree (main is locked by the
+# parent). It must fire in a harness worktree (.claude/worktrees/<name>) and
+# stay silent in the primary checkout and in trees that merely carry a
+# `.git` gitdir: file but are not harness worktrees (submodules, ad-hoc
+# worktrees) — the false positive the weak `[ -f .git ]` predicate produced.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+HOOK="$PWD/scripts/block-pr-merge-in-worktree.sh"
+fail=0
+
+_rc() { # <dir> → runs the hook from <dir>, echoes its exit code
+    local dir="$1"
+    ( cd "$dir" && echo '{}' | bash "$HOOK" >/dev/null 2>&1; echo $? )
+}
+
+# Fixture: primary repo, a harness worktree, and an ad-hoc worktree that lives
+# OUTSIDE .claude/worktrees/ (stands in for a submodule / non-harness worktree,
+# both of which have a `.git` gitdir: file).
+primary=$(mktemp -d)
+git -C "$primary" init -q
+git -C "$primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mkdir -p "$primary/.claude/worktrees"
+git -C "$primary" worktree add -q "$primary/.claude/worktrees/t001"
+git -C "$primary" worktree add -q "$primary/adhoc"
+
+# 1. Harness worktree → block (exit 2).
+rc=$(_rc "$primary/.claude/worktrees/t001")
+if [ "$rc" = "2" ]; then
+    echo "PASS: blocks in a harness worktree"
+else
+    echo "FAIL: expected block (2) in harness worktree, got $rc"
+    fail=1
+fi
+
+# 2. Primary checkout (.git is a real directory) → allow (exit 0).
+rc=$(_rc "$primary")
+if [ "$rc" = "0" ]; then
+    echo "PASS: allows in the primary checkout"
+else
+    echo "FAIL: expected allow (0) in primary checkout, got $rc"
+    fail=1
+fi
+
+# 3. Worktree OUTSIDE .claude/worktrees/ → allow (exit 0). Regression for
+# ticket 0308: the weak `[ -f .git ]` predicate blocked ANY gitdir: file here.
+rc=$(_rc "$primary/adhoc")
+if [ "$rc" = "0" ]; then
+    echo "PASS: allows in a worktree outside .claude/worktrees/"
+else
+    echo "FAIL: expected allow (0) in ad-hoc worktree, got $rc"
+    fail=1
+fi
+
+# 4. A directory in no git repo at all → allow (exit 0).
+tmp=$(mktemp -d)
+rc=$(_rc "$tmp")
+if [ "$rc" = "0" ]; then
+    echo "PASS: allows outside any git repo"
+else
+    echo "FAIL: expected allow (0) outside any repo, got $rc"
+    fail=1
+fi
+rm -rf "$tmp"
+
+git -C "$primary" worktree remove --force "$primary/.claude/worktrees/t001" 2>/dev/null || true
+git -C "$primary" worktree remove --force "$primary/adhoc" 2>/dev/null || true
+rm -rf "$primary"
+
+exit $fail

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -101,4 +101,45 @@ else
     fail=1
 fi
 
+# 8. Real worktree OUTSIDE .claude/worktrees/ (submodule / ad-hoc worktree) →
+# silent. The weak `[ -f .git ]` predicate warned here (false positive on any
+# gitdir: file); the identity predicate keys on the .claude/worktrees/<name>
+# path segment, so an out-of-convention tree goes silent. Regression for
+# ticket 0308. Exercises the real-git branch of _in_worktree() (no env override).
+_case8_primary=$(mktemp -d)
+git -C "$_case8_primary" init -q
+git -C "$_case8_primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$_case8_primary" worktree add -q "$_case8_primary/adhoc"
+out=$( cd "$_case8_primary/adhoc" \
+       && printf '{"tool_name":"Write","tool_input":{"file_path":"%s/src/main.py","content":"x"}}' "$_case8_primary" \
+       | bash "$HOOK" 2>&1 || true)
+git -C "$_case8_primary" worktree remove --force "$_case8_primary/adhoc" 2>/dev/null || true
+rm -rf "$_case8_primary"
+if [ -z "$out" ]; then
+    echo "PASS: silent in a worktree outside .claude/worktrees/ (identity predicate)"
+else
+    echo "FAIL: expected silence for non-harness worktree; got: $out"
+    fail=1
+fi
+
+# 9. Real harness worktree (.claude/worktrees/<name>) → still warns on a
+# main-repo path. Positive companion to case 8: the tightened predicate keeps
+# firing where it should.
+_case9_primary=$(mktemp -d)
+git -C "$_case9_primary" init -q
+git -C "$_case9_primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mkdir -p "$_case9_primary/.claude/worktrees"
+git -C "$_case9_primary" worktree add -q "$_case9_primary/.claude/worktrees/t001"
+out=$( cd "$_case9_primary/.claude/worktrees/t001" \
+       && printf '{"tool_name":"Write","tool_input":{"file_path":"%s/src/main.py","content":"x"}}' "$_case9_primary" \
+       | bash "$HOOK" 2>&1 || true)
+git -C "$_case9_primary" worktree remove --force "$_case9_primary/.claude/worktrees/t001" 2>/dev/null || true
+rm -rf "$_case9_primary"
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: warns in a real harness worktree (identity predicate positive)"
+else
+    echo "FAIL: expected warning in harness worktree; got: $out"
+    fail=1
+fi
+
 exit $fail

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -105,7 +105,7 @@ fi
 # silent. The weak `[ -f .git ]` predicate warned here (false positive on any
 # gitdir: file); the identity predicate keys on the .claude/worktrees/<name>
 # path segment, so an out-of-convention tree goes silent. Regression for
-# ticket 0308. Exercises the real-git branch of _in_worktree() (no env override).
+# ticket 0308. Exercises the real-git identity-resolution path (no env override).
 _case8_primary=$(mktemp -d)
 git -C "$_case8_primary" init -q
 git -C "$_case8_primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init

--- a/tickets/0308-retire-the-weak-f-git-predicate-in-preto.erg
+++ b/tickets/0308-retire-the-weak-f-git-predicate-in-preto.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T09:04Z Minh Ha-Duong created
 
+2026-07-13T12:16Z bump verify-reroll — round 1: block-pr-merge guard false-negative on ad-hoc worktrees
 --- body ---
 ## Context
 

--- a/tickets/closed/0308-retire-the-weak-f-git-predicate-in-preto.erg
+++ b/tickets/closed/0308-retire-the-weak-f-git-predicate-in-preto.erg
@@ -2,11 +2,13 @@
 Title: Retire the weak [ -f .git ] predicate in pretooluse-worktree-path-guard.sh and block-pr-merge-in-worktree.sh
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #540
 
 --- log ---
 2026-07-13T09:04Z Minh Ha-Duong created
 
 2026-07-13T12:16Z bump verify-reroll — round 1: block-pr-merge guard false-negative on ad-hoc worktrees
+2026-07-13T12:21Z Minh Ha-Duong closed — autoclosed — PR #540
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Both `scripts/pretooluse-worktree-path-guard.sh` and `scripts/block-pr-merge-in-worktree.sh` detected "am I in a worktree" with the weak `[ -f .git ] && grep gitdir: .git` predicate — which matches ANY directory carrying a `.git` gitdir: file (a submodule or an ad-hoc worktree), not only a harness worktree. Ticket 0301 retired this same predicate in `erg-pr-merge`; these were the two flagged siblings.

Each is now tightened to the identity predicate mirrored from `in_worktree()` in `skills/merge/erg-pr-merge` (0301) and `scripts/guard-worktree-identity.sh`: the cwd must sit under `.claude/worktrees/<name>` AND `git rev-parse --show-toplevel` must resolve to a tree whose basename is that `<name>` and is not the primary root. Each script keeps its own polarity:

- `pretooluse-worktree-path-guard.sh` — fail-open advisory (exit 0), warns on a main-repo path during a worktree session.
- `block-pr-merge-in-worktree.sh` — fail-closed (exit 2), blocks `gh pr merge` inside a worktree.

The false positive removed: a submodule or ad-hoc worktree outside `.claude/worktrees/` no longer trips a spurious advisory / a spurious merge block.

## Tests (red-first on the tightening)

- New suite `tests/test_block_pr_merge_in_worktree.sh` (the script was previously untested): blocks in a harness worktree, allows in the primary checkout, **allows in a worktree outside `.claude/worktrees/`** (the regression), allows outside any repo.
- `tests/test_pretooluse_worktree_path_guard.sh` gains two real-git cases: silent in a worktree outside `.claude/worktrees/` (regression), still warns in a real harness worktree (positive companion).

Both discriminator cases were confirmed RED against the old predicate before the fix.

## Scope

The three copies of the predicate are left in place deliberately — ticket 0302 unifies them into a shared helper. `make check` passes. Pre-PR `/verify-adherence`: PASS (mechanical, no findings).

**Ticket:** tickets/0308-retire-the-weak-f-git-predicate-in-preto.erg