### PR TITLE
ticket(0206): Copilot-seat trial scorecard + keep-advisory recommendation

### DIFF
--- a/tickets/0205-external-reviewer-panel-for-verify-contr.erg
+++ b/tickets/0205-external-reviewer-panel-for-verify-contr.erg
@@ -2,7 +2,6 @@
 Title: External-reviewer panel for verify — contract, decorrelation rule, trial tracker
 Created: 2026-06-04
 Author: MinhHaDuong
-Blocked-by: 0206
 Blocked-by: 0207
 
 --- log ---
@@ -15,6 +14,7 @@ Blocked-by: 0207
 2026-06-05T09:10Z claude note rewritten around review-is-CI (author directive): ACP dropped as the substrate; a reviewer seat is a sandboxed CI-style job (0217 seat-runner), findings normalize to the contract shape, advisory→required is the optional→required-check toggle. Decorrelation evidence landed (docs/research/ensemble-decorrelation-evidence.md): cap N at 2-4, composition>count, the genuinely-different local open-weights seat buys the real independence (prototype: qwen3.6-35b-a3b usable, devstral hallucinated). 0207/0208 re-scoped off ACP; children now blocked-by 0217
 2026-06-05T11:07Z claude note corrective: the 06:41Z ACP-client architecture decision was superseded the same day by ticket 0217 (sandbox-runner spinoff, PR #289 panel + deep-research evidence) — OS-level sandbox (rootless podman) is the load-bearing containment, ACP demoted to optional plumbing. Current seat mechanism: 0217 seat-runner + /reviewers skill (0208, closed). Do not orient from the 06:41Z note
 2026-06-05T11:08Z MinhHaDuong note blocker 0208 closed — Blocked-by removed.
+2026-07-14T05:05Z Minh Ha-Duong note blocker 0206 closed — Blocked-by removed.
 --- body ---
 ## Context
 

--- a/tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
+++ b/tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg
@@ -16,6 +16,14 @@ Author: MinhHaDuong
 
 2026-07-13T09:30Z claude note lever documented: /reviewers request <pr> runs the forge-bot seat via `gh api --method POST repos/{owner}/{repo}/pulls/<pr>/requested_reviewers -f 'reviewers[]=copilot-pull-request-reviewer[bot]'` (login from panel.yml); gate clause added to skills/gaze/SKILL.md (absent seat silent, requested-but-pending bounded fail-open wait). Exit criteria 1-2 delivered; trial (criteria 3-4) remains
 2026-07-13T19:33Z claude note trial evidence: the 2026-07-13 pipeline raid ran 11 substantive /gaze batteries (PRs #538-#548, all gated, 3 rerolls with real defects) — exceeds the >=5-MR trial volume for exit criteria 3-4; harvest those runs' panel data before scheduling new trial MRs
+2026-07-13T19:43Z claude note correction: the 19:33Z assumption fails — the reviews API shows ZERO Copilot reviews on PRs #538-#548 (the seat was never requested on them; the raid batteries ran without it). No harvestable data there; trial run live instead on the 5 open MRs across 4 projects (request → review posted in 1-2 min each)
+2026-07-13T19:43Z claude note MR ImperialDragonHarness#537 seat=copilot verdict: PASS — 0 verifiable, 0 consider (memory consolidation, 4 files; accurate change summary, no findings)
+2026-07-13T19:43Z claude note MR ImperialDragonHarness#559 seat=copilot verdict: PASS — 0 verifiable, 1 consider (flagged "bounded-wind" slug as typo; FALSE POSITIVE — erg new truncates slugs by design)
+2026-07-13T19:43Z claude note MR climate-finance-het#1016 seat=copilot verdict: PASS — 0 verifiable, 1 consider (header/sample-3 "we" inconsistency; true positive, verified against file lines 9 and 140)
+2026-07-13T19:43Z claude note MR archiveCIRED#59 seat=copilot verdict: PASS — 1 verifiable, 1 consider (Actions§1 allows conferencePaper but Verification requires journalArticle-only: true positive, verified; French spelling "inconditional": true positive; review body written in French, matching the PR language)
+2026-07-13T19:43Z claude note MR padme#66 seat=copilot verdict: PASS — 0 verifiable, 1 consider (grammar fix in ticket prose; true positive)
+2026-07-13T19:43Z claude note trial totals: 5 MRs, 4 projects (meets the 0205 rule-2 bar of >=5 MRs / >=3 projects); 5 findings = 4 true / 1 false positive, 1 verifiable-class; zero spurious bounces; latency 1-2 min per review; zero token cost. Caveat: sample skews to ticket/prose diffs — no complex multi-file code change in the window, exactly where 0205's decorrelation evidence says ensemble value concentrates
+2026-07-13T19:43Z claude note recommendation for 0205 integration review: KEEP AS STANDING ADVISORY SEAT, do not promote to required. Precision (4/5) and cost (zero) justify keeping it on-demand for non-trivial MRs; promotion is barred by 0205 rule 2 until verifiable-class findings prove stable across re-runs AND the seat is observed on complex code diffs, neither demonstrated in this window
 --- body ---
 ## Context
 
@@ -67,5 +75,5 @@ dispositioned in the gate verdict's evidence table.
 - [x] On-demand request path live; exact forge call documented
 - [x] Gate clause merged (absent seat is silent; requested-but-pending
       gets fail-open bounded wait)
-- [ ] Trial scorecard: ≥5 non-trivial MRs, ≥3 projects, logged here
-- [ ] Promote/drop recommendation recorded for 0205's integration review
+- [x] Trial scorecard: ≥5 non-trivial MRs, ≥3 projects, logged here
+- [x] Promote/drop recommendation recorded for 0205's integration review

--- a/tickets/closed/0206-copilot-review-in-the-verify-panel-on-demand.erg
+++ b/tickets/closed/0206-copilot-review-in-the-verify-panel-on-demand.erg
@@ -2,6 +2,7 @@
 Title: Copilot review in the verify panel — on-demand request, gate harvest, advisory trial
 Created: 2026-06-04
 Author: MinhHaDuong
+Closed: autoclosed — PR #560
 
 --- log ---
 2026-06-04T08:41Z MinhHaDuong created
@@ -24,6 +25,7 @@ Author: MinhHaDuong
 2026-07-13T19:43Z claude note MR padme#66 seat=copilot verdict: PASS — 0 verifiable, 1 consider (grammar fix in ticket prose; true positive)
 2026-07-13T19:43Z claude note trial totals: 5 MRs, 4 projects (meets the 0205 rule-2 bar of >=5 MRs / >=3 projects); 5 findings = 4 true / 1 false positive, 1 verifiable-class; zero spurious bounces; latency 1-2 min per review; zero token cost. Caveat: sample skews to ticket/prose diffs — no complex multi-file code change in the window, exactly where 0205's decorrelation evidence says ensemble value concentrates
 2026-07-13T19:43Z claude note recommendation for 0205 integration review: KEEP AS STANDING ADVISORY SEAT, do not promote to required. Precision (4/5) and cost (zero) justify keeping it on-demand for non-trivial MRs; promotion is barred by 0205 rule 2 until verifiable-class findings prove stable across re-runs AND the seat is observed on complex code diffs, neither demonstrated in this window
+2026-07-14T05:05Z Minh Ha-Duong closed — autoclosed — PR #560
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg

Finishes ticket 0206 (Copilot reviewer seat) by delivering its last two exit criteria: the advisory-trial scorecard and the promote/drop recommendation for 0205's integration review.

## What happened

The ticket's 19:33Z log note assumed the 2026-07-13 raid PRs (#538–#548) could be harvested as trial data. Checking the reviews API showed **zero Copilot reviews on any of them** — the seat was never requested, so those batteries ran without it. A log line corrects the record.

The trial was instead run live: the seat was requested (via the documented `requested_reviewers` call) on the 5 open MRs across 4 projects:

| MR | Verdict |
|----|---------|
| ImperialDragonHarness#537 | 0 verifiable, 0 consider |
| ImperialDragonHarness#559 | 0 verifiable, 1 consider (false positive — erg slug truncation) |
| climate-finance-het#1016 | 0 verifiable, 1 consider (true, verified) |
| archiveCIRED#59 | 1 verifiable, 1 consider (both true, verified; review in French) |
| padme#66 | 0 verifiable, 1 consider (true) |

Totals: 4/5 true positives, 1 verifiable-class finding, zero token cost, 1–2 min latency each.

## Recommendation

Keep as **standing advisory seat**, do not promote to required: 0205 rule 2 requires re-run stability of verifiable-class findings and observation on complex code diffs — neither demonstrated in this window (the sample skews to ticket/prose diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)