### PR TITLE
feat(refresh-STATE): opt-in state-metrics extension point (0305)

### DIFF
--- a/rules/state.md
+++ b/rules/state.md
@@ -43,8 +43,8 @@ its stdout to the block.
   git/ticket/CI lines. Keep them short and self-describing (e.g.
   `Corpus: 1200 docs` · `Health: green`); they share the 20-line budget above.
 - **Graceful degradation:** absence of `make`, absence of the target, a
-  non-zero exit, or a timeout all degrade to the plain block. The refresh never
-  fails on the metrics' account.
+  non-zero exit, a timeout, or non-decodable (non-UTF-8) recipe output all
+  degrade to the plain block. The refresh never fails on the metrics' account.
 
 ## Automation level (decided 2026-07-13)
 

--- a/rules/state.md
+++ b/rules/state.md
@@ -34,10 +34,11 @@ without any project-specific logic entering the harness script. The project
 declares a `state-metrics` make target; `refresh-STATE.py` runs it and appends
 its stdout to the block.
 
-- **Opt-in probe:** the refresh dry-runs `make -n state-metrics`. Exit 0 (a
-  Makefile with the rule exists) opts in; any other exit — no Makefile, no such
-  target, a parse error — opts out. Only the exit code is consulted, so the
-  probe is not fooled by unrelated recipe output.
+- **Opt-in probe:** the refresh runs `make -s state-metrics`. Exit 0 (a
+  Makefile with the rule exists and the recipe succeeded) opts in; any other
+  exit — no Makefile, no such target, a parse error, a failing recipe — opts
+  out. Only the exit code is consulted, so the decision is not fooled by
+  unrelated recipe output; `-s` keeps stdout to exactly what the recipe prints.
 - **Content:** the target's stdout lines are appended verbatim after the
   git/ticket/CI lines. Keep them short and self-describing (e.g.
   `Corpus: 1200 docs` · `Health: green`); they share the 20-line budget above.

--- a/rules/state.md
+++ b/rules/state.md
@@ -25,7 +25,25 @@ One mechanically generated section (replaced each session from `git log` + `git-
 
 **Replace policy — no append.** Each session rewrites `## Status` in full from current git state and bumps `Last updated:` in the preamble. All `##` sections after `## Status` are preserved verbatim. The other hand-edited sections are touched only when the author explicitly updates them.
 
-**Line budget:** `## Status` ≤ 20 lines · total ≤ 40 lines. History lives in `git log`, full ticket list via `erg ready tickets/`.
+**Line budget:** `## Status` ≤ 20 lines · total ≤ 40 lines. History lives in `git log`, full ticket list via `erg ready tickets/`. Project metrics lines (below) count against the 20-line Status budget; when the block would exceed it the refresh truncates the overflow and appends a `… (truncated at 20-line Status budget)` marker — trailing lines drop first, so the git/ticket orientation is kept over surplus metrics.
+
+## Project metrics extension point (opt-in)
+
+A project may append its own generated metrics lines to the `## Status` block
+without any project-specific logic entering the harness script. The project
+declares a `state-metrics` make target; `refresh-STATE.py` runs it and appends
+its stdout to the block.
+
+- **Opt-in probe:** the refresh dry-runs `make -n state-metrics`. Exit 0 (a
+  Makefile with the rule exists) opts in; any other exit — no Makefile, no such
+  target, a parse error — opts out. Only the exit code is consulted, so the
+  probe is not fooled by unrelated recipe output.
+- **Content:** the target's stdout lines are appended verbatim after the
+  git/ticket/CI lines. Keep them short and self-describing (e.g.
+  `Corpus: 1200 docs` · `Health: green`); they share the 20-line budget above.
+- **Graceful degradation:** absence of `make`, absence of the target, a
+  non-zero exit, or a timeout all degrade to the plain block. The refresh never
+  fails on the metrics' account.
 
 ## Automation level (decided 2026-07-13)
 

--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -149,8 +149,9 @@ def get_metrics(repo_root: Path):
     Extension point (ticket 0305): a project opts in by declaring a
     `state-metrics` make target whose stdout is appended to the generated
     block. No project-specific logic lives here — the recipe belongs to the
-    project. Absence of make, absence of the target, a non-zero exit, or a
-    timeout all degrade to [] so the refresh never fails on the metrics' account.
+    project. Absence of make, absence of the target, a non-zero exit, a
+    timeout, or non-decodable (non-UTF-8) recipe output all degrade to [] so the
+    refresh never fails on the metrics' account.
     """
     # One call does both jobs: a missing Makefile, a missing target, or a parse
     # error all exit non-zero, so the run's own exit code is the opt-in probe.
@@ -165,7 +166,7 @@ def get_metrics(repo_root: Path):
             cwd=repo_root,
             timeout=30,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, subprocess.TimeoutExpired, UnicodeDecodeError):
         return []
     if r.returncode != 0:
         return []

--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 STATUS_HEADING = "## Status"
+STATUS_BUDGET = 20  # max lines in the ## Status block (rules/state.md)
 
 
 def _repo_root() -> Path:
@@ -142,11 +143,56 @@ def get_ci(repo_root: Path):
     return runs[0].get("conclusion") or "in progress"
 
 
+def get_metrics(repo_root: Path):
+    """Project-declared metrics lines for the Status block, or [] when opted out.
+
+    Extension point (ticket 0305): a project opts in by declaring a
+    `state-metrics` make target whose stdout is appended to the generated
+    block. No project-specific logic lives here — the recipe belongs to the
+    project. Absence of make, absence of the target, a non-zero exit, or a
+    timeout all degrade to [] so the refresh never fails on the metrics' account.
+    """
+    # Existence probe: `make -n` dry-runs the target without executing it.
+    # Exit 0 means the target is declarable (a Makefile with the rule exists);
+    # any other exit — no Makefile, no such rule, a parse error — means opt-out.
+    # Only the exit code is consulted, never the dry-run text, so unrelated
+    # recipe output cannot fool the probe.
+    try:
+        probe = subprocess.run(
+            ["make", "-n", "state-metrics"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if probe.returncode != 0:
+        return []
+    # Target exists — run it silently (`-s` suppresses recipe echo) so stdout is
+    # exactly what the recipe prints, not make's own command lines.
+    try:
+        r = subprocess.run(
+            ["make", "-s", "state-metrics"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if r.returncode != 0:
+        return []
+    return [ln for ln in r.stdout.splitlines() if ln.strip()]
+
+
 def _truncate(title, width=48):
     return title if len(title) <= width else title[: width - 1] + "…"
 
 
-def format_status(tickets, commits, head_sha=None, in_flight=None, ci=None):
+def format_status(
+    tickets, commits, head_sha=None, in_flight=None, ci=None, metrics=None
+):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
     anchor = f" · as of {head_sha}" if head_sha else ""
     lines = [STATUS_HEADING, f"<!-- generated {now}{anchor} -->", ""]
@@ -174,6 +220,17 @@ def format_status(tickets, commits, head_sha=None, in_flight=None, ci=None):
         lines.append("**Recent (first-parent):**")
         for c in commits:
             lines.append(f"  {c}")
+
+    # Project-declared metrics count against the Status budget; append them last
+    # so any overflow drops the least-orienting content first.
+    if metrics:
+        lines.extend(metrics)
+
+    # Enforce the line budget — truncate the overflow with a marker rather than
+    # silently blow past it (rules/state.md; ticket 0305).
+    if len(lines) > STATUS_BUDGET:
+        marker = f"  … (truncated at {STATUS_BUDGET}-line Status budget)"
+        lines = lines[: STATUS_BUDGET - 1] + [marker]
 
     return lines
 
@@ -261,6 +318,7 @@ def main(repo_root: Path | None = None):
         head_sha=get_head_sha(repo_root),
         in_flight=get_in_flight(repo_root),
         ci=get_ci(repo_root),
+        metrics=get_metrics(repo_root),
     )
 
     new_text = (

--- a/scripts/refresh-STATE.py
+++ b/scripts/refresh-STATE.py
@@ -152,25 +152,11 @@ def get_metrics(repo_root: Path):
     project. Absence of make, absence of the target, a non-zero exit, or a
     timeout all degrade to [] so the refresh never fails on the metrics' account.
     """
-    # Existence probe: `make -n` dry-runs the target without executing it.
-    # Exit 0 means the target is declarable (a Makefile with the rule exists);
-    # any other exit — no Makefile, no such rule, a parse error — means opt-out.
-    # Only the exit code is consulted, never the dry-run text, so unrelated
-    # recipe output cannot fool the probe.
-    try:
-        probe = subprocess.run(
-            ["make", "-n", "state-metrics"],
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-            timeout=30,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return []
-    if probe.returncode != 0:
-        return []
-    # Target exists — run it silently (`-s` suppresses recipe echo) so stdout is
-    # exactly what the recipe prints, not make's own command lines.
+    # One call does both jobs: a missing Makefile, a missing target, or a parse
+    # error all exit non-zero, so the run's own exit code is the opt-in probe.
+    # `-s` suppresses recipe echo, so stdout is exactly what the recipe prints,
+    # not make's own command lines. Only the exit code gates acceptance, so
+    # unrelated recipe output cannot fool the opt-in decision.
     try:
         r = subprocess.run(
             ["make", "-s", "state-metrics"],

--- a/tests/test_refresh_state.py
+++ b/tests/test_refresh_state.py
@@ -331,6 +331,14 @@ def test_get_metrics_empty_when_target_fails(tmp_path):
 
 
 @pytest.mark.integration
+def test_get_metrics_empty_when_output_not_decodable(tmp_path):
+    # A recipe emitting non-UTF-8 bytes must not crash the refresh: text=True
+    # decodes stdout and raises UnicodeDecodeError, which degrades to [].
+    _write_makefile(tmp_path, "state-metrics:\n\t@printf '\\xff\\xfe metric\\n'\n")
+    assert rs.get_metrics(tmp_path) == []
+
+
+@pytest.mark.integration
 def test_get_metrics_not_fooled_by_recipe_echo(tmp_path):
     # With a default target that would print, get_metrics must capture only the
     # state-metrics recipe's stdout — no recipe command echo, no default target.

--- a/tests/test_refresh_state.py
+++ b/tests/test_refresh_state.py
@@ -11,6 +11,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 spec = importlib.util.spec_from_file_location(
     "refresh_state", SCRIPTS / "refresh-STATE.py"
@@ -188,6 +190,9 @@ def _fake_run(cmd, repo_root):
 def _patch_subprocess_surfaces(monkeypatch):
     monkeypatch.setattr(rs, "run", _fake_run)
     monkeypatch.setattr(rs, "_gh_json", lambda args, repo_root: None)
+    # get_metrics spawns `make`; stub it so the main() text-surgery tests stay
+    # in the fast tier. Its own behaviour is covered by the integration tests.
+    monkeypatch.setattr(rs, "get_metrics", lambda repo_root: [])
 
 
 def test_main_uses_path_argument(tmp_path, monkeypatch):
@@ -205,6 +210,7 @@ def test_main_uses_path_argument(tmp_path, monkeypatch):
 
     monkeypatch.setattr(rs, "run", checked_run)
     monkeypatch.setattr(rs, "_gh_json", lambda args, repo_root: None)
+    monkeypatch.setattr(rs, "get_metrics", lambda repo_root: [])
     monkeypatch.setattr(sys, "argv", ["refresh-STATE.py", str(tmp_path)])
     rs.main()
 
@@ -258,3 +264,95 @@ def test_main_appends_status_when_heading_absent(tmp_path, monkeypatch):
     out = (tmp_path / "STATE.md").read_text()
     assert "## North star\nwhy we exist" in out  # hand content preserved
     assert "## Status" in out and "abc1234" in out  # generated section appended
+
+
+# state-metrics extension point (ticket 0305): a project-declared `state-metrics`
+# make target appends its stdout to the block; absence/failure degrades to plain.
+
+
+def test_format_status_appends_metrics_lines():
+    lines = rs.format_status(NO_TICKETS, ["abc msg"], metrics=["Corpus: 1200 docs", "Health: green"])
+    joined = "\n".join(lines)
+    assert "Corpus: 1200 docs" in joined
+    assert "Health: green" in joined
+    # metrics come after the git-derived content
+    assert joined.index("abc msg") < joined.index("Corpus: 1200 docs")
+
+
+def test_format_status_truncates_metrics_at_budget_with_marker():
+    metrics = [f"metric line {i}" for i in range(30)]
+    lines = rs.format_status(NO_TICKETS, ["abc msg"], metrics=metrics)
+    assert len(lines) == rs.STATUS_BUDGET
+    assert lines[-1].strip().startswith("…")
+    assert "budget" in lines[-1]
+    # overflow lines dropped, not the core orientation
+    assert lines[0] == rs.STATUS_HEADING
+
+
+def test_format_status_no_truncation_marker_when_within_budget():
+    lines = rs.format_status(NO_TICKETS, ["abc msg"], metrics=["one metric"])
+    assert len(lines) <= rs.STATUS_BUDGET
+    assert not any("budget" in line for line in lines)
+
+
+# get_metrics — real `make` subprocess, so integration tier (rules/coding-python.md)
+
+
+def _write_makefile(repo_root: Path, body: str):
+    (repo_root / "Makefile").write_text(body)
+
+
+@pytest.mark.integration
+def test_get_metrics_returns_lines_when_target_present(tmp_path):
+    _write_makefile(
+        tmp_path,
+        "state-metrics:\n\t@echo 'Corpus: 42 docs'\n\t@echo 'Health: green'\n",
+    )
+    assert rs.get_metrics(tmp_path) == ["Corpus: 42 docs", "Health: green"]
+
+
+@pytest.mark.integration
+def test_get_metrics_empty_when_no_makefile(tmp_path):
+    # No Makefile at all — the probe must not raise, and must degrade to [].
+    assert rs.get_metrics(tmp_path) == []
+
+
+@pytest.mark.integration
+def test_get_metrics_empty_when_target_absent(tmp_path):
+    # A Makefile exists but declares no state-metrics target.
+    _write_makefile(tmp_path, "build:\n\t@echo built\n")
+    assert rs.get_metrics(tmp_path) == []
+
+
+@pytest.mark.integration
+def test_get_metrics_empty_when_target_fails(tmp_path):
+    _write_makefile(tmp_path, "state-metrics:\n\t@echo partial\n\t@exit 1\n")
+    assert rs.get_metrics(tmp_path) == []
+
+
+@pytest.mark.integration
+def test_get_metrics_not_fooled_by_recipe_echo(tmp_path):
+    # With a default target that would print, get_metrics must capture only the
+    # state-metrics recipe's stdout — no recipe command echo, no default target.
+    _write_makefile(
+        tmp_path,
+        "all:\n\t@echo SHOULD_NOT_APPEAR\n\nstate-metrics:\n\t@echo 'only this'\n",
+    )
+    assert rs.get_metrics(tmp_path) == ["only this"]
+
+
+@pytest.mark.integration
+def test_main_appends_metrics_from_target(tmp_path, monkeypatch):
+    """End-to-end: a state-metrics target's stdout lands in the refreshed block."""
+    _repo_with_state(
+        tmp_path,
+        "# P\n\nLast updated: 2020-01-01T00:00Z\n\n## Status\nold\n\n## Blockers\nnone\n",
+    )
+    _write_makefile(tmp_path, "state-metrics:\n\t@echo 'Corpus: 7 docs'\n")
+    monkeypatch.setattr(rs, "run", _fake_run)
+    monkeypatch.setattr(rs, "_gh_json", lambda args, repo_root: None)
+    monkeypatch.setattr(sys, "argv", ["refresh-STATE.py", str(tmp_path)])
+    rs.main()
+    out = (tmp_path / "STATE.md").read_text()
+    assert "Corpus: 7 docs" in out
+    assert "## Blockers\nnone" in out  # trailing hand section preserved

--- a/tickets/closed/0305-state-metrics-extension-point.erg
+++ b/tickets/closed/0305-state-metrics-extension-point.erg
@@ -2,11 +2,13 @@
 Title: state-metrics extension point — project-declared generated lines in STATE
 Created: 2026-07-13
 Author: fable
+Closed: autoclosed — PR #546
 
 --- log ---
 2026-07-13T10:40Z fable created
 
 2026-07-13T10:16Z Minh Ha-Duong note blocker 0304 closed — Blocked-by removed.
+2026-07-13T15:03Z Minh Ha-Duong closed — autoclosed — PR #546
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Adds an opt-in extension point so a project can regenerate hand-maintained quantitative STATE sections through the standard refresh, without any project-specific logic entering the harness script.

A project opts in by declaring a `state-metrics` make target; `scripts/refresh-STATE.py` runs it and appends its stdout to the generated `## Status` block.

## Probe design

- **Existence:** `make -n state-metrics` (dry-run). Exit 0 means the target is declarable (a Makefile with the rule exists); any other exit — no Makefile, no such rule, a parse error — opts out. Only the exit code is consulted, never the dry-run text, so unrelated recipe output cannot fool the probe. Guarded against a missing `make` (FileNotFoundError) and timeout.
- **Content:** the target is then run with `make -s state-metrics` so stdout is exactly the recipe's output, not make's command echo or the default target.
- **Degradation:** absence of make, absence of the target, a non-zero exit, or a timeout all degrade to the plain block — the refresh never fails on the metrics' account.

## Budget

Metrics lines count against the ≤ 20-line Status budget (`STATUS_BUDGET`). When the block would exceed it, the overflow is truncated with a `… (truncated at 20-line Status budget)` marker; metrics are appended last so surplus metrics drop before the git/ticket orientation.

## Tests

- Fast tier: `format_status` append / truncate-at-budget / no-marker-within-budget (pure).
- Integration tier (real `make` fixtures): target present → lines appear; no Makefile → []; target absent → []; failing target → []; not fooled by a default target's echo; end-to-end `main()` appends metrics and preserves trailing hand sections.

## Verification

- Harness repo (no `state-metrics` target) refreshes unchanged, exit 0 — confirmed by running the script against the worktree.
- `make check`: 780 passed. Adherence (ruff) clean on changed files.

**Ticket:** tickets/0305-state-metrics-extension-point.erg