### PR TITLE
memory: worktree deleted mid-run orphans the session base cwd

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Worktree deleted mid-run orphans the session base cwd](feedback_worktree_deleted_midrun_orphans_cwd.md) — a worktree disappearing under a running session permanently blocks EnterWorktree/cwd-dependent Skill calls; recover via manual `git -C` isolation + delegate skill invocations to isolation:"worktree" subagents (raid-217, PR #564, 2026-07-13)
 - [Pin intervention surface to the measured window](feedback_pin_intervention_surface_to_measured_window.md) — git-log the surface before pinning an A/B intervention; the obvious branch may already implement the treatment during the baseline window, making the flag a no-op or the control a live regression (raid 291-245, 2026-07-13)
 - [Worktree-path trap needs a guard](feedback_worktree_path_trap_needs_guard.md) — prompt warnings failed 7/11 execute agents in one raid; RESOLVED: the 0318 deny guard merged (PR #562, 2026-07-13), spot-check now a fallback; residuals ticketed 0323
 - [Supervisor checkpoint pattern](feedback_supervisor_checkpoint_pattern.md) — the primary supervisor chat orchestrates, never executes tickets; clean checkpoint = monitor worker quiescence (open-PR set + heads hash, 30-min quiet), then merge leftover ready PRs, leave drafts to their owners, prune (author doctrine, 2026-07-13)

--- a/projects/-home-haduong--claude/memory/feedback_worktree_deleted_midrun_orphans_cwd.md
+++ b/projects/-home-haduong--claude/memory/feedback_worktree_deleted_midrun_orphans_cwd.md
@@ -1,0 +1,23 @@
+# Worktree deleted mid-run orphans the session base cwd
+
+A background job whose session base-cwd worktree is DELETED mid-run
+permanently loses `EnterWorktree` and cwd-dependent `Skill` invocations for
+the rest of the session. The parked-cwd guard
+(`scripts/guard-enterworktree-parked-cwd.sh`) denies both from the now-orphaned
+base cwd, and a worktree-identity guard blocks a bare `cd <wt> && git`
+compound as a substitute. There is no way back into a normal skill-driven flow
+from that session once the underlying worktree directory is gone.
+
+Working recovery used in raid-217 (ticket 0217, PR #564, 2026-07-13): drop to
+manual isolation — `git -C <repo> worktree add <path> -b <branch>` — and drive
+every git operation with absolute paths and `git -C`, never a bare `cd`.
+Delegate every skill invocation that still needs cwd-resolution (`hunt`,
+`gaze`, `merge`, `roar`) to `Agent(isolation:"worktree")` subagents: each gets
+its own freshly registered worktree, which the parked-cwd guard exempts,
+letting the skill machinery run normally even though the orchestrating
+session's own cwd is unrecoverable.
+
+Related: `feedback_worktree_path_trap_needs_guard.md` (the guard's origin),
+`feedback_shared_worktree_live_session_contention.md` (a sibling worktree
+hazard). This one is specifically about a worktree *disappearing* out from
+under a running session, not about path confusion between live worktrees.


### PR DESCRIPTION
## Summary
- Records a durable lesson from raid-217 (ticket 0217, PR #564): a worktree deleted mid-run permanently orphans the session base cwd for EnterWorktree/cwd-dependent Skill calls; recovery is manual `git -C` isolation plus delegating skill invocations to isolation:"worktree" subagents.

Ticket: none