### PR TITLE
erg-pr-merge: cross-check the ticket close claim against the branch tip

### DIFF
--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -14,6 +14,9 @@
 #   0. Verify: on PR head branch, CI green, no conflicts
 #   1. Find ticket ID(s) from "Ticket: tickets/NNNN-..." lines in PR body only;
 #      title prefixes (chore(NNNN)) are subject references, not close claims
+#   1.5 Cross-check each claim against the branch tip: abort if the claimed
+#      ticket file is absent (force-replaced branch, PR #522); warn on a
+#      title/claim disagreement. Override: ERG_PR_MERGE_ALLOW_MISSING_TICKET=1
 #   2. erg close NNNN "autoclosed — PR #N" + git add + commit + push (always)
 #   3. Queue auto-merge via the forge CLI; falls back to watch-then-merge if auto-merge disabled
 #   4. If not in worktree: git checkout base && git pull --rebase
@@ -126,6 +129,63 @@ if [[ -z "$TICKET_IDS" ]] && [[ -z "$NOCLOSE" ]] && [[ -d tickets ]]; then
     die "no close-claim in PR body — add a 'Ticket: tickets/NNNN-...' line to close a ticket, 'Ticket-ref: tickets/NNNN-...' to reference one without closing, or 'Ticket: none' if this PR closes nothing. (Title prefixes like chore(NNNN) are NOT close claims.)"
 fi
 
+# ── Step 1.5: cross-check close claims against the branch content ─────────────
+#
+# A PR's Ticket close-claim lives in the body, but the branch content can drift
+# away from it. Shared-worktree contention once force-pushed an unrelated
+# changeset over a branch, leaving a stale `**Ticket:** NNNN` claim pointing at
+# work no longer in the diff (PR #522, 2026-07-13). erg-pr-merge would then
+# close NNNN while landing an unrelated change; the only defense was a human
+# noticing and retitling the PR. Two guards close that gap:
+#
+#  (a) Existence-at-tip (blocking, overridable). If a claimed ticket's file is
+#      absent from tickets/ at the branch tip, the claim cannot belong to this
+#      changeset — abort. This is EXISTENCE-at-tip, not touched-by-diff: a claim
+#      on a ticket the diff never modifies is legitimate (close-by-convention on
+#      merge), so we must not require the diff to touch the ticket file. Without
+#      this guard the absent file only surfaced as a cryptic `erg close` failure
+#      under set -e. Override with ERG_PR_MERGE_ALLOW_MISSING_TICKET=1 to
+#      warn-and-skip the absent ticket instead of aborting.
+#
+#  (b) Title/claim disagreement (non-blocking warn). The #522 branch was
+#      retitled to the replacement work; a title prefix `word(NNNN)` naming a
+#      ticket not among the close claims is a cheap tell of a repurposed branch.
+#      Title prefixes are subject references, not claims, so this only warns —
+#      it must never add friction to a well-formed merge.
+#
+# The diff-touch tell from the ticket (claim names N but the diff touches only
+# ticket M's file) is deliberately NOT implemented: close-by-convention means a
+# valid claim routinely touches no ticket file, so that signal both misses the
+# #522 case (its replacement diff touched no ticket) and false-positives on
+# legitimate convention closes. Existence-at-tip plus the title tell cover the
+# observed failure without that noise.
+
+if [[ -n "$TICKET_IDS" ]] && [[ -d tickets ]]; then
+    TIP_TICKETS=$(git ls-tree -r --name-only HEAD -- tickets/ 2>/dev/null || true)
+    MISSING=""
+    while IFS= read -r tid; do
+        [[ -z "$tid" ]] && continue
+        if ! echo "$TIP_TICKETS" | grep -q "^tickets/${tid}-"; then
+            MISSING="${MISSING:+${MISSING} }${tid}"
+        fi
+    done <<< "$TICKET_IDS"
+    if [[ -n "$MISSING" ]]; then
+        if [[ -n "${ERG_PR_MERGE_ALLOW_MISSING_TICKET:-}" ]]; then
+            echo "erg-pr-merge: warning: close-claimed ticket(s) ${MISSING} are absent from tickets/ at the branch tip '${PR_BRANCH}' — ERG_PR_MERGE_ALLOW_MISSING_TICKET set, continuing and skipping their close." >&2
+        else
+            die "close-claimed ticket(s) ${MISSING} are absent from tickets/ at the branch tip '${PR_BRANCH}'. The branch content may have been force-replaced away from the claim (cf. PR #522). Verify the PR's 'Ticket:' lines match the diff; re-run with ERG_PR_MERGE_ALLOW_MISSING_TICKET=1 to override."
+        fi
+    fi
+
+    # Non-blocking title/claim disagreement warn. One extra read-only forge call,
+    # skipped entirely when there is nothing to close. (harness-extension-point)
+    PR_TITLE=$(gh pr view "$PR" --json title --jq '.title' 2>/dev/null || echo "")
+    TITLE_TID=$(echo "$PR_TITLE" | grep -oiP '\(\K\d{3,4}(?=\))' | head -1 || true)
+    if [[ -n "$TITLE_TID" ]] && ! echo "$TICKET_IDS" | grep -qx "$TITLE_TID"; then
+        echo "erg-pr-merge: warning: PR title names ticket ${TITLE_TID} but the close claim(s) are ${TICKET_IDS//$'\n'/, } — verify the branch was not repurposed (cf. PR #522). Title prefixes are subject references, not close claims; proceeding." >&2
+    fi
+fi
+
 # ── Step 2: close ticket (only if erg project and ticket found) ───────────────
 
 ERG=${ERG:-erg}
@@ -139,6 +199,13 @@ if [[ -n "$TICKET_IDS" ]] && [[ -d tickets ]] && command -v "$ERG" &>/dev/null; 
         # stray stash-resurrected file into the close commit and bounced the
         # merge on corpus validation (ticket 0193).
         TICKET_FILE=$(ls tickets/"${tid}"-*.erg 2>/dev/null | head -1 || true)
+        # Reachable only under ERG_PR_MERGE_ALLOW_MISSING_TICKET (Step 1.5 would
+        # otherwise have died): the claimed ticket has no file to close, so skip
+        # it rather than let `erg close` abort the script under set -e.
+        if [[ -z "$TICKET_FILE" ]]; then
+            echo "erg-pr-merge: skipping close of ${tid} — no ticket file at branch tip (override active)." >&2
+            continue
+        fi
         "$ERG" close "$tid" "autoclosed — PR #${PR}"
         "$ERG" archive "$tid" 2>/dev/null || true
         # Stage tracked modifications and deletions across tickets/: this

--- a/skills/merge/erg-pr-merge
+++ b/skills/merge/erg-pr-merge
@@ -70,7 +70,7 @@ fi
 
 echo "PR #$PR"
 
-PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body,isDraft) # harness-extension-point
+PR_JSON=$(gh pr view "$PR" --json number,headRefName,baseRefName,mergeable,statusCheckRollup,body,isDraft,title) # harness-extension-point
 PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
 BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.baseRefName')
 CURRENT_BRANCH=$(git branch --show-current)
@@ -177,9 +177,9 @@ if [[ -n "$TICKET_IDS" ]] && [[ -d tickets ]]; then
         fi
     fi
 
-    # Non-blocking title/claim disagreement warn. One extra read-only forge call,
-    # skipped entirely when there is nothing to close. (harness-extension-point)
-    PR_TITLE=$(gh pr view "$PR" --json title --jq '.title' 2>/dev/null || echo "")
+    # Non-blocking title/claim disagreement warn. Title comes from the Step 0
+    # PR_JSON fetch — no extra forge call.
+    PR_TITLE=$(echo "$PR_JSON" | jq -r '.title // ""')
     TITLE_TID=$(echo "$PR_TITLE" | grep -oiP '\(\K\d{3,4}(?=\))' | head -1 || true)
     if [[ -n "$TITLE_TID" ]] && ! echo "$TICKET_IDS" | grep -qx "$TITLE_TID"; then
         echo "erg-pr-merge: warning: PR title names ticket ${TITLE_TID} but the close claim(s) are ${TICKET_IDS//$'\n'/, } — verify the branch was not repurposed (cf. PR #522). Title prefixes are subject references, not close claims; proceeding." >&2

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -746,5 +746,78 @@ else
     echo "FAIL: erg-pr-merge exited non-zero from a name-collision lookalike path"; fail=1
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# Close-claim / branch-content cross-check (ticket 0312). A PR's Ticket close
+# claim lives in the body, but the branch can drift from it: shared-worktree
+# contention force-pushed an unrelated changeset over t0268-state-guard (PR #522,
+# 2026-07-13), leaving a stale `**Ticket:** 0268` claim. erg-pr-merge would have
+# closed the ticket while landing unrelated work. These cases pin the guard.
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── Case 22: stale close claim — the claimed ticket file is ABSENT from
+# tickets/ at the branch tip (the #522 force-replace mode). erg-pr-merge must
+# ABORT before closing or merging, name the missing ticket, and mention the
+# override. No merge may be attempted.
+seed_repo staleclaim 0281
+MLOG22="$WORK/merge22.log"; : > "$MLOG22"
+BODY22=$'Summary.\n\n**Ticket:** tickets/0299-fixture.erg\n'   # 0299 never seeded
+if out22=$(STUB_MERGE_LOG="$MLOG22" run_merge "$BODY22" "ticket(0299): stale" 2>&1); then
+    echo "FAIL: stale close claim (absent ticket) should have aborted, exited zero"; fail=1
+else
+    s_miss=0
+    echo "$out22" | grep -q '0299' || { echo "  abort msg does not name 0299"; s_miss=1; }
+    echo "$out22" | grep -q 'ERG_PR_MERGE_ALLOW_MISSING_TICKET' || { echo "  abort msg lacks override hint"; s_miss=1; }
+    [[ -s "$MLOG22" ]] && { echo "  a merge was attempted despite the stale claim"; s_miss=1; }
+    if closed_has 0281; then echo "  unrelated seeded ticket 0281 was closed"; s_miss=1; fi
+    if (( s_miss )); then echo "FAIL: stale-claim abort message/behavior wrong"; fail=1
+    else echo "PASS: absent-at-tip close claim aborts before merge; names ticket + override"; fi
+fi
+
+# ── Case 23: override — ERG_PR_MERGE_ALLOW_MISSING_TICKET=1 turns the abort
+# into a warn-and-skip. The merge proceeds (exit 0), the absent 0299 is NOT
+# closed (it cannot be), and a warning is emitted.
+seed_repo staleoverride 0282
+BODY23=$'Summary.\n\n**Ticket:** tickets/0299-fixture.erg\n'
+if out23=$(ERG_PR_MERGE_ALLOW_MISSING_TICKET=1 run_merge "$BODY23" "ticket(0299): override" 2>&1); then
+    o_miss=0
+    echo "$out23" | grep -qi 'warning' || { echo "  no warning emitted under override"; o_miss=1; }
+    if closed_has 0299; then echo "  0299 wrongly closed under override"; o_miss=1; fi
+    if (( o_miss )); then echo "FAIL: override path wrong"; fail=1
+    else echo "PASS: override warns and skips the absent ticket, merge proceeds"; fi
+else
+    echo "FAIL: override should let the merge proceed, exited non-zero"; fail=1
+fi
+
+# ── Case 24: title/claim disagreement — a present, valid claim (0290) while the
+# PR TITLE names a different ticket (0289), the tell of a repurposed branch
+# (#522). Non-blocking: the valid claim still closes (exit 0) and a warning
+# naming the title ticket is emitted.
+seed_repo titleclaim 0290
+BODY24=$'Summary.\n\n**Ticket:** tickets/0290-fixture.erg\n'
+if out24=$(run_merge "$BODY24" "ticket(0289): repurposed" 2>&1); then
+    t_miss=0
+    closed_has 0290 || { echo "  valid claim 0290 not closed"; t_miss=1; }
+    echo "$out24" | grep -q 'title names' || { echo "  no title-disagreement warning"; t_miss=1; }
+    echo "$out24" | grep -q '0289'        || { echo "  warning does not name title ticket 0289"; t_miss=1; }
+    if (( t_miss )); then echo "FAIL: title/claim disagreement not warned or claim not honored"; fail=1
+    else echo "PASS: title names a non-claimed ticket -> warn, valid claim still closes"; fi
+else
+    echo "FAIL: title/claim disagreement should be non-blocking, exited non-zero"; fail=1
+fi
+
+# ── Case 25: anti-regression — title agrees with the claim: NO disagreement
+# warning, ticket closes normally (no new friction on well-formed merges).
+seed_repo titlematch 0291
+BODY25=$'Summary.\n\n**Ticket:** tickets/0291-fixture.erg\n'
+if out25=$(run_merge "$BODY25" "ticket(0291): normal" 2>&1); then
+    m_miss=0
+    closed_has 0291 || { echo "  0291 not closed on happy path"; m_miss=1; }
+    echo "$out25" | grep -q 'title names' && { echo "  spurious title warning on matching title"; m_miss=1; }
+    if (( m_miss )); then echo "FAIL: happy-path title match mishandled"; fail=1
+    else echo "PASS: matching title/claim -> no warning, normal close (no new friction)"; fi
+else
+    echo "FAIL: erg-pr-merge exited non-zero on matching title/claim happy path"; fail=1
+fi
+
 if (( fail )); then exit 1; fi
-echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands, in_worktree() identity-tightened (incl. name-collision guard)"
+echo "PASS: erg-pr-merge closes ALL Ticket lines, single-ticket unchanged, dedup safe, strays unswept, sibling edits staged, --auto/-watch races handled, drafts readied, cosmetic merge failures tolerated, local main synced once the merge lands, in_worktree() identity-tightened (incl. name-collision guard), close claim cross-checked against branch tip"

--- a/tests/test_erg_pr_merge.sh
+++ b/tests/test_erg_pr_merge.sh
@@ -59,14 +59,16 @@ case "$1 $2" in
         echo "${STUB_STATE:-MERGED}"; exit 0
       fi
     fi
-    if [[ "$args" == *"title"* ]]; then
+    if [[ "$args" == *"title"* ]] && [[ "$args" != *"headRefName"* ]]; then
       jq -n --arg t "$STUB_TITLE" '{title:$t}'; exit 0
     fi
-    # the big composite query
+    # the big composite query (carries the title since the Step 1.5 warn
+    # reads it from PR_JSON instead of a second forge call)
     jq -n \
       --arg n "$STUB_PR" --arg h "$STUB_BRANCH" --arg b "$STUB_BASE" \
       --arg body "$STUB_BODY" --arg draft "${STUB_IS_DRAFT:-false}" \
-      '{number:($n|tonumber),headRefName:$h,baseRefName:$b,mergeable:"MERGEABLE",statusCheckRollup:[],body:$body,isDraft:($draft=="true")}'
+      --arg t "$STUB_TITLE" \
+      '{number:($n|tonumber),headRefName:$h,baseRefName:$b,mergeable:"MERGEABLE",statusCheckRollup:[],body:$body,isDraft:($draft=="true"),title:$t}'
     exit 0 ;;
   "pr ready")
     echo "$*" >> "${STUB_READY_LOG:-/dev/null}"

--- a/tickets/0312-erg-pr-merge-cross-check-the-ticket-clos.erg
+++ b/tickets/0312-erg-pr-merge-cross-check-the-ticket-clos.erg
@@ -5,6 +5,7 @@ Author: Minh Ha-Duong
 
 --- log ---
 2026-07-13T10:23Z Minh Ha-Duong created
+2026-07-13T00:00Z claude note cross-check implemented in erg-pr-merge: existence-at-tip abort (override ERG_PR_MERGE_ALLOW_MISSING_TICKET) plus title/claim disagreement warn; tests cases 22-25
 
 --- body ---
 ## Context

--- a/tickets/closed/0312-erg-pr-merge-cross-check-the-ticket-clos.erg
+++ b/tickets/closed/0312-erg-pr-merge-cross-check-the-ticket-clos.erg
@@ -2,11 +2,13 @@
 Title: erg-pr-merge: cross-check the Ticket close claim against the PR diff
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #544
 
 --- log ---
 2026-07-13T10:23Z Minh Ha-Duong created
 2026-07-13T00:00Z claude note cross-check implemented in erg-pr-merge: existence-at-tip abort (override ERG_PR_MERGE_ALLOW_MISSING_TICKET) plus title/claim disagreement warn; tests cases 22-25
 
+2026-07-13T13:58Z Minh Ha-Duong closed — autoclosed — PR #544
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`erg-pr-merge` parses the `**Ticket:**` close claim from the PR body and closes
it unconditionally; nothing verified the claim still matches the branch content.
Shared-worktree contention once force-pushed an unrelated changeset over a
branch (PR #522, 2026-07-13), leaving a stale `**Ticket:** 0268` claim that
would have closed the ticket while landing unrelated work. The only defense was
a human noticing and retitling the PR.

## What changed

New **Step 1.5** in `skills/merge/erg-pr-merge`, before the close loop:

- **Existence-at-tip (blocking, overridable).** Abort if a claimed ticket's
  file is absent from `tickets/` at the branch tip. This is *existence-at-tip*,
  not touched-by-diff — a claim on a ticket the diff never modifies is
  legitimate (close-by-convention on merge), so the diff is not required to
  touch the ticket file. Override with `ERG_PR_MERGE_ALLOW_MISSING_TICKET=1` to
  warn-and-skip the absent ticket instead of aborting.
- **Title/claim disagreement (non-blocking warn).** A title prefix `word(NNNN)`
  naming a ticket not among the close claims is a cheap tell of a repurposed
  branch. Warn only — title prefixes are subject references, not close claims.

The diff-touch tell the ticket floats (claim names N but the diff touches only
ticket M's file) is deliberately skipped, with a note in the script: a valid
convention close routinely touches no ticket file, so that signal both misses
the #522 case (its replacement diff touched no ticket) and false-positives on
legitimate closes.

## Design choice: abort vs warn

Existence-at-tip **aborts** by default (satisfies the exit criterion: a
force-replaced branch can no longer silently close the originally-claimed
ticket), with a documented override env var. The title tell only **warns**
(titles legitimately diverge from claims).

## Invariant

Happy path is behaviorally identical: when every claim resolves at the tip and
the title agrees, no new output and no new blocking. The title check adds one
read-only forge call, skipped entirely when there is nothing to close.

## Tests

`tests/test_erg_pr_merge.sh` cases 22-25 (red-first): absent-claim abort names
ticket + override and attempts no merge; override warn-and-skip; title
disagreement warns while the valid claim still closes; matching-title
anti-regression (no spurious warn). `make check` passes (the shell suite runs
under `test_bash_suites.py`).

**Ticket:** tickets/0312-erg-pr-merge-cross-check-the-ticket-clos.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
