### PR TITLE
memory: pipeline presentation overlays parallel raids

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [Pipeline presentation overlays parallel raids](feedback_pipeline_presentation_overlays_raids.md) — a "ready" ticket may already be claimed by a raid worktree, branch, or open merge request; check worktree list + branch names + open MRs in the same pass and report ready/claimed/blocked lanes (author directive, 2026-07-14)
 - [Worktree deleted mid-run orphans the session base cwd](feedback_worktree_deleted_midrun_orphans_cwd.md) — a worktree disappearing under a running session permanently blocks EnterWorktree/cwd-dependent Skill calls; recover via manual `git -C` isolation + delegate skill invocations to isolation:"worktree" subagents (raid-217, PR #564, 2026-07-13)
 - [Pin intervention surface to the measured window](feedback_pin_intervention_surface_to_measured_window.md) — git-log the surface before pinning an A/B intervention; the obvious branch may already implement the treatment during the baseline window, making the flag a no-op or the control a live regression (raid 291-245, 2026-07-13)
 - [Worktree-path trap needs a guard](feedback_worktree_path_trap_needs_guard.md) — prompt warnings failed 7/11 execute agents in one raid; RESOLVED: the 0318 deny guard merged (PR #562, 2026-07-13), spot-check now a fallback; residuals ticketed 0323

--- a/projects/-home-haduong--claude/memory/feedback_pipeline_presentation_overlays_raids.md
+++ b/projects/-home-haduong--claude/memory/feedback_pipeline_presentation_overlays_raids.md
@@ -1,0 +1,21 @@
+---
+name: feedback-pipeline-presentation-overlays-raids
+description: When presenting a ticket pipeline, overlay what parallel instances are raiding — worktrees, branches, open PRs — so claimed tickets aren't shown as available
+metadata:
+  type: feedback
+---
+
+When asked to present the ticket pipeline, the `erg ready`/`erg list` view is
+incomplete: overlay live parallel-instance activity before calling a ticket
+available (author directive, 2026-07-14).
+
+**Why:** a ticket can be "ready" in the DAG while a raid worktree or open PR
+has already claimed it; presenting it as free invites a duplicate claim —
+the same optimistic-allocation trap as ticket IDs.
+
+**How to apply:** after the erg queries, in the same pass run
+`git worktree list` (raid-N-M and tN-* names encode claims), scan branch
+names and open merge requests for ticket IDs, and check worktree recency
+(mtime, commits ahead, dirty state) to separate live claims from stale
+leftovers. Report three lanes: ready-and-unclaimed, claimed-in-flight,
+blocked/parked. Related: [[feedback_shared_worktree_live_session_contention]].


### PR DESCRIPTION
Feedback memory from the author (2026-07-14): when presenting the ticket pipeline, overlay what parallel instances are raiding — worktree list, branch names, open merge requests — so claimed tickets are not shown as available. Adds the entry file and its MEMORY.md index line.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)