### PR TITLE
memory: worktree-path-trap lesson from the pipeline raid

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Worktree-path trap needs a guard](feedback_worktree_path_trap_needs_guard.md) — prompt warnings failed 7/11 execute agents in one raid; the model resolves paths from quoted context, not cwd; check primary status after each agent until the 0318 Edit|Write guard lands (2026-07-13)
 - [Supervisor checkpoint pattern](feedback_supervisor_checkpoint_pattern.md) — the primary supervisor chat orchestrates, never executes tickets; clean checkpoint = monitor worker quiescence (open-PR set + heads hash, 30-min quiet), then merge leftover ready PRs, leave drafts to their owners, prune (author doctrine, 2026-07-13)
 - [Classifier prohibition paraphrase](feedback_classifier_prohibition_paraphrase.md) — the auto-mode permission classifier inflates any transcript-visible "Never X" into a blanket ban while STATE.md grants stay invisible; write scope as ownership ("decision belongs to the caller"), sequencing rules in positive form, and quote standing grants into the transcript before gated actions (ticket 0249, 2026-07-13)
 - [Shared-worktree live-session contention](feedback_shared_worktree_live_session_contention.md) — a live session can switch branches under a background job between Bash calls; assert branch and commit in ONE compound in any worktree you didn't create; recover misplaced commits by cherry-pick from a fresh worktree, never by resetting the other branch (2026-07-13)

--- a/projects/-home-haduong--claude/memory/feedback_worktree_path_trap_needs_guard.md
+++ b/projects/-home-haduong--claude/memory/feedback_worktree_path_trap_needs_guard.md
@@ -1,0 +1,27 @@
+---
+name: worktree-path-trap-needs-guard
+description: Prompt warnings do not prevent worktree-isolated agents from editing the primary checkout — 7/11 execute agents hit the trap in one raid; only a hook guard closes the class (ticket 0318)
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 07d7cb00-b790-4546-9c26-062a639b4ad1
+---
+
+In the 2026-07-13 ticket-pipeline raid (11 sequential hunt waves), 7 of 11
+worktree-isolated execute agents let their first Edit/Write land in the
+primary checkout via absolute `~/.claude/...` paths, despite the trap being
+documented in `rules/workflow.md` and despite increasingly explicit
+"WORKTREE DISCIPLINE" warnings added to each successive agent prompt. All
+self-recovered, but each recovery cost tokens and one nearly polluted main.
+
+**Why:** the model resolves file paths from conversation context (ticket
+bodies, tool outputs quoting primary paths), not from its git cwd; a prose
+warning competes with every quoted absolute path and loses often.
+
+**How to apply:** do not rely on prompt text to keep agent edits inside a
+worktree. Until ticket 0318 lands (PreToolUse `Edit|Write` guard denying
+primary-checkout writes during worktree sessions, mirroring
+`scripts/guard-cd-primary-repo.sh` on the Bash surface), expect the trap in
+~2/3 of worktree-isolated agent runs and check `git -C <primary> status`
+after each agent returns. Related: [[fork-skills-bare-context]],
+[[parallel-execute-branch-contamination]].


### PR DESCRIPTION
Saves the raid's durable lesson (prompt warnings fail ~2/3 of worktree-isolated agents; guard ticketed 0318) and its MEMORY.md index line.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)