### PR TITLE
feat(0321): codify gaze fork-liveness window + verify-gate fallback

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -65,7 +65,7 @@ sub-agent's.
 narration with no `## /verify-gate verdict` block (APPROVED/REROLL/ESCALATE),
 treat it as a non-result: do **not** relaunch the reviewer battery. Wait for
 the background reviewer notifications, then run `/verify-gate <pr>
-worktree=$primary_root/.claude/worktrees/review-<pr>` directly to produce the verdict from their outputs.
+worktree=$primary_root/.claude/worktrees/review-<pr-number>` directly to produce the verdict from their outputs.
 
 **Fork liveness.** Once the phase 2–4 review comment has posted on the PR, the
 caller must see either the phase-6 verdict comment or a bump log line within
@@ -79,9 +79,9 @@ commit, no verdict, review worktree mtime frozen).
 
 **On window expiry, do not re-run phases 2–5.** Check three completion markers:
 (1) a posted verdict comment, (2) branch-tip motion on the PR branch, (3) the
-review worktree's file mtime. All stale/absent → invoke `/verify-gate
-<pr-number> worktree=$primary_root/.claude/worktrees/review-<pr>` directly (the
-same invocation form Caller-side recovery uses) and continue the normal round
+review worktree's file mtime. All stale/absent → invoke `/verify-gate`
+directly, with the same invocation form as **Caller-side recovery** above
+(one recipe, stated once), and continue the normal round
 flow from its verdict; log a bump line on the ticket. The fallback skips only
 the redundant phase 2–5 re-execution — verify-gate runs at full rigor and the
 two-round cap is unaffected.

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -67,6 +67,25 @@ treat it as a non-result: do **not** relaunch the reviewer battery. Wait for
 the background reviewer notifications, then run `/verify-gate <pr>
 worktree=$primary_root/.claude/worktrees/review-<pr>` directly to produce the verdict from their outputs.
 
+**Fork liveness.** Once the phase 2–4 review comment has posted on the PR, the
+caller must see either the phase-6 verdict comment or a bump log line within
+`fork_liveness_seconds` (`skills/gaze/telemetry.yml`, env override
+`GAZE_LIVENESS_WINDOW_S`; default 1200s / ~20 min) — same knob pattern as the
+wall/token thresholds in § Telemetry. Two independent stalls landed in exactly
+this window, both silent: 2026-07-11 (memory
+`feedback_agent_stall_watchdog_recovery`) and 2026-07-13 (raid 291-245, PR
+#551, where the review comment posted, then ~30 min of quiet: no simplify
+commit, no verdict, review worktree mtime frozen).
+
+**On window expiry, do not re-run phases 2–5.** Check three completion markers:
+(1) a posted verdict comment, (2) branch-tip motion on the PR branch, (3) the
+review worktree's file mtime. All stale/absent → invoke `/verify-gate
+<pr-number> worktree=$primary_root/.claude/worktrees/review-<pr>` directly (the
+same invocation form Caller-side recovery uses) and continue the normal round
+flow from its verdict; log a bump line on the ticket. The fallback skips only
+the redundant phase 2–5 re-execution — verify-gate runs at full rigor and the
+two-round cap is unaffected.
+
 ## Phases
 
 ### 1. Setup
@@ -346,10 +365,14 @@ for missing), `cost~=` (best-effort USD, `na` if incomplete).
 ### Thresholds
 
 Read from `skills/gaze/telemetry.yml`; env vars override. Defaults:
-wall warn=15min escalate=30min; tokens warn=500k escalate=1M.
+wall warn=15min escalate=30min; tokens warn=500k escalate=1M; fork liveness
+window=20min (monitored by the caller, not checked at internal phase
+boundaries).
 
 On warn: post `/gaze: slow run` comment, continue. On escalate: stop, post
-`/gaze stopped:` with measured value. Escalate > warn. Check at phase boundaries only.
+`/gaze stopped:` with measured value. Escalate > warn. Check at phase boundaries
+only — except fork liveness, which a silent fork cannot self-check, so the
+caller monitors it (§ Fork execution contract).
 
 ## Convergence mode (ticket 0315, measure-B pre-registration)
 

--- a/skills/gaze/telemetry.yml
+++ b/skills/gaze/telemetry.yml
@@ -18,11 +18,8 @@ tokens:
 convergence:
   enabled: false
 
-# Fork liveness window (ticket 0321). After the phase 2–4 review comment posts,
-# the CALLER — not an internal phase boundary — must see the verdict comment or
-# a bump log line within this window; a silent fork cannot self-check. On expiry
-# the caller drives /verify-gate directly (see gaze SKILL.md § Fork execution
-# contract).
+# Fork liveness window (ticket 0321), caller-monitored — see gaze SKILL.md
+# § Fork execution contract.
 fork_liveness_seconds: 1200  # ~20 min
 
 env:

--- a/skills/gaze/telemetry.yml
+++ b/skills/gaze/telemetry.yml
@@ -18,9 +18,17 @@ tokens:
 convergence:
   enabled: false
 
+# Fork liveness window (ticket 0321). After the phase 2–4 review comment posts,
+# the CALLER — not an internal phase boundary — must see the verdict comment or
+# a bump log line within this window; a silent fork cannot self-check. On expiry
+# the caller drives /verify-gate directly (see gaze SKILL.md § Fork execution
+# contract).
+fork_liveness_seconds: 1200  # ~20 min
+
 env:
   wall_seconds_warn:      VERIFY_WALL_WARN_S
   wall_seconds_escalate:  VERIFY_WALL_ESCALATE_S
   tokens_warn:            VERIFY_TOKENS_WARN
   tokens_escalate:        VERIFY_TOKENS_ESCALATE
   convergence_enabled:    GAZE_CONVERGENCE_ENABLED
+  fork_liveness_seconds:  GAZE_LIVENESS_WINDOW_S

--- a/tests/test_verify_fork_contracts.py
+++ b/tests/test_verify_fork_contracts.py
@@ -16,6 +16,7 @@ REPO = Path(__file__).resolve().parent.parent
 SKILLS = REPO / "skills"
 
 VERIFY = (SKILLS / "gaze" / "SKILL.md").read_text()
+TELEMETRY = (SKILLS / "gaze" / "telemetry.yml").read_text()
 ERG_PR_MERGE = (SKILLS / "merge" / "erg-pr-merge").read_text()
 
 
@@ -135,6 +136,51 @@ def test_gaze_only_reroll_fix_agent_gets_isolation():
     # The sole grant lives in the REROLL fix-agent line.
     assert 'spawn a fix subagent with `isolation: "worktree"`' in norm, (
         "gaze/SKILL.md: the REROLL fix-agent isolation grant changed or was removed"
+    )
+
+
+def test_gaze_documents_fork_liveness_window():
+    """A silent fork stalls between the review comment and the verdict (twice
+    seen: 2026-07-11, 2026-07-13). The caller-monitored liveness window must be
+    documented in SKILL.md and carried as a knob in telemetry.yml — prose and
+    knob must not drift apart (ticket 0321)."""
+    assert "Fork liveness" in VERIFY, (
+        "gaze/SKILL.md: missing the 'Fork liveness' clause"
+    )
+    assert "fork_liveness_seconds" in VERIFY, (
+        "gaze/SKILL.md: does not name the fork_liveness_seconds knob"
+    )
+    assert "fork_liveness_seconds" in TELEMETRY, (
+        "telemetry.yml: missing the fork_liveness_seconds knob"
+    )
+    assert "GAZE_LIVENESS_WINDOW_S" in VERIFY, (
+        "gaze/SKILL.md: does not name the GAZE_LIVENESS_WINDOW_S env override"
+    )
+    assert "GAZE_LIVENESS_WINDOW_S" in TELEMETRY, (
+        "telemetry.yml: missing the GAZE_LIVENESS_WINDOW_S env override"
+    )
+
+
+def test_gaze_liveness_fallback_names_verify_gate_not_a_rerun():
+    """On window expiry the fallback must skip re-running phases 2–5, drive
+    /verify-gate directly, and key off the three completion markers (verdict
+    comment, branch-tip motion, review-worktree mtime) — never relax the gate
+    (ticket 0321)."""
+    norm = _normalize(VERIFY)
+    assert "do not re-run phases 2–5" in norm.lower(), (
+        "gaze/SKILL.md: liveness fallback does not forbid re-running phases 2–5"
+    )
+    assert "/verify-gate" in norm, (
+        "gaze/SKILL.md: liveness fallback does not name the direct /verify-gate call"
+    )
+    assert "verdict comment" in norm, (
+        "gaze/SKILL.md: liveness fallback omits the verdict-comment marker"
+    )
+    assert "branch-tip" in norm, (
+        "gaze/SKILL.md: liveness fallback omits the branch-tip-motion marker"
+    )
+    assert "mtime" in norm, (
+        "gaze/SKILL.md: liveness fallback omits the review-worktree mtime marker"
     )
 
 

--- a/tickets/0321-gaze-fork-liveness-contract-bounded-wind.erg
+++ b/tickets/0321-gaze-fork-liveness-contract-bounded-wind.erg
@@ -6,6 +6,8 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T19:36Z Minh Ha-Duong created
 
+2026-07-14T05:20Z claude note RED: fork-liveness window and fallback tests fail on pre-fix SKILL.md/telemetry.yml before edits
+2026-07-14T05:21Z claude note GREEN: both new tests pass after SKILL.md + telemetry.yml edits (12 passed); YAML validates
 --- body ---
 ## Context
 

--- a/tickets/0327-supersede-feedback-agent-stall-watchdog.erg
+++ b/tickets/0327-supersede-feedback-agent-stall-watchdog.erg
@@ -1,0 +1,46 @@
+%erg 0.1
+Title: supersede feedback_agent_stall_watchdog_recovery tactical content — fork-liveness now codified in gaze SKILL.md
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T05:24Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Ticket 0321 codified the gaze fork-liveness window (`fork_liveness_seconds`,
+default 1200s, env override `GAZE_LIVENESS_WINDOW_S`) and the direct
+verify-gate fallback in `skills/gaze/SKILL.md` § Fork execution contract, with
+adherence tests pinning both. The memory entry
+`feedback_agent_stall_watchdog_recovery` still carries the tactical detection
+and recovery steps (branch-tip / worktree-mtime / verdict-comment markers, the
+"do not re-run the panel, drive /verify-gate" recipe) as tribal knowledge. Now
+that the skill owns that contract, the memory duplicate can drift from it.
+
+## Actions
+
+1. Trim the tactical detection/recovery detail from the memory entry
+   `feedback_agent_stall_watchdog_recovery` to a short pointer at the gaze
+   SKILL.md § Fork execution contract "Fork liveness" clause (the codified
+   window + fallback).
+2. Keep only what the skill does not capture: the historical incident record
+   and any cross-cutting lesson beyond gaze's own contract.
+
+## Invariants
+
+- Do not edit the memory entry as part of ticket 0321's PR — that PR touches
+  the skill + tests only. The memory trim is this ticket's sole change.
+
+## Exit criteria
+
+- [ ] `feedback_agent_stall_watchdog_recovery` points at the gaze SKILL.md
+      liveness clause instead of restating the detection/recovery steps
+- [ ] No detail contradicts the codified contract
+
+## Dependency
+
+Actionable once tickets/0321-gaze-fork-liveness-contract-bounded-wind.erg
+merges (the skill clause this ticket points the memory at). No hard
+`Blocked-by` header — the memory edit is safe to do independently of 0321's
+review.

--- a/tickets/closed/0321-gaze-fork-liveness-contract-bounded-wind.erg
+++ b/tickets/closed/0321-gaze-fork-liveness-contract-bounded-wind.erg
@@ -2,12 +2,14 @@
 Title: gaze fork-liveness contract: bounded window from review comment to verdict, with direct verify-gate fallback
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #571
 
 --- log ---
 2026-07-13T19:36Z Minh Ha-Duong created
 
 2026-07-14T05:20Z claude note RED: fork-liveness window and fallback tests fail on pre-fix SKILL.md/telemetry.yml before edits
 2026-07-14T05:21Z claude note GREEN: both new tests pass after SKILL.md + telemetry.yml edits (12 passed); YAML validates
+2026-07-14T05:47Z Minh Ha-Duong closed — autoclosed — PR #571
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Codify the twice-seen /gaze fork-stall failure class and its proven recovery, which until now lived only in a memory entry.

A /gaze fork went silent between posting its review comment and its verdict comment — no error surfaced to the caller — on 2026-07-11 and again 2026-07-13 (raid 291-245, PR #551). The recovery that worked both times: do not re-run the panel, drive `/verify-gate` directly, continue the normal round flow. This PR moves detection and the caller instruction into the skill.

## Changes

- **`skills/gaze/SKILL.md` § Fork execution contract** — new "Fork liveness" clause: after the phase 2–4 review comment posts, the caller must see the verdict comment or a bump log line within `fork_liveness_seconds` (default 1200s / ~20 min, env override `GAZE_LIVENESS_WINDOW_S`). On expiry, check three completion markers (verdict comment, branch-tip motion, review-worktree mtime), then invoke `/verify-gate` directly. The fallback skips only the redundant phase 2–5 re-run; verify-gate keeps full rigor and the two-round cap is unaffected.
- **`skills/gaze/SKILL.md` § Telemetry** — the liveness window is caller-monitored, not checked at internal phase boundaries (a silent fork cannot self-check).
- **`skills/gaze/telemetry.yml`** — new `fork_liveness_seconds` knob + `GAZE_LIVENESS_WINDOW_S` env mapping, same pattern as the wall/token thresholds.
- **`tests/test_verify_fork_contracts.py`** — two new adherence tests pinning the window (prose/knob drift check across SKILL.md + telemetry.yml) and the fallback wording (forbids phase 2–5 re-run, names `/verify-gate`, lists the three markers). RED on the pre-fix state, green after.

## Invariants held

- No behavior change to gaze's phases — caller-facing contract text + one knob + tests.
- The fallback never relaxes the gate: verify-gate runs at full rigor, rounds capped at 2.

## Tests

`make check` exits 0 (full suite). New fork-contract tests RED before edits, green after. `/verify-adherence` PASS.

Related follow-up: tickets/0327-supersede-feedback-agent-stall-watchdog.erg

**Ticket:** tickets/0321-gaze-fork-liveness-contract-bounded-wind.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)