### PR TITLE
study(0245): pin measure-B weeks, record measure-A authorization

### DIFF
--- a/docs/trace-ab-2026-06.md
+++ b/docs/trace-ab-2026-06.md
@@ -133,9 +133,12 @@ guardrail here (per the phase-4 routing decision).
   range. `filter_window` does not apply to arm A.
 - **Measure B**: two **disjoint weeks**, one control (flag off) and one
   treatment (flag on), fixed at B-arm launch **before any data is collected**.
-  <!-- TODO(0245): pin the two disjoint week date ranges here at B-arm launch,
-       before collecting any B-arm data. Do not fabricate dates ahead of the
-       run. -->
+  Pinned by the author on 2026-07-14, before any B-arm data collection:
+  - **Control week (flag off)**: 2026-07-20 → 2026-07-26 (UTC, inclusive).
+    Normal operation; no configuration change.
+  - **Treatment week (flag on)**: 2026-07-27 → 2026-08-02 (UTC, inclusive).
+    `convergence.enabled: true` in `skills/gaze/telemetry.yml` (or
+    `GAZE_CONVERGENCE_ENABLED=1`) at week start, reverted at week end.
 
 ## Exclusion rules
 

--- a/tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
+++ b/tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg
@@ -7,6 +7,8 @@ Author: Integration Test
 2026-06-10T20:09Z Integration Test created
 
 2026-07-13T16:03Z Minh Ha-Duong note pre-registration split to 0315: interventions pinned, decision rule + red-first tests landed, gaze convergence flag documented default off; live A/B arms remain here
+
+2026-07-14T09:34Z Minh Ha-Duong note authorized measure-A replay spend (5 paired Sonnet replays, smoke-first on 0319); pinned measure-B windows in docs/trace-ab-2026-06.md — control 2026-07-20..2026-07-26 (flag off), treatment 2026-07-27..2026-08-02 (flag on)
 --- body ---
 ## Context
 


### PR DESCRIPTION
Pre-registration completion for the phase-5 A/B (ticket 0245): replaces the `TODO(0245)` window placeholder in `docs/trace-ab-2026-06.md` with the author-pinned measure-B weeks — control 2026-07-20..2026-07-26 (flag off), treatment 2026-07-27..2026-08-02 (flag on) — and records the measure-A replay-spend authorization (5 paired Sonnet replays, smoke-first on 0319) in the 0245 ticket log.

Committed before any B-arm data collection; the commit timestamp is the pre-registration proof required by 0245's verification criteria.

Ticket-ref: tickets/0245-trace-doctor-phase-5-targeted-a-b-model.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)