### PR TITLE
fix(0324): scope seat-runner stale-ref sweep to tracked files

### DIFF
--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -84,9 +84,12 @@ fi
 # ── reference sweep: the old prototype name is gone outside tickets/ ──────────
 # This suite mentions the old name in its own sweep pattern; exclude it and the
 # append-only ticket history (which keeps the historical name deliberately).
-stale="$(cd "$REPO_ROOT" && grep -rl "seat-runner-prototype" \
-    --include='*.sh' --include='*.md' --include='*.py' --include='*.yml' --include='*.json' . \
-    2>/dev/null | grep -v -e '^\./tickets/' -e 'tests/test_seat_runner.sh' || true)"
+# Scoped to TRACKED files via git grep — immune to nested runtime worktrees
+# and other untracked staging dirs (e.g. leftover .claude/worktrees/ siblings
+# on a primary checkout) that a plain `grep -r .` would wander into.
+stale="$(git -C "$REPO_ROOT" grep -l "seat-runner-prototype" \
+    -- '*.sh' '*.md' '*.py' '*.yml' '*.json' \
+    2>/dev/null | grep -v -e '^tickets/' -e '^tests/test_seat_runner.sh$' || true)"
 if [ -z "$stale" ]; then pass "no seat-runner-prototype refs outside tickets/"; else fail "stale seat-runner-prototype refs: $stale"; fi
 
 # ── tier 2a: timeout behaviour (stubbed podman; no image needed) ─────────────

--- a/tickets/0324-test-seat-runner-sweep-trips-on-nested-r.erg
+++ b/tickets/0324-test-seat-runner-sweep-trips-on-nested-r.erg
@@ -1,0 +1,25 @@
+%erg 0.1
+Title: test_seat_runner sweep trips on nested runtime worktrees
+Created: 2026-07-13
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-13T21:18Z Minh Ha-Duong created
+
+--- body ---
+## Context
+`tests/test_seat_runner.sh`'s "stale seat-runner-prototype refs" sweep
+(lines 84-90) runs `grep -rl "seat-runner-prototype" ... .` over the whole
+working tree. On a primary checkout with leftover sibling worktrees under
+`.claude/worktrees/` (untracked runtime dirs, sometimes containing
+pre-rename copies of tracked files), the sweep trips on paths that were
+never part of the tracked source. It passes in CI and in a fresh PR
+worktree (no nested worktrees present) but fails `make check` on a
+checkout that has sibling worktrees. Reproduced 2026-07-13.
+
+## Exit criteria
+- [ ] Sweep uses `git grep` over tracked files only, not `grep -r` over the
+      working tree
+- [ ] `bash tests/test_seat_runner.sh` passes on a checkout containing a
+      nested worktree stub with old refs
+- [ ] `make check-fast` passes

--- a/tickets/closed/0324-test-seat-runner-sweep-trips-on-nested-r.erg
+++ b/tickets/closed/0324-test-seat-runner-sweep-trips-on-nested-r.erg
@@ -2,10 +2,12 @@
 Title: test_seat_runner sweep trips on nested runtime worktrees
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #567
 
 --- log ---
 2026-07-13T21:18Z Minh Ha-Duong created
 
+2026-07-13T21:33Z Minh Ha-Duong closed — autoclosed — PR #567
 --- body ---
 ## Context
 `tests/test_seat_runner.sh`'s "stale seat-runner-prototype refs" sweep


### PR DESCRIPTION
The "stale seat-runner-prototype refs" sweep in `tests/test_seat_runner.sh` (lines 84-90) used `grep -rl ... .` over the whole working tree, so it tripped on pre-rename copies of the old name found inside untracked nested worktrees under `.claude/worktrees/` — a state that arises on a primary checkout with leftover sibling worktrees. CI and fresh PR worktrees never have nested worktrees present, so the defect passed both there while failing `make check` on the primary checkout (26/27 checks passing, only this sweep failing). The fix scopes the sweep to tracked files via `git grep`, which is immune to untracked runtime directories by construction.

**Ticket:** tickets/0324-test-seat-runner-sweep-trips-on-nested-r.erg