### PR TITLE
feat(0315): trace-doctor phase-5 pre-registration

### DIFF
--- a/docs/trace-ab-2026-06.md
+++ b/docs/trace-ab-2026-06.md
@@ -1,0 +1,108 @@
+# Trace phase-5 A/B pre-registration — 2026-06 (ticket 0315, trace-doctor phase 5)
+
+**Shadow dollars**: every $ below is a list-price API-equivalent under
+subscription auth — capacity consumption (rate limits, context budget), never
+invoiced money. Baselines carry over from the phase-4 counterfactual accounting
+(`docs/trace-counterfactuals-2026-06.md`).
+
+This document is the **pre-registration** for the two phase-5 A/B measures
+routed by phase 4. It is committed **before any B-arm data exists**, so git
+history proves the ordering (interventions and decision rule fixed first, data
+second). The live arms and the verdicts stay on ticket 0245; this ticket (0315)
+lands the interventions, metrics, windows, exclusions, and the decision rule.
+
+## Pinned interventions
+
+One intervention per measure, confirming 0245's Action-1 defaults.
+
+### Measure A — model right-sizing of long Opus mains
+
+**Intervention**: paired replay. Re-run ~5 closed tickets from their original
+base SHA through the same skill path with a **Sonnet main** (instead of the
+original Opus main), and compare each replay against its original Opus trace on
+two axes: total shadow-$ spent, and whether the fresh PR passes `/gaze`. Paired
+same-ticket comparison beats a week-vs-week contrast for a model change that
+would otherwise put a whole nightbeat week at risk.
+
+The **procedure** is pinned here; the **sample selection** (which ~5 closed
+tickets) is deferred to 0245, chosen at replay time from the closed-ticket
+corpus. No calendar window applies — measure A is ticket-keyed, not
+time-windowed.
+
+### Measure B — verification convergence
+
+**Intervention**: caller-level convergence. After a PR already carries one
+completed full `/gaze` round, a repeat **caller-level** `/gaze` invocation on
+the same PR runs phase 6 (verify-gate) only — no phases 2–5 panel re-run.
+
+Surface decision (important — see the measurement-window rationale below): the
+flag governs **caller-level re-invocation** of `/gaze` on an already-reviewed
+PR, *not* the internal round-1 REROLL re-entry branch inside `skills/gaze/`.
+The internal branch is already gate-only and was live and unchanged during the
+June measurement window; the $259/wk `vg` bucket that phase 4 flagged is
+measured from **caller-level repeat invocations** of the full `/gaze` on the
+same PR (turns after the 2nd verify/gaze invocation). Instrumenting the
+internal branch would move a surface the baseline never charged; instrumenting
+the caller-level re-run is exactly what the `vg` bucket counts. The flag ships
+default off (current practice), so live behaviour is unchanged until the B-arm
+week flips it on — see `skills/gaze/telemetry.yml` (`convergence.enabled`,
+env override `GAZE_CONVERGENCE_ENABLED`).
+
+## Metric definitions
+
+All metrics are computed by the committed scripts (`scripts/trace-stats.py`,
+`scripts/trace-hypotheses.py`, `scripts/trace-pr-join.py`) over cached inputs,
+reproducibly, without network.
+
+- **`cost_per_merged_pr`** — total shadow-$ in the arm divided by merged PR
+  count. Primary cost metric.
+- **`cost_per_cycle`** — total shadow-$ divided by gaze/verify cycle count.
+  Secondary cost metric for measure B (convergence changes cycles, not PRs).
+- **`reroll_per_pr`** — REROLL mentions per PR. Guardrail. Baseline **33/112**.
+- **`escalate_count`** — ESCALATE mentions in the window. Guardrail. Baseline
+  **18**.
+- **`gaze_verdict_distribution`** — counts of APPROVED / REROLL / ESCALATE
+  gaze verdicts. Reported for context.
+
+**Explicitly excluded metric**: merged-rate. It is saturated at 112/112 = 100%
+in the phase-4 corpus, so it carries no discriminating signal and is not a
+guardrail here (per the phase-4 routing decision).
+
+## Windows
+
+- **Measure A**: ticket-keyed, **no calendar window**. Each replay is paired to
+  its original ticket's trace; the comparison unit is the ticket, not a date
+  range. `filter_window` does not apply to arm A.
+- **Measure B**: two **disjoint weeks**, one control (flag off) and one
+  treatment (flag on), fixed at B-arm launch **before any data is collected**.
+  <!-- TODO(0245): pin the two disjoint week date ranges here at B-arm launch,
+       before collecting any B-arm data. Do not fabricate dates ahead of the
+       run. -->
+
+## Exclusion rules
+
+- **Study-session reflexivity**: sessions whose work *is* this trace-doctor
+  study (the phase-4/5 measurement sessions themselves) are excluded from both
+  arms, per the counterfactuals doc — a study session's spend is not
+  representative production work and would contaminate the arm it measures.
+
+## Decision rule
+
+Implemented as a pure function in `scripts/trace_ab_decision.py` (`decide`),
+unit-tested red-first in `tests/test_trace_ab_decision.py`:
+
+> **Adopt** the candidate config **iff** its cost is strictly below baseline
+> (`cost_per_merged_pr` for the primary comparison) **AND** each guardrail
+> (`reroll_per_pr`, `escalate_count`) stays **at or below**
+> `baseline * (1 + noise)`. Otherwise **reject**.
+
+- **Noise band**: pre-registered at **10%** (`guardrail_noise_pct = 0.10`). The
+  band is inclusive (`<=`): a guardrail exactly at `baseline * 1.10` still
+  adopts; any excess rejects.
+- The guardrail is **binding**: a cost win with a breached guardrail is a
+  REJECT. No post-hoc metric shopping — verdicts come only from the metrics
+  defined above.
+
+Per-window guardrail metrics are sliced with `filter_window(rows, start, end)`
+(ISO-date inclusive on both ends) before the decision is computed for measure
+B's two weeks.

--- a/docs/trace-ab-2026-06.md
+++ b/docs/trace-ab-2026-06.md
@@ -96,9 +96,15 @@ unit-tested red-first in `tests/test_trace_ab_decision.py`:
 > (`reroll_per_pr`, `escalate_count`) stays **at or below**
 > `baseline * (1 + noise)`. Otherwise **reject**.
 
-- **Noise band**: pre-registered at **10%** (`guardrail_noise_pct = 0.10`). The
-  band is inclusive (`<=`): a guardrail exactly at `baseline * 1.10` still
-  adopts; any excess rejects.
+- **Cost key**: `decide()` compares on `cost_key`, defaulting to
+  `cost_per_merged_pr` (measure A). Measure B passes `cost_key="cost_per_cycle"`,
+  since convergence changes cycles, not merged-PR count. These are the exact
+  dict keys the metric definitions above name — the harvest step reads this doc
+  and builds those keys.
+- **Noise band**: pre-registered at **10%**, exported as the module constant
+  `PREREGISTERED_NOISE_PCT` and used as the `decide()` default; the harvest step
+  uses this value, not an ad-hoc override. The band is inclusive (`<=`): a
+  guardrail exactly at `baseline * 1.10` still adopts; any excess rejects.
 - The guardrail is **binding**: a cost win with a breached guardrail is a
   REJECT. No post-hoc metric shopping — verdicts come only from the metrics
   defined above.

--- a/scripts/trace_ab_decision.py
+++ b/scripts/trace_ab_decision.py
@@ -9,7 +9,18 @@ Decision rule (pre-registered before any B-arm data):
          AND each guardrail (reroll_per_pr, escalate_count) stays at or below
              baseline * (1 + guardrail_noise_pct).
 A cost win with a breached guardrail is a REJECT — the guardrail is binding.
+
+The metric keys match docs/trace-ab-2026-06.md exactly: the primary cost metric
+is `cost_per_merged_pr` (measure A / default); measure B compares on
+`cost_per_cycle` by passing `cost_key="cost_per_cycle"`. Keeping the code keys
+identical to the pre-registration doc is the whole point of this ticket — the
+0245 harvest reads the doc and must not hit a KeyError.
 """
+
+# Pre-registered guardrail noise band (10%). Named so the doc and the harvest
+# step share one source of truth; a caller may override for testing the band
+# mechanics, but production harvest uses this pre-registered value.
+PREREGISTERED_NOISE_PCT = 0.10
 
 # Guardrail metrics: lower is better, capped at baseline*(1+noise).
 _GUARDRAILS = ("reroll_per_pr", "escalate_count")
@@ -20,33 +31,40 @@ def filter_window(
 ) -> list[dict]:
     """Keep rows whose ISO date lies within [start, end], inclusive both ends.
 
-    Dates are compared as ISO-8601 strings (YYYY-MM-DD), which sort
-    lexicographically in chronological order, so no date parsing is needed.
+    Dates are compared on their `YYYY-MM-DD` prefix, which sorts
+    lexicographically in chronological order, so no date parsing is needed and a
+    full ISO timestamp (`2026-06-30T14:00Z`) still matches a bare-date window.
+    `start` and `end` are bare `YYYY-MM-DD` strings.
     """
-    return [r for r in rows if start <= r[date_key] <= end]
+    return [r for r in rows if start <= r[date_key][:10] <= end]
 
 
 def decide(
-    baseline: dict, candidate: dict, *, guardrail_noise_pct: float = 0.10
+    baseline: dict,
+    candidate: dict,
+    *,
+    cost_key: str = "cost_per_merged_pr",
+    guardrail_noise_pct: float = PREREGISTERED_NOISE_PCT,
 ) -> dict:
     """Return {"verdict": "adopt"|"reject", "reasons": [...]} for candidate.
 
-    `baseline` and `candidate` each carry keys: cost_per_pr, reroll_per_pr,
-    escalate_count. `guardrail_noise_pct` is the pre-registered tolerance band
-    on the guardrails (default 0.10 = 10%).
+    `baseline` and `candidate` each carry the compared cost key (`cost_key`,
+    default `cost_per_merged_pr`; pass `cost_per_cycle` for measure B) plus the
+    guardrail keys reroll_per_pr and escalate_count. `guardrail_noise_pct` is
+    the pre-registered tolerance band on the guardrails (default 10%).
     """
     reasons: list[str] = []
 
-    if candidate["cost_per_pr"] < baseline["cost_per_pr"]:
+    if candidate[cost_key] < baseline[cost_key]:
         reasons.append(
-            f"cost_per_pr {candidate['cost_per_pr']} < baseline "
-            f"{baseline['cost_per_pr']} (cost win)"
+            f"{cost_key} {candidate[cost_key]} < baseline "
+            f"{baseline[cost_key]} (cost win)"
         )
         cost_win = True
     else:
         reasons.append(
-            f"cost_per_pr {candidate['cost_per_pr']} not below baseline "
-            f"{baseline['cost_per_pr']} (no cost win)"
+            f"{cost_key} {candidate[cost_key]} not below baseline "
+            f"{baseline[cost_key]} (no cost win)"
         )
         cost_win = False
 

--- a/scripts/trace_ab_decision.py
+++ b/scripts/trace_ab_decision.py
@@ -1,0 +1,63 @@
+"""Phase-5 A/B decision rule — pure functions (ticket 0315).
+
+Pre-registered in docs/trace-ab-2026-06.md. No argparse, no __main__: the sole
+consumers are the unit tests now and the 0245 harvest step later, which imports
+`decide` and `filter_window` directly. Zero LLM calls, no network, no I/O.
+
+Decision rule (pre-registered before any B-arm data):
+    adopt iff candidate cost is strictly below baseline
+         AND each guardrail (reroll_per_pr, escalate_count) stays at or below
+             baseline * (1 + guardrail_noise_pct).
+A cost win with a breached guardrail is a REJECT — the guardrail is binding.
+"""
+
+# Guardrail metrics: lower is better, capped at baseline*(1+noise).
+_GUARDRAILS = ("reroll_per_pr", "escalate_count")
+
+
+def filter_window(
+    rows: list[dict], start: str, end: str, *, date_key: str = "date"
+) -> list[dict]:
+    """Keep rows whose ISO date lies within [start, end], inclusive both ends.
+
+    Dates are compared as ISO-8601 strings (YYYY-MM-DD), which sort
+    lexicographically in chronological order, so no date parsing is needed.
+    """
+    return [r for r in rows if start <= r[date_key] <= end]
+
+
+def decide(
+    baseline: dict, candidate: dict, *, guardrail_noise_pct: float = 0.10
+) -> dict:
+    """Return {"verdict": "adopt"|"reject", "reasons": [...]} for candidate.
+
+    `baseline` and `candidate` each carry keys: cost_per_pr, reroll_per_pr,
+    escalate_count. `guardrail_noise_pct` is the pre-registered tolerance band
+    on the guardrails (default 0.10 = 10%).
+    """
+    reasons: list[str] = []
+
+    if candidate["cost_per_pr"] < baseline["cost_per_pr"]:
+        reasons.append(
+            f"cost_per_pr {candidate['cost_per_pr']} < baseline "
+            f"{baseline['cost_per_pr']} (cost win)"
+        )
+        cost_win = True
+    else:
+        reasons.append(
+            f"cost_per_pr {candidate['cost_per_pr']} not below baseline "
+            f"{baseline['cost_per_pr']} (no cost win)"
+        )
+        cost_win = False
+
+    guardrails_hold = True
+    for key in _GUARDRAILS:
+        band = baseline[key] * (1 + guardrail_noise_pct)
+        if candidate[key] <= band:
+            reasons.append(f"{key} {candidate[key]} <= band {band} (holds)")
+        else:
+            reasons.append(f"{key} {candidate[key]} > band {band} (breach)")
+            guardrails_hold = False
+
+    verdict = "adopt" if cost_win and guardrails_hold else "reject"
+    return {"verdict": verdict, "reasons": reasons}

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -349,6 +349,21 @@ wall warn=15min escalate=30min; tokens warn=500k escalate=1M.
 On warn: post `/gaze: slow run` comment, continue. On escalate: stop, post
 `/gaze stopped:` with measured value. Escalate > warn. Check at phase boundaries only.
 
+## Convergence mode (ticket 0315, measure-B pre-registration)
+
+An **opt-in** experimental flag for the phase-5 measure-B A/B (see
+`docs/trace-ab-2026-06.md`). It governs **caller-level** re-invocation of
+`/gaze` on a PR that already carries a completed full gaze round — not the
+internal round-1 REROLL re-entry branch (§ Branch on verdict), which is already
+gate-only and stays unchanged.
+
+When `convergence.enabled` is true (`skills/gaze/telemetry.yml`, env override
+`GAZE_CONVERGENCE_ENABLED`) **and** the PR already carries a completed full
+gaze round (a prior `/verify-gate verdict` comment from an earlier invocation),
+a repeat `/gaze` invocation runs **phase 6 (verify-gate) only** — no phases 2–5
+panel re-run. Default **off** = current practice, so live behaviour is
+unchanged until the B-arm week flips it on.
+
 ## `--force-approve`
 
 Explicit human override. Usage: `/gaze <pr-number> --force-approve <reason>`.

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -33,6 +33,8 @@ merge** — the merge decision belongs to the caller (the human or the raid).
 - The fix loop between rounds makes commits on the PR branch; no changes to other branches.
 - `--force-approve` is supported for explicit human override; it is logged loudly in the
   PR comments and the skill transcript.
+- Convergence mode (`convergence.enabled`, default off) may shorten a *repeat* invocation
+  to the gate phase only — see § Convergence mode; it never relaxes the gate itself.
 - **Cross-repo prerequisite**: the caller must ensure cwd is the target project before
   invoking `/gaze`. The skill and its sub-skills (`/verify-gate`, `/simplify`, etc.)
   use `gh` and `git` commands that resolve against cwd.

--- a/skills/gaze/telemetry.yml
+++ b/skills/gaze/telemetry.yml
@@ -12,8 +12,15 @@ tokens:
   warn: 500000    # 500k in+out → post "verify: token-heavy run" comment, continue
   escalate: 1000000  # 1M → ESCALATE
 
+# Convergence mode (ticket 0315, phase-5 measure-B A/B). Opt-in: when true and
+# the PR already carries a completed full gaze round, a repeat caller-level
+# /gaze runs phase 6 (verify-gate) only. Default off = current practice.
+convergence:
+  enabled: false
+
 env:
   wall_seconds_warn:      VERIFY_WALL_WARN_S
   wall_seconds_escalate:  VERIFY_WALL_ESCALATE_S
   tokens_warn:            VERIFY_TOKENS_WARN
   tokens_escalate:        VERIFY_TOKENS_ESCALATE
+  convergence_enabled:    GAZE_CONVERGENCE_ENABLED

--- a/tests/test_trace_ab_decision.py
+++ b/tests/test_trace_ab_decision.py
@@ -59,7 +59,7 @@ def test_boundary_exactly_at_noise_band_adopts_epsilon_over_rejects():
     # Band is baseline*(1+noise) with inclusive <=; parameterized, not hardcoded.
     noise = 0.05
     baseline = _metrics(cost_per_merged_pr=100.0, reroll_per_pr=0.40, escalate_count=20)
-    # reroll exactly at 0.40 * 1.05 = 0.42 → within band (<=)
+    # band = 0.40 * 1.05 ≈ 0.42 (float: 0.42000000000000004); 0.42 <= band holds
     at_band = _metrics(cost_per_merged_pr=90.0, reroll_per_pr=0.42, escalate_count=21)
     assert tad.decide(baseline, at_band, guardrail_noise_pct=noise)["verdict"] == "adopt"
     # epsilon over the band rejects

--- a/tests/test_trace_ab_decision.py
+++ b/tests/test_trace_ab_decision.py
@@ -18,27 +18,29 @@ tad = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(tad)
 
 
-def _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18):
-    return {
-        "cost_per_pr": cost_per_pr,
+def _metrics(cost_per_merged_pr=100.0, reroll_per_pr=0.30, escalate_count=18, **extra):
+    m = {
+        "cost_per_merged_pr": cost_per_merged_pr,
         "reroll_per_pr": reroll_per_pr,
         "escalate_count": escalate_count,
     }
+    m.update(extra)
+    return m
 
 
 # --- decide() -------------------------------------------------------------
 
 
 def test_adopt_when_cost_drops_and_guardrails_hold():
-    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
-    candidate = _metrics(cost_per_pr=80.0, reroll_per_pr=0.30, escalate_count=18)
+    baseline = _metrics(cost_per_merged_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
+    candidate = _metrics(cost_per_merged_pr=80.0, reroll_per_pr=0.30, escalate_count=18)
     res = tad.decide(baseline, candidate)
     assert res["verdict"] == "adopt", res["reasons"]
 
 
 def test_reject_when_cost_not_below_baseline():
-    baseline = _metrics(cost_per_pr=100.0)
-    candidate = _metrics(cost_per_pr=100.0)  # perfect guardrails, no cost win
+    baseline = _metrics(cost_per_merged_pr=100.0)
+    candidate = _metrics(cost_per_merged_pr=100.0)  # perfect guardrails, no cost win
     res = tad.decide(baseline, candidate)
     assert res["verdict"] == "reject"
     assert any("cost" in r for r in res["reasons"])
@@ -46,8 +48,8 @@ def test_reject_when_cost_not_below_baseline():
 
 def test_reject_on_guardrail_breach_despite_cost_win():
     # The binding-invariant case: cost wins big but a guardrail degrades.
-    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
-    candidate = _metrics(cost_per_pr=50.0, reroll_per_pr=0.50, escalate_count=18)
+    baseline = _metrics(cost_per_merged_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
+    candidate = _metrics(cost_per_merged_pr=50.0, reroll_per_pr=0.50, escalate_count=18)
     res = tad.decide(baseline, candidate)
     assert res["verdict"] == "reject"
     assert any("reroll_per_pr" in r for r in res["reasons"])
@@ -56,23 +58,32 @@ def test_reject_on_guardrail_breach_despite_cost_win():
 def test_boundary_exactly_at_noise_band_adopts_epsilon_over_rejects():
     # Band is baseline*(1+noise) with inclusive <=; parameterized, not hardcoded.
     noise = 0.05
-    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.40, escalate_count=20)
+    baseline = _metrics(cost_per_merged_pr=100.0, reroll_per_pr=0.40, escalate_count=20)
     # reroll exactly at 0.40 * 1.05 = 0.42 → within band (<=)
-    at_band = _metrics(cost_per_pr=90.0, reroll_per_pr=0.42, escalate_count=21)
+    at_band = _metrics(cost_per_merged_pr=90.0, reroll_per_pr=0.42, escalate_count=21)
     assert tad.decide(baseline, at_band, guardrail_noise_pct=noise)["verdict"] == "adopt"
     # epsilon over the band rejects
-    over_band = _metrics(cost_per_pr=90.0, reroll_per_pr=0.42001, escalate_count=21)
+    over_band = _metrics(cost_per_merged_pr=90.0, reroll_per_pr=0.42001, escalate_count=21)
     res = tad.decide(baseline, over_band, guardrail_noise_pct=noise)
     assert res["verdict"] == "reject"
 
 
 def test_reject_on_escalate_breach_only():
-    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
+    baseline = _metrics(cost_per_merged_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
     # escalate band at 10% = 19.8; 21 breaches. reroll fine, cost fine.
-    candidate = _metrics(cost_per_pr=80.0, reroll_per_pr=0.30, escalate_count=21)
+    candidate = _metrics(cost_per_merged_pr=80.0, reroll_per_pr=0.30, escalate_count=21)
     res = tad.decide(baseline, candidate)
     assert res["verdict"] == "reject"
     assert any("escalate_count" in r for r in res["reasons"])
+
+
+def test_cost_key_selects_measure_b_metric():
+    # Measure B compares on cost_per_cycle; cost_per_merged_pr must be ignored.
+    baseline = _metrics(cost_per_merged_pr=100.0, cost_per_cycle=50.0)
+    candidate = _metrics(cost_per_merged_pr=999.0, cost_per_cycle=40.0)
+    res = tad.decide(baseline, candidate, cost_key="cost_per_cycle")
+    assert res["verdict"] == "adopt"
+    assert any("cost_per_cycle" in r for r in res["reasons"])
 
 
 # --- filter_window() ------------------------------------------------------
@@ -101,3 +112,10 @@ def test_filter_window_custom_date_key():
     rows = [{"when": "2026-06-10"}, {"when": "2026-07-10"}]
     kept = tad.filter_window(rows, "2026-06-01", "2026-06-30", date_key="when")
     assert kept == [{"when": "2026-06-10"}]
+
+
+def test_filter_window_matches_full_iso_timestamp_on_last_day():
+    # A full ISO timestamp on the window's last day must not be dropped.
+    rows = [_row("2026-06-30T14:00Z"), _row("2026-07-01T00:00Z")]
+    kept = tad.filter_window(rows, "2026-06-01", "2026-06-30")
+    assert [r["date"] for r in kept] == ["2026-06-30T14:00Z"]

--- a/tests/test_trace_ab_decision.py
+++ b/tests/test_trace_ab_decision.py
@@ -1,0 +1,103 @@
+"""Tests for scripts/trace_ab_decision.py — phase-5 A/B decision rule (ticket 0315).
+
+Pre-registered decision rule: adopt a candidate config iff its cost is strictly
+below baseline AND both guardrails (reroll_per_pr, escalate_count) hold within a
+pre-registered noise band above baseline. A cost win with a breached guardrail
+is a REJECT — the guardrail is binding.
+"""
+
+import importlib.util
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+spec = importlib.util.spec_from_file_location(
+    "trace_ab_decision", SCRIPTS / "trace_ab_decision.py"
+)
+tad = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tad)
+
+
+def _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18):
+    return {
+        "cost_per_pr": cost_per_pr,
+        "reroll_per_pr": reroll_per_pr,
+        "escalate_count": escalate_count,
+    }
+
+
+# --- decide() -------------------------------------------------------------
+
+
+def test_adopt_when_cost_drops_and_guardrails_hold():
+    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
+    candidate = _metrics(cost_per_pr=80.0, reroll_per_pr=0.30, escalate_count=18)
+    res = tad.decide(baseline, candidate)
+    assert res["verdict"] == "adopt", res["reasons"]
+
+
+def test_reject_when_cost_not_below_baseline():
+    baseline = _metrics(cost_per_pr=100.0)
+    candidate = _metrics(cost_per_pr=100.0)  # perfect guardrails, no cost win
+    res = tad.decide(baseline, candidate)
+    assert res["verdict"] == "reject"
+    assert any("cost" in r for r in res["reasons"])
+
+
+def test_reject_on_guardrail_breach_despite_cost_win():
+    # The binding-invariant case: cost wins big but a guardrail degrades.
+    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
+    candidate = _metrics(cost_per_pr=50.0, reroll_per_pr=0.50, escalate_count=18)
+    res = tad.decide(baseline, candidate)
+    assert res["verdict"] == "reject"
+    assert any("reroll_per_pr" in r for r in res["reasons"])
+
+
+def test_boundary_exactly_at_noise_band_adopts_epsilon_over_rejects():
+    # Band is baseline*(1+noise) with inclusive <=; parameterized, not hardcoded.
+    noise = 0.05
+    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.40, escalate_count=20)
+    # reroll exactly at 0.40 * 1.05 = 0.42 → within band (<=)
+    at_band = _metrics(cost_per_pr=90.0, reroll_per_pr=0.42, escalate_count=21)
+    assert tad.decide(baseline, at_band, guardrail_noise_pct=noise)["verdict"] == "adopt"
+    # epsilon over the band rejects
+    over_band = _metrics(cost_per_pr=90.0, reroll_per_pr=0.42001, escalate_count=21)
+    res = tad.decide(baseline, over_band, guardrail_noise_pct=noise)
+    assert res["verdict"] == "reject"
+
+
+def test_reject_on_escalate_breach_only():
+    baseline = _metrics(cost_per_pr=100.0, reroll_per_pr=0.30, escalate_count=18)
+    # escalate band at 10% = 19.8; 21 breaches. reroll fine, cost fine.
+    candidate = _metrics(cost_per_pr=80.0, reroll_per_pr=0.30, escalate_count=21)
+    res = tad.decide(baseline, candidate)
+    assert res["verdict"] == "reject"
+    assert any("escalate_count" in r for r in res["reasons"])
+
+
+# --- filter_window() ------------------------------------------------------
+
+
+def _row(date, **kw):
+    base = {"date": date, "reroll": 1}
+    base.update(kw)
+    return base
+
+
+def test_filter_window_inclusive_boundaries():
+    rows = [
+        _row("2026-06-01"),
+        _row("2026-06-15"),
+        _row("2026-06-30"),
+        _row("2026-07-01"),
+        _row("2026-05-31"),
+    ]
+    kept = tad.filter_window(rows, "2026-06-01", "2026-06-30")
+    dates = {r["date"] for r in kept}
+    assert dates == {"2026-06-01", "2026-06-15", "2026-06-30"}
+
+
+def test_filter_window_custom_date_key():
+    rows = [{"when": "2026-06-10"}, {"when": "2026-07-10"}]
+    kept = tad.filter_window(rows, "2026-06-01", "2026-06-30", date_key="when")
+    assert kept == [{"when": "2026-06-10"}]

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -12,6 +12,7 @@ Author: claude
 2026-06-10T16:40Z claude note 0244 executed: addressable $2356/28d exact; H10 confound confirmed (~4x); H12/H5 dissolved; phase-5 shortlist fixed
 2026-06-10T20:09Z claude note 0245 filed (phase 5 A/B); remaining beyond children: trace-doctor skill assembly + phase-4 adopt items #1/#3
 2026-07-12T22:31Z child 0292 delivered: six-way tool taxonomy + per-category char volume in scripts/trace-stats.py (PR pending)
+2026-07-13T16:03Z Minh-Ha-Duong note phase-5 pre-registration split to 0315 (docs/trace-ab-2026-06.md + trace_ab_decision.py + gaze convergence flag); live arms remain on 0245
 --- body ---
 ## Context
 

--- a/tickets/0236-trace-doctor-session-trace-economics-aud.erg
+++ b/tickets/0236-trace-doctor-session-trace-economics-aud.erg
@@ -12,7 +12,7 @@ Author: claude
 2026-06-10T16:40Z claude note 0244 executed: addressable $2356/28d exact; H10 confound confirmed (~4x); H12/H5 dissolved; phase-5 shortlist fixed
 2026-06-10T20:09Z claude note 0245 filed (phase 5 A/B); remaining beyond children: trace-doctor skill assembly + phase-4 adopt items #1/#3
 2026-07-12T22:31Z child 0292 delivered: six-way tool taxonomy + per-category char volume in scripts/trace-stats.py (PR pending)
-2026-07-13T16:03Z Minh-Ha-Duong note phase-5 pre-registration split to 0315 (docs/trace-ab-2026-06.md + trace_ab_decision.py + gaze convergence flag); live arms remain on 0245
+2026-07-13T16:03Z Minh Ha-Duong note phase-5 pre-registration split to 0315 (docs/trace-ab-2026-06.md + trace_ab_decision.py + gaze convergence flag); live arms remain on 0245
 --- body ---
 ## Context
 

--- a/tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
+++ b/tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
@@ -6,6 +6,7 @@ Author: Integration Test
 --- log ---
 2026-06-10T20:09Z Integration Test created
 
+2026-07-13T16:03Z Minh-Ha-Duong note pre-registration split to 0315: interventions pinned, decision rule + red-first tests landed, gaze convergence flag documented default off; live A/B arms remain here
 --- body ---
 ## Context
 

--- a/tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
+++ b/tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
@@ -6,7 +6,7 @@ Author: Integration Test
 --- log ---
 2026-06-10T20:09Z Integration Test created
 
-2026-07-13T16:03Z Minh-Ha-Duong note pre-registration split to 0315: interventions pinned, decision rule + red-first tests landed, gaze convergence flag documented default off; live A/B arms remain here
+2026-07-13T16:03Z Minh Ha-Duong note pre-registration split to 0315: interventions pinned, decision rule + red-first tests landed, gaze convergence flag documented default off; live A/B arms remain here
 --- body ---
 ## Context
 

--- a/tickets/0315-trace-doctor-phase-5-pre-registration-pi.erg
+++ b/tickets/0315-trace-doctor-phase-5-pre-registration-pi.erg
@@ -1,0 +1,72 @@
+%erg 0.1
+Title: trace-doctor phase 5 pre-registration: pin interventions, decision rule, convergence flag
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T15:48Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Child of 0245 (trace-doctor phase 5 targeted A/B), itself a child of
+tracker 0236. 0245 is not completable in one autonomous pass: measure B
+needs a live nightbeat week and measure A needs paired replays of ~5
+closed tickets. This child carves out everything that MUST land before
+any B-arm data exists (0245 Actions 1-2 plus the test and the flag), so
+the pre-registration ordering is provable from git history. The live
+arms and the verdicts stay on 0245.
+
+## Relevant files
+
+- `tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg` — the spec;
+  Actions 1-2 are this ticket's scope
+- `docs/trace-counterfactuals-2026-06.md` — routing decision + guardrail
+  baselines (REROLL/PR 33/112, ESCALATE 18)
+- `scripts/trace-stats.py`, `scripts/trace-hypotheses.py`,
+  `scripts/trace-pr-join.py` — committed measurement scripts (reused,
+  untouched)
+- `skills/gaze/SKILL.md` — measure-B intervention surface
+
+## Actions
+
+1. Pin one intervention per measure in `docs/trace-ab-2026-06.md`:
+   A = paired replay of ~5 closed tickets with a Sonnet main;
+   B = convergence rule (after the first full gaze round, REROLL fixes
+   re-check through verify-gate only, no full panel re-run). Confirm or
+   revise 0245's defaults with reasons.
+2. Pre-register in the same doc, before any B-arm data: metric
+   definitions ($ per merged PR / per cycle, REROLL/PR, ESCALATE count,
+   gaze verdict distribution), window dates, exclusion rules
+   (study-session reflexivity), decision rule with thresholds
+   (adopt iff cost drops AND guardrails hold within stated noise).
+3. Implement the decision rule as a pure function
+   (`scripts/trace_ab_decision.py`) with unit tests written red-first:
+   fixture metric values map to expected adopt/reject verdicts;
+   per-window date filtering of guardrail metrics gets a fixture.
+4. Ship the measure-B convergence rule behind an explicit opt-in flag in
+   `skills/gaze/SKILL.md` (default off; the B-arm week turns it on).
+5. Append a note to 0245 and tracker 0236: pre-registration landed,
+   live arms remain.
+
+## Test
+
+- Red first: `tests/test_trace_ab_decision.py` — decision-rule verdicts
+  and window filtering on fixtures, before the implementation exists.
+
+## Invariants
+
+- Zero LLM calls in committed scripts; no trace content in committed
+  artifacts (aggregates ok)
+- Existing census accounting untouched (additive only)
+- No B-arm data collected or interpreted here — this ticket is the
+  ordering proof, not the experiment
+
+## Exit criteria
+
+- [ ] `docs/trace-ab-2026-06.md` pins both interventions and
+      pre-registers metrics, windows, exclusions, decision rule
+- [ ] `scripts/trace_ab_decision.py` pure function + red-first tests pass
+- [ ] gaze convergence flag documented, default off
+- [ ] 0245 and 0236 logs note the split
+- [ ] `make check` passes

--- a/tickets/0315-trace-doctor-phase-5-pre-registration-pi.erg
+++ b/tickets/0315-trace-doctor-phase-5-pre-registration-pi.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T15:48Z Minh Ha-Duong created
 
+2026-07-13T16:59Z gate note verify-reroll-round-1 doc-propagation verifiable minor unresolved: SKILL.md Invariants block still lacks a cross-reference to the convergence flag (skills/gaze/SKILL.md:352); see PR 551 comment 2026-07-13T16:24:44Z
 --- body ---
 ## Context
 

--- a/tickets/closed/0315-trace-doctor-phase-5-pre-registration-pi.erg
+++ b/tickets/closed/0315-trace-doctor-phase-5-pre-registration-pi.erg
@@ -2,11 +2,13 @@
 Title: trace-doctor phase 5 pre-registration: pin interventions, decision rule, convergence flag
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #551
 
 --- log ---
 2026-07-13T15:48Z Minh Ha-Duong created
 
 2026-07-13T16:59Z gate note verify-reroll-round-1 doc-propagation verifiable minor unresolved: SKILL.md Invariants block still lacks a cross-reference to the convergence flag (skills/gaze/SKILL.md:352); see PR 551 comment 2026-07-13T16:24:44Z
+2026-07-13T17:14Z Minh Ha-Duong closed — autoclosed — PR #551
 --- body ---
 ## Context
 


### PR DESCRIPTION
Carves the pre-registration half of ticket 0245 (trace-doctor phase-5 A/B) into its own child ticket, so the study ordering — interventions and decision rule fixed **before** any B-arm data exists — is provable from git history. The live A/B arms and the per-measure verdicts stay on 0245.

## What lands here

- **`docs/trace-ab-2026-06.md`** — pre-registration doc. Pins one intervention per measure (A: paired Sonnet-main replay of ~5 closed tickets; B: caller-level gaze convergence), and pre-registers metric definitions, windows, exclusion rules (study-session reflexivity), and the decision rule with a 10% guardrail noise band. Measure-B week dates are left as an explicit TODO placeholder to be pinned at B-arm launch — deliberately not fabricated ahead of the run.
- **`scripts/trace_ab_decision.py`** — `decide()` + `filter_window()` as pure, importable functions. No argparse / no `__main__`: the only consumers are the tests now and the 0245 harvest step later. The underscored filename is deliberate (must import cleanly), a noted deviation from the hyphenated `trace-*.py` siblings which are CLI scripts.
- **`tests/test_trace_ab_decision.py`** — written red-first (verified failing on the missing module before implementation): adopt, reject-on-cost, the binding reject-on-guardrail-despite-cost-win case, a parameterized noise-band boundary (`<=` inclusive, epsilon-over rejects, noise passed explicitly), escalate-only breach, and inclusive-boundary window filtering.
- **`skills/gaze/{telemetry.yml,SKILL.md}`** — measure-B convergence flag, default **off** (`convergence.enabled: false`, env override `GAZE_CONVERGENCE_ENABLED`).

## Convergence-flag surface decision

The flag governs **caller-level re-invocation** of `/gaze` on a PR that already carries a completed full gaze round — it does **not** touch the internal round-1 REROLL re-entry branch in `skills/gaze/`. Rationale: that internal branch is already gate-only and was live and unchanged during the June measurement window; the \$259/wk `vg` bucket that phase 4 flagged is measured from caller-level repeat invocations of the full `/gaze` (turns after the 2nd verify/gaze invocation). Instrumenting the internal branch would move a surface the baseline never charged. Default-off means live behaviour is unchanged until the B-arm week flips it on.

## Gates

- `make check` — 789 passed
- `/verify-adherence` — PASS (mechanical tier; no `rules/*.md` changed)

**Ticket:** tickets/0315-trace-doctor-phase-5-pre-registration-pi.erg
Ticket-ref: tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
Ticket-ref: tickets/0236-trace-doctor-session-trace-economics-aud.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)