### PR TITLE
ticket(0325): worktree-gc husk detection + memory update

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_worktree_deleted_midrun_orphans_cwd.md
+++ b/projects/-home-haduong--claude/memory/feedback_worktree_deleted_midrun_orphans_cwd.md
@@ -21,3 +21,12 @@ Related: `feedback_worktree_path_trap_needs_guard.md` (the guard's origin),
 `feedback_shared_worktree_live_session_contention.md` (a sibling worktree
 hazard). This one is specifically about a worktree *disappearing* out from
 under a running session, not about path confusion between live worktrees.
+
+Re-confirmed 2026-07-14 (session a645ef77): the removed worktree's path can
+persist as an empty husk directory that resolves into the PRIMARY repo, not a
+worktree, once deregistered. The parked-cwd guard then denies `EnterWorktree`
+(by design) and the worktree-identity guard blocks every non-`git -C`
+mutation from that path. Recovery is unchanged — `git -C <primary> worktree
+add` for manual isolation, plus delegating committable work and skill
+invocations to `Agent(isolation:"worktree")` subagents. Husk detection/cleanup
+in `worktree-gc` is ticketed as tickets/0325.

--- a/tickets/0325-worktree-gc-detect-unregistered-husk-dir.erg
+++ b/tickets/0325-worktree-gc-detect-unregistered-husk-dir.erg
@@ -1,0 +1,50 @@
+%erg 0.1
+Title: worktree-gc: detect unregistered husk dirs under .claude/worktrees
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T05:16Z Minh Ha-Duong created
+
+--- body ---
+## Context
+On 2026-07-14, session a645ef77 found its base worktree
+`.claude/worktrees/explore-ticket-pipeline` deregistered mid-session, with an
+empty husk directory left behind at the path (containing only an empty
+`.claude/` scratch subdir, likely recreated by the harness to keep the shell
+cwd alive). git commands run inside the husk resolve to the PRIMARY repo, so:
+the parked-cwd guard (`scripts/guard-enterworktree-parked-cwd.sh`) correctly
+denies `EnterWorktree` and cwd-dependent `Skill` calls, and the
+worktree-identity guard (`scripts/guard-worktree-identity.sh`) blocks every
+non-`git -C` mutating Bash command — the session permanently loses its skill
+surface. `scripts/worktree-gc.sh` iterates only REGISTERED worktrees (`git
+worktree list`), so husks are invisible to it and accumulate.
+
+## Relevant files
+- `scripts/worktree-gc.sh` — only sees registered worktrees
+- `scripts/guard-worktree-identity.sh` — the guard whose I1 fall-through message fires in a husk
+- `tickets/0267-*.erg`, `tickets/0306-*.erg`, `tickets/0317-*.erg` — prior parked-cwd work (reference only)
+
+## Actions
+1. Extend worktree-gc.sh: after the registered-worktree pass, list dirs under
+   `.claude/worktrees/` absent from `git worktree list --porcelain`; report
+   each husk found.
+2. Remove a husk only when it is safe: empty of real content (only empty
+   scratch subdirs). NEVER remove a husk that may be a live session's base
+   cwd — the harness resets the shell cwd there after every Bash call, so
+   deletion breaks the session. Safe heuristic to design: report-only by
+   default, or age/mtime threshold.
+
+## Test
+- Red-first: a test creating a fake husk dir under a temp repo's
+  `.claude/worktrees/` and asserting worktree-gc reports it.
+
+## Invariants
+- gc must never remove a registered worktree with uncommitted changes
+  (existing behavior), and never the tree it runs from.
+
+## Exit criteria
+- [ ] worktree-gc.sh detects and reports unregistered husk dirs
+- [ ] Removal (if implemented) is provably safe for live-session base cwds
+- [ ] Test covers husk detection
+- [ ] `make check` passes


### PR DESCRIPTION
## Summary
- Files ticket 0325: extend worktree-gc.sh to detect unregistered husk
  directories under .claude/worktrees (a deregistered worktree can leave
  behind an empty directory that resolves into the primary repo, silently
  defeating the parked-cwd and worktree-identity guards' recovery path).
- Updates the existing feedback memory
  (feedback_worktree_deleted_midrun_orphans_cwd.md) with the re-confirmed
  incident and a pointer to the new ticket.

No code changes — ticket + memory filing only.

Ticket: none
Related follow-up: tickets/0325