### PR TITLE
ticket(0303): document maw-audit /tmp scratch-worktree guard exemption

### DIFF
--- a/skills/maw-audit/SKILL.md
+++ b/skills/maw-audit/SKILL.md
@@ -138,8 +138,12 @@ Phases:
    sibling sites; surviving siblings = instance-pinned contract.
 6. **Guards** (serialized) — the designated canary guard tests run alone (not
    under fan-out load). Skipped openly if none designated.
-7. **Cleanup** — prunes any hand-rolled `/tmp/fang-*` scratch worktrees agents
-   left on detached HEAD.
+7. **Cleanup** — prunes any hand-rolled `/tmp/maw-*` / `/tmp/fang-*` scratch
+   worktrees agents left on detached HEAD. These scratch trees live outside the
+   guarded `*/.claude/worktrees/*` namespace by design (ticket 0303): being on a
+   detached HEAD they never commit, push, or track a branch, so the main-repo
+   protection guards have nothing to protect — their lifecycle is self-contained
+   in this phase. Not an oversight; see the rationale in `maw-audit.js`.
 
 Then the engine assembles a deterministic report (no LLM formatting) and returns
 it; write it to `CONFIG.OUTPUT`.

--- a/skills/maw-audit/maw-audit.js
+++ b/skills/maw-audit/maw-audit.js
@@ -707,6 +707,21 @@ const scopes = await parallel(scopeTargets.map(file => () =>
 // /tmp/maw-* or /tmp/fang-* scratch patterns (agents improvise these names
 // from the audit name in their prompts; fang- is the pre-rename legacy),
 // never the session checkout or any named worktree, then `git worktree prune`.
+//
+// 0303 — GUARD-COVERAGE EXEMPTION (decided, not an oversight). These /tmp
+// scratch trees sit OUTSIDE the guarded `*/.claude/worktrees/*` namespace, and
+// that is intentional. Ticket 0300 moved gaze's review worktrees UNDER that
+// namespace because they track a branch and its guards protect commits/pushes
+// from landing on the wrong branch. maw-audit's scratch trees are the opposite:
+// they are on a detached HEAD, never commit, never push, never track a branch,
+// and every mutation an agent makes in them is reverted or discarded — so the
+// main-repo protection guards (`guard-commit-on-main`, the worktree path guard)
+// have nothing to protect here. Their whole lifecycle is self-contained: this
+// Cleanup phase reaps them by path prefix. Moving them under the guarded
+// namespace would buy no safety and complicate the prefix-match reaper. The
+// exemption is recorded here (and pinned by
+// tests/test_maw_audit_skill.py::test_tmp_scratch_worktree_exemption_documented)
+// so a future guard-coverage sweep does not re-flag this as an uncovered gap.
 phase('Cleanup')
 await agent(
   `Post-run cleanup for the maw-audit of ${CONFIG.PROJECT}. During the audit, some agents may have hand-rolled scratch git worktrees under /tmp (paths like \`/tmp/maw-${CONFIG.PROJECT}-*\`, \`/tmp/maw-*\`, or the legacy \`/tmp/fang-*\`), typically on a detached HEAD, that outlived the run. Remove ONLY those scratch worktrees — never the session checkout, never any worktree under .claude/worktrees/, never a worktree on a named branch.

--- a/tests/test_maw_audit_skill.py
+++ b/tests/test_maw_audit_skill.py
@@ -614,10 +614,13 @@ def test_tmp_scratch_worktree_exemption_documented():
     at the creation/cleanup site so a future guard-coverage sweep does not
     re-flag it."""
     src = js()
-    assert "0303" in src, "the /tmp scratch-worktree exemption must cite ticket 0303"
+    marker = "0303 — GUARD-COVERAGE EXEMPTION"
+    assert marker in src, "the /tmp scratch-worktree exemption must cite ticket 0303"
     # The rationale must name the guarded namespace it is exempt from and WHY
-    # (detached HEAD → no branch/commit/push for a guard to protect).
-    cleanup = src[src.index("phase('Cleanup')") - 1200 : src.index("phase('Cleanup')")]
+    # (detached HEAD → no branch/commit/push for a guard to protect). Slice from
+    # the exemption marker to the Cleanup phase it annotates (marker-to-marker,
+    # like the other slices in this file).
+    cleanup = src[src.index(marker) : src.index("phase('Cleanup')")]
     assert ".claude/worktrees" in cleanup, (
         "exemption must reference the guarded .claude/worktrees namespace it sits outside"
     )

--- a/tests/test_maw_audit_skill.py
+++ b/tests/test_maw_audit_skill.py
@@ -599,3 +599,28 @@ def test_fixtures_are_excluded_from_collection():
     )
     # And the fixture files must actually live there.
     assert list(FIXTURES.glob("fixture_*_test.py")), "no fixture test anchors present"
+
+
+# ── 0303: /tmp scratch-worktree guard-coverage exemption is documented ────────
+
+
+def test_tmp_scratch_worktree_exemption_documented():
+    """Ticket 0303: maw-audit agents hand-roll detached-HEAD scratch worktrees
+    under /tmp (paths like `/tmp/maw-*`, legacy `/tmp/fang-*`), which sit outside
+    the guarded `*/.claude/worktrees/*` namespace. Unlike gaze's branch-tracking
+    review worktrees (moved under the guarded namespace by ticket 0300), these
+    never commit, never push, and never track a branch, so the main-repo
+    protection guards have nothing to protect. The exemption must be documented
+    at the creation/cleanup site so a future guard-coverage sweep does not
+    re-flag it."""
+    src = js()
+    assert "0303" in src, "the /tmp scratch-worktree exemption must cite ticket 0303"
+    # The rationale must name the guarded namespace it is exempt from and WHY
+    # (detached HEAD → no branch/commit/push for a guard to protect).
+    cleanup = src[src.index("phase('Cleanup')") - 1200 : src.index("phase('Cleanup')")]
+    assert ".claude/worktrees" in cleanup, (
+        "exemption must reference the guarded .claude/worktrees namespace it sits outside"
+    )
+    assert "detached HEAD" in cleanup or "detached-HEAD" in cleanup, (
+        "exemption rationale must anchor on the detached-HEAD (no branch to protect) property"
+    )

--- a/tickets/0303-maw-audit-tmp-worktrees-bring-under-guar.erg
+++ b/tickets/0303-maw-audit-tmp-worktrees-bring-under-guar.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T07:18Z Minh Ha-Duong created child of 0252 (found in the 0300 worktree-ownership sweep)
 
+2026-07-13T13:13Z MinhHaDuong note decision option 2 (document exemption): /tmp/maw-* and /tmp/fang-* are detached-HEAD scratch trees hand-rolled by audit agents, never commit/push/track a branch, so main-repo guards have nothing to protect; self-contained cleanup by the Cleanup phase. Exemption recorded at the creation/cleanup site in maw-audit.js + SKILL.md, pinned by test_tmp_scratch_worktree_exemption_documented (0302 pattern).
 --- body ---
 ## Context
 
@@ -36,5 +37,5 @@ Pick one; do not leave the location silently uncovered.
 
 ## Exit criteria
 
-- [ ] Decision recorded (move applied, or exemption documented at the creation site)
-- [ ] No maw-audit worktree is silently outside guard coverage
+- [x] Decision recorded (move applied, or exemption documented at the creation site)
+- [x] No maw-audit worktree is silently outside guard coverage

--- a/tickets/closed/0303-maw-audit-tmp-worktrees-bring-under-guar.erg
+++ b/tickets/closed/0303-maw-audit-tmp-worktrees-bring-under-guar.erg
@@ -2,11 +2,13 @@
 Title: maw-audit /tmp worktrees: bring under guard coverage or document the exemption
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #543
 
 --- log ---
 2026-07-13T07:18Z Minh Ha-Duong created child of 0252 (found in the 0300 worktree-ownership sweep)
 
 2026-07-13T13:13Z MinhHaDuong note decision option 2 (document exemption): /tmp/maw-* and /tmp/fang-* are detached-HEAD scratch trees hand-rolled by audit agents, never commit/push/track a branch, so main-repo guards have nothing to protect; self-contained cleanup by the Cleanup phase. Exemption recorded at the creation/cleanup site in maw-audit.js + SKILL.md, pinned by test_tmp_scratch_worktree_exemption_documented (0302 pattern).
+2026-07-13T13:29Z Minh Ha-Duong closed — autoclosed — PR #543
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Ticket 0303, a child of the 0252/0300 worktree-ownership sweep. maw-audit's
audit agents hand-roll detached-HEAD scratch worktrees under `/tmp`
(`/tmp/maw-*`, legacy `/tmp/fang-*`), which sit outside the guarded
`*/.claude/worktrees/*` namespace. The ticket asked to either move them under
the guarded namespace (as ticket 0300 did for gaze) or document the exemption.

## Decision: option 2 (document the exemption)

The 0300 precedent does not transfer. Gaze's review worktrees track a branch,
so bringing them under the guarded namespace lets the main-repo protection
guards catch stray commits/pushes. maw-audit's scratch trees are the opposite
case: on a detached HEAD, they never commit, never push, never track a branch,
and every agent mutation is reverted or discarded — so those guards have nothing
to protect. Their lifecycle is self-contained: the existing Cleanup phase reaps
them by path prefix. Moving them would buy no safety and complicate the
prefix-match reaper.

## Changes

- `skills/maw-audit/maw-audit.js` — exemption rationale at the Cleanup creation/reap site.
- `skills/maw-audit/SKILL.md` — matching note at the Cleanup step.
- `tests/test_maw_audit_skill.py` — new `test_tmp_scratch_worktree_exemption_documented` pins the rationale (0302 pattern), so a future guard-coverage sweep does not re-flag the location. Red-first verified.

## Verification

- `make check` passes (exit 0); touched module 38 passed; adherence tier 12 passed.
- `/verify-adherence` self-gate: PASS (no mechanical or semantic findings).
- Both exit criteria met: decision recorded; no maw-audit worktree location silently outside coverage.

**Ticket:** tickets/0303-maw-audit-tmp-worktrees-bring-under-guar.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)