### PR TITLE
fix(0323): strict-parse project .env, refuse GUARD_* keys (residual 2)

### DIFF
--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -5,18 +5,71 @@
 #
 # BASH_ENV is honored by non-interactive bash (i.e. "bash -c ..."), which is
 # exactly what Claude Code uses for Bash tool calls.
+#
+# Two .env sources with DIFFERENT trust levels:
+#
+#   * $HOME/.claude/.env — user-owned, TRUSTED. Sourced as shell code (full
+#     expansion), exactly as before. Only the user writes this file.
+#
+#   * $PWD/.env — project-level, UNTRUSTED. An agent, a cloned repo, or any
+#     project write can place it. It is NEVER sourced: it is strict-parsed
+#     KEY=VALUE, values are assigned LITERALLY (no eval / $() / backticks), and
+#     any GUARD_*-namespaced key is REFUSED. This structurally closes the
+#     escape-hatch provenance hole (ticket 0323, residual 2): a sourced project
+#     .env could otherwise forge a per-process guard nonce
+#     (e.g. GUARD_ALLOW_PRIMARY_EDIT) or execute arbitrary shell via BASH_ENV.
+#
+# The script runs on every bash subprocess, so it stays fast and never aborts on
+# a missing or malformed .env — bad lines in the project file are skipped, never
+# fatal.
 
+# --- trusted user-level .env: source as before (full expansion) ---
 set -a  # mark all subsequent assignments for export
-
 [ -f "$HOME/.claude/.env" ] && source "$HOME/.claude/.env"
+set +a
 
-# Project-level .env, identified by PWD (Claude Code sets PWD to the project dir
-# for each subprocess). Skip if it resolves to the same file as the user-level one.
+# --- untrusted project-level .env: strict KEY=VALUE parse, never executed ---
+# Claude Code sets PWD to the project dir for each subprocess. Skip if it
+# resolves to the same file as the trusted user-level one (already loaded).
 if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
     _be_proj="$(realpath "$PWD/.env" 2>/dev/null)"
     _be_user="$(realpath "$HOME/.claude/.env" 2>/dev/null)"
-    [ "$_be_proj" != "$_be_user" ] && source "$PWD/.env"
+    if [ "$_be_proj" != "$_be_user" ]; then
+        while IFS= read -r _be_line || [ -n "$_be_line" ]; do
+            # strip leading whitespace for blank/comment detection
+            _be_trim="${_be_line#"${_be_line%%[![:space:]]*}"}"
+            [ -z "$_be_trim" ] && continue          # blank line
+            [ "${_be_trim:0:1}" = "#" ] && continue # comment
+            _be_trim="${_be_trim#export }"          # optional `export ` prefix
+            # require KEY=VALUE with a valid identifier key
+            case "$_be_trim" in
+                [A-Za-z_]*=*) ;;
+                *) continue ;;
+            esac
+            _be_key="${_be_trim%%=*}"
+            case "$_be_key" in
+                *[!A-Za-z0-9_]*) continue ;;        # key has an invalid char
+            esac
+            _be_val="${_be_trim#*=}"                # everything after the FIRST =
+            # strip ONE matching pair of surrounding quotes (literal, no escapes)
+            if [ "${#_be_val}" -ge 2 ]; then
+                _be_first="${_be_val:0:1}"
+                _be_last="${_be_val: -1}"
+                if { [ "$_be_first" = '"' ] && [ "$_be_last" = '"' ]; } ||
+                   { [ "$_be_first" = "'" ] && [ "$_be_last" = "'" ]; }; then
+                    _be_val="${_be_val:1:${#_be_val}-2}"
+                fi
+            fi
+            # structural refusal: an untrusted file cannot set guard vars
+            if [[ "$_be_key" == GUARD_* ]]; then
+                printf 'bash-env: refusing GUARD_* key from project .env: %s\n' \
+                    "$_be_key" >&2
+                continue
+            fi
+            # assign the value LITERALLY — never expanded, never executed
+            export "$_be_key=$_be_val"
+        done < "$PWD/.env"
+        unset _be_line _be_trim _be_key _be_val _be_first _be_last
+    fi
     unset _be_proj _be_user
 fi
-
-set +a

--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -14,10 +14,13 @@
 #   * $PWD/.env — project-level, UNTRUSTED. An agent, a cloned repo, or any
 #     project write can place it. It is NEVER sourced: it is strict-parsed
 #     KEY=VALUE, values are assigned LITERALLY (no eval / $() / backticks), and
-#     any GUARD_*-namespaced key is REFUSED. This structurally closes the
-#     escape-hatch provenance hole (ticket 0323, residual 2): a sourced project
-#     .env could otherwise forge a per-process guard nonce
-#     (e.g. GUARD_ALLOW_PRIMARY_EDIT) or execute arbitrary shell via BASH_ENV.
+#     any guard-namespaced key — any key whose name contains GUARD_, covering
+#     both GUARD_* and the leading-underscore _GUARD_* override pair — is
+#     REFUSED. This structurally closes the escape-hatch provenance hole
+#     (ticket 0323, residual 2): a sourced project .env could otherwise forge a
+#     per-process guard nonce (e.g. GUARD_ALLOW_PRIMARY_EDIT) or the worktree-
+#     path override (_GUARD_WORKTREE_ROOT / _GUARD_PRIMARY_ROOT), or execute
+#     arbitrary shell via BASH_ENV.
 #
 # The script runs on every bash subprocess, so it stays fast and never aborts on
 # a missing or malformed .env — bad lines in the project file are skipped, never
@@ -60,9 +63,14 @@ if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
                     _be_val="${_be_val:1:${#_be_val}-2}"
                 fi
             fi
-            # structural refusal: an untrusted file cannot set guard vars
-            if [[ "$_be_key" == GUARD_* ]]; then
-                printf 'bash-env: refusing GUARD_* key from project .env: %s\n' \
+            # structural refusal: an untrusted file cannot set guard vars.
+            # Match every guard-namespaced key — both the GUARD_* form and the
+            # leading-underscore _GUARD_* override pair (_GUARD_WORKTREE_ROOT /
+            # _GUARD_PRIMARY_ROOT) that pretooluse-worktree-path-guard.sh honors
+            # as an unconditional worktree-path override. Substring match, since
+            # no legitimate project key contains the harness-internal GUARD_ token.
+            if [[ "$_be_key" == *GUARD_* ]]; then
+                printf 'bash-env: refusing guard-namespaced key from project .env: %s\n' \
                     "$_be_key" >&2
                 continue
             fi

--- a/tests/test_bash_env_project_env_parse.sh
+++ b/tests/test_bash_env_project_env_parse.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Tests for scripts/bash-env.sh — the BASH_ENV shim sourced at the start of every
+# Claude Code bash subprocess. It loads two .env sources with DIFFERENT trust:
+#
+#   * $HOME/.claude/.env  — user-owned, trusted: sourced as shell code.
+#   * $PWD/.env           — project-level, UNTRUSTED: strict KEY=VALUE parse,
+#                           values assigned literally, GUARD_* keys refused.
+#
+# The untrusted project file must never be executed and must never set a
+# GUARD_*-namespaced variable, or a project-controlled .env could forge the
+# per-process guard nonce (GUARD_ALLOW_PRIMARY_EDIT) or run arbitrary shell via
+# BASH_ENV (ticket 0323, residual 2).
+#
+# Harness idiom: run bash-env.sh in an isolated subprocess with a controlled
+# HOME (so the real ~/.claude/.env is never read) and a controlled project dir
+# as PWD, then assert on the resulting environment.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+SCRIPT="$PWD/scripts/bash-env.sh"
+fail=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Load bash-env.sh in a subprocess with $HOME=<home> and PWD=<projdir>, then
+# print the value of environment variable <var> ("" if unset). stderr silenced.
+_load_var() {
+    local home="$1" projdir="$2" var="$3"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+        n="$3"
+        printf "%s" "${!n-}"
+    ' _ "$projdir" "$SCRIPT" "$var" 2>/dev/null
+}
+
+# Load bash-env.sh as above but return only the exit code (0 = no shell error).
+_load_rc() {
+    local home="$1" projdir="$2"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+    ' _ "$projdir" "$SCRIPT" >/dev/null 2>&1
+    echo $?
+}
+
+_assert_eq() {
+    local label="$1" got="$2" want="$3"
+    if [[ "$got" == "$want" ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — got [$got], want [$want]"
+        fail=1
+    fi
+}
+
+_assert_file_absent() {
+    local label="$1" path="$2"
+    if [[ ! -e "$path" ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — file was created: $path"
+        fail=1
+    fi
+}
+
+# An empty HOME so no trusted ~/.claude/.env exists (isolates the project file).
+EMPTY_HOME="$WORK/empty-home"
+mkdir -p "$EMPTY_HOME"
+
+# --- (1) a GUARD_* key in the project .env must NOT be set --------------------
+P1="$WORK/p1"; mkdir -p "$P1"
+printf 'GUARD_ALLOW_PRIMARY_EDIT=1\n' > "$P1/.env"
+_assert_eq "project .env cannot set GUARD_ALLOW_PRIMARY_EDIT" \
+    "$(_load_var "$EMPTY_HOME" "$P1" GUARD_ALLOW_PRIMARY_EDIT)" ""
+
+# --- (2) a command substitution in the project .env must NOT execute ----------
+P2="$WORK/p2"; mkdir -p "$P2"
+PWNED="$WORK/pwned"
+rm -f "$PWNED"
+# If the file were sourced as code, $(touch ...) and `touch ...` would run and
+# create $PWNED. Trigger the load FIRST, then check for the side effect.
+{
+    printf 'EVIL=$(touch %q)\n' "$PWNED"
+    printf 'ALSO=`touch %q`\n' "$PWNED"
+} > "$P2/.env"
+rc2="$(_load_rc "$EMPTY_HOME" "$P2")"
+_assert_file_absent "project .env command substitution does not execute" "$PWNED"
+_assert_eq "project .env with command-substitution values loads without shell error" \
+    "$rc2" "0"
+# And the literal text is stored, not the command result.
+_assert_eq "command-substitution value stored literally" \
+    "$(_load_var "$EMPTY_HOME" "$P2" EVIL)" "\$(touch $PWNED)"
+
+# --- (3) a plain KEY=VALUE loads exactly --------------------------------------
+P3="$WORK/p3"; mkdir -p "$P3"
+printf 'FOO=bar\n' > "$P3/.env"
+_assert_eq "plain FOO=bar loads as bar" \
+    "$(_load_var "$EMPTY_HOME" "$P3" FOO)" "bar"
+
+# --- (4) a quoted value strips one quote pair, preserves the space ------------
+P4="$WORK/p4"; mkdir -p "$P4"
+printf 'BAZ="a b"\n' > "$P4/.env"
+_assert_eq "quoted BAZ=\"a b\" loads as: a b" \
+    "$(_load_var "$EMPTY_HOME" "$P4" BAZ)" "a b"
+
+# --- (5) regression: trusted ~/.claude/.env still gets full source behavior ---
+USER_HOME="$WORK/user-home"
+mkdir -p "$USER_HOME/.claude"
+printf 'USERKEY=uval\n' > "$USER_HOME/.claude/.env"
+P5="$WORK/p5"; mkdir -p "$P5"   # project dir with NO .env — isolates the user file
+_assert_eq "trusted ~/.claude/.env is sourced (USERKEY=uval)" \
+    "$(_load_var "$USER_HOME" "$P5" USERKEY)" "uval"
+
+exit "$fail"

--- a/tests/test_bash_env_project_env_parse.sh
+++ b/tests/test_bash_env_project_env_parse.sh
@@ -75,6 +75,17 @@ printf 'GUARD_ALLOW_PRIMARY_EDIT=1\n' > "$P1/.env"
 _assert_eq "project .env cannot set GUARD_ALLOW_PRIMARY_EDIT" \
     "$(_load_var "$EMPTY_HOME" "$P1" GUARD_ALLOW_PRIMARY_EDIT)" ""
 
+# --- (1b) the LEADING-UNDERSCORE guard override pair must NOT be set -----------
+# pretooluse-worktree-path-guard.sh reads _GUARD_WORKTREE_ROOT / _GUARD_PRIMARY_ROOT
+# as an unconditional worktree-path override; a project .env forging both to equal
+# values would bypass the deny guard. The GUARD_* refusal must also catch _GUARD_*.
+P1B="$WORK/p1b"; mkdir -p "$P1B"
+printf '_GUARD_WORKTREE_ROOT=/x\n_GUARD_PRIMARY_ROOT=/x\n' > "$P1B/.env"
+_assert_eq "project .env cannot set _GUARD_WORKTREE_ROOT" \
+    "$(_load_var "$EMPTY_HOME" "$P1B" _GUARD_WORKTREE_ROOT)" ""
+_assert_eq "project .env cannot set _GUARD_PRIMARY_ROOT" \
+    "$(_load_var "$EMPTY_HOME" "$P1B" _GUARD_PRIMARY_ROOT)" ""
+
 # --- (2) a command substitution in the project .env must NOT execute ----------
 P2="$WORK/p2"; mkdir -p "$P2"
 PWNED="$WORK/pwned"

--- a/tickets/0323-worktree-path-guard-residuals-realpath-n.erg
+++ b/tickets/0323-worktree-path-guard-residuals-realpath-n.erg
@@ -6,6 +6,7 @@ Author: Minh Ha-Duong
 --- log ---
 2026-07-13T20:27Z Minh Ha-Duong created
 
+2026-07-14T10:28Z bump verify-reroll — round 1: GUARD_* refusal missed _GUARD_WORKTREE_ROOT/_GUARD_PRIMARY_ROOT override pair
 --- body ---
 ## Context
 

--- a/tickets/closed/0323-worktree-path-guard-residuals-realpath-n.erg
+++ b/tickets/closed/0323-worktree-path-guard-residuals-realpath-n.erg
@@ -2,11 +2,13 @@
 Title: Worktree-path guard residuals: realpath normalization and escape-hatch env provenance
 Created: 2026-07-13
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #588
 
 --- log ---
 2026-07-13T20:27Z Minh Ha-Duong created
 
 2026-07-14T10:28Z bump verify-reroll — round 1: GUARD_* refusal missed _GUARD_WORKTREE_ROOT/_GUARD_PRIMARY_ROOT override pair
+2026-07-14T10:35Z Minh Ha-Duong closed — autoclosed — PR #588
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

The BASH_ENV shim `scripts/bash-env.sh` sourced the project-level `$PWD/.env`
**as shell code**. A project-controlled `.env` — any agent write, any cloned
repo — could therefore forge the per-process guard nonce
`GUARD_ALLOW_PRIMARY_EDIT` (bypassing the worktree-path deny guard) or run
arbitrary shell on **every** bash subprocess. This is the escape-hatch
provenance hole flagged at review of ticket 0323 (residual 2).

The earlier residual-2 attempt (snapshot/restore of `GUARD_ALLOW_PRIMARY_EDIT`
in the shim) was structurally unsound per the gaze **ESCALATE**: a sourced
project `.env` forges the nonce before any restore runs. That approach never
reached main. This PR is the structural replacement.

## Design — strict parser for the UNTRUSTED project file only

`$PWD/.env` is now **parsed, never executed**:

- iterate lines with `while IFS= read -r`; skip blank lines and `#` comments;
- strip an optional leading `export `;
- require `^[A-Za-z_][A-Za-z0-9_]*=`; the value is everything after the FIRST
  `=`, assigned **literally** — a `$(cmd)`/backtick value is stored as text,
  never run;
- strip ONE matching pair of surrounding quotes (literal, no escape processing);
- **REFUSE** any `GUARD_*` key with a one-line stderr warning
  (`bash-env: refusing GUARD_* key from project .env: <key>`) — an untrusted
  file structurally cannot set guard vars;
- malformed lines are skipped, never fatal, so the shim stays fast on every
  subprocess.

The **trusted, user-owned** `$HOME/.claude/.env` KEEPS its `source` behavior
(full expansion) — only the untrusted project file switches to strict parse.
The same-file dedup guard (project realpath == user realpath) is preserved.

## Tests — `tests/test_bash_env_project_env_parse.sh` (red before the fix)

New shell suite (auto-discovered by `tests/test_bash_suites.py`). Runs
bash-env.sh in an isolated subprocess with a controlled `HOME` and project dir:

1. project `.env` with `GUARD_ALLOW_PRIMARY_EDIT=1` → var is **not** set.
2. project `.env` with `EVIL=$(touch …)` / backticks → side-effect file is
   **not** created, no shell error, and the literal text is stored.
3. `FOO=bar` → loads as exactly `bar`.
4. quoted `BAZ="a b"` → loads as `a b` (one quote pair stripped, space kept).
5. regression: a user-owned `$HOME/.claude/.env` (`USERKEY=uval`) still loads
   via full `source` — proving the trusted file was not strict-parsed.

**Red-proof** against the pre-fix (source-based) script:
- case 1 → FAIL: `GUARD_ALLOW_PRIMARY_EDIT` was set to `1`.
- case 2 → FAIL: the `pwned` file **was created** (arbitrary code executed) and
  the literal value was not stored.

After the fix: all 7 assertions PASS.

## Old test note

No `test_bash_env_guard_var_protection.sh` was deleted — that test and the
snapshot/restore mechanism lived only in the abandoned PR #574 and never
reached main. Its concern is subsumed here: a project `.env` cannot set
`GUARD_*` at all.

## Gates

- new suite: 7/7 PASS
- `tests/test_bash_suites.py`: 23 shell suites PASS
- `make lint`: 17 adherence tests PASS
- `make check`: 836 passed

## Sibling

Residual 1 (realpath normalization of the guard `file_path`) is PR #587. With
#587 already in main, merging this PR completes ticket 0323.

**Ticket:** tickets/0323-worktree-path-guard-residuals-realpath-n.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)