### PR TITLE
feat(0289): trace-based path-access scan for verify-adherence

### DIFF
--- a/scripts/trace-path-scan.py
+++ b/scripts/trace-path-scan.py
@@ -45,9 +45,14 @@ _TS_SPEC.loader.exec_module(ts)
 
 # (compiled pattern, human reason). High precision — each class is one a
 # diff-only check cannot see and a reviewer would call a scope violation.
+# The credential-directory patterns must match the *bare* directory too — a
+# `cd ~/.ssh` (no trailing slash, extracted as the token `~/.ssh`) is itself the
+# sensitive act, independent of the relative filename read afterward. So `.ssh`
+# and `.aws` are anchored by a following `/` OR end-of-string, not a mandatory
+# trailing slash.
 FORBIDDEN_PATH_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"/\.ssh/"), "ssh credentials directory"),
-    (re.compile(r"/\.aws/"), "aws credentials directory"),
+    (re.compile(r"/\.ssh(?:/|$)"), "ssh credentials directory"),
+    (re.compile(r"/\.aws(?:/|$)"), "aws credentials directory"),
     (re.compile(r"/\.netrc$"), "netrc credentials file"),
     (re.compile(r"bash-env\.sh$"), "secret-loading bash-env.sh"),
     (re.compile(r"/\.git-credentials$"), "git-credentials file"),

--- a/scripts/trace-path-scan.py
+++ b/scripts/trace-path-scan.py
@@ -96,15 +96,19 @@ def _worktree_segment(path: str) -> str | None:
     return m.group(1) if m else None
 
 
-def classify_path(path: str, worktree_root: str | None = None) -> str | None:
-    """Return a forbidden-class reason for `path`, or None if allowed."""
+def classify_path(path: str, own_worktree_segment: str | None = None) -> str | None:
+    """Return a forbidden-class reason for `path`, or None if allowed.
+
+    `own_worktree_segment` is the caller's own worktree segment, already
+    extracted once by the caller — not the raw worktree-root path — so a
+    scan over many paths doesn't re-derive the same constant on every call.
+    """
     for pattern, reason in FORBIDDEN_PATH_PATTERNS:
         if pattern.search(path):
             return reason
-    if worktree_root:
-        own = _worktree_segment(worktree_root)
+    if own_worktree_segment:
         seen = _worktree_segment(path)
-        if own and seen and seen != own:
+        if seen and seen != own_worktree_segment:
             return f"another session's worktree ({seen})"
     return None
 
@@ -120,6 +124,7 @@ def scan_trace_for_forbidden_paths(
     """
     hits: list[dict] = []
     seen_tool_use_ids: set[str] = set()
+    own_worktree_segment = _worktree_segment(worktree_root) if worktree_root else None
     with open(trace_path, encoding="utf-8") as fh:
         for line_no, raw in enumerate(fh, start=1):
             raw = raw.strip()
@@ -150,7 +155,7 @@ def scan_trace_for_forbidden_paths(
                 if not isinstance(tool_input, dict):
                     continue
                 for path in tool_paths(name, tool_input):
-                    reason = classify_path(path, worktree_root)
+                    reason = classify_path(path, own_worktree_segment)
                     if reason:
                         hits.append(
                             {"tool": name, "path": path, "reason": reason, "line": line_no}

--- a/scripts/trace-path-scan.py
+++ b/scripts/trace-path-scan.py
@@ -58,10 +58,12 @@ FORBIDDEN_PATH_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 # root belongs to another session.
 WORKTREE_RE = re.compile(r"/worktrees/([^/]+)")
 
-# A path-like token inside a Bash command: a whitespace-delimited run that starts
-# with / or ~ (absolute or home-relative). Good enough to catch a `cat
-# ~/.aws/credentials` without a full shell parse.
-BASH_PATH_RE = re.compile(r"(?<!\S)([~/][^\s'\"|;&><]+)")
+# A path-like token inside a Bash command: a run starting with / or ~ (absolute
+# or home-relative), bounded on the left by start-of-string, whitespace, a quote,
+# or `=` — so `cat "~/.ssh/id_rsa"` and `FILE=/home/u/.aws/creds` are caught, not
+# only the bare `cat ~/.aws/credentials` form. Good enough without a full shell
+# parse; the classifier is narrow enough that an over-matched token is harmless.
+BASH_PATH_RE = re.compile(r"(?:^|(?<=[\s\"'=]))([~/][^\s'\"|;&><]*)")
 
 
 def extract_bash_paths(command: str) -> list[str]:

--- a/scripts/trace-path-scan.py
+++ b/scripts/trace-path-scan.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Path-access allow/forbid scan over the agent tool trace — ticket 0289.
+
+Child of tracker 0266 (pillage manifest, technique 1;
+docs/pillage-0266-agentic-reproduction-2026-07-12.md). verify-adherence checks
+the diff and rule files, but nothing inspects the tool-call trace for
+out-of-scope file access. The paper's guardrail (arXiv:2604.21965 App. B.3)
+catches an agent that READS a forbidden path even when it never writes it — a
+scope-violation class a diff-only check structurally misses.
+
+Pure-Python, zero LLM tokens. Walks a single session-trace JSONL (the same
+record shape scripts/trace-stats.py parses) and flags every
+Read/Edit/Write/NotebookEdit/Bash call whose path argument falls in one of two
+high-precision forbidden classes:
+
+  1. Credential/secret files — ~/.ssh, ~/.aws, ~/.netrc, bash-env.sh,
+     .git-credentials.
+  2. ANOTHER session's worktree — a /worktrees/<segment>/ whose segment differs
+     from the caller's own worktree-root segment.
+
+Deliberately NOT a blanket "outside the worktree" rule: that would false-positive
+on legitimate reads of shared rules/ and skills/ files. The two classes above are
+the ones a diff never reveals and a human would call scope violations.
+"""
+
+import argparse
+import importlib.util
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+
+log = logging.getLogger("trace-path-scan")
+
+# Reuse trace-stats.py for its PATH_TOOLS convention (importlib sibling pattern,
+# precedent scripts/trace-compact-audit.py). We keep our own tolerant JSONL loop
+# rather than threading through ts.parse_trace_file — this scan needs per-line
+# numbers and a much narrower record view.
+_TS_SPEC = importlib.util.spec_from_file_location(
+    "trace_stats", Path(__file__).resolve().parent / "trace-stats.py"
+)
+ts = importlib.util.module_from_spec(_TS_SPEC)
+_TS_SPEC.loader.exec_module(ts)
+
+# (compiled pattern, human reason). High precision — each class is one a
+# diff-only check cannot see and a reviewer would call a scope violation.
+FORBIDDEN_PATH_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"/\.ssh/"), "ssh credentials directory"),
+    (re.compile(r"/\.aws/"), "aws credentials directory"),
+    (re.compile(r"/\.netrc$"), "netrc credentials file"),
+    (re.compile(r"bash-env\.sh$"), "secret-loading bash-env.sh"),
+    (re.compile(r"/\.git-credentials$"), "git-credentials file"),
+)
+
+# Captures the segment immediately under a worktrees/ dir — the per-session
+# discriminator. A path whose segment differs from the caller's own worktree
+# root belongs to another session.
+WORKTREE_RE = re.compile(r"/worktrees/([^/]+)")
+
+# A path-like token inside a Bash command: a whitespace-delimited run that starts
+# with / or ~ (absolute or home-relative). Good enough to catch a `cat
+# ~/.aws/credentials` without a full shell parse.
+BASH_PATH_RE = re.compile(r"(?<!\S)([~/][^\s'\"|;&><]+)")
+
+
+def extract_bash_paths(command: str) -> list[str]:
+    """Path-like tokens (absolute or ~-relative) inside a Bash command string."""
+    return BASH_PATH_RE.findall(command or "")
+
+
+def tool_paths(name: str, tool_input: dict) -> list[str]:
+    """Every filesystem path a single tool call touches.
+
+    For path tools we read both `file_path` and `notebook_path` — the field name
+    for NotebookEdit is inconsistent across the existing harness code, so we take
+    whichever is present defensively. For Bash we extract path tokens from the
+    command.
+    """
+    if name in ts.PATH_TOOLS:
+        paths = []
+        for field in ("file_path", "notebook_path"):
+            value = tool_input.get(field)
+            if value:
+                paths.append(str(value))
+        return paths
+    if name == "Bash":
+        return extract_bash_paths(str(tool_input.get("command", "")))
+    return []
+
+
+def _worktree_segment(path: str) -> str | None:
+    m = WORKTREE_RE.search(path)
+    return m.group(1) if m else None
+
+
+def classify_path(path: str, worktree_root: str | None = None) -> str | None:
+    """Return a forbidden-class reason for `path`, or None if allowed."""
+    for pattern, reason in FORBIDDEN_PATH_PATTERNS:
+        if pattern.search(path):
+            return reason
+    if worktree_root:
+        own = _worktree_segment(worktree_root)
+        seen = _worktree_segment(path)
+        if own and seen and seen != own:
+            return f"another session's worktree ({seen})"
+    return None
+
+
+def scan_trace_for_forbidden_paths(
+    trace_path: str | Path, worktree_root: str | None = None
+) -> list[dict]:
+    """Scan one trace JSONL for forbidden-path tool calls.
+
+    Returns a list of {tool, path, reason, line}. Tolerant: malformed JSON lines
+    are skipped. tool_use blocks are deduped by id (same rule as
+    trace-stats.py) so a block repeated across content-block rows is scored once.
+    """
+    hits: list[dict] = []
+    seen_tool_use_ids: set[str] = set()
+    with open(trace_path, encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict):
+                continue
+            msg = rec.get("message")
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                block_id = block.get("id")
+                if block_id and block_id in seen_tool_use_ids:
+                    continue
+                if block_id:
+                    seen_tool_use_ids.add(block_id)
+                name = block.get("name", "?")
+                tool_input = block.get("input") or {}
+                if not isinstance(tool_input, dict):
+                    continue
+                for path in tool_paths(name, tool_input):
+                    reason = classify_path(path, worktree_root)
+                    if reason:
+                        hits.append(
+                            {"tool": name, "path": path, "reason": reason, "line": line_no}
+                        )
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan an agent tool-call trace for forbidden path access "
+        "(credential files, other sessions' worktrees). Zero LLM tokens."
+    )
+    parser.add_argument("--trace", required=True, type=Path, help="Session-trace JSONL to scan.")
+    parser.add_argument(
+        "--worktree-root",
+        default=None,
+        help="The caller's own worktree root; enables the other-session-worktree class.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit hits as a JSON array.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if not args.trace.exists():
+        log.error("trace not found: %s", args.trace)
+        return 2
+
+    hits = scan_trace_for_forbidden_paths(args.trace, worktree_root=args.worktree_root)
+
+    if args.json:
+        print(json.dumps(hits, indent=2))
+    else:
+        for h in hits:
+            log.info("%s:%d  %s touched %s — %s", args.trace, h["line"], h["tool"], h["path"], h["reason"])
+        if not hits:
+            log.info("no forbidden path access found in %s", args.trace)
+
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/verify-adherence/SKILL.md
+++ b/skills/verify-adherence/SKILL.md
@@ -143,6 +143,29 @@ suggested_test: |
 This is non-blocking — it does not set `adherence: FAIL`. It triggers the ratchet
 so the next `/gaze` cycle opens a follow-up ticket.
 
+### 1.2 Path-access allow/forbid scan (trace-based)
+
+Scans the agent's tool-call **trace** (not the diff) for
+Read/Edit/Write/NotebookEdit/Bash calls that touch a forbidden path — a
+credential/secret file (`~/.ssh`, `~/.aws`, `~/.netrc`, `bash-env.sh`,
+`.git-credentials`) or another session's worktree. This is the scope-violation
+class a diff-only check structurally misses: an agent that READS a forbidden
+path leaves no trace in the diff (arXiv:2604.21965 App. B.3).
+
+Runs only when the caller supplies `trace=<path>` alongside the branch argument
+(mirroring the existing `worktree=<path>` convention). No `trace=` → skip this
+phase silently.
+
+```bash
+python3 ~/.claude/scripts/trace-path-scan.py --trace <path> [--worktree-root <path>] --json
+```
+
+The scan is pure Python, zero LLM tokens. Pass `--worktree-root` (the caller's
+own worktree path) so the other-session-worktree class can fire; without it only
+the credential class runs. Any hit is **blocking**: record each as a
+`mechanical_failures` entry `{tool, path, reason, file:line}` with rule ref
+`verify-adherence#path-access-scan`.
+
 ### 2. Grep rules live as adherence tests (no central bank)
 
 Grep-based checks are just adherence tests that call `rg` or use a regex
@@ -218,6 +241,8 @@ This ratchet is the whole point. Do not accept `semantic_findings` as a steady s
 
 - `uv` missing → ESCALATE (environment broken, all phases need it).
 - No `scripts/` directory → skip phase 1.0 silently (legitimate repo layout).
+- No `trace=<path>` argument supplied → skip phase 1.2 silently (the trace is an
+  optional input, like `worktree=`; a standalone author pre-check has none).
 - Phase 1 fails to run (env broken) → ESCALATE; don't fall through.
 - Semantic subagent output lacks `file:line` or `suggested_test` → reject the output and
   flag as adherence-infrastructure bug. Don't silently accept.

--- a/skills/verify-adherence/SKILL.md
+++ b/skills/verify-adherence/SKILL.md
@@ -162,9 +162,14 @@ python3 ~/.claude/scripts/trace-path-scan.py --trace <path> [--worktree-root <pa
 
 The scan is pure Python, zero LLM tokens. Pass `--worktree-root` (the caller's
 own worktree path) so the other-session-worktree class can fire; without it only
-the credential class runs. Any hit is **blocking**: record each as a
-`mechanical_failures` entry `{tool, path, reason, file:line}` with rule ref
-`verify-adherence#path-access-scan`.
+the credential class runs. Exit codes: `0` clean, `1` at least one hit, `2` the
+trace path does not exist (an error, **not** a clean pass — treat it like the
+other circuit breakers).
+
+Each JSON hit is `{tool, path, reason, line}`, where `line` is the trace-record
+number. Any hit is **blocking**: record each as a `mechanical_failures` entry
+`{tool, path, reason, file:line}` — using the `--trace` path as `file` and the
+hit's `line` — with rule ref `verify-adherence#path-access-scan`.
 
 ### 2. Grep rules live as adherence tests (no central bank)
 

--- a/tests/test_trace_path_scan.py
+++ b/tests/test_trace_path_scan.py
@@ -1,0 +1,101 @@
+"""Tests for scripts/trace-path-scan.py — path-access allow/forbid scan (ticket 0289).
+
+Child of tracker 0266 (pillage manifest, technique 1). The scan inspects the
+agent tool-call trace for Read/Edit/Write/NotebookEdit/Bash calls that touch a
+forbidden path — credential files or another session's worktree — the
+scope-violation class a diff-only adherence check structurally misses
+(arXiv:2604.21965 App. B.3). Pure-Python, zero LLM tokens → fast tier, no marker.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+spec = importlib.util.spec_from_file_location("trace_path_scan", SCRIPTS / "trace-path-scan.py")
+tps = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tps)
+
+
+def _tool_row(msg_id, name, tool_input, ts_str="2026-07-12T10:00:00.000Z"):
+    """One assistant row carrying a single tool_use block."""
+    block = {"type": "tool_use", "id": f"{msg_id}_tu", "name": name, "input": tool_input}
+    return {
+        "type": "assistant",
+        "timestamp": ts_str,
+        "message": {
+            "id": msg_id,
+            "model": "claude-opus-4-8",
+            "role": "assistant",
+            "content": [block],
+        },
+    }
+
+
+def _write_trace(tmp_path, rows):
+    trace = tmp_path / "trace.jsonl"
+    trace.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    return trace
+
+
+def test_forbidden_credential_path_detected(tmp_path):
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Read", {"file_path": "/home/u/.ssh/id_rsa"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["tool"] == "Read"
+    assert hits[0]["path"] == "/home/u/.ssh/id_rsa"
+    assert "ssh" in hits[0]["reason"].lower()
+    assert hits[0]["line"] == 1
+
+
+def test_bash_command_touching_forbidden_path_detected(tmp_path):
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Bash", {"command": "cat ~/.aws/credentials"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["tool"] == "Bash"
+    assert ".aws/credentials" in hits[0]["path"]
+
+
+def test_other_session_worktree_path_detected(tmp_path):
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Read", {"file_path": "/home/u/.claude/worktrees/other-session/file.py"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(
+        trace, worktree_root="/home/u/.claude/worktrees/mine"
+    )
+    assert len(hits) == 1
+    assert "worktree" in hits[0]["reason"].lower()
+
+
+def test_own_worktree_path_allowed(tmp_path):
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Read", {"file_path": "/home/u/.claude/worktrees/mine/file.py"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(
+        trace, worktree_root="/home/u/.claude/worktrees/mine"
+    )
+    assert hits == []
+
+
+def test_clean_trace_no_violations(tmp_path):
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Read", {"file_path": "/home/u/proj/scripts/foo.py"}),
+        _tool_row("m2", "Edit", {"file_path": "/home/u/proj/rules/bar.md"}),
+        _tool_row("m3", "Bash", {"command": "uv run pytest -q"}),
+    ])
+    assert tps.scan_trace_for_forbidden_paths(trace) == []
+
+
+def test_line_numbers_reported(tmp_path):
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Read", {"file_path": "/home/u/proj/scripts/foo.py"}),
+        _tool_row("m2", "Read", {"file_path": "/home/u/.ssh/known_hosts"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["line"] == 2

--- a/tests/test_trace_path_scan.py
+++ b/tests/test_trace_path_scan.py
@@ -61,6 +61,35 @@ def test_bash_command_touching_forbidden_path_detected(tmp_path):
     assert ".aws/credentials" in hits[0]["path"]
 
 
+def test_quoted_bash_path_detected(tmp_path):
+    """A quoted path inside a Bash command must still be caught."""
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Bash", {"command": 'cat "~/.ssh/id_rsa"'}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["path"] == "~/.ssh/id_rsa"
+    assert "ssh" in hits[0]["reason"].lower()
+
+
+def test_duplicate_tool_use_id_deduped(tmp_path):
+    """The same tool_use block repeated across content rows scores once."""
+    row = _tool_row("m1", "Read", {"file_path": "/home/u/.ssh/id_rsa"})
+    trace = _write_trace(tmp_path, [row, row])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+
+
+def test_notebook_path_field_detected(tmp_path):
+    """NotebookEdit carries its path in notebook_path, read defensively."""
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "NotebookEdit", {"notebook_path": "/home/u/.aws/nb.ipynb"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["tool"] == "NotebookEdit"
+
+
 def test_other_session_worktree_path_detected(tmp_path):
     trace = _write_trace(tmp_path, [
         _tool_row("m1", "Read", {"file_path": "/home/u/.claude/worktrees/other-session/file.py"}),

--- a/tests/test_trace_path_scan.py
+++ b/tests/test_trace_path_scan.py
@@ -72,6 +72,30 @@ def test_quoted_bash_path_detected(tmp_path):
     assert "ssh" in hits[0]["reason"].lower()
 
 
+def test_bash_cd_into_credential_dir_detected(tmp_path):
+    """`cd ~/.ssh && cat id_rsa` — cd-ing into a credential directory is itself the
+    sensitive act, so the bare directory (no trailing slash) must be flagged even
+    though the relative filename that follows is never a path token."""
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Bash", {"command": "cd ~/.ssh && cat id_rsa"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["path"] == "~/.ssh"
+    assert "ssh" in hits[0]["reason"].lower()
+
+
+def test_bash_cd_into_aws_dir_detected(tmp_path):
+    """Same idiom for the aws credential directory."""
+    trace = _write_trace(tmp_path, [
+        _tool_row("m1", "Bash", {"command": "cd ~/.aws && cat credentials"}),
+    ])
+    hits = tps.scan_trace_for_forbidden_paths(trace)
+    assert len(hits) == 1
+    assert hits[0]["path"] == "~/.aws"
+    assert "aws" in hits[0]["reason"].lower()
+
+
 def test_duplicate_tool_use_id_deduped(tmp_path):
     """The same tool_use block repeated across content rows scores once."""
     row = _tool_row("m1", "Read", {"file_path": "/home/u/.ssh/id_rsa"})

--- a/tests/test_verify_adherence_invokes_path_scan.py
+++ b/tests/test_verify_adherence_invokes_path_scan.py
@@ -8,26 +8,28 @@ step 11 once did. Text-grep only → fast tier, no marker.
 
 from pathlib import Path
 
+import pytest
+
 SKILL = Path(__file__).resolve().parent.parent / "skills" / "verify-adherence" / "SKILL.md"
 
 
-def test_skill_documents_path_scan_phase():
-    text = SKILL.read_text()
-    assert "### 1.2 Path-access" in text, (
-        "verify-adherence SKILL.md must document the path-access scan as phase 1.2"
-    )
-
-
-def test_skill_names_the_detector_script():
-    text = SKILL.read_text()
-    assert "scripts/trace-path-scan.py" in text, (
-        "verify-adherence SKILL.md must invoke scripts/trace-path-scan.py"
-    )
-
-
-def test_skill_has_trace_circuit_breaker():
-    text = SKILL.read_text()
-    assert "skip phase 1.2" in text, (
-        "verify-adherence SKILL.md circuit breakers must state that a missing "
-        "trace= argument skips phase 1.2 silently"
-    )
+@pytest.mark.parametrize(
+    "needle,reason",
+    [
+        (
+            "### 1.2 Path-access",
+            "verify-adherence SKILL.md must document the path-access scan as phase 1.2",
+        ),
+        (
+            "scripts/trace-path-scan.py",
+            "verify-adherence SKILL.md must invoke scripts/trace-path-scan.py",
+        ),
+        (
+            "skip phase 1.2",
+            "verify-adherence SKILL.md circuit breakers must state that a missing "
+            "trace= argument skips phase 1.2 silently",
+        ),
+    ],
+)
+def test_skill_wires_path_scan(needle, reason):
+    assert needle in SKILL.read_text(), reason

--- a/tests/test_verify_adherence_invokes_path_scan.py
+++ b/tests/test_verify_adherence_invokes_path_scan.py
@@ -1,0 +1,33 @@
+"""Guard: verify-adherence must wire the trace-based path-access scan (ticket 0289).
+
+Child of tracker 0266 (pillage manifest, technique 1). The path-access scan
+(scripts/trace-path-scan.py) is a mechanical verify-adherence phase; its
+SKILL.md wiring must not drift into a paraphrase the way raid Phase 5 and hunt
+step 11 once did. Text-grep only → fast tier, no marker.
+"""
+
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parent.parent / "skills" / "verify-adherence" / "SKILL.md"
+
+
+def test_skill_documents_path_scan_phase():
+    text = SKILL.read_text()
+    assert "### 1.2 Path-access" in text, (
+        "verify-adherence SKILL.md must document the path-access scan as phase 1.2"
+    )
+
+
+def test_skill_names_the_detector_script():
+    text = SKILL.read_text()
+    assert "scripts/trace-path-scan.py" in text, (
+        "verify-adherence SKILL.md must invoke scripts/trace-path-scan.py"
+    )
+
+
+def test_skill_has_trace_circuit_breaker():
+    text = SKILL.read_text()
+    assert "skip phase 1.2" in text, (
+        "verify-adherence SKILL.md circuit breakers must state that a missing "
+        "trace= argument skips phase 1.2 silently"
+    )

--- a/tickets/0289-verify-adherence-path-access-trace-scan.erg
+++ b/tickets/0289-verify-adherence-path-access-trace-scan.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-12T18:55Z claude created
 
+2026-07-13T16:25Z bump verify-reroll — round 1: BASH_PATH_RE / FORBIDDEN_PATH_PATTERNS miss 'cd <dir> && cat <relative-file>' (e.g. cd ~/.ssh && cat id_rsa evades detection entirely — no trailing slash on dir token, relative filename never tokenized); confirmed live at HEAD 1f6db44, unrelated to 4bea8fd's quoted-path fix
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 1).

--- a/tickets/closed/0289-verify-adherence-path-access-trace-scan.erg
+++ b/tickets/closed/0289-verify-adherence-path-access-trace-scan.erg
@@ -2,11 +2,13 @@
 Title: verify-adherence: path-access allow/forbid scan over the agent tool trace
 Created: 2026-07-12
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #549
 
 --- log ---
 2026-07-12T18:55Z claude created
 
 2026-07-13T16:25Z bump verify-reroll — round 1: BASH_PATH_RE / FORBIDDEN_PATH_PATTERNS miss 'cd <dir> && cat <relative-file>' (e.g. cd ~/.ssh && cat id_rsa evades detection entirely — no trailing slash on dir token, relative filename never tokenized); confirmed live at HEAD 1f6db44, unrelated to 4bea8fd's quoted-path fix
+2026-07-13T17:10Z Minh Ha-Duong closed — autoclosed — PR #549
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 1).


### PR DESCRIPTION
Adds a pure-Python, zero-LLM-token phase to `verify-adherence` that scans the
agent's tool-call **trace** (not the diff) for Read/Edit/Write/NotebookEdit/Bash
calls touching a forbidden path. An agent that only READS a forbidden path
(credentials, another session's worktree) leaves no diff, so a diff-only
adherence check structurally misses that scope-violation class
(arXiv:2604.21965 App. B.3). Child of tracker 0266 (pillage manifest, technique 1).

## What lands
- `scripts/trace-path-scan.py` — walks one session-trace JSONL (same record
  shape `trace-stats.py` parses; `PATH_TOOLS` reused via the importlib sibling
  pattern), dedupes tool_use blocks by id, reports `{tool, path, reason, line}`,
  exits 1 on any hit.
- `skills/verify-adherence/SKILL.md` — new phase **1.2 Path-access allow/forbid
  scan (trace-based)** plus a circuit-breaker bullet (no `trace=` → skip silently).
- `tests/test_trace_path_scan.py` — six behavioral tests (credential file, Bash
  command, other-session worktree caught; own worktree + clean trace allowed;
  line numbers reported).
- `tests/test_verify_adherence_invokes_path_scan.py` — three wiring guards
  against SKILL.md paraphrase drift.

## Implementation decisions the ticket's Actions left open
- **Two-class taxonomy, not a blanket outside-worktree rule.** Forbidden =
  credential/secret files (`~/.ssh`, `~/.aws`, `~/.netrc`, `bash-env.sh`,
  `.git-credentials`) and ANOTHER session's worktree only. A blanket
  outside-worktree rule would false-positive on legitimate shared `rules/` and
  `skills/` reads (pinned by `test_own_worktree_path_allowed`).
- **No new YAML config.** Forbidden patterns are module-level Python constants;
  the SKILL.md already argues against a central grep/YAML bank.
- **Explicit `trace=<path>` argument** mirroring the existing `worktree=<path>`
  convention; absent → phase 1.2 skips silently. No cheap-model severity rater.

## Deviation from the plan
The plan's invocation line `python3 scripts/trace-path-scan.py ...` tripped the
`check-agnostic` gate (repo-relative script path). Switched to the harness
convention `python3 ~/.claude/scripts/trace-path-scan.py ...`; the wiring test
greps for the `scripts/trace-path-scan.py` substring, still satisfied.

## Gates
`make check-fast`, `make lint`, `make check` all green (791 passed).
Pre-PR `/verify-adherence` self-gate: **PASS** (no blockers, no nits).

**Ticket:** tickets/0289-verify-adherence-path-access-trace-scan.erg