### PR TITLE
feat(0207): agnostic CLI reviewer seat — OpenRouter + llama-server endpoints

### DIFF
--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -20,8 +20,11 @@
 #     pure code) — never all of ~/.local, which also holds keyrings, wallets,
 #     jupyter/neo4j tokens, and browser cookies. The self-test proves ~/.local
 #     is scoped, not wholesale-mounted.
-#   - env is explicitly constructed (no BASH_ENV, no inherited secrets; only
-#     a dummy OPENAI_API_KEY for the local endpoint)
+#   - env is explicitly constructed (no BASH_ENV, no inherited secrets). A
+#     per-seat endpoint credential MAY be injected via --credential-env, read
+#     from the runner's own env and passed as a bare `-e OPENAI_API_KEY` so it
+#     never enters podman argv; a local unauthenticated endpoint uses an inline
+#     dummy OPENAI_API_KEY instead.
 #   - NETWORK IS DENY-BY-DEFAULT: the seat runs under --network=none, so its
 #     netns has no interface but loopback — no route to any host. It reaches
 #     the ONE model endpoint through a bind-mounted Unix-domain socket

--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -34,9 +34,13 @@
 #     DESTINATION — no arbitrary outbound host, no domain-fronting exfil.
 #     (Replaces the v1 --network=host gap: pasta/slirp4netns do full outbound
 #     NAT with no per-destination allowlist, so they were rejected.) The relay
-#     forwards raw bytes to a PLAIN host:port; it does not terminate or preserve
-#     TLS, so it fits a local/plain-HTTP endpoint (0217's target). A real HTTPS
-#     cloud endpoint would need SNI/cert-preserving forwarding — out of scope.
+#     forwards raw bytes to a PLAIN host:port; it neither terminates nor inspects
+#     TLS. A plain-HTTP endpoint (0217's local target) uses the same port on
+#     both sides. An HTTPS cloud endpoint (0207) rides through the same raw pump
+#     end-to-end: --add-host maps the real hostname to loopback and the seat's
+#     client dials an in-container bridge on 8443 (a --userns=keep-id seat cannot
+#     bind 443), so the client still presents valid SNI and validates the real
+#     cert — the relay just moves the encrypted bytes; it never sees plaintext.
 #   - PER-SEAT TIMEOUT: every container invocation is wrapped in `timeout`
 #     (SEAT_TIMEOUT, default 600s). timeout SIGKILLs only the podman CLIENT —
 #     rootless conmon keeps the container alive — so each seat is named and
@@ -50,7 +54,14 @@
 # Usage:
 #   seat-runner.sh --branch BRANCH [--repo PATH] [--base REF]
 #                  [--endpoint URL] [--model NAME] [--out FILE]
+#                  [--credential-env VAR] [--health-path PATH]
 #   seat-runner.sh --self-test-only      # prove containment; no endpoint, no diff
+#
+#   --credential-env VAR : read the endpoint's API key from env var VAR and pass
+#                          it to the seat via env (never argv). Default: a dummy
+#                          key for a local, unauthenticated endpoint.
+#   --health-path PATH   : probe path appended to the endpoint ORIGIN (default
+#                          /health); empty string skips the reachability probe.
 #
 # Env: SEAT_TIMEOUT (per-seat wall-clock cap, seconds; default 600)
 set -euo pipefail
@@ -67,6 +78,8 @@ OUT="/dev/stdout"
 IMAGE="localhost/seat-runner:v1"   # ubuntu:24.04 + python3 + git + ca-certs
 SEAT_TIMEOUT="${SEAT_TIMEOUT:-600}"
 SELF_TEST_ONLY=0
+CREDENTIAL_ENV=""          # env var holding the endpoint's API key (never argv)
+HEALTH_PATH="/health"      # probe path appended to the origin; "" skips the probe
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -76,6 +89,8 @@ while [[ $# -gt 0 ]]; do
         --endpoint)       ENDPOINT="$2"; shift 2 ;;
         --model)          MODEL="$2"; shift 2 ;;
         --out)            OUT="$2"; shift 2 ;;
+        --credential-env) CREDENTIAL_ENV="$2"; shift 2 ;;
+        --health-path)    HEALTH_PATH="$2"; shift 2 ;;
         --self-test-only) SELF_TEST_ONLY=1; shift ;;
         *) echo "seat-runner: unknown arg $1" >&2; exit 2 ;;
     esac
@@ -83,23 +98,61 @@ done
 
 command -v podman >/dev/null || { echo "seat-runner: podman not installed" >&2; exit 1; }
 
-if [[ "$SELF_TEST_ONLY" -eq 0 ]]; then
-    [[ -n "$BRANCH" ]] || { echo "seat-runner: --branch required" >&2; exit 2; }
-    # Fail loud if the endpoint is down (0217: unreachable endpoint = non-zero).
-    curl -sf --max-time 5 "${ENDPOINT%/v1}/health" >/dev/null \
-        || { echo "seat-runner: endpoint ${ENDPOINT} unreachable" >&2; exit 1; }
-fi
-
-# Endpoint host:port for the host-side relay. The container reaches the SAME
-# port on its own loopback (bridged through the socket), so only the host part
-# changes to 127.0.0.1 for the in-container OPENAI_API_BASE.
-EP="${ENDPOINT#*://}"; EP="${EP%%/*}"
+# ── Endpoint decomposition (unconditional; the health probe AND the relay both
+#    need it). Origin = SCHEME://EP where EP is the authority host[:port]; the
+#    container reaches the endpoint through its own loopback, bridged over the
+#    relay socket. ──────────────────────────────────────────────────────────────
+SCHEME="${ENDPOINT%%://*}"
+EP="${ENDPOINT#*://}"; EP="${EP%%/*}"                                     # host[:port]
+ENDPOINT_PATH="${ENDPOINT#*://}"; ENDPOINT_PATH="${ENDPOINT_PATH#"$EP"}"  # /path… or ""
 ENDPOINT_HOST="${EP%%:*}"
 ENDPOINT_PORT="${EP##*:}"
 if [[ "$ENDPOINT_PORT" == "$ENDPOINT_HOST" ]]; then   # no explicit port
-    case "$ENDPOINT" in https://*) ENDPOINT_PORT=443 ;; *) ENDPOINT_PORT=80 ;; esac
+    case "$SCHEME" in https) ENDPOINT_PORT=443 ;; *) ENDPOINT_PORT=80 ;; esac
 fi
-CONTAINER_BASE="${ENDPOINT/${ENDPOINT_HOST}/127.0.0.1}"
+
+# The in-container OPENAI_API_BASE (CONTAINER_BASE) and the bridge port
+# (CONTAINER_PORT). http: same port, host swapped to loopback — byte-identical
+# to v1. https: a --userns=keep-id seat cannot bind a <1024 port (EACCES), so
+# the bridge listens on 8443 and --add-host maps the real hostname to 127.0.0.1;
+# the client still presents valid SNI/cert for the real host and TLS stays
+# end-to-end to the cloud through the raw (byte-pumping) relay.
+ADD_HOST_ARGS=()
+if [[ "$SCHEME" == https ]]; then
+    CONTAINER_PORT=8443
+    CONTAINER_BASE="${SCHEME}://${ENDPOINT_HOST}:${CONTAINER_PORT}${ENDPOINT_PATH}"
+    ADD_HOST_ARGS=(--add-host "${ENDPOINT_HOST}:127.0.0.1")
+else
+    CONTAINER_PORT="$ENDPOINT_PORT"
+    CONTAINER_BASE="${ENDPOINT/${ENDPOINT_HOST}/127.0.0.1}"
+fi
+
+# ── Per-seat credential injection. Default: a dummy key for a local endpoint
+#    (NOT a secret), passed inline. With --credential-env NAME: read the secret
+#    from that env var HERE, export it, and pass the BARE `-e OPENAI_API_KEY`
+#    form so podman reads the value from the runner's env — never argv (argv
+#    leaks to `ps -ef`). Fail loud if the named var is empty; never echo it. ────
+CRED_ARGS=(-e OPENAI_API_KEY=local-dummy)
+if [[ -n "$CREDENTIAL_ENV" ]]; then
+    if [[ -z "${!CREDENTIAL_ENV:-}" ]]; then
+        echo "seat-runner: FATAL --credential-env ${CREDENTIAL_ENV} names an empty or unset variable" >&2
+        exit 1
+    fi
+    export OPENAI_API_KEY="${!CREDENTIAL_ENV}"
+    CRED_ARGS=(-e OPENAI_API_KEY)
+fi
+
+if [[ "$SELF_TEST_ONLY" -eq 0 ]]; then
+    [[ -n "$BRANCH" ]] || { echo "seat-runner: --branch required" >&2; exit 2; }
+    # Fail loud if the endpoint is down (0217: unreachable endpoint = non-zero).
+    # Build the probe URL from the ORIGIN + --health-path, NOT ${ENDPOINT%/v1}
+    # (which double-prefixes /api for an /api/v1 endpoint). Empty --health-path
+    # skips the probe for endpoints that expose no health route.
+    if [[ -n "$HEALTH_PATH" ]]; then
+        curl -sf --max-time 5 "${SCHEME}://${EP}${HEALTH_PATH}" >/dev/null \
+            || { echo "seat-runner: endpoint ${ENDPOINT} unreachable" >&2; exit 1; }
+    fi
+fi
 
 HOMEDIR="$HOME"   # --userns=keep-id keeps uids aligned; paths match host
 
@@ -196,6 +249,7 @@ run_seat() {
         --tmpfs "$HOMEDIR":rw,size=256m \
         --tmpfs /tmp:rw,size=64m \
         ${SEAT_CODE_MOUNTS[@]+"${SEAT_CODE_MOUNTS[@]}"} \
+        ${ADD_HOST_ARGS[@]+"${ADD_HOST_ARGS[@]}"} \
         -v "$WORK/clone":/repo:ro \
         -v "$WORK/review.diff":/review.diff:ro \
         -v "$WORK/prompt.txt":/prompt.txt:ro \
@@ -205,7 +259,7 @@ run_seat() {
         -e PATH="/usr/bin:/bin" \
         -e TERM=dumb \
         -e COLUMNS=500 \
-        -e OPENAI_API_KEY=local-dummy \
+        ${CRED_ARGS[@]+"${CRED_ARGS[@]}"} \
         -e OPENAI_API_BASE="$CONTAINER_BASE" \
         -w /repo \
         "$IMAGE" "$@" || rc=$?
@@ -245,8 +299,8 @@ fi
 # a bash builtin dash lacks (without it the wait degrades to a blind sleep).
 echo "seat-runner: reviewing ${BRANCH} vs ${BASE} with ${MODEL}..." >&2
 BRIDGE_AND_REVIEW=$(cat <<EOF
-python3 /net-relay.py --listen tcp:127.0.0.1:${ENDPOINT_PORT} --connect unix:/relay.sock &
-for _ in \$(seq 1 50); do (: < /dev/tcp/127.0.0.1/${ENDPOINT_PORT}) 2>/dev/null && break; sleep 0.1; done
+python3 /net-relay.py --listen tcp:127.0.0.1:${CONTAINER_PORT} --connect unix:/relay.sock &
+for _ in \$(seq 1 50); do (: < /dev/tcp/127.0.0.1/${CONTAINER_PORT}) 2>/dev/null && break; sleep 0.1; done
 exec ${AIDER_REAL} \\
     --no-git --chat-mode ask --model "${MODEL}" \\
     --message "\$(cat /prompt.txt)" \\

--- a/skills/reviewers/panel.yml
+++ b/skills/reviewers/panel.yml
@@ -12,6 +12,10 @@
 #     # cli-agent / local-model seats also carry:
 #     endpoint:     OpenAI-compatible base URL (e.g. http://127.0.0.1:8012/v1)
 #     model:        model id passed to the seat-runner
+#     credential-env: (optional) name of the env var holding the endpoint's API
+#                   key — passed to the seat-runner as --credential-env and read
+#                   from the BASH_ENV-loaded env, NEVER written here. Omit for a
+#                   local, unauthenticated endpoint.
 #     # forge-bot seats also carry:
 #     login:        the bot's forge login, passed to the reviewer-request API
 #
@@ -22,14 +26,26 @@
 # The shipped roster below is inert until explicitly invoked: no seat fires
 # without `/reviewers request <pr>`. An empty roster (`reviewers: []`) makes
 # /reviewers a no-op entirely.
-# Example cli/model seat (commented; uncomment + adjust to enable):
+# Example cli/model seats (commented; uncomment + adjust to enable):
 #
+# A fully local, free, private llama-server seat — no credential:
 #   - name: local-qwen
 #     kind: local-model
 #     status: advisory
 #     trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
 #     endpoint: http://127.0.0.1:8012/v1
 #     model: openai/qwen3.6-35b-a3b
+#
+# An OpenRouter-hosted frontier seat — the key loads via BASH_ENV, never here.
+# The seat-runner bridges the HTTPS endpoint end-to-end through its network
+# sandbox (--add-host + in-container 8443 bridge):
+#   - name: openrouter-frontier
+#     kind: cli-agent
+#     status: advisory
+#     trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+#     endpoint: https://openrouter.ai/api/v1
+#     model: openai/gpt-4o-mini
+#     credential-env: OPENROUTER_API_KEY
 
 reviewers:
   - name: copilot

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -34,25 +34,27 @@ EOF
 
 # ── roster parsing ───────────────────────────────────────────────────────────
 # Emit one pipe-separated record per seat: name kind status endpoint model
-# login trial-ticket. Minimal block parser for the flat panel.yml schema;
-# comment and blank lines are ignored, and an explicit `reviewers: []` yields
-# nothing.
+# login trial-ticket credential-env. Minimal block parser for the flat
+# panel.yml schema; comment and blank lines are ignored, and an explicit
+# `reviewers: []` yields nothing. Pipe (not tab) is the delimiter so an empty
+# middle field (e.g. a seat with no credential-env) does not shift later fields.
 roster_records() {
     awk '
         /^[[:space:]]*#/        { next }
         /^reviewers:[[:space:]]*\[\][[:space:]]*$/ { exit }
         /^[[:space:]]*-[[:space:]]*name:/ {
-            if (have) print rec(); have=1; name=val($0); kind=st=ep=mo=lg=tt=""; next
+            if (have) print rec(); have=1; name=val($0); kind=st=ep=mo=lg=tt=ce=""; next
         }
-        /^[[:space:]]+kind:/          { kind=val($0) }
-        /^[[:space:]]+status:/        { st=val($0) }
-        /^[[:space:]]+endpoint:/      { ep=val($0) }
-        /^[[:space:]]+model:/         { mo=val($0) }
-        /^[[:space:]]+login:/         { lg=val($0) }
-        /^[[:space:]]+trial-ticket:/  { tt=val($0) }
+        /^[[:space:]]+kind:/           { kind=val($0) }
+        /^[[:space:]]+status:/         { st=val($0) }
+        /^[[:space:]]+endpoint:/       { ep=val($0) }
+        /^[[:space:]]+model:/          { mo=val($0) }
+        /^[[:space:]]+login:/          { lg=val($0) }
+        /^[[:space:]]+trial-ticket:/   { tt=val($0) }
+        /^[[:space:]]+credential-env:/ { ce=val($0) }
         END { if (have) print rec() }
         function val(line,  v) { sub(/^[^:]*:[[:space:]]*/, "", line); gsub(/^[[:space:]]+|[[:space:]]+$/, "", line); return line }
-        function rec() { return name"|"kind"|"st"|"ep"|"mo"|"lg"|"tt }
+        function rec() { return name"|"kind"|"st"|"ep"|"mo"|"lg"|"tt"|"ce }
     ' "$PANEL" 2>/dev/null
 }
 
@@ -79,7 +81,7 @@ case "$subcmd" in
     list)
         if panel_is_empty; then echo "no reviewers configured"; exit 0; fi
         printf '%-18s %-12s %-9s %s\n' NAME KIND STATUS TRIAL-TICKET
-        while IFS='|' read -r name kind st ep mo lg tt; do
+        while IFS='|' read -r name kind st ep mo lg tt ce; do
             printf '%-18s %-12s %-9s %s\n' "$name" "$kind" "${st:-advisory}" "$tt"
         done < <(roster_records)
         ;;
@@ -91,7 +93,7 @@ case "$subcmd" in
         [ -n "$branch" ] || { echo "error: could not resolve branch for MR #${pr}" >&2; exit 1; }
         dest="${FINDINGS_DIR}/${pr}"; mkdir -p "$dest"
         ran=0
-        while IFS='|' read -r name kind st ep mo lg tt; do
+        while IFS='|' read -r name kind st ep mo lg tt ce; do
             case "$kind" in
                 forge-bot)
                     # Server-side reviewer, requested on demand — nothing
@@ -110,8 +112,13 @@ case "$subcmd" in
                 cli-agent|local-model)
                     # Per-seat fail-open: a seat that errors WARNs and the
                     # others proceed — one seat never blocks the verdict (0205).
+                    # Thread the credential-env NAME only when the seat sets it;
+                    # a local, unauthenticated endpoint carries no credential.
+                    cred_args=()
+                    [ -n "$ce" ] && cred_args=(--credential-env "$ce")
                     if "$SEAT_RUNNER" --repo "$REPO_ROOT" --branch "$branch" \
                         --endpoint "$ep" --model "$mo" --out "${dest}/${name}.findings" \
+                        ${cred_args[@]+"${cred_args[@]}"} \
                         >/dev/null 2>"${dest}/${name}.err"; then
                         echo "request: seat '${name}' ok → ${dest}/${name}.findings" >&2
                         ran=$((ran+1))
@@ -170,7 +177,7 @@ case "$subcmd" in
         [ -n "$pr" ] && [ -n "$seat" ] && [ -n "$verdict" ] || { echo "error: scorecard requires <pr> <seat> <verdict-summary>" >&2; exit 1; }
         # Resolve the seat's trial ticket from the roster.
         tt=""
-        while IFS='|' read -r n k s e m l t; do [ "$n" = "$seat" ] && tt="$t"; done < <(roster_records)
+        while IFS='|' read -r n k s e m l t ce; do [ "$n" = "$seat" ] && tt="$t"; done < <(roster_records)
         [ -n "$tt" ] || { echo "error: seat '${seat}' not in roster (no trial-ticket)" >&2; exit 1; }
         tid=$(sed -n 's#.*/\([0-9]\{4\}\)-.*#\1#p' <<<"$tt")
         # Fixed schema so 0205's integration review is evidence-based, not vibes.

--- a/tests/test_reviewers.sh
+++ b/tests/test_reviewers.sh
@@ -18,7 +18,9 @@ assert_eq() {
 }
 assert_contains() {
     local label="$1" needle="$2" hay="$3"
-    if printf '%s' "$hay" | grep -qF -- "$needle"; then echo "PASS: $label"; PASS=$((PASS+1))
+    # Here-string, not `printf | grep`: pipefail + grep -q closing the pipe early
+    # SIGPIPEs printf, a nondeterministic false FAIL on a large haystack.
+    if grep -qF -- "$needle" <<<"$hay"; then echo "PASS: $label"; PASS=$((PASS+1))
     else echo "FAIL: $label (missing: $needle)"; echo "  in: $hay"; FAIL=$((FAIL+1)); fi
 }
 assert_exit_0() { local label="$1"; shift; if "$@" >/dev/null 2>&1; then echo "PASS: $label"; PASS=$((PASS+1)); else echo "FAIL: $label (exit $?)"; FAIL=$((FAIL+1)); fi; }
@@ -150,6 +152,51 @@ YAML
     fi
 else
     echo "SKIP: erg binary absent — scorecard erg-integration test"
+fi
+
+# ── credential-env threads from roster to seat-runner (0207) ─────────────────
+# A seat carrying `credential-env: NAME` must pass `--credential-env NAME` to
+# the seat-runner; a seat without it must NOT pass the flag. The stub captures
+# each seat's full argv so both cases are checked against real invocations.
+CE_STUB="$WORK/seat-runner-ce-stub.sh"
+cat > "$CE_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+argv="$*"; out=""
+while [ $# -gt 0 ]; do [ "$1" = "--out" ] && { out="$2"; shift 2; continue; }; shift; done
+name="$(basename "$out" .findings)"
+printf '%s\n' "$argv" > "${out%.findings}.argv"
+{ echo "FINDING|severity=verifiable|file=foo.sh:10|rationale=x"; echo "SUMMARY|findings=1|verdict=revise"; } > "$out"
+STUBEOF
+chmod +x "$CE_STUB"
+
+CEROSTER="$WORK/ce.yml"
+cat > "$CEROSTER" <<'YAML'
+reviewers:
+  - name: seat-with-cred
+    kind: cli-agent
+    status: advisory
+    trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+    endpoint: https://openrouter.ai/api/v1
+    model: openai/stub
+    credential-env: MY_ROSTER_KEY
+  - name: seat-no-cred
+    kind: local-model
+    status: advisory
+    trial-ticket: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+    endpoint: http://127.0.0.1:9/v1
+    model: openai/stub
+YAML
+
+CEDIR="$WORK/ce-findings"
+REVIEWERS_PANEL="$CEROSTER" SEAT_RUNNER="$CE_STUB" REVIEWERS_FINDINGS_DIR="$CEDIR" \
+    REVIEWERS_PR_BRANCH="some-branch" "$REVIEWERS" request 77 >/dev/null 2>&1
+assert_contains "request: credential-env seat passes the flag through" \
+    "--credential-env MY_ROSTER_KEY" "$(cat "$CEDIR/77/seat-with-cred.argv" 2>/dev/null || true)"
+if grep -qF -- '--credential-env' "$CEDIR/77/seat-no-cred.argv" 2>/dev/null; then
+    echo "FAIL: request: no-cred seat must not pass --credential-env"; FAIL=$((FAIL+1))
+else
+    echo "PASS: request: no-cred seat omits --credential-env"; PASS=$((PASS+1))
 fi
 
 # ── forge-bot seat: on-demand request via the forge review API (0206) ────────

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -48,7 +48,7 @@ CODE="$(printf '%s\n' "$SRC" | grep -v '^[[:space:]]*#')"
 assert_absent   "no --network=host in live code"    "--network=host"   "$CODE"
 assert_contains "per-seat timeout env honoured"     "SEAT_TIMEOUT"     "$SRC"
 # The timeout must actually WRAP the container invocation, not merely be read.
-if printf '%s' "$SRC" | grep -Eq 'timeout[^|]*"?\$\{?SEAT_TIMEOUT'; then
+if grep -Eq 'timeout[^|]*"?\$\{?SEAT_TIMEOUT' <<<"$SRC"; then
     pass "timeout wraps the seat invocation"
 else
     fail "timeout wraps the seat invocation"
@@ -69,7 +69,7 @@ assert_contains "self-test proves ~/.local scoped"   "LOCAL-SCOPED"     "$SRC"
 assert_contains "venv root validated by pyvenv.cfg"  "pyvenv.cfg"       "$CODE"
 assert_contains "home-exposing mount rejected"       "_reject_home_exposing_mount" "$CODE"
 # The rejection must actually cover the ancestor case, not just equality.
-if printf '%s' "$CODE" | grep -Eq '\$HOMEDIR" == "\$_path"/\*|\$HOMEDIR == \$_path/\*'; then
+if grep -Eq '\$HOMEDIR" == "\$_path"/\*|\$HOMEDIR == \$_path/\*' <<<"$CODE"; then
     pass "home-exposing guard covers ancestor case"
 else
     fail "home-exposing guard covers ancestor case"
@@ -154,7 +154,7 @@ assert_contains "https branch adds --add-host"       "--add-host"       "$SRC"
 # The in-container bridge port must be one variable used consistently: in the
 # CONTAINER_BASE the client dials, AND in the container-side relay listen/wait.
 assert_contains "in-container port var in CONTAINER_BASE" 'CONTAINER_PORT}${ENDPOINT_PATH}' "$CODE"
-if printf '%s' "$CODE" | grep -Eq 'net-relay.py --listen tcp:127.0.0.1:\$\{CONTAINER_PORT\}'; then
+if grep -Eq 'net-relay.py --listen tcp:127.0.0.1:\$\{CONTAINER_PORT\}' <<<"$CODE"; then
     pass "in-container port var drives the bridge listen"
 else
     fail "in-container port var drives the bridge listen"

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -26,10 +26,14 @@ WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
 pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
 assert_contains() {  # label needle haystack
-    if printf '%s' "$3" | grep -qF -- "$2"; then pass "$1"; else fail "$1 (missing: $2)"; echo "  in: $3" >&2; fi
+    # Here-string, not `printf | grep`: with `set -o pipefail`, grep -q closing
+    # the pipe on an early match SIGPIPEs printf (141), which pipefail then
+    # reports as the pipeline status — a nondeterministic false FAIL on a large
+    # haystack. A here-string has no pipe, so no race.
+    if grep -qF -- "$2" <<<"$3"; then pass "$1"; else fail "$1 (missing: $2)"; echo "  in: $3" >&2; fi
 }
 assert_absent() {  # label needle haystack
-    if printf '%s' "$3" | grep -qF -- "$2"; then fail "$1 (found forbidden: $2)"; else pass "$1"; fi
+    if grep -qF -- "$2" <<<"$3"; then fail "$1 (found forbidden: $2)"; else pass "$1"; fi
 }
 
 # ── tier 1: source inspection (no podman needed) ─────────────────────────────
@@ -139,6 +143,114 @@ guard_err="$(HOME="$FH" PATH="$STUBBIN2:$FH/bin:$PATH" bash "$SR" --self-test-on
 [ "$guard_rc" -ne 0 ] && pass "home-exposing venv root exits non-zero" || fail "home-exposing venv root exits non-zero"
 assert_contains "guard names the refused mount"      "refusing to mount" "$guard_err"
 assert_absent   "guard fires before any podman run"  "GUARD-BYPASS"      "$guard_err"
+
+# ── tier 1b: new-flag source assertions ──────────────────────────────────────
+# The two new flags must be handled in the arg parser (a case arm each).
+assert_contains "--credential-env flag parsed"       "--credential-env" "$SRC"
+assert_contains "--health-path flag parsed"          "--health-path"    "$SRC"
+# The https branch maps the real hostname to loopback via --add-host so the
+# client still presents valid SNI/cert while the traffic is bridged.
+assert_contains "https branch adds --add-host"       "--add-host"       "$SRC"
+# The in-container bridge port must be one variable used consistently: in the
+# CONTAINER_BASE the client dials, AND in the container-side relay listen/wait.
+assert_contains "in-container port var in CONTAINER_BASE" 'CONTAINER_PORT}${ENDPOINT_PATH}' "$CODE"
+if printf '%s' "$CODE" | grep -Eq 'net-relay.py --listen tcp:127.0.0.1:\$\{CONTAINER_PORT\}'; then
+    pass "in-container port var drives the bridge listen"
+else
+    fail "in-container port var drives the bridge listen"
+fi
+# The secret must NEVER be inlined into podman argv (ps -ef leak). The live code
+# builds the BARE `-e OPENAI_API_KEY` passthrough when a credential is set, so
+# podman reads the value from the process env instead of argv.
+assert_contains "credential passed as bare -e passthrough" "CRED_ARGS=(-e OPENAI_API_KEY)" "$CODE"
+
+# ── tier 2a″: --credential-env moves the secret via ENV, never argv ──────────
+# RED before this feature: seat-runner rejects --credential-env as an unknown
+# arg and exits 2 without ever invoking podman. Stub podman captures its argv
+# and the environment it was launched with.
+if command -v python3 >/dev/null; then
+    STUBBIN3="$WORK/stubbin3"; mkdir -p "$STUBBIN3"
+    cat > "$STUBBIN3/podman" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+    run)
+        [ -n "${PODMAN_ARGV_CAP:-}" ] && printf '%s\n' "$@" > "$PODMAN_ARGV_CAP"
+        [ -n "${PODMAN_ENV_CAP:-}"  ] && env         > "$PODMAN_ENV_CAP"
+        ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUBBIN3/podman"
+
+    PROBE_VAL="probe-${RANDOM}-${RANDOM}"
+    ARGV_CAP="$WORK/cred.argv"; ENV_CAP="$WORK/cred.env"
+    MY_TEST_VAR="$PROBE_VAL" PODMAN_ARGV_CAP="$ARGV_CAP" PODMAN_ENV_CAP="$ENV_CAP" \
+        PATH="$STUBBIN3:$PATH" bash "$SR" --self-test-only --credential-env MY_TEST_VAR \
+        >/dev/null 2>&1 || true
+    if [ -f "$ARGV_CAP" ] && [ -f "$ENV_CAP" ]; then
+        # The secret reaches the container through the process env podman inherits...
+        assert_contains "credential-env: secret reaches podman via process env" \
+            "OPENAI_API_KEY=${PROBE_VAL}" "$(cat "$ENV_CAP")"
+        # ...as a BARE -e passthrough in argv (a line that is exactly the var name)...
+        if grep -qx 'OPENAI_API_KEY' "$ARGV_CAP"; then
+            pass "credential-env: argv carries bare -e OPENAI_API_KEY passthrough"
+        else
+            fail "credential-env: argv carries bare -e OPENAI_API_KEY passthrough"
+        fi
+        # ...and the VALUE must NEVER appear in argv (that is the ps -ef leak).
+        if grep -qF "OPENAI_API_KEY=${PROBE_VAL}" "$ARGV_CAP"; then
+            fail "credential-env: SECRET LEAKED into podman argv (ps -ef visible)"
+        else
+            pass "credential-env: secret absent from podman argv (no ps -ef leak)"
+        fi
+    else
+        fail "credential-env: podman never invoked (arg rejected?)"
+    fi
+
+    # ── https branch: --add-host + 8443 CONTAINER_BASE reach the podman run ──
+    HTTPS_ARGV="$WORK/https.argv"
+    PODMAN_ARGV_CAP="$HTTPS_ARGV" PATH="$STUBBIN3:$PATH" \
+        bash "$SR" --self-test-only --endpoint https://openrouter.ai/api/v1 \
+        >/dev/null 2>&1 || true
+    https_argv="$(cat "$HTTPS_ARGV" 2>/dev/null || true)"
+    assert_contains "https: --add-host maps real host to loopback" \
+        "openrouter.ai:127.0.0.1" "$https_argv"
+    assert_contains "https: container base = scheme + real host + 8443 + path" \
+        "https://openrouter.ai:8443/api/v1" "$https_argv"
+
+    # ── http branch: byte-identical to v1 (no --add-host, same host:port) ────
+    HTTP_ARGV="$WORK/http.argv"
+    PODMAN_ARGV_CAP="$HTTP_ARGV" PATH="$STUBBIN3:$PATH" \
+        bash "$SR" --self-test-only --endpoint http://127.0.0.1:8012/v1 \
+        >/dev/null 2>&1 || true
+    http_argv="$(cat "$HTTP_ARGV" 2>/dev/null || true)"
+    assert_absent   "http: no --add-host on a plain-http endpoint" "add-host" "$http_argv"
+    assert_contains "http: container base unchanged (byte-identical)" \
+        "http://127.0.0.1:8012/v1" "$http_argv"
+else
+    echo "SKIP: python3 absent — credential-env / add-host argv tests"
+fi
+
+# ── tier 2a‴: health-path URL is built from the origin (no double-/api) ───────
+# The probe URL must be SCHEME://AUTHORITY + --health-path, NOT ${ENDPOINT%/v1}
+# + path (which double-prefixes /api for an /api/v1 endpoint). Stub curl to
+# capture the URL and fail so seat-runner stops right at the probe.
+CURLBIN="$WORK/curlbin"; mkdir -p "$CURLBIN"
+cat > "$CURLBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do url="$a"; done          # the URL is the last argument
+[ -n "${CURL_URL_CAP:-}" ] && printf '%s\n' "$url" > "$CURL_URL_CAP"
+exit 22                                    # "unreachable" → seat-runner stops here
+STUB
+chmod +x "$CURLBIN/curl"
+URL_CAP="$WORK/curl.url"
+CURL_URL_CAP="$URL_CAP" PATH="$CURLBIN:${STUBBIN3:-$WORK/stubbin3}:$PATH" \
+    bash "$SR" --endpoint https://openrouter.ai/api/v1 --health-path /api/v1/models \
+    --branch dummy >/dev/null 2>&1 || true
+probe_url="$(cat "$URL_CAP" 2>/dev/null || true)"
+assert_contains "health-path: exact URL built from origin" \
+    "https://openrouter.ai/api/v1/models" "$probe_url"
+assert_absent   "health-path: no double-/api prefix" "api/api" "$probe_url"
 
 # ── tier 2b: real containment self-test (podman + image) ─────────────────────
 if ! command -v podman >/dev/null; then

--- a/tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
+++ b/tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg
@@ -16,6 +16,8 @@ Author: MinhHaDuong
 
 2026-06-05T09:10Z claude note re-scoped off ACP (author "review is CI" directive): the seat is just an agnostic CLI reviewer run by the 0217 sandbox-runner — no bespoke ACP agent. Blocked-by flipped 0208→0217 (the runner is the dependency, not a management surface). Prototype already done in 0217: aider --ask over llama-server, contained in rootless podman; scorecard 1 devstral-small-2 (13/13 hallucinations, unusable), scorecard 2 qwen3.6-35b-a3b (1 real cross-file catch, usable, 80 tok/s). This ticket now = generalize that to the {OpenRouter, llama-server} matrix + the advisory trial
 2026-07-13T21:13Z Minh Ha-Duong note blocker 0217 closed — Blocked-by removed.
+2026-07-14T05:29Z claude note raid-207 execute (PR pending): landed criteria 1-2 MACHINERY — seat-runner --credential-env (env-passthrough bare -e, never argv; empty-var fail-loud), --health-path built from origin scheme://authority (fixes double-/api), https end-to-end TLS branch (--add-host real-host:127.0.0.1 + in-container 8443 bridge; http byte-identical), reviewers.sh credential-env roster field threaded through all 3 read-sites, commented OpenRouter panel.yml example. Tests: test_seat_runner.sh 42/42, test_reviewers.sh 27/27, test_net_relay.py 2/2 (unchanged). Local TLS-bridge behavioral proof PASSED (self-signed cloud.test origin, HTTP 200, cert validated end-to-end through raw relay inside --network=none container).
+2026-07-14T05:29Z claude note criterion 2 OpenRouter real smoke record BLOCKED on author provisioning OPENROUTER_API_KEY (not set in this environment); llama-server side smoke-tested under 0217. Advisory trial (criteria 3-4) stays OPEN — PR uses Ticket-ref, does not close this ticket. Containment self-test receives CRED_ARGS but is --network=none, a known non-issue.
 --- body ---
 ## Context
 
@@ -74,7 +76,7 @@ unreachable (fail-loud).
 
 ## Exit criteria
 
-- [ ] Seat runs an agnostic CLI reviewer via the 0217 sandbox-runner, credentials via BASH_ENV minimal-env path
-- [ ] Both endpoint configs (OpenRouter, llama-server) smoke-tested and logged
+- [x] Seat runs an agnostic CLI reviewer via the 0217 sandbox-runner, credentials via BASH_ENV minimal-env path
+- [ ] Both endpoint configs (OpenRouter, llama-server) smoke-tested and logged (llama-server done under 0217; OpenRouter real smoke blocked on author key — local TLS-bridge transport proof passed)
 - [ ] Advisory trial: ≥5 MRs, ≥3 projects per config, scorecards logged
 - [ ] Promote/drop recommendation recorded for 0205's integration review


### PR DESCRIPTION
Implements criteria 1-2 **machinery** of ticket 0207. The advisory trial (criteria 3-4) stays OPEN — this PR does not close the ticket.

## What landed

**scripts/seat-runner.sh**
- `--credential-env NAME`: reads the endpoint API key from the named env var in the runner process, exports `OPENAI_API_KEY`, and passes the **bare** `-e OPENAI_API_KEY` passthrough so podman reads the value from the invoking env. The secret never enters podman argv (`ps -ef` leak). Empty/unset var fails loud without echoing the value. Local endpoints keep the inline dummy key.
- `--health-path PATH` (default `/health`, `""` skips): probe URL built from the endpoint **origin** (`SCHEME://authority` + path), not `${ENDPOINT%/v1}`+path which double-prefixed `/api` for an `/api/v1` endpoint. The endpoint decomposition moved ahead of the probe (it already ran unconditionally — the move is safe).
- **https branch**: end-to-end TLS to a cloud endpoint through the raw relay. A `--userns=keep-id` seat cannot bind <1024 (EACCES), so the bridge listens on 8443, `CONTAINER_BASE` keeps scheme+real host with the port swapped, and `--add-host` maps the real hostname to 127.0.0.1 (works under `--network=none`). The client presents valid SNI/cert; the relay moves only encrypted bytes. http endpoints stay **byte-identical** to v1. `net-relay.py` is unchanged.

**skills/reviewers/**
- `credential-env` roster field, threaded through all three `IFS='|' read` sites in lockstep; `--credential-env` passed to the seat-runner only when set.
- panel.yml schema comment + a commented OpenRouter example seat.

**tests/**
- `test_seat_runner.sh`: stubbed-podman argv/env capture proves the secret rides the process env and appears in argv only as bare `-e OPENAI_API_KEY` (ps-leak regression guard); https `--add-host` + 8443 base; http byte-identity; exact health-path URL for `/api/v1` (double-/api guard); new-flag source checks. **42/42.**
- `test_reviewers.sh`: credential-env threads through when set, absent otherwise. **27/27.**
- Fixed a latent `pipefail`+SIGPIPE flake in both suites' assert helpers (`printf | grep -q` → here-string) — grep -q closing the pipe early SIGPIPEd printf, a nondeterministic false FAIL on a large haystack. Now stable across 5 consecutive runs.
- `test_net_relay.py` unchanged: 2/2.

## Verification
- `make check` exit 0 (skills-drift, agnostic-tickets, agnostic-skills, full pytest).
- **Local TLS-bridge behavioral proof PASSED**: self-signed `cloud.test` origin, HTTP 200, cert validated end-to-end through the raw relay inside a `--network=none` container with `--add-host` + in-container 8443 bridge.
- Real containment self-test (podman + image) ran GREEN locally (not SKIPed).

## Known non-issues / follow-ups
- The containment self-test receives `CRED_ARGS` but is `--network=none`; a known, network-denied non-issue.
- **Criterion 2 OpenRouter real smoke is blocked on the author provisioning `OPENROUTER_API_KEY`** (not set in this environment). The llama-server config was smoke-tested under 0217; the local TLS-bridge proof stands in for the OpenRouter transport.

Ticket-ref: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)