### PR TITLE
docs(roar): skip ExitWorktree when running inside isolation worktree subagent

### DIFF
--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -95,7 +95,10 @@ branch — there are no remote branches nor merge requests to inspect.
        `git switch -c <branch> <sha>`.
     No-forge repo: every ancestry probe in this step compares against the
     local default branch instead of `origin/main`.
-    Skip if not in a worktree.
+    Skip if not in a worktree. When roar runs inside an `isolation:"worktree"`
+    subagent, `ExitWorktree` is unavailable — skip this step; the harness
+    auto-cleans the agent's worktree once its branch is merged and the tree
+    is clean.
 10. **GC stale worktrees** (from the main repo): prune any registered worktree on an upstream-gone branch — regardless of path or name, including ones outside `.claude/worktrees/` — intact dirs that `git worktree prune` misses. The `[gone]` status only registers after the remote-tracking ref is pruned, so fetch first:
     ```bash
     git fetch --prune origin


### PR DESCRIPTION
## Summary
- Step 9 (worktree exit) of `skills/roar/SKILL.md` assumed an interactive session owns its worktree; when roar runs inside an `isolation:"worktree"` subagent, `ExitWorktree` is unavailable.
- Adds one sentence documenting the skip: the harness auto-cleans the agent's worktree once its branch is merged and the tree is clean.

Context: both roar runs in raid 322/207 (2026-07-14) hit this gap.

## Test plan
- [x] `make check-skills-drift` — OK, skills catalog in sync (frontmatter unchanged)
- [x] `tests/test_skill_descriptions.py` — passes
- [x] `pytest tests/ -m adherence` — 17 passed

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)