### PR TITLE
build: wire the adherence test tier (make lint + check-fast exclusion)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
-.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check check-fast check-tests
+.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check check-fast check-tests lint
 
 skills-catalog:
 	./scripts/update-skills-catalog.py
 
 # Fast gate (coding-python.md): unit tests only — excludes the integration
-# (subprocess/sleep) and slow (network/real-data) tiers. Includes the static
-# AST marker-hygiene check (ticket 0229), which dogfoods that very exclusion.
+# (subprocess/sleep), slow (network/real-data), and adherence (mechanical
+# gate) tiers. Includes the static AST marker-hygiene check (ticket 0229),
+# which dogfoods that very exclusion.
 check-fast:
-	python3 -m pytest tests/ -m "not integration and not slow"
+	python3 -m pytest tests/ -m "not integration and not slow and not adherence"
+
+# Adherence gate (coding-python.md): the mechanical tier only — grep/AST
+# ratchets and hygiene checks. Run apart from the logic loop so check-fast
+# stays pure and quick.
+lint:
+	python3 -m pytest tests/ -m adherence
 
 check-skills-drift:
 	./scripts/check-skills-drift.py

--- a/tests/test_makefile_gates.py
+++ b/tests/test_makefile_gates.py
@@ -38,19 +38,14 @@ def test_check_keeps_static_checks():
         assert dep in deps, f"'check' lost its static prerequisite {dep}"
 
 
-def test_check_fast_excludes_integration_and_slow():
+def test_check_fast_excludes_non_fast_tiers():
     rule = target_recipe("check-fast")
-    assert "not integration" in rule and "not slow" in rule, (
-        f"'check-fast' must exclude integration and slow tiers; current rule:\n{rule}"
-    )
-
-
-def test_check_fast_excludes_adherence():
-    rule = target_recipe("check-fast")
-    assert "not adherence" in rule, (
-        "coding-python.md keeps the adherence tier out of the fast loop — "
-        f"'check-fast' must exclude adherence; current rule:\n{rule}"
-    )
+    for marker in ("not integration", "not slow", "not adherence"):
+        assert marker in rule, (
+            "coding-python.md keeps the integration, slow, and adherence tiers "
+            f"out of the fast loop — 'check-fast' must filter '{marker}'; "
+            f"current rule:\n{rule}"
+        )
 
 
 def test_lint_runs_adherence_tier_only():

--- a/tests/test_makefile_gates.py
+++ b/tests/test_makefile_gates.py
@@ -1,7 +1,9 @@
 """Hygiene: Makefile gate targets match the coding-python.md definitions.
 
 `check` is the pre-PR gate: full pytest suite (integration + slow included)
-plus the static checks. `check-fast` is the development gate: unit tests only.
+plus the static checks. `check-fast` is the development gate: unit tests only,
+excluding the integration, slow, and adherence tiers. `lint` is the adherence
+gate: the mechanical `-m adherence` tier run apart from the logic loop.
 Source inspection, not subprocess (ticket 0238).
 """
 

--- a/tests/test_makefile_gates.py
+++ b/tests/test_makefile_gates.py
@@ -41,3 +41,20 @@ def test_check_fast_excludes_integration_and_slow():
     assert "not integration" in rule and "not slow" in rule, (
         f"'check-fast' must exclude integration and slow tiers; current rule:\n{rule}"
     )
+
+
+def test_check_fast_excludes_adherence():
+    rule = target_recipe("check-fast")
+    assert "not adherence" in rule, (
+        "coding-python.md keeps the adherence tier out of the fast loop — "
+        f"'check-fast' must exclude adherence; current rule:\n{rule}"
+    )
+
+
+def test_lint_runs_adherence_tier_only():
+    rule = target_recipe("lint")
+    assert re.search(r"pytest tests/ -m adherence\s*$", rule, re.MULTILINE), (
+        "coding-python.md defines 'make lint' as the adherence tier only — "
+        "pytest over tests/ filtered to -m adherence; "
+        f"current rule:\n{rule}"
+    )

--- a/tickets/closed/0313-wire-the-adherence-test-tier-make-lint-t.erg
+++ b/tickets/closed/0313-wire-the-adherence-test-tier-make-lint-t.erg
@@ -2,10 +2,12 @@
 Title: Wire the adherence test tier: make lint target and check-fast exclusion
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #547
 
 --- log ---
 2026-07-13T12:48Z Minh Ha-Duong created
 
+2026-07-13T15:24Z Minh Ha-Duong closed — autoclosed — PR #547
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

PR #541 (ticket 0310) registered the `adherence` pytest marker in this repo but nothing wired the tier per `rules/coding-python.md`. Adherence tests ran only inside the full `make check` sweep, and `check-fast`'s tier boundary was undeclared.

This PR:
- Adds a `lint` target running `python3 -m pytest tests/ -m adherence` — the mechanical gate, run apart from the logic loop.
- Extends `check-fast`'s exclusion to `not integration and not slow and not adherence`, keeping the fast loop pure.
- Leaves `make check` running the whole suite (adherence included) — coverage unchanged.
- Adds two hygiene tests in `test_makefile_gates.py` that lock the new `lint` target and the `check-fast` adherence exclusion.

## Per-tier test counts (verified)

| Tier | Command | Count |
|------|---------|-------|
| adherence | `make lint` | 12 pass, 770 deselected |
| fast | `make check-fast` | 720 pass, 62 deselected (adherence now excluded) |
| full | `make check` | 782 pass |

Baseline was 781 total; the new tests bring it to 782 (two check-fast exclusion assertions folded into one parametrized test by /simplify), so no coverage lost.

## Exit criteria
- [x] `make lint` runs the adherence tier only
- [x] The fast tier excludes adherence tests
- [x] `make check` coverage unchanged

Pre-PR self-gate: `/verify-adherence` PASS (no mechanical or semantic findings) — `/gaze` can skip the mechanical phase.

**Ticket:** tickets/0313-wire-the-adherence-test-tier-make-lint-t.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)