### PR TITLE
fix(guard): realpath-normalize cwd to close symlink-traversal bypass

### DIFF
--- a/scripts/guard-enterworktree-parked-cwd.sh
+++ b/scripts/guard-enterworktree-parked-cwd.sh
@@ -27,7 +27,6 @@ cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 # deny (ticket 0314). Fail open if resolution fails (e.g. a race removed the
 # dir): a normalization failure must never flip an allow into a deny.
 cwd=$(cd "$cwd" 2>/dev/null && pwd -P) || exit 0
-[ -z "$cwd" ] && exit 0
 
 # Not inside a git repo: the tool fails on its own (or hook-delegated
 # VCS-agnostic mode handles it) — nothing for this guard to judge.

--- a/scripts/guard-enterworktree-parked-cwd.sh
+++ b/scripts/guard-enterworktree-parked-cwd.sh
@@ -20,6 +20,15 @@ cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 [ -z "$cwd" ] && exit 0
 [ -d "$cwd" ] || exit 0
 
+# Normalize away symlinks before the repo-membership and check-ignore probes.
+# A path that reaches the repo through a symlink otherwise makes
+# `git check-ignore "$cwd"` error "outside repository", which the guard treats
+# as allow — letting a parked runtime dir addressed via a symlink bypass the
+# deny (ticket 0314). Fail open if resolution fails (e.g. a race removed the
+# dir): a normalization failure must never flip an allow into a deny.
+cwd=$(cd "$cwd" 2>/dev/null && pwd -P) || exit 0
+[ -z "$cwd" ] && exit 0
+
 # Not inside a git repo: the tool fails on its own (or hook-delegated
 # VCS-agnostic mode handles it) — nothing for this guard to judge.
 toplevel=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit 0

--- a/tests/test_guard_enterworktree_parked_cwd.sh
+++ b/tests/test_guard_enterworktree_parked_cwd.sh
@@ -66,6 +66,21 @@ _assert 0 "allows Skill at repo root"            "$REPO"                 "Skill"
 _assert 0 "allows Skill in tracked subdir"       "$REPO/src"             "Skill"
 _assert 0 "allows Skill outside any repo"        "$NOREPO"               "Skill"
 
+# --- Symlink traversal: cwd is realpath-normalized before the probes (0314) ---
+# A path that reaches the repo through a symlink must resolve to its real
+# location before the check-ignore probe. Otherwise check-ignore errors
+# "outside repository", the guard falls through to allow, and a parked runtime
+# directory addressed via a symlink bypasses the deny (found by the PR #545 panel).
+LINK_PARKED="$TMP/link-parked"
+ln -s "$REPO/projects/session-x" "$LINK_PARKED"
+LINK_ROOT="$TMP/link-root"
+ln -s "$REPO" "$LINK_ROOT"
+
+_assert 2 "denies symlinked parked cwd"              "$LINK_PARKED"
+_assert 2 "denies symlinked parked cwd (Skill)"      "$LINK_PARKED"          "Skill"
+_assert 0 "allows symlinked repo-root cwd"           "$LINK_ROOT"
+_assert 0 "allows symlinked repo-root cwd (Skill)"   "$LINK_ROOT"            "Skill"
+
 # --- Payload without .cwd → fail-safe allow ---------------------------------
 rc=$(printf '{"tool_name":"EnterWorktree","tool_input":{}}' \
         | bash "$HOOK" >/dev/null 2>&1; echo $?)

--- a/tests/test_guard_enterworktree_parked_cwd.sh
+++ b/tests/test_guard_enterworktree_parked_cwd.sh
@@ -78,6 +78,9 @@ ln -s "$REPO" "$LINK_ROOT"
 
 _assert 2 "denies symlinked parked cwd"              "$LINK_PARKED"
 _assert 2 "denies symlinked parked cwd (Skill)"      "$LINK_PARKED"          "Skill"
+# A symlinked ancestor *component* (real leaf under a symlinked root) must also
+# normalize before the probes.
+_assert 2 "denies parked cwd via symlinked ancestor" "$LINK_ROOT/projects/session-x"
 _assert 0 "allows symlinked repo-root cwd"           "$LINK_ROOT"
 _assert 0 "allows symlinked repo-root cwd (Skill)"   "$LINK_ROOT"            "Skill"
 

--- a/tickets/0317-parked-cwd-guard-nested-git-repo-inside.erg
+++ b/tickets/0317-parked-cwd-guard-nested-git-repo-inside.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: Parked-cwd guard: nested git repo inside an ignored runtime dir escapes the deny
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T15:52Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Flagged by the /gaze panel on PR #548 (ticket 0314) as a pre-existing,
+out-of-scope residual in `scripts/guard-enterworktree-parked-cwd.sh`: if a git
+repository is initialized *inside* a git-ignored runtime directory (e.g.
+`git init` under `projects/<session>/`), `git rev-parse --show-toplevel` from
+that cwd resolves to the nested repo itself, the toplevel self-match passes,
+and the deny is bypassed on both guarded surfaces (EnterWorktree and Skill).
+
+## Actions
+
+1. Decide whether the escape is worth closing: the guard is deny-only
+   defense-in-depth, and a nested repo in a runtime dir may be legitimate
+   (scratch clones). If closing: after resolving the toplevel, walk up from
+   the nested toplevel's parent and re-run the ignored-runtime-dir probe
+   against any enclosing repo.
+2. Either way, record the decision at the probe site and pin it with a test
+   case (nested repo inside an ignored dir → chosen behavior).
+
+## Exit criteria
+
+- [ ] Decision recorded (deny extended, or exemption documented at the site)
+- [ ] Test case pins the chosen behavior
+- [ ] `make check` and `make lint` pass

--- a/tickets/closed/0314-parked-cwd-guard-realpath-normalize-cwd.erg
+++ b/tickets/closed/0314-parked-cwd-guard-realpath-normalize-cwd.erg
@@ -2,10 +2,12 @@
 Title: Parked-cwd guard: realpath-normalize cwd to close the symlink-traversal bypass
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #548
 
 --- log ---
 2026-07-13T14:36Z Minh Ha-Duong created
 
+2026-07-13T15:54Z Minh Ha-Duong closed — autoclosed — PR #548
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Closes the symlink-traversal bypass in the parked-cwd guard found by the PR #545 review panel (pre-existing since ticket 0267).

The guard resolved the repo toplevel with `git rev-parse --show-toplevel` (which canonicalizes symlinks) but left `$cwd` symlinked. A path reaching a git-ignored runtime dir through a symlink then made `git check-ignore "$cwd"` error "outside repository", which the guard treats as allow — so a parked runtime directory addressed via a symlinked path bypassed the deny on both guarded surfaces (EnterWorktree and Skill).

## Change

`scripts/guard-enterworktree-parked-cwd.sh`: normalize `$cwd` with `cd … && pwd -P` before the repo-membership and check-ignore probes. Resolution failure fails open (`|| exit 0`), preserving the guard's deny-only polarity — a normalization failure never flips an allow into a deny.

## Tests (red-first)

`tests/test_guard_enterworktree_parked_cwd.sh` gains 4 cases, confirmed RED before the fix:
- symlinked parked cwd denied (EnterWorktree + Skill)
- symlinked path to a legitimate repo root stays allowed (EnterWorktree + Skill)

The `settings.json` matcher (`EnterWorktree|Skill`) is untouched.

## Verification

- `make check` — pass
- `make lint` — pass
- `/verify-adherence` — PASS (mechanical, no findings)

**Ticket:** tickets/0314-parked-cwd-guard-realpath-normalize-cwd.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related follow-up: tickets/0317-parked-cwd-guard-nested-git-repo-inside.erg (panel finding: nested-git-repo escape, pre-existing)
