### PR TITLE
tickets: gaze battery-scaling proposal + 0206 trial evidence

### DIFF
--- a/tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
+++ b/tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
@@ -15,6 +15,7 @@ Author: MinhHaDuong
 2026-07-13T08:50Z MinhHaDuong note design change: auto-request on every MR is too much — some PRs are trivial. Switch to on-demand: the review is requested per-PR when warranted, never enabled repo-wide. Body rewritten accordingly by claude
 
 2026-07-13T09:30Z claude note lever documented: /reviewers request <pr> runs the forge-bot seat via `gh api --method POST repos/{owner}/{repo}/pulls/<pr>/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'` (login from panel.yml); gate clause added to skills/gaze/SKILL.md (absent seat silent, requested-but-pending bounded fail-open wait). Exit criteria 1-2 delivered; trial (criteria 3-4) remains
+2026-07-13T19:33Z claude note trial evidence: the 2026-07-13 pipeline raid ran 11 substantive /gaze batteries (PRs #538-#548, all gated, 3 rerolls with real defects) — exceeds the >=5-MR trial volume for exit criteria 3-4; harvest those runs' panel data before scheduling new trial MRs
 --- body ---
 ## Context
 

--- a/tickets/0320-gaze-scale-the-reviewer-battery-to-diff.erg
+++ b/tickets/0320-gaze-scale-the-reviewer-battery-to-diff.erg
@@ -1,0 +1,42 @@
+%erg 0.1
+Title: gaze: scale the reviewer battery to diff size
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T19:32Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+In the 2026-07-13 pipeline raid, /gaze ran 11 times; 4 runs crossed the
+500k-token warn threshold (peak ~665k on PR #540) and the raid's gaze cost
+dominated its total spend, while several gated diffs were under 100 changed
+lines (e.g. #538: 3 files, one doc paragraph plus one test). The gate's
+verdict quality was excellent (3 rerolls, each a real defect), so the lever
+is not fewer gates — it is a battery sized to the diff. gaze already has a
+size-gate notion (the #542 report mentions "no size-gate skip"); this ticket
+extends it from skip/no-skip to a graduated battery.
+
+## Evidence to gather first
+
+Confirm on telemetry from subsequent raids (e.g. the 291/245 raid running
+2026-07-13) that small-diff gaze runs stay ~400-600k tokens. If they come in
+materially cheaper, close wontfix with the numbers.
+
+## Actions
+
+1. Define 2-3 diff-size tiers (changed lines and file count) in
+   skills/gaze/SKILL.md, mapping each to a reviewer battery (e.g. tiny:
+   adherence + gate only; small: + one review agent; full: current battery).
+2. Keep the anti-rubber-stamp property: /verify-gate always runs, every
+   exit criterion still checked.
+3. Record per-run tier + token count in the verdict telemetry line so the
+   tiering can be audited.
+
+## Exit criteria
+
+- [ ] Battery tiers defined and documented in the gaze skill
+- [ ] verify-gate coverage unchanged at every tier
+- [ ] Telemetry line carries the tier
+- [ ] `make check` passes


### PR DESCRIPTION
Perch close-out of the pipeline-raid session.

- tickets/0320 — new: scale the gaze reviewer battery to diff size (4/11 runs crossed the 500k-token warn on small diffs; evidence-gated, may close wontfix on cheaper telemetry).
- tickets/0206 — log note only: the raid's 11 gated PRs (#538-#548) satisfy the ticket's >=5-MR trial volume; harvest before scheduling new trial MRs.

Ticket-ref: tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)