### PR TITLE
fix(0323): normalize guard file_path with realpath -m (residual 1)

### DIFF
--- a/scripts/guard-cd-primary-repo.sh
+++ b/scripts/guard-cd-primary-repo.sh
@@ -54,15 +54,21 @@ target="${target%/}"
 target="${target/#\~/$HOME}"
 target="${target//\$HOME/$HOME}"
 
-# Normalize `..` traversal and symlinks before the equality check (ticket 0323,
-# minor A): `cd $primary/sub/.. && git commit` resolves back to $primary but does
-# not lexically equal it, so it would slip past the string compare below. This is
-# the same evasion residual 1 closed in pretooluse-worktree-path-guard.sh.
-# realpath -m collapses `..` and resolves symlinks in existing components while
-# tolerating a not-yet-existing leaf. Warn on the fallback so the degraded
-# (raw-path, still-vulnerable) mode is visible rather than silent.
+# Normalize `..` traversal and symlinks on BOTH sides before the equality check
+# (ticket 0323, residual 1). Two evasions this closes: `cd $primary/sub/.. &&
+# git commit` resolves back to $primary without lexically equalling it (minor A);
+# and a session cwd spelled through a symlink alias of the primary root leaves
+# primary_root aliased while the target resolves canonical, so the two spellings
+# of the same directory would not string-match. Normalizing only one side would
+# miss the second — both target and primary_root must be canonicalized. This
+# closes the symlink/`..` evasion class here for parity with residual 1 in
+# pretooluse-worktree-path-guard.sh (whose roots come from `git rev-parse`, so
+# they are already canonical). realpath -m collapses `..` and resolves symlinks in
+# existing components while tolerating a not-yet-existing leaf. Warn on the
+# fallback so the degraded (raw-path, still-vulnerable) mode is visible.
 if command -v realpath &>/dev/null; then
     target=$(realpath -m -- "$target" 2>/dev/null || echo "$target")
+    primary_root=$(realpath -m -- "$primary_root" 2>/dev/null || echo "$primary_root")
 else
     echo "guard: realpath unavailable, path normalization skipped" >&2
 fi

--- a/scripts/guard-cd-primary-repo.sh
+++ b/scripts/guard-cd-primary-repo.sh
@@ -54,6 +54,19 @@ target="${target%/}"
 target="${target/#\~/$HOME}"
 target="${target//\$HOME/$HOME}"
 
+# Normalize `..` traversal and symlinks before the equality check (ticket 0323,
+# minor A): `cd $primary/sub/.. && git commit` resolves back to $primary but does
+# not lexically equal it, so it would slip past the string compare below. This is
+# the same evasion residual 1 closed in pretooluse-worktree-path-guard.sh.
+# realpath -m collapses `..` and resolves symlinks in existing components while
+# tolerating a not-yet-existing leaf. Warn on the fallback so the degraded
+# (raw-path, still-vulnerable) mode is visible rather than silent.
+if command -v realpath &>/dev/null; then
+    target=$(realpath -m -- "$target" 2>/dev/null || echo "$target")
+else
+    echo "guard: realpath unavailable, path normalization skipped" >&2
+fi
+
 # Only the primary repo root itself is the offence; subtrees (incl. the
 # worktree path, which lives under primary_root) are fine.
 [ "$target" = "$primary_root" ] || exit 0

--- a/scripts/pretooluse-worktree-path-guard.sh
+++ b/scripts/pretooluse-worktree-path-guard.sh
@@ -71,6 +71,21 @@ if [ "${file_path#/}" = "$file_path" ]; then
     fi
 fi
 
+# Normalize before the prefix match (ticket 0323, residual 1): a raw path with
+# `..` traversal or through a symlinked directory does not lexically begin with
+# $primary_root and would slip past the string-prefix `case` below. `realpath -m`
+# collapses `..` and resolves symlinks in the existing dir components while
+# tolerating a not-yet-existing leaf (--canonicalize-missing), which is correct
+# at PreToolUse time — the file being written need not exist yet. Fall back to
+# the raw path if realpath is unavailable. primary_root/worktree_root are left
+# as-is: git rev-parse --show-toplevel already canonicalizes them, and they are
+# opaque literals under the _GUARD_*_ROOT test override.
+if command -v realpath &>/dev/null; then
+    file_path=$(realpath -m -- "$file_path" 2>/dev/null || echo "$file_path")
+else
+    echo "guard: realpath unavailable, path normalization skipped" >&2
+fi
+
 case "$file_path" in
     "$primary_root"/*)
         case "$file_path" in

--- a/tests/test_guard_cd_primary_repo.sh
+++ b/tests/test_guard_cd_primary_repo.sh
@@ -78,6 +78,11 @@ _assert_blocked "cd PRIMARY && git reset HEAD~1" "cd $PRIMARY && git reset HEAD~
 _assert_blocked "cd PRIMARY && git push origin main" "cd $PRIMARY && git push origin main" "$WORKTREE"
 _assert_blocked "cd PRIMARY && erg close 123"   "cd $PRIMARY && erg close 123"            "$WORKTREE"
 _assert_blocked "cd ~/repo && git commit (tilde)" "cd ~/repo && git commit -m x"          "$WORKTREE"
+# Evasion (ticket 0323, minor A): `..` traversal resolves back to PRIMARY but is
+# not lexically equal to it, so a raw string compare misses it. realpath -m
+# normalization must catch it.
+_assert_blocked "cd PRIMARY/sub/.. && git commit (dotdot evasion)" \
+                "cd $PRIMARY/sub/.. && git commit -m x"    "$WORKTREE"
 
 # --- ALLOW ----------------------------------------------------------------
 # Same cd+commit but cwd is the primary repo itself (not a worktree session).

--- a/tests/test_guard_cd_primary_repo.sh
+++ b/tests/test_guard_cd_primary_repo.sh
@@ -83,6 +83,20 @@ _assert_blocked "cd ~/repo && git commit (tilde)" "cd ~/repo && git commit -m x"
 # normalization must catch it.
 _assert_blocked "cd PRIMARY/sub/.. && git commit (dotdot evasion)" \
                 "cd $PRIMARY/sub/.. && git commit -m x"    "$WORKTREE"
+# Evasion (ticket 0323, residual 1): the session cwd is spelled through a symlink
+# alias of the primary root, so primary_root (derived from cwd) stays aliased while
+# the cd target resolves canonical. Normalizing target alone misses it — both sides
+# must be realpath'd. Uses real on-disk fixtures because realpath resolves symlinks
+# in existing components only.
+_symbase=$(mktemp -d)
+mkdir -p "$_symbase/primary/.claude/worktrees/t001"
+ln -s "$_symbase/primary" "$_symbase/alias"
+_assert_blocked "cd CANONICAL primary && git commit, cwd via symlink alias" \
+                "cd $_symbase/primary && git commit -m x" \
+                "$_symbase/alias/.claude/worktrees/t001"
+rm "$_symbase/alias"
+rm -r "$_symbase/primary"
+rmdir "$_symbase"
 
 # --- ALLOW ----------------------------------------------------------------
 # Same cd+commit but cwd is the primary repo itself (not a worktree session).

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -262,4 +262,52 @@ else
     fail=1
 fi
 
+# 16. `..`-traversal evasion (ticket 0323, residual 1): a raw file_path that does
+# NOT lexically begin with $PRIMARY but collapses into it via `..` must still be
+# denied. Without realpath normalization the prefix match on the raw string
+# passes (exit 0, silent bypass); `realpath -m` collapses the `..` — tolerating a
+# not-yet-existing leaf — so the normalized path matches $PRIMARY and denies.
+rc=$(_rc "$WORKTREE" "$PRIMARY" "/home/testuser/x/../repo/evil.py")
+if [ "$rc" = "2" ]; then
+    echo "PASS: denies dot-dot-traversal path that collapses into primary (exit 2)"
+else
+    echo "FAIL: expected exit 2 for dot-dot-traversal into primary; got: $rc"
+    fail=1
+fi
+out=$(_run_hook "$WORKTREE" "$PRIMARY" "/home/testuser/x/../repo/evil.py")
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: dot-dot-traversal into primary emits corrective message"
+else
+    echo "FAIL: expected corrective message for dot-dot-traversal; got: $out"
+    fail=1
+fi
+
+# 17. Symlink-through evasion (ticket 0323, residual 1): a file_path routed through
+# a symlink that points at the primary root has a raw string that does NOT start
+# with the real primary-root path, so the prefix match misses (silent bypass).
+# `realpath -m` resolves the symlink in the existing dir components, exposing the
+# primary root, and the guard denies. Real-git fixture (no env override), mirroring
+# cases 8/9 so the identity predicate and root resolution run for real.
+_case17_base=$(mktemp -d)
+_case17_primary="$_case17_base/primary"
+mkdir -p "$_case17_primary"
+git -C "$_case17_primary" init -q
+git -C "$_case17_primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mkdir -p "$_case17_primary/.claude/worktrees"
+git -C "$_case17_primary" worktree add -q "$_case17_primary/.claude/worktrees/t001"
+# Symlink OUTSIDE the primary root pointing back at it; a path through it evades
+# the raw-string prefix match against the real primary-root path.
+ln -s "$_case17_primary" "$_case17_base/plink"
+out=$( cd "$_case17_primary/.claude/worktrees/t001" \
+       && printf '{"tool_name":"Write","tool_input":{"file_path":"%s/src/main.py","content":"x"}}' "$_case17_base/plink" \
+       | bash "$HOOK" 2>&1 || true)
+git -C "$_case17_primary" worktree remove --force "$_case17_primary/.claude/worktrees/t001" 2>/dev/null || true
+rm -r "$_case17_base"
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: denies path routed through a symlink into primary (identity predicate)"
+else
+    echo "FAIL: expected deny for symlink-through into primary; got: $out"
+    fail=1
+fi
+
 exit $fail


### PR DESCRIPTION
## What

Extracts **residual 1** from PR #574 onto a clean `origin/main` base and opens it standalone.

Both path guards (`scripts/pretooluse-worktree-path-guard.sh`,
`scripts/guard-cd-primary-repo.sh`) compared a **raw, un-normalized** path
against the primary-repo root, so a path that resolves *into* the primary
checkout but does not lexically begin with its root slipped past the
string compare — a silent bypass. Two evasion classes:

- `..`-traversal: `/home/user/x/../repo/evil.py` collapses into the primary
  root but the raw string does not prefix-match it.
- symlink-through: a path routed via a symlink pointing at the primary root
  has a raw string that never starts with the real root path.

The fix normalizes the candidate path with `realpath -m` before the
prefix/equality check: it collapses `..` and resolves symlinks in the
existing directory components while **tolerating a not-yet-existing leaf**
(`--canonicalize-missing`), which is correct at PreToolUse time — the file
being written need not exist yet. When `realpath` is unavailable the guard
falls back to the raw path and **warns** so the degraded (still-vulnerable)
mode is visible rather than silent.

## Tests (red before the fix)

- `tests/test_pretooluse_worktree_path_guard.sh` — case 16 (`..`-traversal
  into primary, exit 2 + corrective message) and case 17 (symlink-through,
  real-git fixture mirroring cases 8/9). Suite: 22 PASS.
- `tests/test_guard_cd_primary_repo.sh` — dot-dot evasion case. Suite: 20 PASS.
- `make lint`: 17 adherence tests pass.

## Residual 2 dropped

Residual 2 from PR #574 (snapshot/restore of `GUARD_ALLOW_PRIMARY_EDIT` in
`scripts/bash-env.sh`, plus its guard-var test) is **not** carried here. It
is structurally unsound per the gaze ESCALATE — a sourced project `.env`
can forge the per-process nonce — and is being redesigned under ticket 0323
(strict `KEY=VALUE` parse), with the keys-wiring split to 0330. The
residual-2 provenance comment in the pretooluse guard was reverted to
`origin/main`'s wording so this PR documents only what it ships.
`scripts/bash-env.sh` is untouched here.

Ticket-ref: tickets/0323-worktree-path-guard-residuals-realpath-n.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)