### PR TITLE
ticket(0319): carry resolve-$$-to-literal caveat into workflow.md worktree-name table

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -17,7 +17,7 @@ The hook handles worktree entry automatically. When naming the worktree (if prom
 | Active feature branch + open MR | `t{N}-{pid}` | `[→ Execute]` |
 | MR review | `review-{N}` | `[→ Verify]` |
 
-The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel sessions on the same ticket land in distinct worktree paths; legacy bare `t{N}` names remain valid.
+The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel sessions on the same ticket land in distinct worktree paths; legacy bare `t{N}` names remain valid. Resolve `$$` to its literal value with `bash -c 'echo $$'` before calling `EnterWorktree` (its name schema rejects `$` characters), per hunt step 3's recipe.
 
 After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→ Execute]`) so the user sees which Five-Claws claw is active.
 

--- a/tickets/0319-workflow-md-worktree-name-table-carry-th.erg
+++ b/tickets/0319-workflow-md-worktree-name-table-carry-th.erg
@@ -5,6 +5,7 @@ Author: Minh Ha-Duong
 
 --- log ---
 2026-07-13T16:55Z Minh Ha-Duong created
+2026-07-13T17:30Z Minh Ha-Duong note Doc-prose change with no test surface; make check is the verification. Appended resolve-$$-to-literal caveat to workflow.md worktree-name paragraph.
 
 --- body ---
 ## Context
@@ -23,5 +24,5 @@ call site hand-typed from that table reproduces the InputValidationError.
 
 ## Exit criteria
 
-- [ ] workflow.md `{pid}` description carries the caveat
-- [ ] `make check` passes
+- [x] workflow.md `{pid}` description carries the caveat
+- [x] `make check` passes

--- a/tickets/closed/0319-workflow-md-worktree-name-table-carry-th.erg
+++ b/tickets/closed/0319-workflow-md-worktree-name-table-carry-th.erg
@@ -2,11 +2,13 @@
 Title: workflow.md worktree-name table: carry the resolve-$$-to-literal caveat from hunt step 3
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #563
 
 --- log ---
 2026-07-13T16:55Z Minh Ha-Duong created
 2026-07-13T17:30Z Minh Ha-Duong note Doc-prose change with no test surface; make check is the verification. Appended resolve-$$-to-literal caveat to workflow.md worktree-name paragraph.
 
+2026-07-13T20:30Z Minh Ha-Duong closed — autoclosed — PR #563
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`rules/workflow.md:20` described the `{pid}` worktree-name suffix generically as "e.g. `$$`" with no caveat. A call site hand-typed from that table reproduces the `EnterWorktree` `InputValidationError` that ticket 0309 (PR #538) fixed in hunt step 3 — its name schema rejects `$` characters. The /gaze verdict on #538 flagged this sibling.

Appended the resolve-to-literal caveat to the `{pid}` paragraph, pointing at hunt step 3's `bash -c 'echo $$'` recipe.

## Change

Doc-only prose change; no runtime or test surface. Verified no test pins this line (test_hunt_worktree_ownership.py pins skills/hunt/SKILL.md step 3 only, untouched); skills/hunt/SKILL.md is the already-correct source recipe and is unchanged.

Wording of the appended sentence differs slightly from the raid plan's draft: rephrased the em-dash pair to parentheses to satisfy the prose/_all.md one-em-dash-per-paragraph rule flagged as a non-blocking adherence nit. Meaning preserved.

## Verification

- `make check` green (814 passed)
- `/verify-adherence` PASS (mechanical + semantic; the one em-dash nit is fixed)

**Ticket:** tickets/0319-workflow-md-worktree-name-table-carry-th.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)