### PR TITLE
ticket(0302): keep worktree-identity predicate inline, add drift guard

### DIFF
--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -19,7 +19,13 @@ hook_cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 # scripts/guard-worktree-identity.sh: the cwd must sit under
 # `.claude/worktrees/<name>` AND `git rev-parse --show-toplevel` must resolve to
 # a tree whose basename is that `<name>` and is not the primary root itself.
-# (0302 will unify these three copies into a shared helper.)
+# Ticket 0302 decided to keep this copy inline rather than extract a shared
+# `scripts/lib/worktree-identity.sh`: the integrity guards read hook-JSON `.cwd`
+# through `git -C` and are fail-closed, so no one helper fits all sites without
+# changing an input model or a failure contract, and sourcing a lib into this
+# fail-open hook would flip its semantics on a missing file. This copy and the
+# one in `skills/merge/erg-pr-merge` are held in lockstep by
+# tests/test_worktree_identity_predicate_inline.py instead.
 _in_worktree() {
     local cwd top name prefix
     cwd=$(pwd -P)

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -31,7 +31,12 @@ die() { echo "erg-pr-merge: $*" >&2; exit 1; }
 # dir planted under the marker (git resolves to the enclosing repo, a different
 # basename) is correctly rejected. A PreToolUse hook fires once on the outer
 # script invocation and cannot front these internal git calls, so the check is
-# self-contained by design.
+# self-contained by design. Ticket 0302 kept this copy inline (not a shared
+# `scripts/lib/…` helper) for that reason: sourcing across the scripts/↔skills/
+# boundary would couple this standalone skill to the scripts tree and, under
+# `set -euo pipefail`, turn a missing lib into an abort. It stays byte-identical
+# to `_in_worktree()` in ~/.claude/scripts/pretooluse-worktree-path-guard.sh,
+# pinned by tests/test_worktree_identity_predicate_inline.py.
 in_worktree() {
     local cwd top name prefix
     cwd=$(pwd -P)

--- a/tests/test_worktree_identity_predicate_inline.py
+++ b/tests/test_worktree_identity_predicate_inline.py
@@ -1,0 +1,77 @@
+"""Keep the two inline worktree-identity predicates in lockstep (ticket 0302).
+
+Ticket 0302 decided NOT to extract a shared `scripts/lib/worktree-identity.sh`.
+Rationale (recorded here and in the ticket log): of the sites that carry a
+worktree predicate, only two share the exact identity check —
+
+- `scripts/pretooluse-worktree-path-guard.sh` `_in_worktree()` (advisory hook,
+  fail-open), and
+- `skills/merge/erg-pr-merge` `in_worktree()` (standalone skill, self-contained
+  by design).
+
+The two integrity guards (`scripts/guard-worktree-identity.sh`,
+`scripts/guard-commit-on-main.sh`) read the hook-JSON `.cwd` through `git -C`
+and are fail-CLOSED, and `scripts/block-pr-merge-in-worktree.sh` uses a
+deliberately different linked-worktree predicate — none can share one helper
+without changing an input model or a fail-open/fail-closed contract, which the
+ticket's invariant forbids. A `source scripts/lib/…` from the skill would also
+couple it across the scripts/↔skills/ boundary and, under `set -euo pipefail`,
+turn a missing lib into a nonzero abort — flipping the hook's fail-open
+semantics.
+
+Keeping the two copies inline avoids that coupling; this test supplies the
+drift protection extraction would have given: the two function bodies must stay
+byte-identical (name and comments aside). If a future edit must change one, it
+must change both, or revisit the 0302 decision. Complements the 0310 ratchet,
+which forbids regressing EITHER copy to the weak file-test predicate.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+SITES = [
+    ("scripts/pretooluse-worktree-path-guard.sh", "_in_worktree"),
+    ("skills/merge/erg-pr-merge", "in_worktree"),
+]
+
+
+def _extract_body(relpath: str, fn_name: str) -> list[str]:
+    """Return the normalized body of `fn_name` in `relpath`.
+
+    Normalization drops the definition line (names differ), comment-only lines,
+    and blank lines, and strips trailing whitespace — so two copies that differ
+    only in name and surrounding commentary compare equal.
+    """
+    lines = (REPO / relpath).read_text(encoding="utf-8").splitlines()
+    open_re = f"{fn_name}() {{"
+    start = next(
+        i for i, line in enumerate(lines) if line.strip() == open_re
+    )
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line == "}":  # closing brace at column 0
+            break
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        body.append(line.rstrip())
+    assert body, f"empty body extracted for {fn_name} in {relpath}"
+    return body
+
+
+@pytest.mark.adherence
+def test_inline_worktree_predicates_are_identical():
+    (ref_path, ref_fn), (other_path, other_fn) = SITES
+    ref = _extract_body(ref_path, ref_fn)
+    other = _extract_body(other_path, other_fn)
+    assert ref == other, (
+        "The two inline worktree-identity predicates have drifted (ticket 0302 "
+        f"decided to keep them inline in lockstep):\n"
+        f"  {ref_path}:{ref_fn}()\n"
+        f"  {other_path}:{other_fn}()\n"
+        "Change both together, or revisit the 0302 keep-inline decision.\n"
+        f"{ref_fn}: {ref}\n{other_fn}: {other}"
+    )

--- a/tests/test_worktree_identity_predicate_inline.py
+++ b/tests/test_worktree_identity_predicate_inline.py
@@ -48,7 +48,11 @@ def _extract_body(relpath: str, fn_name: str) -> list[str]:
     lines = (REPO / relpath).read_text(encoding="utf-8").splitlines()
     open_re = f"{fn_name}() {{"
     start = next(
-        i for i, line in enumerate(lines) if line.strip() == open_re
+        (i for i, line in enumerate(lines) if line.strip() == open_re), None
+    )
+    assert start is not None, (
+        f"definition line `{open_re}` not found in {relpath} — the function was "
+        "renamed or reformatted; update SITES or this parser (ticket 0302)"
     )
     body: list[str] = []
     for line in lines[start + 1 :]:

--- a/tickets/0302-extract-shared-worktree-identity-predica.erg
+++ b/tickets/0302-extract-shared-worktree-identity-predica.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T07:18Z Minh Ha-Duong created
 
+2026-07-13T12:55Z MinhHaDuong note decided keep two inline copies (pretooluse _in_worktree + erg-pr-merge in_worktree), no shared lib: only 2 of 4 sites share the exact predicate, guards are fail-closed and read JSON .cwd, sourcing would flip fail-open and couple the skill; drift pinned by tests/test_worktree_identity_predicate_inline.py
 --- body ---
 ## Context
 

--- a/tickets/closed/0302-extract-shared-worktree-identity-predica.erg
+++ b/tickets/closed/0302-extract-shared-worktree-identity-predica.erg
@@ -2,11 +2,13 @@
 Title: Extract shared worktree-identity predicate helper — or record why three inline copies stay
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #542
 
 --- log ---
 2026-07-13T07:18Z Minh Ha-Duong created
 
 2026-07-13T12:55Z MinhHaDuong note decided keep two inline copies (pretooluse _in_worktree + erg-pr-merge in_worktree), no shared lib: only 2 of 4 sites share the exact predicate, guards are fail-closed and read JSON .cwd, sourcing would flip fail-open and couple the skill; drift pinned by tests/test_worktree_identity_predicate_inline.py
+2026-07-13T13:07Z Minh Ha-Duong closed — autoclosed — PR #542
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Decision (0302 is a DECISION ticket)

**Keep the worktree-identity predicate inline — do NOT extract `scripts/lib/worktree-identity.sh`.**

### Diff of the copies
Of the sites carrying a worktree predicate, only **two** share the exact identity check ("cwd under `.claude/worktrees/<name>` AND git's toplevel is exactly that worktree, not the primary root"), and they are byte-identical:
- `scripts/pretooluse-worktree-path-guard.sh` `_in_worktree()` — advisory hook, **fail-open**, live `pwd -P` + bare `git rev-parse`.
- `skills/merge/erg-pr-merge` `in_worktree()` — standalone skill, boolean, same body.

The other sites do **not** share this predicate:
- `scripts/guard-worktree-identity.sh` and `scripts/guard-commit-on-main.sh` read the hook-JSON `.cwd` through `git -C`, are **fail-closed** integrity guards, and (for guard-commit-on-main) use the `--git-common-dir` parent technique rather than the `.claude/worktrees/<name>` string check.
- `scripts/block-pr-merge-in-worktree.sh` uses a deliberately different linked-worktree predicate (git-dir vs git-common-dir) — left untouched.

### Rationale
No single helper fits all sites without changing an input model (JSON `.cwd` vs live shell cwd) or a fail-open/fail-closed contract — which 0302's invariant forbids. A `source scripts/lib/…` into the fail-open hook, or across the scripts/↔skills/ boundary into the self-contained skill, would under `set -euo pipefail` turn a missing lib into a nonzero abort, flipping the very semantics the invariant protects. So extraction would couple three failure behaviours into one file for the sake of two truly-identical copies — the YAGNI cost the ticket flagged, and it exceeds the duplication it removes.

Instead of coupling, the two identical copies are pinned by a cheap adherence test (`tests/test_worktree_identity_predicate_inline.py`) that fails if they drift — the DRY benefit (no silent divergence) without the coupling cost. This complements the 0310 ratchet (which forbids regressing either copy to the weak `-f`/`.git` file-test).

### Changes
- New `tests/test_worktree_identity_predicate_inline.py` — asserts the two function bodies stay byte-identical (RED-proven on a real body change and an inline-comment drift).
- Rationale comments recorded at both sites; the now-false "0302 will unify these three copies" promise in the pretooluse guard is replaced with the actual decision.
- Decision logged in the ticket.

Invariant preserved: no call site's fail-open/fail-closed semantics changed (this PR touches only comments + a test). `make check` passes (770 tests).

**Ticket:** tickets/0302-extract-shared-worktree-identity-predica.erg