### PR TITLE
feat(0318): harden worktree-path guard to a blocking deny

### DIFF
--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -11,7 +11,10 @@ input=$(cat)
 
 command -v jq &>/dev/null || exit 0
 
-file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+# NotebookEdit carries its target in notebook_path, Write/Edit in file_path. A
+# payload has only one, so read either; without this the guard silently exits 0
+# on every NotebookEdit despite the settings.json matcher covering it.
+file_path=$(echo "$input" | jq -r '.tool_input.notebook_path // .tool_input.file_path // empty' 2>/dev/null || true)
 [ -z "$file_path" ] && exit 0
 hook_cwd=$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || true)
 

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -76,6 +76,22 @@ case "$file_path" in
                 ;;
         esac
         rel="${file_path#$primary_root/}"
+        # projects/*/memory/** is tracked via the primary .gitignore whitelist by
+        # design, and skills/memory tells every session to write it directly by
+        # absolute path — so a primary-checkout write there is intended, not the
+        # trap. Scoped narrowly (NOT a blanket projects/* exemption); for a
+        # non-harness project the pattern never matches, so it is a no-op.
+        case "$rel" in
+            projects/*/memory/*) exit 0 ;;
+        esac
+        # Escape hatch: a human pre-authorizes intentional primary edits by
+        # exporting GUARD_ALLOW_PRIMARY_EDIT in the shell/systemd environment
+        # BEFORE session start. The hook is spawned by the CLI, not a Bash-tool
+        # subshell, so an agent cannot set it mid-turn — deliberate, no
+        # self-service bypass.
+        if [ -n "${GUARD_ALLOW_PRIMARY_EDIT:-}" ]; then
+            exit 0
+        fi
         echo "Worktree path guard: '$rel' resolves to the main repo, not the worktree." >&2
         echo "Did you mean: $worktree_root/$rel" >&2
         echo "For an intentional primary-checkout edit, export GUARD_ALLOW_PRIMARY_EDIT before starting the session." >&2

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -92,7 +92,7 @@ case "$file_path" in
         if [ -n "${GUARD_ALLOW_PRIMARY_EDIT:-}" ]; then
             exit 0
         fi
-        echo "Worktree path guard: '$rel' resolves to the main repo, not the worktree." >&2
+        echo "BLOCKED: Worktree path guard: '$rel' resolves to the main repo, not the worktree." >&2
         echo "Did you mean: $worktree_root/$rel" >&2
         echo "For an intentional primary-checkout edit, export GUARD_ALLOW_PRIMARY_EDIT before starting the session." >&2
         exit 2

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
-# PreToolUse hook: warn when Write/Edit/NotebookEdit targets the main repo
-# path during a worktree session. Non-blocking (exit 0) — advisory only.
-# See ticket 0171.
+# PreToolUse hook: deny (exit 2 + stderr) when Write/Edit/NotebookEdit targets
+# the main repo path during a worktree session — the worktree-path trap
+# (rules/workflow.md § Worktree paths). Ticket 0171 shipped this as an advisory
+# (exit 0); ticket 0318 hardened it to a blocking deny after prose warnings
+# failed to stop 7/11 execute agents in one raid.
+# See tickets 0171 and 0318.
 
 input=$(cat)
 
@@ -75,6 +78,8 @@ case "$file_path" in
         rel="${file_path#$primary_root/}"
         echo "Worktree path guard: '$rel' resolves to the main repo, not the worktree." >&2
         echo "Did you mean: $worktree_root/$rel" >&2
+        echo "For an intentional primary-checkout edit, export GUARD_ALLOW_PRIMARY_EDIT before starting the session." >&2
+        exit 2
         ;;
 esac
 

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -159,4 +159,59 @@ else
     fail=1
 fi
 
+# 10. Memory-dir exemption: projects/*/memory/** in the primary checkout is
+# written directly by absolute path by design (the primary .gitignore whitelist
+# tracks it; skills/memory tells every session to write it there). Not denied.
+rc=$(_rc "$WORKTREE" "$PRIMARY" "$PRIMARY/projects/-home-haduong--claude/memory/MEMORY.md")
+if [ "$rc" = "0" ]; then
+    echo "PASS: exempts primary projects/*/memory/** path (exit 0)"
+else
+    echo "FAIL: expected exit 0 for memory-dir path; got: $rc"
+    fail=1
+fi
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "$PRIMARY/projects/-home-haduong--claude/memory/MEMORY.md")
+if [ -z "$out" ]; then
+    echo "PASS: silent for memory-dir path"
+else
+    echo "FAIL: unexpected output for memory-dir path: $out"
+    fail=1
+fi
+
+# 11. Escape hatch: GUARD_ALLOW_PRIMARY_EDIT set → intentional primary edit is
+# allowed. A human pre-authorizes by exporting it BEFORE session start; the hook
+# is spawned by the CLI, so an agent cannot set it mid-turn.
+rc=$(_rc "$WORKTREE" "$PRIMARY" "$PRIMARY/src/main.py" GUARD_ALLOW_PRIMARY_EDIT=1)
+if [ "$rc" = "0" ]; then
+    echo "PASS: escape hatch allows primary edit (exit 0)"
+else
+    echo "FAIL: expected exit 0 with GUARD_ALLOW_PRIMARY_EDIT; got: $rc"
+    fail=1
+fi
+
+# 12. Deny message names the escape hatch so the operator knows the recourse.
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "$PRIMARY/src/main.py")
+if echo "$out" | grep -q "GUARD_ALLOW_PRIMARY_EDIT"; then
+    echo "PASS: deny message names GUARD_ALLOW_PRIMARY_EDIT"
+else
+    echo "FAIL: deny message missing GUARD_ALLOW_PRIMARY_EDIT; got: $out"
+    fail=1
+fi
+
+# 13. Allow cases exit 0 explicitly — silence alone no longer implies allowed
+# now that the guard can deny (exit 2).
+rc=$(_rc "$WORKTREE" "$PRIMARY" "$WORKTREE/src/main.py")
+if [ "$rc" = "0" ]; then
+    echo "PASS: worktree-rooted path exits 0"
+else
+    echo "FAIL: expected exit 0 for worktree-rooted path; got: $rc"
+    fail=1
+fi
+rc=$(_rc "$WORKTREE" "$PRIMARY" "/tmp/unrelated/file.py")
+if [ "$rc" = "0" ]; then
+    echo "PASS: unrelated path exits 0"
+else
+    echo "FAIL: expected exit 0 for unrelated path; got: $rc"
+    fail=1
+fi
+
 exit $fail

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -19,6 +19,25 @@ _payload_with_cwd() {
     printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"},"cwd":"%s"}' "$fp" "$cwd"
 }
 
+# NotebookEdit carries its target in notebook_path (not file_path). The
+# settings.json matcher includes NotebookEdit, so the guard must read it too.
+_payload_notebook() {
+    local np="$1"
+    printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"%s","new_source":"x"}}' "$np"
+}
+
+_run_hook_notebook() {
+    local wt="$1" pr="$2" np="$3"
+    _payload_notebook "$np" | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" 2>&1 || true
+}
+
+_rc_notebook() {
+    local wt="$1" pr="$2" np="$3"
+    _payload_notebook "$np" \
+        | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" \
+            >/dev/null 2>&1 && echo 0 || echo $?
+}
+
 _run_hook() {
     local wt="$1" pr="$2" fp="$3"
     _payload "$fp" | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" 2>&1 || true
@@ -211,6 +230,35 @@ if [ "$rc" = "0" ]; then
     echo "PASS: unrelated path exits 0"
 else
     echo "FAIL: expected exit 0 for unrelated path; got: $rc"
+    fail=1
+fi
+
+# 14. NotebookEdit whose notebook_path (NOT file_path) targets the primary
+# checkout → deny (exit 2 + corrective message). The settings.json matcher
+# covers NotebookEdit, so the guard must read notebook_path; a jq that reads
+# only file_path returns empty here and silently allows the primary-checkout
+# write (the exact bypass this case guards).
+rc=$(_rc_notebook "$WORKTREE" "$PRIMARY" "$PRIMARY/nb.ipynb")
+if [ "$rc" = "2" ]; then
+    echo "PASS: denies NotebookEdit notebook_path into primary (exit 2)"
+else
+    echo "FAIL: expected exit 2 for NotebookEdit into primary; got: $rc"
+    fail=1
+fi
+out=$(_run_hook_notebook "$WORKTREE" "$PRIMARY" "$PRIMARY/nb.ipynb")
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: NotebookEdit into primary emits corrective message"
+else
+    echo "FAIL: expected corrective message for NotebookEdit into primary; got: $out"
+    fail=1
+fi
+
+# 15. NotebookEdit whose notebook_path is inside the worktree → allow (exit 0).
+rc=$(_rc_notebook "$WORKTREE" "$PRIMARY" "$WORKTREE/nb.ipynb")
+if [ "$rc" = "0" ]; then
+    echo "PASS: allows NotebookEdit notebook_path inside worktree (exit 0)"
+else
+    echo "FAIL: expected exit 0 for NotebookEdit inside worktree; got: $rc"
     fail=1
 fi
 

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -30,12 +30,29 @@ _run_hook_with_cwd() {
         | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" bash "$HOOK" 2>&1 || true
 }
 
-# 1. Main-repo path while in worktree → warn
+# Return the guard's exit code (not its output), so a deny (exit 2) is
+# distinguishable from an advisory-then-allow (exit 0). Extra env pairs after
+# the payload args are passed through to the hook (used for GUARD_ALLOW_PRIMARY_EDIT).
+_rc() {
+    local wt="$1" pr="$2" fp="$3"; shift 3
+    _payload "$fp" \
+        | env _GUARD_WORKTREE_ROOT="$wt" _GUARD_PRIMARY_ROOT="$pr" "$@" bash "$HOOK" \
+            >/dev/null 2>&1 && echo 0 || echo $?
+}
+
+# 1. Main-repo path while in worktree → deny (exit 2) with a corrective message
 out=$(_run_hook "$WORKTREE" "$PRIMARY" "$PRIMARY/src/main.py")
 if echo "$out" | grep -q "Worktree path guard"; then
     echo "PASS: warns on main-repo path"
 else
     echo "FAIL: expected warning for main-repo path; got: $out"
+    fail=1
+fi
+rc=$(_rc "$WORKTREE" "$PRIMARY" "$PRIMARY/src/main.py")
+if [ "$rc" = "2" ]; then
+    echo "PASS: denies (exit 2) on main-repo path"
+else
+    echo "FAIL: expected exit 2 for main-repo path; got: $rc"
     fail=1
 fi
 

--- a/tickets/0318-guard-execute-agents-against-primary-che.erg
+++ b/tickets/0318-guard-execute-agents-against-primary-che.erg
@@ -5,6 +5,7 @@ Author: Minh Ha-Duong
 
 --- log ---
 2026-07-13T16:55Z Minh Ha-Duong created
+2026-07-13T18:30Z claude note Hardened existing scripts/pretooluse-worktree-path-guard.sh (0171) from advisory to blocking deny (exit 2); added projects/*/memory/** exemption + GUARD_ALLOW_PRIMARY_EDIT escape hatch; extended tests staged red-first. No settings.json change (already wired at Write|Edit|NotebookEdit).
 
 --- body ---
 ## Context
@@ -40,7 +41,7 @@ git/erg>`); the Edit/Write surface has none.
 
 ## Exit criteria
 
-- [ ] A worktree-isolated agent's Edit/Write to the primary checkout is
+- [x] A worktree-isolated agent's Edit/Write to the primary checkout is
       denied with a corrective message
-- [ ] Non-worktree sessions and legitimate paths unaffected
-- [ ] `make check` and `make lint` pass
+- [x] Non-worktree sessions and legitimate paths unaffected
+- [x] `make check` and `make lint` pass

--- a/tickets/0318-guard-execute-agents-against-primary-che.erg
+++ b/tickets/0318-guard-execute-agents-against-primary-che.erg
@@ -7,6 +7,7 @@ Author: Minh Ha-Duong
 2026-07-13T16:55Z Minh Ha-Duong created
 2026-07-13T18:30Z claude note Hardened existing scripts/pretooluse-worktree-path-guard.sh (0171) from advisory to blocking deny (exit 2); added projects/*/memory/** exemption + GUARD_ALLOW_PRIMARY_EDIT escape hatch; extended tests staged red-first. No settings.json change (already wired at Write|Edit|NotebookEdit).
 
+2026-07-13T20:11Z note fixed verify-reroll round-1 blocker: NotebookEdit notebook_path now guarded
 --- body ---
 ## Context
 

--- a/tickets/0323-worktree-path-guard-residuals-realpath-n.erg
+++ b/tickets/0323-worktree-path-guard-residuals-realpath-n.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: Worktree-path guard residuals: realpath normalization and escape-hatch env provenance
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T20:27Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+PR #562 (ticket 0318) hardened `scripts/pretooluse-worktree-path-guard.sh`
+from advisory to deny. The /gaze verdict flagged two non-blocking residuals,
+both pre-existing since the guard's creation (ticket 0171):
+
+1. **No realpath/`..` normalization of `file_path`**: the deny is a string
+   prefix match on git-resolved roots; a symlinked or `..`-laden path into
+   the primary checkout evades it. Unobserved defect class so far (the
+   2026-07-13 raid failures were all plain absolute paths) — close only with
+   a red test demonstrating the evasion first.
+2. **Escape-hatch env provenance**: `GUARD_ALLOW_PRIMARY_EDIT` is documented
+   as human-only (hook env is the CLI's launch env, not a Bash-tool subshell),
+   but a BASH_ENV-style poisoning path was raised at review. Establish
+   whether any agent-writable file feeds the hook's environment; document or
+   close the hole.
+
+## Exit criteria
+
+- [ ] Red test showing a normalized-path or symlink evasion, then fix (or a
+      recorded decision that the class stays out of scope, at the probe site)
+- [ ] Escape-hatch env provenance established and documented in the script
+      header
+- [ ] `make check` and `make lint` pass

--- a/tickets/closed/0318-guard-execute-agents-against-primary-che.erg
+++ b/tickets/closed/0318-guard-execute-agents-against-primary-che.erg
@@ -2,12 +2,14 @@
 Title: Guard execute agents against primary-checkout writes during worktree isolation
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #562
 
 --- log ---
 2026-07-13T16:55Z Minh Ha-Duong created
 2026-07-13T18:30Z claude note Hardened existing scripts/pretooluse-worktree-path-guard.sh (0171) from advisory to blocking deny (exit 2); added projects/*/memory/** exemption + GUARD_ALLOW_PRIMARY_EDIT escape hatch; extended tests staged red-first. No settings.json change (already wired at Write|Edit|NotebookEdit).
 
 2026-07-13T20:11Z note fixed verify-reroll round-1 blocker: NotebookEdit notebook_path now guarded
+2026-07-13T20:29Z Minh Ha-Duong closed — autoclosed — PR #562
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Hardens the existing worktree-path guard from an advisory (exit 0 + stderr) to a blocking deny (exit 2), so a worktree-isolated agent's first Edit/Write can no longer silently land in the primary checkout. In the 2026-07-13 ticket-pipeline raid, 7 of 11 execute agents hit this trap via absolute `~/.claude/...` paths; every one self-recovered at token cost, and escalating prose warnings did not stop the recurrence.

## Key finding — ticket premise was stale

The ticket asks for a *new* PreToolUse `Edit|Write` guard, but `scripts/pretooluse-worktree-path-guard.sh` (ticket 0171) already exists and is already wired in `settings.json` at matcher `Write|Edit|NotebookEdit`. It already resolves worktree identity, cwd-relative `file_path`, and primary/worktree roots. It was merely **advisory**: the deny branch warned then fell through to `exit 0`. So this PR **hardens the existing script** — no new script, no `settings.json` change, no rename.

## Changes

`scripts/pretooluse-worktree-path-guard.sh`:
- Primary-root deny branch now `exit 2` (repo's PreToolUse deny convention) with the corrective message plus a third line naming the escape hatch.
- **Memory exemption** (narrow): `projects/*/memory/*` under the primary checkout is exempt — it is tracked via the primary `.gitignore` whitelist by design and `skills/memory` tells every session to write it directly by absolute path. Not a blanket `projects/*` exemption; a no-op for non-harness projects.
- **Escape hatch**: `GUARD_ALLOW_PRIMARY_EDIT` (exported before session start) bypasses the deny. The hook is CLI-spawned, not a Bash-tool subshell, so an agent cannot set it mid-turn — no self-service bypass.
- Header comment updated: states blocking-deny behavior and ticket 0318.

`tests/test_pretooluse_worktree_path_guard.sh` (auto-discovered, no wiring): extended staged red-first. Added an `_rc` helper (captures exit code, distinguishing deny=2 from advisory-then-allow=0), an rc==2 assertion on primary write, memory-exemption and escape-hatch rc==0 cases, a deny-message content check, and explicit rc==0 assertions on the allow cases (silence no longer implies allowed). 16/16 pass; the original 9 cases stay green.

## Residual gaps (out of scope, flagged not dropped)

- Cross-worktree writes (a worktree writing into a *sibling* worktree) — unobserved defect class, not guarded.
- `realpath`/symlink normalization of `file_path` — a symlinked path into the primary checkout could still evade the prefix match. Unobserved here; the parked-cwd guard (0314) normalizes for a different reason, but this guard does not.

## Verification

- `make check` and `make lint` pass; `/verify-adherence` PASS (no findings).
- Staged TDD: each RED committed before its GREEN implementation.

**Ticket:** tickets/0318-guard-execute-agents-against-primary-che.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related follow-up: tickets/0323 (gaze non-blocking residuals: realpath normalization, escape-hatch env provenance)