### PR TITLE
tickets(0318,0319): roar-sweep filings from the pipeline raid

### DIFF
--- a/tickets/0318-guard-execute-agents-against-primary-che.erg
+++ b/tickets/0318-guard-execute-agents-against-primary-che.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: Guard execute agents against primary-checkout writes during worktree isolation
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T16:55Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+In the 2026-07-13 ticket-pipeline raid, 7 of 11 worktree-isolated execute
+agents let their first Edit/Write land in the primary checkout via absolute
+`/home/haduong/.claude/...` paths — the documented worktree-path trap
+(`rules/workflow.md` § Worktree paths). Every agent self-recovered (revert +
+re-apply in the worktree), but at token cost, and escalating prompt warnings
+across the raid did not stop the recurrence. Prose does not fix a class
+defect; a guard does. The Bash surface already has one
+(`scripts/guard-cd-primary-repo.sh` blocks `cd <primary> && <mutating
+git/erg>`); the Edit/Write surface has none.
+
+## Relevant files
+
+- `scripts/guard-cd-primary-repo.sh` — Bash-surface precedent
+- `settings.json` — PreToolUse wiring (matcher `Edit|Write`)
+- `scripts/inject_rule_on_edit.py` — existing PreToolUse Edit|Write hook to
+  coexist with
+
+## Actions
+
+1. PreToolUse guard on `Edit|Write`: during a worktree session (cwd inside
+   `*/.claude/worktrees/*`), deny a `file_path` that resolves inside the
+   primary checkout but outside every registered worktree. Deny message
+   names the worktree-rooted path to use instead.
+2. Decide the escape hatch for intentional primary edits (e.g. an env
+   override), and the interaction with non-worktree sessions (guard must
+   exit 0 when the session is not worktree-isolated).
+3. Red-first test suite in the style of
+   `tests/test_guard_enterworktree_parked_cwd.sh`.
+
+## Exit criteria
+
+- [ ] A worktree-isolated agent's Edit/Write to the primary checkout is
+      denied with a corrective message
+- [ ] Non-worktree sessions and legitimate paths unaffected
+- [ ] `make check` and `make lint` pass

--- a/tickets/0318-guard-execute-agents-against-primary-che.erg
+++ b/tickets/0318-guard-execute-agents-against-primary-che.erg
@@ -11,7 +11,7 @@ Author: Minh Ha-Duong
 
 In the 2026-07-13 ticket-pipeline raid, 7 of 11 worktree-isolated execute
 agents let their first Edit/Write land in the primary checkout via absolute
-`/home/haduong/.claude/...` paths — the documented worktree-path trap
+`~/.claude/...` paths — the documented worktree-path trap
 (`rules/workflow.md` § Worktree paths). Every agent self-recovered (revert +
 re-apply in the worktree), but at token cost, and escalating prompt warnings
 across the raid did not stop the recurrence. Prose does not fix a class

--- a/tickets/0319-workflow-md-worktree-name-table-carry-th.erg
+++ b/tickets/0319-workflow-md-worktree-name-table-carry-th.erg
@@ -1,0 +1,27 @@
+%erg 0.1
+Title: workflow.md worktree-name table: carry the resolve-$$-to-literal caveat from hunt step 3
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T16:55Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Ticket 0309 (PR #538, merged 2026-07-13) taught hunt step 3 to resolve the
+`$$` session discriminator to a literal number (`bash -c 'echo $$'`) before
+calling EnterWorktree, whose name schema rejects `$`. The /gaze verdict on
+#538 flagged the sibling: `rules/workflow.md:20` still describes the `{pid}`
+suffix generically as "e.g. `$$`" with no resolve-to-literal caveat — a
+call site hand-typed from that table reproduces the InputValidationError.
+
+## Actions
+
+1. In the workflow.md worktree-naming table, add the one-line caveat:
+   resolve `$$` to its literal value first (pointer to hunt step 3's recipe).
+
+## Exit criteria
+
+- [ ] workflow.md `{pid}` description carries the caveat
+- [ ] `make check` passes


### PR DESCRIPTION
Files two tickets found by the /roar step-3 sweep after the 11-ticket raid of 2026-07-13.

- tickets/0318 — PreToolUse Edit|Write guard against primary-checkout writes during worktree isolation (the trap hit 7/11 execute agents this raid; prompt warnings did not stop the class). Its red-first test suite doubles as the standing regression defense.
- tickets/0319 — workflow.md {pid} table still shows generic `$$` without the resolve-to-literal caveat hunt step 3 now carries (flagged by the #538 gaze verdict).

Ticket filings only, no fixes.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)