### PR TITLE
raid(0330): cure merge-permission denial with external review, don't park

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_classifier_prohibition_paraphrase.md
+++ b/projects/-home-haduong--claude/memory/feedback_classifier_prohibition_paraphrase.md
@@ -28,6 +28,11 @@ autonomous run must exercise a standing authorization, quote the grant
 verbatim into the transcript before the gated action (ticket 0249 option 2).
 The system-prompt-level "never merge" for background sessions remains outside
 harness control — residual denials there are expected. Effectiveness of the
-wording fix is under observation by experience. Related:
+wording fix is under observation by experience. One objection no quoted
+grant answers: "self-authored and self-reviewed" (raid 245/320, 2026-07-14
+— denied twice with the Phase 7 grant quoted). The author ruled the
+objection valid; cure it with decorrelated external review via the
+reviewer seats and retry once, parking merge-ready only as fallback (raid
+Phase 7 § Merge-permission denial, ticket 0330). Related:
 [[feedback_merge_classifier_blocks_autonomous_raid]] (referenced in ticket
 0249 but never written; this entry supersedes it).

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -242,6 +242,34 @@ For each eligible PR, sequentially within the wave:
 3. Check PR is still mergeable (no conflicts from earlier merges in this wave).
 4. Run `/merge <pr-number>`. This atomically closes the ticket and merges via GitHub API.
 5. If merge fails (conflict, CI regression), ESCALATE — leave a PR comment and move to the next PR.
+   A *permission denial* on the merge call is not a merge failure — handle it
+   per § Merge-permission denial below, not by ESCALATE.
+
+### Merge-permission denial: cure the objection, don't park
+
+The permission layer may decline the merge call for an APPROVED PR on the
+ground that it is self-authored and self-reviewed (observed 2026-07-14,
+raid 245/320: `erg-pr-merge` denied twice, both PRs parked for a human
+word). That objection is valid: the coder and the gaze battery share one
+model family. The cure is decorrelated external review, which the raid
+already owns. Answer the objection with evidence; two moves are always
+wrong: weakening permissions (exiting auto mode, skipping permission
+checks) and hand-merging around the guard.
+
+1. Do not retry the denied call verbatim.
+2. Run `/reviewers request <pr>` then `/reviewers harvest <pr>` — the
+   external seats (0205 panel, 0207 agnostic CLI seats) review the same
+   diff on a different provider. Disposition every harvested finding
+   through the verify-gate contract like any panel comment; a blocking
+   finding sends the PR back through Phase 6 rather than to merge.
+3. On a clean disposition, record the external verdict on the merge
+   request (a comment naming the seats and their disposition), quote that
+   verdict and this section's grant in the transcript, and retry the merge
+   once. The PR is no longer self-reviewed-only.
+4. Fallback — empty roster, seat-runner failure, or a second denial: park
+   the PR merge-ready, continue the wave, and make the briefing name each
+   parked PR *and* its deferred post-merge steps (cleanup + per-PR roar),
+   so the author's one-word merge does not strand Phase 8.
 
 After all waves, in one compound so the `cd` persists across the rebase:
 `cd <session-worktree> && git checkout main && git pull --rebase origin main`, then

--- a/tickets/0330-raid-merge-denial-cure-with-external-review.erg
+++ b/tickets/0330-raid-merge-denial-cure-with-external-review.erg
@@ -1,0 +1,52 @@
+%erg 0.1
+Title: Raid Phase 7: cure a merge-permission denial with external review, don't park
+Created: 2026-07-14
+Author: claude
+
+--- log ---
+2026-07-14T09:31Z claude created
+
+--- body ---
+## Context
+Raid 245/320 (2026-07-14, job f10f81b4) ended with both PRs APPROVED and
+merge-ready, but the auto-mode permission classifier denied `erg-pr-merge`
+twice: it wants a human in the merge loop for self-authored, self-reviewed
+merge requests. The raid parked the PRs and stopped ("needs input"), so the
+merges landed hours later on the author's word and the deferred roar nearly
+evaporated.
+
+The author's verdict: the classifier's objection is valid — the coder and
+the gaze battery share one model family — and the correct move is to cure
+the objection with decorrelated external review, not to give up the
+workflow (and not to exit auto mode or skip permissions). The machinery
+already exists: the 0205 reviewer panel and the 0207 agnostic CLI seats
+(`/reviewers request` / `harvest`) review a diff on a different provider.
+What is missing is the raid Phase 7 recovery path wiring them to the
+denial.
+
+## Relevant files
+- `skills/raid/SKILL.md` — Phase 7 merge steps; today a denial has no
+  handling and improvises into park-and-ask
+- `skills/reviewers/SKILL.md` — the external-seat interface the cure uses
+- `projects/-home-haduong--claude/memory/feedback_classifier_prohibition_paraphrase.md`
+  — records the quoted-grant mitigation; the self-review objection is the
+  case no quoted grant answers
+
+## Actions
+1. Add a "Merge-permission denial" subsection to raid Phase 7: distinguish
+   denial from merge failure; cure via `/reviewers request` + `harvest`,
+   disposition findings through the gate contract, record the external
+   verdict on the merge request, then retry the merge once.
+2. Forbid the two wrong moves explicitly: weakening permissions and
+   hand-merging around the guard.
+3. Fallback (empty roster, seat failure, second denial): park merge-ready,
+   and require the briefing to name the deferred post-merge steps
+   (cleanup + per-PR roar) so an author-word merge doesn't strand them.
+4. Update the classifier-prohibition memory entry with the self-review
+   case and its cure.
+
+## Exit criteria
+- [ ] Raid Phase 7 documents the denial-recovery path (cure, retry once,
+      park as fallback with deferred steps named)
+- [ ] Memory entry updated
+- [ ] `make check` passes

--- a/tickets/0331-roar-per-pr-celebrations-since-last-sha.erg
+++ b/tickets/0331-roar-per-pr-celebrations-since-last-sha.erg
@@ -1,0 +1,33 @@
+%erg 0.1
+Title: Roar: log one celebration per merged PR since roar-last-sha, not one aggregate blob
+Created: 2026-07-14
+Author: claude
+
+--- log ---
+2026-07-14T09:31Z claude created
+
+--- body ---
+## Context
+Interactive sessions merge PRs one at a time and roar once at the end (per
+rules/git.md, an interactive merge only proposes /roar). Roar then measures
+"everything since roar-last-sha" and logs a single celebrations.jsonl
+entry. On 2026-07-13 the pipeline session merged eleven ticket PRs
+(#538-#548) between 11:34 and 15:54 and the 16:55 roar recorded them as one
+record (51 commits, 36 files, ticket null). Reflection, state refresh, and
+cleanup all happened; what is lost is per-ticket attribution, which bump
+tallies and celebration stats feed on. Raid roars (per merged PR) do not
+have this problem.
+
+## Actions
+1. In roar's telemetry step, enumerate the merge commits in
+   `roar-last-sha..HEAD` on the default branch; recover branch and ticket
+   from each merge-commit subject.
+2. Log one celebration entry per merged PR, falling back to the current
+   aggregate entry only when no merge commits are found (squash-merge
+   repos, no-forge repos).
+
+## Exit criteria
+- [ ] A batched interactive roar produces per-PR celebration entries
+      telemetry-equivalent to a raid's per-PR roars
+- [ ] Aggregate fallback preserved where merge commits are absent
+- [ ] `make check` passes

--- a/tickets/closed/0330-raid-merge-denial-cure-with-external-review.erg
+++ b/tickets/closed/0330-raid-merge-denial-cure-with-external-review.erg
@@ -2,10 +2,12 @@
 Title: Raid Phase 7: cure a merge-permission denial with external review, don't park
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #581
 
 --- log ---
 2026-07-14T09:31Z claude created
 
+2026-07-14T09:40Z Minh Ha-Duong closed — autoclosed — PR #581
 --- body ---
 ## Context
 Raid 245/320 (2026-07-14, job f10f81b4) ended with both PRs APPROVED and


### PR DESCRIPTION
## Summary

Raid 245/320 (2026-07-14) ended with both PRs APPROVED, CI-green, and merge-ready, yet parked for a human word: the auto-mode permission classifier denied `erg-pr-merge` twice because the PRs were self-authored and self-reviewed. The author ruled the objection valid and the park wrong — the harness should cure the objection, not abandon the workflow (and never weaken permissions to get past it).

## Changes

- **skills/raid/SKILL.md — Phase 7 § Merge-permission denial**: a permission denial is distinguished from a merge failure (no ESCALATE). Recovery path: `/reviewers request` + `harvest` (0205 panel / 0207 agnostic CLI seats — a different provider than the coder), disposition findings through the gate contract, record the external verdict on the merge request, retry the merge once. Fallback (empty roster, seat failure, second denial): park merge-ready and make the briefing name the deferred post-merge steps (cleanup + per-PR roar) so an author-word merge does not strand Phase 8.
- **memory/feedback_classifier_prohibition_paraphrase.md**: records that no quoted grant answers the self-review objection, and points to the cure.
- **tickets/0331** (bundled, stays open): roar should log one celebration per merged PR since `roar-last-sha` instead of one aggregate blob — the case-3 telemetry-granularity loss from the same log examination.

## Verification

- `make lint` (adherence tier): 17 passed
- `make check-fast`: exit 0

**Ticket:** tickets/0330-raid-merge-denial-cure-with-external-review.erg
Ticket-ref: tickets/0331-roar-per-pr-celebrations-since-last-sha.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)