### PR TITLE
fix(0322): extend agnostic gate to scripts/ dir

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check for consumer-project assumptions in skills and tickets
+      - name: Check for consumer-project assumptions in skills, tickets, and scripts
         run: bash scripts/check-agnostic.sh
       - name: Self-test — script must catch a deliberate violation
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check check-fast check-tests lint
+.PHONY: skills-catalog check-skills-drift check-agnostic-tickets check-agnostic-skills check-agnostic-scripts check check-fast check-tests lint
 
 skills-catalog:
 	./scripts/update-skills-catalog.py
@@ -25,8 +25,11 @@ check-agnostic-tickets:
 check-agnostic-skills:
 	./scripts/check-agnostic.sh skills
 
+check-agnostic-scripts:
+	./scripts/check-agnostic.sh scripts
+
 # Full gate (coding-python.md): the whole suite, integration + slow included.
 check-tests:
 	python3 -m pytest tests/
 
-check: check-skills-drift check-agnostic-tickets check-agnostic-skills check-tests
+check: check-skills-drift check-agnostic-tickets check-agnostic-skills check-agnostic-scripts check-tests

--- a/scripts/beat-settings.json
+++ b/scripts/beat-settings.json
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/home/haduong/.claude/scripts/guard-destructive-bash.sh",
+            "command": "$HOME/.claude/scripts/guard-destructive-bash.sh",
             "timeout": 5
           }
         ]

--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 if [ $# -eq 0 ]; then
-    DIRS=(skills tickets)
+    DIRS=(skills tickets scripts)
 else
     DIRS=("$@")
 fi

--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect consumer-project assumptions in harness skills and tickets.
-# Usage: check-agnostic.sh [dir ...]   (default: skills tickets)
+# Usage: check-agnostic.sh [dir ...]   (default: skills tickets scripts)
 # Escape hatch: add  <!-- harness-extension-point -->  on the same or preceding line,
 # or (for a `\`-continued multi-line command) on any of its continuation lines.
 # `closed/` subdirs are skipped — closed tickets are frozen archives, not amended.

--- a/scripts/check-agnostic.sh
+++ b/scripts/check-agnostic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Detect consumer-project assumptions in harness skills and tickets.
+# Detect consumer-project assumptions in harness skills, tickets, and scripts.
 # Usage: check-agnostic.sh [dir ...]   (default: skills tickets scripts)
 # Escape hatch: add  <!-- harness-extension-point -->  on the same or preceding line,
 # or (for a `\`-continued multi-line command) on any of its continuation lines.
@@ -12,7 +12,7 @@ else
     DIRS=("$@")
 fi
 
-# Patterns checked everywhere (skills + tickets).
+# Patterns checked everywhere (skills + tickets + scripts).
 # Use class-level patterns — never hardcode a specific username, path, or project name.
 GLOBAL_PATTERNS=(
     '/home/[a-z]'   # any absolute home path (use ~/.claude or $HOME instead)

--- a/scripts/trace-path-scan.py
+++ b/scripts/trace-path-scan.py
@@ -65,7 +65,7 @@ WORKTREE_RE = re.compile(r"/worktrees/([^/]+)")
 
 # A path-like token inside a Bash command: a run starting with / or ~ (absolute
 # or home-relative), bounded on the left by start-of-string, whitespace, a quote,
-# or `=` — so `cat "~/.ssh/id_rsa"` and `FILE=/home/u/.aws/creds` are caught, not
+# or `=` — so `cat "~/.ssh/id_rsa"` and `FILE=/root/.aws/creds` are caught, not
 # only the bare `cat ~/.aws/credentials` form. Good enough without a full shell
 # parse; the classifier is narrow enough that an over-matched token is harmless.
 BASH_PATH_RE = re.compile(r"(?:^|(?<=[\s\"'=]))([~/][^\s'\"|;&><]*)")

--- a/tests/test_check_agnostic.py
+++ b/tests/test_check_agnostic.py
@@ -149,6 +149,46 @@ UNMARKED_MULTILINE = (
 )
 
 
+# --- scripts/ dir coverage (ticket 0322) ---
+#
+# The default scan (no args, as CI runs it) must include scripts/, so a
+# hardcoded home path in a shell/python helper is caught mechanically instead
+# of only in human review. SKILL_PATTERNS must NOT fire in scripts/, which
+# legitimately use gh/uv/repo-relative script paths.
+
+
+def test_real_scripts_dir_is_agnostic():
+    """The actual scripts/ tree passes the agnostic gate (ticket 0322)."""
+    result = _run(SCRIPT.parent)
+    assert result.returncode == 0, result.stdout
+
+
+def test_default_no_arg_scan_includes_scripts_dir(tmp_path):
+    """No-arg invocation (as CI runs it) must scan a scripts/ subdir."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "helper.sh").write_text("HOMEDIR=/home/someone/.claude\n")
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, result.stdout
+    assert "VIOLATION" in result.stdout
+
+
+def test_skill_patterns_do_not_fire_in_scripts_dir(tmp_path):
+    """gh/uv/repo-relative script tokens are legal in scripts/ — no false fire."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "helper.sh").write_text(
+        "gh pr view 5\nuv run pytest\n./scripts/other.sh\n"
+    )
+    result = _run(scripts)
+    assert result.returncode == 0, result.stdout
+
+
 def test_marker_on_continuation_line_exempts_command(tmp_path):
     """A marker on the command's closing continuation line exempts the whole command."""
     d = _skill_dir(tmp_path)

--- a/tests/test_check_agnostic.py
+++ b/tests/test_check_agnostic.py
@@ -34,6 +34,16 @@ def _run(target):
     )
 
 
+def _run_no_args(cwd):
+    """Invoke the gate with no dir args (as CI does), from the given cwd."""
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_fails_on_hardcoded_home_path(tmp_path):
     (tmp_path / "0001-bad.erg").write_text(BAD_TICKET)
     result = _run(tmp_path)
@@ -168,12 +178,7 @@ def test_default_no_arg_scan_includes_scripts_dir(tmp_path):
     scripts = tmp_path / "scripts"
     scripts.mkdir()
     (scripts / "helper.sh").write_text("HOMEDIR=/home/someone/.claude\n")
-    result = subprocess.run(
-        ["bash", str(SCRIPT)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_no_args(tmp_path)
     assert result.returncode != 0, result.stdout
     assert "VIOLATION" in result.stdout
 

--- a/tests/test_makefile_gates.py
+++ b/tests/test_makefile_gates.py
@@ -34,7 +34,12 @@ def test_check_runs_full_pytest_suite():
 
 def test_check_keeps_static_checks():
     deps = target_recipe("check").splitlines()[0]
-    for dep in ("check-skills-drift", "check-agnostic-tickets", "check-agnostic-skills"):
+    for dep in (
+        "check-skills-drift",
+        "check-agnostic-tickets",
+        "check-agnostic-skills",
+        "check-agnostic-scripts",
+    ):
         assert dep in deps, f"'check' lost its static prerequisite {dep}"
 
 

--- a/tickets/closed/0322-extend-agnostic-gate-to-scripts-dir.erg
+++ b/tickets/closed/0322-extend-agnostic-gate-to-scripts-dir.erg
@@ -2,10 +2,12 @@
 Title: Extend agnostic gate to scripts/ dir
 Created: 2026-07-13
 Author: claude
+Closed: autoclosed — PR #570
 
 --- log ---
 2026-07-13T20:08Z claude created
 
+2026-07-14T05:59Z Minh Ha-Duong closed — autoclosed — PR #570
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Extends the mechanical agnostic gate to cover `scripts/`. The default scan (`skills tickets`, as CI's `agnostic-guard` runs it) never covered `scripts/`, so a hardcoded home path in a shell/python helper escaped every mechanical gate — caught only in human review (the 0217 seat-runner `HOMEDIR` regression). This closes the gap.

## Changes

- `scripts/check-agnostic.sh`: default `DIRS` now `(skills tickets scripts)`. The existing `case "$dir" in skills*|*/skills*)` gate keeps SKILL_PATTERNS (`gh`, `uv run`, repo-relative script paths) out of `scripts/`, which legitimately uses them.
- `scripts/beat-settings.json`: hardcoded `/home/haduong/...guard-destructive-bash.sh` → `$HOME/...`. The live `settings.json` runs the identical guard via `$HOME` (all command entries use it), and nothing parses this file's content (`beat.py` passes only the path) — the ticket's flagged blocker is genuinely settled.
- `scripts/trace-path-scan.py`: doc-comment example `/home/u/.aws/creds` → `/root/.aws/creds`, preserving the unquoted-absolute-path form the docstring illustrates.
- `Makefile`: new `check-agnostic-scripts` target, added to `.PHONY` and the `check:` dependency list, for local parity with CI.
- Tests: three new regression tests in `test_check_agnostic.py` (real `scripts/` clean; no-arg scan includes `scripts/`; skill-only tokens ignored in `scripts/`) and `check-agnostic-scripts` pinned in `test_makefile_gates.py`.

## Verification

- No-arg `bash scripts/check-agnostic.sh` exits 0.
- `tests/test_check_agnostic.py` + `tests/test_makefile_gates.py`: 16 passed.
- `/verify-adherence`: PASS (all mechanical phases; no semantic residue).

TDD: `test_real_scripts_dir_is_agnostic` written first, RED on the unfixed tree with exactly 2 violations (beat-settings.json:25, trace-path-scan.py:68).

**Ticket:** tickets/0322-extend-agnostic-gate-to-scripts-dir.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)