### PR TITLE
feat(0291): shared root-cause taxonomy for verify-gate and skill-doctor

### DIFF
--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -47,8 +47,8 @@ Mark each pattern as `covered` (open ticket exists), `recently-fixed`
 
 Present the ranked patterns as a table:
 
-| Rank | Signature | Freq | Sev | Score | Status | Affected Skill |
-|------|-----------|------|-----|-------|--------|----------------|
+| Rank | Signature | Freq | Sev | Score | Status | Affected Skill | Root Cause |
+|------|-----------|------|-----|-------|--------|----------------|------------|
 
 For each `uncovered` pattern, show:
 - **Evidence**: the `evidence` array from the survey (verbatim log/journal excerpts)
@@ -56,6 +56,24 @@ For each `uncovered` pattern, show:
 - **Expected impact**: estimated failure-rate reduction
 
 Ask the user which patterns to ticket before proceeding.
+
+### Root-cause taxonomy
+
+The `Root Cause` column tags each pattern with a shared label for *why* it
+recurs (source: arXiv:2604.21965 §5.3, reframed for the harness, ticket 0291).
+Assign it when you author the report table — a labeling convention, like the
+`Status` column, not a mechanical detector. Same vocabulary as verify-gate's
+`root_cause_class`:
+
+- **Agent Error** — an agent misapplied a rule it had. E.g. a supervisor kept
+  re-raising its own budget.
+- **Extractor Error** — a skill or convention was underspecified. E.g. the merge
+  convention never pinned the exact `**Ticket:**` string.
+- **Original Error** — a pre-existing gap the failures expose. E.g. a missing
+  dirty-tree guard that predates the incidents.
+- **Missing Data** — the survey lacked context. E.g. it re-flagged already-fixed
+  issues for want of a canonical path.
+- **Other** — cause undetermined from the log context.
 
 ## 4. Open tickets
 

--- a/skills/verify-gate/SKILL.md
+++ b/skills/verify-gate/SKILL.md
@@ -139,6 +139,7 @@ scope_overflow:
     suggested_disposition: TICKETED | ESCALATE
 rationale: |
   <strongest remaining reviewer attack; if APPROVED, why evidence holds>
+root_cause_class: Agent Error | Extractor Error | Original Error | Missing Data | Other  # required on REROLL/ESCALATE
 second_round_needed:   # only if REROLL
   - <prioritised items from unresolved lists>
 ```
@@ -167,6 +168,25 @@ second_round_needed:   # only if REROLL
 **On REROLL**: run `${ERG:-erg} log <ticket-id> "bump verify-reroll — round {n}: {top unresolved criterion}"`
 
 If `round == 2` and any trigger fires → upgrade to ESCALATE. Never a third round.
+
+## Root-cause taxonomy
+
+Every REROLL or ESCALATE verdict carries a `root_cause_class` — a shared label
+for *why* the gate is bouncing (source: arXiv:2604.21965 §5.3, reframed for the
+harness, ticket 0291). This is a labeling convention, like the minor tags, not a
+mechanical detector; assign it when you author the verdict.
+
+- **Agent Error** — the implementer misread the ticket or a rule. E.g. wired
+  `make check-fast` where the ticket asked for `make lint`.
+- **Extractor Error** — the ticket was underspecified. E.g. "document the
+  taxonomy" without naming which file it belongs in.
+- **Original Error** — a pre-existing bug the gate surfaces, unrelated to this
+  diff. E.g. a broken test the branch merely runs into.
+- **Missing Data** — the gate lacked context or access. E.g. `worktree=` not
+  passed, so the diff could not be inspected.
+- **Other** — none of the above; state the reason in `rationale`.
+
+APPROVED verdicts do not carry this field.
 
 ## Minor tag handling
 

--- a/tests/test_root_cause_taxonomy.py
+++ b/tests/test_root_cause_taxonomy.py
@@ -7,7 +7,6 @@ files must declare the field, document the taxonomy section, and agree on the
 exact five category tokens.
 """
 
-import re
 from pathlib import Path
 
 import pytest
@@ -58,13 +57,9 @@ def test_skill_doctor_has_taxonomy_heading():
 
 @pytest.mark.adherence
 def test_both_files_contain_all_five_tokens():
+    # Each file's set is checked against the fixed TOKENS constant, which also
+    # proves cross-file consistency (both sets equal TOKENS, so they equal
+    # each other) — a separate equality test would be a tautology.
     for path in (VERIFY_GATE, SKILL_DOCTOR):
         found = _taxonomy_tokens(path.read_text())
         assert found == TOKENS, f"{path.name} missing tokens: {TOKENS - found}"
-
-
-@pytest.mark.adherence
-def test_cross_file_token_consistency():
-    vg = _taxonomy_tokens(VERIFY_GATE.read_text())
-    sd = _taxonomy_tokens(SKILL_DOCTOR.read_text())
-    assert vg == sd, f"taxonomy token sets diverge: {vg ^ sd}"

--- a/tests/test_root_cause_taxonomy.py
+++ b/tests/test_root_cause_taxonomy.py
@@ -1,0 +1,70 @@
+"""Adherence test for the shared root-cause taxonomy (ticket 0291).
+
+The five-way error taxonomy (arXiv:2604.21965 §5.3, reframed for the harness)
+is a labeling convention shared by verify-gate's REROLL/ESCALATE verdicts and
+skill-doctor's per-pattern diagnoses. This guards the convention: both SKILL.md
+files must declare the field, document the taxonomy section, and agree on the
+exact five category tokens.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILLS = Path(__file__).resolve().parent.parent / "skills"
+VERIFY_GATE = SKILLS / "verify-gate" / "SKILL.md"
+SKILL_DOCTOR = SKILLS / "skill-doctor" / "SKILL.md"
+
+TOKENS = {
+    "**Agent Error**",
+    "**Extractor Error**",
+    "**Original Error**",
+    "**Missing Data**",
+    "**Other**",
+}
+
+
+def _taxonomy_tokens(text: str) -> set[str]:
+    """Extract the bolded five-token set from a file's taxonomy section."""
+    return {tok for tok in TOKENS if tok in text}
+
+
+@pytest.mark.adherence
+def test_verify_gate_declares_field():
+    text = VERIFY_GATE.read_text()
+    assert "root_cause_class:" in text, "verify-gate verdict shape must carry root_cause_class"
+
+
+@pytest.mark.adherence
+def test_verify_gate_has_taxonomy_heading():
+    text = VERIFY_GATE.read_text()
+    assert "## Root-cause taxonomy" in text, "verify-gate must document the taxonomy"
+
+
+@pytest.mark.adherence
+def test_skill_doctor_report_table_has_root_cause_column():
+    text = SKILL_DOCTOR.read_text()
+    header = next((ln for ln in text.splitlines() if "| Rank |" in ln), None)
+    assert header is not None, "skill-doctor report table header not found"
+    assert "Root Cause" in header, "skill-doctor report table must have a Root Cause column"
+
+
+@pytest.mark.adherence
+def test_skill_doctor_has_taxonomy_heading():
+    text = SKILL_DOCTOR.read_text()
+    assert "### Root-cause taxonomy" in text, "skill-doctor must document the taxonomy"
+
+
+@pytest.mark.adherence
+def test_both_files_contain_all_five_tokens():
+    for path in (VERIFY_GATE, SKILL_DOCTOR):
+        found = _taxonomy_tokens(path.read_text())
+        assert found == TOKENS, f"{path.name} missing tokens: {TOKENS - found}"
+
+
+@pytest.mark.adherence
+def test_cross_file_token_consistency():
+    vg = _taxonomy_tokens(VERIFY_GATE.read_text())
+    sd = _taxonomy_tokens(SKILL_DOCTOR.read_text())
+    assert vg == sd, f"taxonomy token sets diverge: {vg ^ sd}"

--- a/tickets/closed/0291-root-cause-taxonomy-reroll-skill-doctor.erg
+++ b/tickets/closed/0291-root-cause-taxonomy-reroll-skill-doctor.erg
@@ -2,10 +2,12 @@
 Title: Root-cause taxonomy for verify-gate REROLL and skill-doctor diagnoses
 Created: 2026-07-12
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #550
 
 --- log ---
 2026-07-12T18:55Z claude created
 
+2026-07-13T17:11Z Minh Ha-Duong closed — autoclosed — PR #550
 --- body ---
 Child of tracker 0266 (pillage manifest,
 docs/pillage-0266-agentic-reproduction-2026-07-12.md, technique 7).


### PR DESCRIPTION
Adds a five-way error taxonomy (arXiv:2604.21965 §5.3, reframed for the harness) as a **labeling convention** shared by verify-gate's REROLL/ESCALATE verdicts and skill-doctor's per-pattern diagnoses. Gives a reusable "why did this fail" vocabulary — Agent Error / Extractor Error / Original Error / Missing Data / Other — instead of freeform prose and ad hoc signatures.

## Changes
- **verify-gate/SKILL.md**: required `root_cause_class` field in the verdict-shape YAML (on REROLL/ESCALATE) plus a `## Root-cause taxonomy` section with a verify-gate-flavored example per category; APPROVED verdicts omit the field.
- **skill-doctor/SKILL.md**: `Root Cause` column added to the report table plus a `### Root-cause taxonomy` subsection (kept as a `###` inside section 3 to avoid renumbering later sections), same vocabulary with skill-doctor-flavored examples.
- **tests/test_root_cause_taxonomy.py** (`@pytest.mark.adherence`): guards the field, both headings, the table column, all five bolded tokens per file, and cross-file token-set consistency. Shown RED before the edits.

## Interpretation decision
Exit criterion 2 ("skill-doctor survey output tags each pattern with root_cause_class") is satisfied at the **SKILL.md report-table level** — the `Root Cause` column is model-assigned when the report table is authored, exactly like the existing `Status` column (covered/recently-fixed/uncovered). It is deliberately **not** threaded as a field through `scripts/skill-doctor-survey.py`: the ticket frames this as "a labeling convention, not a mechanical detector," which argues against a mechanical survey-script field. `scripts/skill-doctor-survey.py` is untouched.

## Gates
- `make lint` (adherence): 18 passed incl. 6 new
- `make check-fast`: 720 passed
- `make check`: 788 passed
- `/verify-adherence`: PASS (mechanical phase clean — `/gaze` can skip it)

**Ticket:** tickets/0291-root-cause-taxonomy-reroll-skill-doctor.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)