### PR TITLE
replay(0319): carry resolve-$$-to-literal caveat into workflow.md

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -17,7 +17,7 @@ The hook handles worktree entry automatically. When naming the worktree (if prom
 | Active feature branch + open MR | `t{N}-{pid}` | `[→ Execute]` |
 | MR review | `review-{N}` | `[→ Verify]` |
 
-The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel sessions on the same ticket land in distinct worktree paths; legacy bare `t{N}` names remain valid.
+The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel sessions on the same ticket land in distinct worktree paths; legacy bare `t{N}` names remain valid. Resolve `$$` to its literal value with `bash -c 'echo $$'` before calling `EnterWorktree` (its name schema rejects `$` characters), per hunt step 3's recipe.
 
 After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→ Execute]`) so the user sees which Five-Claws claw is active.
 


### PR DESCRIPTION
Measure-A replay (study ticket 0245) — DO NOT MERGE. Control PR: #563.

Implements tickets/0319-workflow-md-worktree-name-table-carry-th.erg:
carries the resolve-`$$`-to-literal caveat from hunt step 3 into the
worktree-naming table in rules/workflow.md, so a call site hand-typed
from that table doesn't reproduce EnterWorktree's InputValidationError
on raw `$` characters.

`make check` passes (814 passed).

Ticket: none