### PR TITLE
feat(0320): graduated reviewer-battery tiers in /gaze

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -104,7 +104,16 @@ git worktree remove "$primary_root/.claude/worktrees/review-<pr-number>" --force
   - PR body, full diff, all existing review comments, all inline comments, all commit
     messages on the branch.
 - Check CI status for the merge request if the forge exposes it. If the forge CLI or API is unavailable, skip gracefully — CI status is informational only. If checks are configured and any are failing, note this in the setup summary; do not block on it (reviewer decides).
-- Compute PR size: `git diff origin/main...HEAD --stat` → `pr_lines` (total insertions + deletions) and `pr_files` (files changed). A PR is **small** if `pr_lines ≤ 20` and `pr_files ≤ 2` and this is round 1.
+- Compute PR size: `git diff origin/main...HEAD --stat` → `pr_lines` (total insertions + deletions) and `pr_files` (files changed). Classify the battery **tier**:
+  - **tiny** — `pr_lines ≤ 20` and `pr_files ≤ 2` and this is round 1.
+  - **small** — `pr_lines ≤ 150` and `pr_files ≤ 5` and this is round 1 (and not already tiny).
+  - **full** — everything else, **and unconditionally any round ≥ 2**: a REROLL escalates to the full battery regardless of diff size — #562's round-2 needed the full battery on an unchanged diff. The round-2 override wins over any size test.
+
+  The tier selects which reviewer agents run (see §§ 2–4, 5); phase 6 (`/verify-gate`) is **invariant** — it runs at every tier, never reduced. Per-tier battery:
+  - **tiny** → Agent A (adherence) + phase 6 gate only. Skip Agent B (`/review`), Agent C (`/review-pr`), and phase 5 (`/simplify`) — each skip logged like the existing `review-pr: skipped (…)` line.
+  - **small** → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate. Agent C runs with the reduced "correctness only" perspective set (trivial risk, § 2–4) instead of the full five-perspective panel.
+  - **full** → the complete battery below, unchanged.
+  Carry the resolved `tier` into the telemetry footer and the output-shape template (see § Telemetry, § Output shape).
 - If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
 
 ### 2–4. Read-only review fan-out (parallel)
@@ -168,7 +177,9 @@ ruff, emit one non-blocking `untested_rules` entry. (4) Only if a
 (each with `severity: blocking|nit`), and `untested_rules`. The orchestrator's
 early-exit reads `adherence` and the count of `blocking` findings.
 
-**Agent B — built-in review** (`/review`). This is a built-in slash command
+**Agent B — built-in review** (`/review`). **Tier-skip:** skip this agent when
+the tier is **tiny** and log `review: skipped (tier: tiny)` in the setup
+summary; it runs on the **small** and **full** tiers. This is a built-in slash command
 whose procedure cannot be embedded as text, so it is **Agent-WRAPped, not
 embedded**: spawn a read-only Agent, cwd pinned to `$primary_root/.claude/worktrees/review-<pr-number>`,
 same containment rails, whose prompt simply invokes `/review` on the PR and
@@ -178,9 +189,12 @@ and would be Agent-WRAPped the same way when converted.)
 
 **Agent C — PR review** (`/review-pr <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`
 or `/review-pr-prose <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`).
-**Size-gate:** skip this agent if the PR is small (as computed in phase 1) and
-log `review-pr: skipped (size-gate: <pr_lines> lines, <pr_files> files)` in the
-setup summary. Otherwise pick by file type: if any `*.qmd` changed → prose
+**Tier-gate:** skip this agent when the tier is **tiny** and log
+`review-pr: skipped (tier: tiny, <pr_lines> lines, <pr_files> files)` in the
+setup summary. When the tier is **small**, run it with the reduced **correctness
+only** perspective set (the `trivial` risk band below) regardless of the risk
+assessment. When the tier is **full**, run the full proportional panel as
+assessed. Otherwise pick by file type: if any `*.qmd` changed → prose
 panel; else code panel. Spawn a read-only Agent, cwd `$primary_root/.claude/worktrees/review-<pr-number>`,
 whose embedded procedure is: read the linked ticket's exit criteria and the
 diff, assess risk, and run the proportional perspective set in parallel —
@@ -209,7 +223,9 @@ Wait for all spawned agents to complete. Collect their structured outputs.
 
 ### 5. Simplify (sequential)
 
-After 2–4 land their comments (and the early-exit check passes), run `/simplify <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`. This phase may commit fixes
+**Tier-skip:** when the tier is **tiny**, skip this phase and log
+`simplify: skipped (tier: tiny)` in the telemetry phase line; it runs on the
+**small** and **full** tiers. Otherwise, after 2–4 land their comments (and the early-exit check passes), run `/simplify <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`. This phase may commit fixes
 to the PR branch. Wait for its fixes (if any) to land before the gate reads state.
 
 ### 6. Gate (the non-rubber-stamp step)
@@ -338,10 +354,11 @@ Each phase emits start/end lines: `[verify] phase=<name> start=<ISO> / end=<ISO>
 
 ### Verdict footer (PR comment)
 
-Appended to verdict comment: `telemetry: wall=<s>s agents=<n> tokens=<in+out> cost~=$<usd>`
+Appended to verdict comment: `telemetry: tier=<tiny|small|full> wall=<s>s agents=<n> tokens=<in+out> cost~=$<usd>`
 
-Fields: `wall` (phase-1 to verdict), `agents` (sub-agent count), `tokens` (sum, use `na`
-for missing), `cost~=` (best-effort USD, `na` if incomplete).
+Fields: `tier` (battery tier from phase 1 — `tiny|small|full`), `wall` (phase-1 to
+verdict), `agents` (sub-agent count), `tokens` (sum, use `na` for missing),
+`cost~=` (best-effort USD, `na` if incomplete).
 
 ### Thresholds
 
@@ -413,9 +430,11 @@ final report is the signal.
 ## /gaze actions
 
 round: <n>
+tier: tiny|small|full
 adherence: PASS|FAIL — <n_blocking> blocking
-review-pr: <n_comments_posted> | skipped (size-gate) | skipped (adherence blocking)
-simplify: <n_fixes_applied> | skipped (adherence blocking)
+review: <n_comments_posted> | skipped (tier: tiny)
+review-pr: <n_comments_posted> | skipped (tier: tiny) | skipped (adherence blocking)
+simplify: <n_fixes_applied> | skipped (tier: tiny) | skipped (adherence blocking)
 fix agent: <n_commits> commits (round 2 only, omit if round 1)
 
 ## /verify-gate verdict
@@ -433,7 +452,7 @@ Adherence: PASS | FAIL (<count>)
 Rationale:
 <paragraph>
 
-telemetry: wall=<seconds>s agents=<n> tokens=<in+out> cost~=$<usd>
+telemetry: tier=<tiny|small|full> wall=<seconds>s agents=<n> tokens=<in+out> cost~=$<usd>
 ```
 
 On `--force-approve`, Part A is annotated `FORCE-APPROVED by <reason>`

--- a/tests/test_verify_fork_contracts.py
+++ b/tests/test_verify_fork_contracts.py
@@ -138,6 +138,39 @@ def test_gaze_only_reroll_fix_agent_gets_isolation():
     )
 
 
+def test_gaze_tier_recorded_in_telemetry_and_output_shape():
+    """The graduated battery tier (ticket 0320) must be auditable: the per-run
+    tier has to surface in BOTH the verdict-footer telemetry template and the
+    `## /gaze actions` output-shape template, so a reviewer can read which
+    battery ran from the posted comment. We assert the token in each rendered
+    template, not the tier-definition prose — the prose can be reworded, but the
+    machine-visible telemetry field is the contract."""
+    # 1. Verdict-footer template — the section under "### Verdict footer".
+    _, _, footer_after = VERIFY.partition("### Verdict footer")
+    assert footer_after, "gaze/SKILL.md: no `### Verdict footer` section found"
+    footer_section = footer_after.split("###", 1)[0]
+    footer_telemetry = [
+        line for line in footer_section.splitlines() if "telemetry:" in line and "wall=" in line
+    ]
+    assert footer_telemetry, (
+        "gaze/SKILL.md: no `telemetry: … wall=…` template in the verdict-footer section"
+    )
+    assert any("tier" in line for line in footer_telemetry), (
+        "gaze/SKILL.md: verdict-footer telemetry template does not carry a "
+        "`tier` field (ticket 0320 exit criterion — tiering must be auditable)"
+    )
+
+    # 2. Output-shape template — the fenced block after "## Output shape".
+    _, _, after = VERIFY.partition("## Output shape")
+    assert after, "gaze/SKILL.md: no `## Output shape` section found"
+    fenced = re.findall(r"```(.*?)```", after, re.DOTALL)
+    assert fenced, "gaze/SKILL.md: no fenced template under `## Output shape`"
+    assert any("tier" in block for block in fenced), (
+        "gaze/SKILL.md: `## /gaze actions` output-shape template does not carry "
+        "a `tier` field (ticket 0320 exit criterion)"
+    )
+
+
 def test_no_bare_stash_in_skills_and_scripts():
     """The stash stack is repo-global (shared across every worktree): a
     clean-tree `git stash` + `git stash pop` round-trip pops someone else's

--- a/tickets/closed/0320-gaze-scale-the-reviewer-battery-to-diff.erg
+++ b/tickets/closed/0320-gaze-scale-the-reviewer-battery-to-diff.erg
@@ -2,11 +2,13 @@
 Title: gaze: scale the reviewer battery to diff size
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #572
 
 --- log ---
 2026-07-13T19:32Z Minh Ha-Duong created
 2026-07-14T05:20Z claude note evidence: post-2026-07-13 telemetry confirms small diffs not materially cheaper — PR #563 (9 lines/2 files, inside size-gate) ~378k tokens/7 agents; #561 (119 lines) ~448k; #562 (199 lines, round 2) ~713k/15 agents; #564 (951 lines) ~912k. Existing size-gate only trims /review-pr (phase 4) — #563 datum proves insufficient. Verdict: IMPLEMENT graduated battery tiers.
 
+2026-07-14T09:10Z Minh Ha-Duong closed — autoclosed — PR #572
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Extends `/gaze`'s binary size-gate (which only skipped `/review-pr`) into a three-tier reviewer battery sized to the diff, so small PRs stop paying the full reviewer cost while the anti-rubber-stamp gate is preserved.

**Evidence (logged in ticket):** post-2026-07-13 telemetry shows small diffs are NOT materially cheaper under the existing gate — PR #563 (9 lines, 2 files, inside the size-gate) still cost ~378k tokens / 7 agents; #561 (119 lines) ~448k; #562 (199 lines, round 2) ~713k / 15 agents; #564 (951 lines) ~912k. The size-gate only trimmed phase-4 `/review-pr`; Agent B (`/review`) and phase-5 `/simplify` still ran full.

## Tiers (phase 1)

- **tiny** — ≤20 lines AND ≤2 files AND round 1 → Agent A (adherence) + phase 6 gate only.
- **small** — ≤150 lines AND ≤5 files AND round 1 → A + B + simplify + gate; `/review-pr` runs the reduced correctness-only perspective set.
- **full** — everything else, **and unconditionally any round ≥ 2** (a REROLL escalates to the full battery regardless of diff size — #562's round-2 needed it on an unchanged diff).

## Invariants preserved

- **`/verify-gate` (phase 6) runs at every tier, never reduced** — the anti-rubber-stamp exit criterion.
- Each conditional agent keeps its `worktree=` invocation-line text (pinned by `test_verify_fork_contracts`).
- **Zero new `isolation: "worktree"` occurrences** (still exactly 4).
- No `run_in_background: true` / "background agent" wording added (pinned by `test_gaze_fork_blocking`).
- Tier recorded in both the verdict-footer telemetry line and the `## /gaze actions` output-shape template so tiering is auditable.

## Test

New behavioral test `test_gaze_tier_recorded_in_telemetry_and_output_shape` asserts the `tier` field appears in both templates. `make check` green (the one seat-runner sandbox-startup flake under parallel load passes in isolation and is unrelated).

Scope: no config machinery, exactly 3 tiers, changes limited to `skills/gaze/SKILL.md` + tests (plus auto-regenerated `README.md` catalog).

**Ticket:** tickets/0320-gaze-scale-the-reviewer-battery-to-diff.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)