### PR TITLE
fix(0323): normalize guard paths and protect escape-hatch provenance

### DIFF
--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -8,6 +8,24 @@
 
 set -a  # mark all subsequent assignments for export
 
+# Provenance guard for GUARD_ALLOW_PRIMARY_EDIT (ticket 0323, residual 2). The
+# worktree-path guard (scripts/pretooluse-worktree-path-guard.sh) treats this
+# variable as a human-only, pre-session escape hatch. That guard runs as a bash
+# subprocess with BASH_ENV pointing here, so this script is sourced into its
+# environment. Because the `.env` files below are sourced under `set -a`, an
+# agent could write a `.env` in its own worktree setting
+# GUARD_ALLOW_PRIMARY_EDIT=1 and have it auto-exported into the guard's env,
+# self-authorizing a primary-checkout write. Snapshot the pre-sourcing value and
+# restore-or-unset it afterwards, so only a value present in the launch
+# environment (systemd/shell, before this script ran) survives. Only this one
+# variable is protected; all other .env values load unchanged.
+if [ -n "${GUARD_ALLOW_PRIMARY_EDIT+x}" ]; then
+    _be_guard_had=1
+    _be_guard_val=$GUARD_ALLOW_PRIMARY_EDIT
+else
+    _be_guard_had=0
+fi
+
 [ -f "$HOME/.claude/.env" ] && source "$HOME/.claude/.env"
 
 # Project-level .env, identified by PWD (Claude Code sets PWD to the project dir
@@ -18,5 +36,14 @@ if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
     [ "$_be_proj" != "$_be_user" ] && source "$PWD/.env"
     unset _be_proj _be_user
 fi
+
+# Restore GUARD_ALLOW_PRIMARY_EDIT to its pre-sourcing provenance (see snapshot
+# above). Still under `set -a`, so a restored value keeps its export attribute.
+if [ "$_be_guard_had" = 1 ]; then
+    GUARD_ALLOW_PRIMARY_EDIT=$_be_guard_val
+else
+    unset GUARD_ALLOW_PRIMARY_EDIT
+fi
+unset _be_guard_had _be_guard_val
 
 set +a

--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -5,26 +5,47 @@
 #
 # BASH_ENV is honored by non-interactive bash (i.e. "bash -c ..."), which is
 # exactly what Claude Code uses for Bash tool calls.
+#
+# Provenance protection for guard-trusted variables (ticket 0323, residual 2 +
+# REROLL). The worktree-path guard (scripts/pretooluse-worktree-path-guard.sh)
+# treats a small set of variables as human-only, pre-session inputs:
+#   GUARD_ALLOW_PRIMARY_EDIT  — the escape hatch that disables the deny entirely;
+#   _GUARD_WORKTREE_ROOT  \     the test-only root override — if BOTH are set the
+#   _GUARD_PRIMARY_ROOT   /     guard trusts them instead of the git-derived
+#                              roots, so matching bogus values disarm it for
+#                              every path.
+# That guard runs as a bash subprocess with BASH_ENV pointing here, so this
+# script is sourced into its environment, and the `.env` files below are sourced
+# under `set -a` (auto-export). An agent can write a `.env` in its OWN worktree
+# (an ordinary, unblocked write); any of these variables set there would be
+# auto-exported into the guard's environment and either self-authorize a
+# primary-checkout write or silently disarm the guard. Only a value present in
+# the launch environment (systemd/shell, before this script ran) may survive; a
+# `.env` contribution must be dropped.
+#
+# The protection covers the FULL trusted set (not just the escape hatch), and its
+# bookkeeping is UNFORGEABLE. A prior fix snapshotted with static, committed
+# variable names (_be_guard_had / _be_guard_val); because `.env` is sourced as
+# bash, a static file could pre-set those exact names and forge the snapshot the
+# restore trusts. Here the snapshot variables are suffixed with a per-process
+# nonce computed BEFORE any `.env` is sourced, so a statically-written `.env`
+# cannot name them. Each trusted var is captured before sourcing and restored to
+# its captured value — or unset if it had none — afterwards. All other `.env`
+# values load unchanged.
+
+_be_guard_vars='GUARD_ALLOW_PRIMARY_EDIT _GUARD_WORKTREE_ROOT _GUARD_PRIMARY_ROOT'
+_be_nonce="$$_${RANDOM}_${RANDOM}_${SRANDOM:-$RANDOM}"
+
+# Snapshot launch-env values into nonce-named scalars. Done before `set -a` so the
+# bookkeeping variables themselves are never exported into the guard's env.
+for _be_v in $_be_guard_vars; do
+    if [ -n "${!_be_v+x}" ]; then
+        printf -v "_be_snap_${_be_nonce}_${_be_v}" %s "${!_be_v}"
+    fi
+done
+unset _be_v
 
 set -a  # mark all subsequent assignments for export
-
-# Provenance guard for GUARD_ALLOW_PRIMARY_EDIT (ticket 0323, residual 2). The
-# worktree-path guard (scripts/pretooluse-worktree-path-guard.sh) treats this
-# variable as a human-only, pre-session escape hatch. That guard runs as a bash
-# subprocess with BASH_ENV pointing here, so this script is sourced into its
-# environment. Because the `.env` files below are sourced under `set -a`, an
-# agent could write a `.env` in its own worktree setting
-# GUARD_ALLOW_PRIMARY_EDIT=1 and have it auto-exported into the guard's env,
-# self-authorizing a primary-checkout write. Snapshot the pre-sourcing value and
-# restore-or-unset it afterwards, so only a value present in the launch
-# environment (systemd/shell, before this script ran) survives. Only this one
-# variable is protected; all other .env values load unchanged.
-if [ -n "${GUARD_ALLOW_PRIMARY_EDIT+x}" ]; then
-    _be_guard_had=1
-    _be_guard_val=$GUARD_ALLOW_PRIMARY_EDIT
-else
-    _be_guard_had=0
-fi
 
 [ -f "$HOME/.claude/.env" ] && source "$HOME/.claude/.env"
 
@@ -37,13 +58,18 @@ if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
     unset _be_proj _be_user
 fi
 
-# Restore GUARD_ALLOW_PRIMARY_EDIT to its pre-sourcing provenance (see snapshot
-# above). Still under `set -a`, so a restored value keeps its export attribute.
-if [ "$_be_guard_had" = 1 ]; then
-    GUARD_ALLOW_PRIMARY_EDIT=$_be_guard_val
-else
-    unset GUARD_ALLOW_PRIMARY_EDIT
-fi
-unset _be_guard_had _be_guard_val
+# Restore each guard-trusted var to its captured launch-env provenance. Still under
+# `set -a`, so a restored value keeps its export attribute; an unset drops any
+# value a `.env` tried to inject.
+for _be_v in $_be_guard_vars; do
+    _be_snap="_be_snap_${_be_nonce}_${_be_v}"
+    if [ -n "${!_be_snap+x}" ]; then
+        printf -v "$_be_v" %s "${!_be_snap}"
+    else
+        unset "$_be_v"
+    fi
+    unset "$_be_snap"
+done
+unset _be_v _be_snap _be_guard_vars _be_nonce
 
 set +a

--- a/scripts/guard-cd-primary-repo.sh
+++ b/scripts/guard-cd-primary-repo.sh
@@ -54,6 +54,19 @@ target="${target%/}"
 target="${target/#\~/$HOME}"
 target="${target//\$HOME/$HOME}"
 
+# Normalize `..` traversal and symlinks before the equality check (ticket 0323,
+# minor A): `cd $primary/sub/.. && git commit` resolves back to $primary but does
+# not lexically equal it, so it would slip past the string compare below. This is
+# the same evasion residual 1 closed in pretooluse-worktree-path-guard.sh.
+# realpath -m collapses `..` and resolves symlinks in existing components while
+# tolerating a not-yet-existing leaf. Warn on the fallback so the degraded
+# (raw-path, still-vulnerable) mode is visible rather than silent.
+if command -v realpath &>/dev/null; then
+    target=$(realpath -m -- "$target" 2>/dev/null || echo "$target")
+else
+    echo "guard: realpath unavailable, path normalization skipped" >&2
+fi
+
 # Only the primary repo root itself is the offence; subtrees (incl. the
 # worktree path, which lives under primary_root) are fine.
 [ "$target" = "$primary_root" ] || exit 0

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -71,6 +71,19 @@ if [ "${file_path#/}" = "$file_path" ]; then
     fi
 fi
 
+# Normalize before the prefix match (ticket 0323, residual 1): a raw path with
+# `..` traversal or through a symlinked directory does not lexically begin with
+# $primary_root and would slip past the string-prefix `case` below. `realpath -m`
+# collapses `..` and resolves symlinks in the existing dir components while
+# tolerating a not-yet-existing leaf (--canonicalize-missing), which is correct
+# at PreToolUse time — the file being written need not exist yet. Fall back to
+# the raw path if realpath is unavailable. primary_root/worktree_root are left
+# as-is: git rev-parse --show-toplevel already canonicalizes them, and they are
+# opaque literals under the _GUARD_*_ROOT test override.
+if command -v realpath &>/dev/null; then
+    file_path=$(realpath -m -- "$file_path" 2>/dev/null || echo "$file_path")
+fi
+
 case "$file_path" in
     "$primary_root"/*)
         case "$file_path" in
@@ -90,8 +103,16 @@ case "$file_path" in
         # Escape hatch: a human pre-authorizes intentional primary edits by
         # exporting GUARD_ALLOW_PRIMARY_EDIT in the shell/systemd environment
         # BEFORE session start. The hook is spawned by the CLI, not a Bash-tool
-        # subshell, so an agent cannot set it mid-turn — deliberate, no
-        # self-service bypass.
+        # subshell, so an agent cannot set it mid-turn.
+        #
+        # Provenance is enforced upstream (ticket 0323, residual 2): this hook
+        # runs as a bash subprocess with BASH_ENV=scripts/bash-env.sh, which
+        # sources a project `.env` under `set -a`. Without a guard an agent could
+        # drop a `.env` in its own worktree setting GUARD_ALLOW_PRIMARY_EDIT=1
+        # and have it auto-exported into this env before the check below —
+        # self-service bypass. bash-env.sh now snapshots this one variable and
+        # restores-or-unsets it around the `.env` sourcing, so only a value
+        # present in the launch environment survives. See scripts/bash-env.sh.
         if [ -n "${GUARD_ALLOW_PRIMARY_EDIT:-}" ]; then
             exit 0
         fi

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -82,6 +82,8 @@ fi
 # opaque literals under the _GUARD_*_ROOT test override.
 if command -v realpath &>/dev/null; then
     file_path=$(realpath -m -- "$file_path" 2>/dev/null || echo "$file_path")
+else
+    echo "guard: realpath unavailable, path normalization skipped" >&2
 fi
 
 case "$file_path" in

--- a/tests/test_bash_env_guard_var_protection.sh
+++ b/tests/test_bash_env_guard_var_protection.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tests for scripts/bash-env.sh — provenance protection of the
+# GUARD_ALLOW_PRIMARY_EDIT escape hatch (ticket 0323, residual 2).
+#
+# The guard scripts/pretooluse-worktree-path-guard.sh honours
+# GUARD_ALLOW_PRIMARY_EDIT as a human-only, pre-session escape hatch. The guard
+# hook runs as a bash subprocess with BASH_ENV=scripts/bash-env.sh, so bash-env.sh
+# is sourced into the guard's environment. bash-env.sh sources a project `.env`
+# under `set -a` (auto-export). An agent can write a `.env` inside its OWN worktree
+# (an ordinary, unblocked write); without a provenance snapshot that value would
+# be auto-exported into the guard's environment and self-authorize a
+# primary-checkout write. bash-env.sh must therefore let only a value present
+# BEFORE it ran (the session/systemd launch env) survive.
+#
+# Both directions are required. A naive "always unset GUARD_ALLOW_PRIMARY_EDIT"
+# fix passes (a) but breaks (b) — the real human escape hatch.
+#
+# NEVER source the real ~/.claude/.env here (it holds secrets): HOME is pointed
+# at an empty temp dir so bash-env.sh's user-level source is skipped, and the
+# project .env contains ONLY the one guard variable under test.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BASHENV="$PWD/scripts/bash-env.sh"
+fail=0
+
+_tmphome=$(mktemp -d)          # empty HOME → no ~/.claude/.env to source
+_projdir=$(mktemp -d)          # stands in for the agent's worktree cwd
+printf 'GUARD_ALLOW_PRIMARY_EDIT=1\n' > "$_projdir/.env"
+
+# Drive bash-env.sh the way the guard hook receives it: BASH_ENV points at the
+# script, so a fresh non-interactive `bash -c` sources it exactly once at startup
+# (an explicit re-source would collide with the session's own ambient BASH_ENV).
+# cd into $_projdir so PWD — which bash-env.sh keys on for the project .env — is
+# the .env's dir. HOME points at an empty dir so the user-level ~/.claude/.env
+# source is skipped. -u BASH_ENV first clears any inherited value; the trailing
+# BASH_ENV="$BASHENV" then sets the one under test.
+_report='echo "${GUARD_ALLOW_PRIMARY_EDIT:-UNSET}"'
+
+# (a) No prior value; project .env sets =1 → must NOT survive (dropped).
+got=$( cd "$_projdir" && env -u GUARD_ALLOW_PRIMARY_EDIT -u BASH_ENV \
+        HOME="$_tmphome" BASH_ENV="$BASHENV" bash -c "$_report" )
+if [ "$got" = "UNSET" ]; then
+    echo "PASS: agent-set project .env GUARD_ALLOW_PRIMARY_EDIT does not survive sourcing"
+else
+    echo "FAIL: expected UNSET (dropped) for project-only guard var; got: '$got'"
+    fail=1
+fi
+
+# (b) Genuine prior value (inherited launch env) + project .env also sets it →
+# the prior value MUST survive (the real human escape hatch).
+got=$( cd "$_projdir" && env -u BASH_ENV \
+        GUARD_ALLOW_PRIMARY_EDIT=1 HOME="$_tmphome" BASH_ENV="$BASHENV" bash -c "$_report" )
+if [ "$got" = "1" ]; then
+    echo "PASS: pre-session GUARD_ALLOW_PRIMARY_EDIT survives sourcing"
+else
+    echo "FAIL: expected '1' (preserved) for inherited-env guard var; got: '$got'"
+    fail=1
+fi
+
+rm -r "$_tmphome" "$_projdir"
+exit $fail

--- a/tests/test_bash_env_guard_var_protection.sh
+++ b/tests/test_bash_env_guard_var_protection.sh
@@ -36,6 +36,11 @@ printf 'GUARD_ALLOW_PRIMARY_EDIT=1\n' > "$_projdir/.env"
 # source is skipped. -u BASH_ENV first clears any inherited value; the trailing
 # BASH_ENV="$BASHENV" then sets the one under test.
 _report='echo "${GUARD_ALLOW_PRIMARY_EDIT:-UNSET}"'
+# Combined report over the FULL guard-trusted var set: the escape hatch plus the
+# two test-only root overrides the guard trusts unconditionally (ticket 0323
+# REROLL). Setting both _GUARD_*_ROOT to matching bogus values disarms the guard
+# for every path, so they need the same provenance protection as the escape hatch.
+_report_all='echo "GAPE=${GUARD_ALLOW_PRIMARY_EDIT:-UNSET};WT=${_GUARD_WORKTREE_ROOT:-UNSET};PR=${_GUARD_PRIMARY_ROOT:-UNSET}"'
 
 # (a) No prior value; project .env sets =1 → must NOT survive (dropped).
 got=$( cd "$_projdir" && env -u GUARD_ALLOW_PRIMARY_EDIT -u BASH_ENV \
@@ -55,6 +60,49 @@ if [ "$got" = "1" ]; then
     echo "PASS: pre-session GUARD_ALLOW_PRIMARY_EDIT survives sourcing"
 else
     echo "FAIL: expected '1' (preserved) for inherited-env guard var; got: '$got'"
+    fail=1
+fi
+
+# (c) Forged OLD bookkeeping. The first 0323 fix snapshotted with STATIC,
+# committed names (_be_guard_had / _be_guard_val). Because `.env` is sourced as
+# bash, a static file could set those exact names and forge the snapshot, so the
+# restore re-exported GUARD_ALLOW_PRIMARY_EDIT=1 without the `.env` ever naming
+# it. With unforgeable (per-process-nonce) bookkeeping the forgery is inert: the
+# variable was absent from the launch env, so it must come back UNSET.
+printf 'GUARD_ALLOW_PRIMARY_EDIT=1\n_be_guard_had=1\n_be_guard_val=1\n' > "$_projdir/.env"
+got=$( cd "$_projdir" && env -u GUARD_ALLOW_PRIMARY_EDIT -u BASH_ENV \
+        HOME="$_tmphome" BASH_ENV="$BASHENV" bash -c "$_report" )
+if [ "$got" = "UNSET" ]; then
+    echo "PASS: forged static bookkeeping (_be_guard_had/_be_guard_val) cannot resurrect GUARD_ALLOW_PRIMARY_EDIT"
+else
+    echo "FAIL: forged static bookkeeping smuggled GUARD_ALLOW_PRIMARY_EDIT back; expected UNSET, got: '$got'"
+    fail=1
+fi
+
+# (d) The two test-only root overrides, set only in a project .env, must NOT
+# survive — an agent that sets both to matching bogus values otherwise disarms
+# the guard for every path (ticket 0323 REROLL, blocker 2).
+printf '_GUARD_WORKTREE_ROOT=/nonexistent\n_GUARD_PRIMARY_ROOT=/nonexistent\n' > "$_projdir/.env"
+got=$( cd "$_projdir" && env -u _GUARD_WORKTREE_ROOT -u _GUARD_PRIMARY_ROOT -u BASH_ENV \
+        HOME="$_tmphome" BASH_ENV="$BASHENV" bash -c "$_report_all" )
+if [ "$got" = "GAPE=UNSET;WT=UNSET;PR=UNSET" ]; then
+    echo "PASS: agent-set project .env _GUARD_*_ROOT overrides do not survive sourcing"
+else
+    echo "FAIL: expected all UNSET for agent-set root overrides; got: '$got'"
+    fail=1
+fi
+
+# (e) Genuine pre-session (launch env) root overrides MUST survive even when a
+# project .env also sets them — the legitimate test-override mechanism. The
+# launch value wins; the .env value is dropped.
+printf '_GUARD_WORKTREE_ROOT=/env-bogus\n_GUARD_PRIMARY_ROOT=/env-bogus\n' > "$_projdir/.env"
+got=$( cd "$_projdir" && env -u BASH_ENV \
+        _GUARD_WORKTREE_ROOT=/launch/wt _GUARD_PRIMARY_ROOT=/launch/pr \
+        HOME="$_tmphome" BASH_ENV="$BASHENV" bash -c "$_report_all" )
+if [ "$got" = "GAPE=UNSET;WT=/launch/wt;PR=/launch/pr" ]; then
+    echo "PASS: pre-session _GUARD_*_ROOT overrides survive sourcing (test-override mechanism intact)"
+else
+    echo "FAIL: expected inherited root overrides preserved; got: '$got'"
     fail=1
 fi
 

--- a/tests/test_guard_cd_primary_repo.sh
+++ b/tests/test_guard_cd_primary_repo.sh
@@ -78,6 +78,11 @@ _assert_blocked "cd PRIMARY && git reset HEAD~1" "cd $PRIMARY && git reset HEAD~
 _assert_blocked "cd PRIMARY && git push origin main" "cd $PRIMARY && git push origin main" "$WORKTREE"
 _assert_blocked "cd PRIMARY && erg close 123"   "cd $PRIMARY && erg close 123"            "$WORKTREE"
 _assert_blocked "cd ~/repo && git commit (tilde)" "cd ~/repo && git commit -m x"          "$WORKTREE"
+# Evasion (ticket 0323, minor A): `..` traversal resolves back to PRIMARY but is
+# not lexically equal to it, so a raw string compare misses it. realpath -m
+# normalization must catch it.
+_assert_blocked "cd PRIMARY/sub/.. && git commit (dotdot evasion)" \
+                "cd $PRIMARY/sub/.. && git commit -m x"    "$WORKTREE"
 
 # --- ALLOW ----------------------------------------------------------------
 # Same cd+commit but cwd is the primary repo itself (not a worktree session).

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -262,4 +262,52 @@ else
     fail=1
 fi
 
+# 16. `..`-traversal evasion (ticket 0323, residual 1): a raw file_path that does
+# NOT lexically begin with $PRIMARY but collapses into it via `..` must still be
+# denied. Without realpath normalization the prefix match on the raw string
+# passes (exit 0, silent bypass); `realpath -m` collapses the `..` — tolerating a
+# not-yet-existing leaf — so the normalized path matches $PRIMARY and denies.
+rc=$(_rc "$WORKTREE" "$PRIMARY" "/home/testuser/x/../repo/evil.py")
+if [ "$rc" = "2" ]; then
+    echo "PASS: denies dot-dot-traversal path that collapses into primary (exit 2)"
+else
+    echo "FAIL: expected exit 2 for dot-dot-traversal into primary; got: $rc"
+    fail=1
+fi
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "/home/testuser/x/../repo/evil.py")
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: dot-dot-traversal into primary emits corrective message"
+else
+    echo "FAIL: expected corrective message for dot-dot-traversal; got: $out"
+    fail=1
+fi
+
+# 17. Symlink-through evasion (ticket 0323, residual 1): a file_path routed through
+# a symlink that points at the primary root has a raw string that does NOT start
+# with the real primary-root path, so the prefix match misses (silent bypass).
+# `realpath -m` resolves the symlink in the existing dir components, exposing the
+# primary root, and the guard denies. Real-git fixture (no env override), mirroring
+# cases 8/9 so the identity predicate and root resolution run for real.
+_case17_base=$(mktemp -d)
+_case17_primary="$_case17_base/primary"
+mkdir -p "$_case17_primary"
+git -C "$_case17_primary" init -q
+git -C "$_case17_primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mkdir -p "$_case17_primary/.claude/worktrees"
+git -C "$_case17_primary" worktree add -q "$_case17_primary/.claude/worktrees/t001"
+# Symlink OUTSIDE the primary root pointing back at it; a path through it evades
+# the raw-string prefix match against the real primary-root path.
+ln -s "$_case17_primary" "$_case17_base/plink"
+out=$( cd "$_case17_primary/.claude/worktrees/t001" \
+       && printf '{"tool_name":"Write","tool_input":{"file_path":"%s/src/main.py","content":"x"}}' "$_case17_base/plink" \
+       | bash "$HOOK" 2>&1 || true)
+git -C "$_case17_primary" worktree remove --force "$_case17_primary/.claude/worktrees/t001" 2>/dev/null || true
+rm -r "$_case17_base"
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: denies path routed through a symlink into primary (identity predicate)"
+else
+    echo "FAIL: expected deny for symlink-through into primary; got: $out"
+    fail=1
+fi
+
 exit $fail


### PR DESCRIPTION
## Summary

Closes the two non-blocking residuals /gaze flagged on PR #562 (ticket 0318),
both pre-existing since the worktree-path guard's creation (ticket 0171).

### Residual 1 — realpath/`..`/symlink evasion of the deny prefix match

`scripts/pretooluse-worktree-path-guard.sh` denies via a string prefix match
`case "$file_path" in "$primary_root"/*)`. A path with `..` traversal
(`/home/u/x/../repo/evil.py`) or routed through a symlinked directory into the
primary root has a raw string that does not lexically begin with `$primary_root`,
so it slips past. Fix: normalize `file_path` with `realpath -m` (collapses `..`,
resolves symlinks in existing dir components, tolerates a not-yet-existing leaf
— correct at PreToolUse time, the target file need not exist yet) before the
match, with a raw-path fallback if realpath is unavailable. The roots are left
as-is: `git rev-parse --show-toplevel` already canonicalizes them and they are
opaque literals under the `_GUARD_*_ROOT` test override, so normalizing them
would be a no-op that only widens the diff. The `projects/*/memory/*` exemption
and the `GUARD_ALLOW_PRIMARY_EDIT` escape hatch (both after the insertion point)
are preserved exactly.

### Residual 2 — REAL self-service bypass of `GUARD_ALLOW_PRIMARY_EDIT`

The ticket asked to establish whether any agent-writable file feeds the hook's
environment. **The chain holds and was verified empirically:**

1. `settings.json` top-level `env` sets `BASH_ENV=scripts/bash-env.sh`, applied
   to subprocesses.
2. The guard hook runs as a `bash` subprocess, which sources `bash-env.sh` at
   startup (non-interactive bash honours `BASH_ENV`).
3. `bash-env.sh` sources `$PWD/.env` under `set -a` (auto-export); the hook's
   `PWD` is the agent's own worktree.
4. An agent writing a `.env` containing `GUARD_ALLOW_PRIMARY_EDIT=1` inside its
   OWN worktree (an ordinary, unblocked write) gets that var auto-exported into
   the guard's env **before** the guard checks it — self-authorizing a
   primary-checkout write. This contradicted the guard's "no self-service
   bypass" header comment.

Fix: `bash-env.sh` snapshots `GUARD_ALLOW_PRIMARY_EDIT` before the `.env`
sourcing and restores-or-unsets it after, so only a value present in the launch
environment (systemd/shell, before the script ran) survives; an agent-set
project-`.env` value is dropped. Only this one variable is touched; all other
`.env` secrets load unchanged. The guard header comment now documents the
enforced provenance and cross-references `bash-env.sh` and ticket 0323.

## Tests (TDD, glob-discovered, integration tier)

- **Guard cases 16/17** in `test_pretooluse_worktree_path_guard.sh`:
  `..`-traversal (env-override fixture) and symlink-through (real-git fixture
  mirroring cases 8/9). Both confirmed RED against the pre-fix guard (silent
  exit 0), GREEN after.
- **New `test_bash_env_guard_var_protection.sh`**, two directions:
  (a) an agent-set project `.env` value must NOT survive sourcing;
  (b) a genuine pre-session (inherited-env) value MUST survive.
  Both required — a naive always-unset fix passes (a) but breaks (b), the real
  human escape hatch. Case (a) confirmed RED against the pre-fix `bash-env.sh`
  (leaked `1`). No real secrets touched: `HOME` points at an empty temp dir so
  `~/.claude/.env` is skipped, and the test `.env` holds only the one guard var.

Test count delta: +3 assertions in the guard suite, +1 new shell suite (2
assertions).

## Gates

- `make check`: 818 passed (a transient `test_seat_runner.sh` container-timing
  flake cleared on re-run; my branch touches nothing seat-runner-related).
- `make lint`: 17 passed.

**Ticket:** tickets/0323-worktree-path-guard-residuals-realpath.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)