### PR TITLE
feat(roar): log one celebration per merged PR since last sha

### DIFF
--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -60,7 +60,7 @@ branch — there are no remote branches nor merge requests to inspect.
    SENTINEL="$(git rev-parse --git-common-dir)/roar-last-sha"
    ROWS=""
    if [ -f "$SENTINEL" ] && git merge-base --is-ancestor "$(cat "$SENTINEL")" HEAD; then
-       ROWS="$(~/.claude/skills/roar/enumerate-merges.py "$(cat "$SENTINEL")" --project "<name>")"
+       ROWS="$(~/.claude/skills/roar/enumerate-merges.py "$(cat "$SENTINEL")" --project "<name>")" || ROWS=""
    fi
    if [ -n "$ROWS" ]; then
        # Per-PR path: one telemetry-equivalent record per merged PR.

--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -50,9 +50,28 @@ branch — there are no remote branches nor merge requests to inspect.
 ## Reflect and update
 
 1. **Reflect**: what worked, what didn't, what was surprising.
-2. **Log to telemetry**: pipe a JSON summary to `~/.claude/skills/roar/log-celebration`:
+2. **Log to telemetry**: log one celebration per merged PR since the sentinel,
+   falling back to a single aggregate entry when no merge commits are found.
+   A batched interactive session merges several PRs then roars once, so a single
+   aggregate blob loses per-ticket attribution (ticket 0331). Enumerate the merge
+   commits in `roar-last-sha..HEAD` and log each as its own record when the
+   sentinel exists, is an ancestor of HEAD, and the enumeration is non-empty:
    ```bash
-   echo '{"project":"<name>","branch":"<branch>","commits":<n>,"files_changed":<n>,"ticket":<number|null>}' | ~/.claude/skills/roar/log-celebration
+   SENTINEL="$(git rev-parse --git-common-dir)/roar-last-sha"
+   ROWS=""
+   if [ -f "$SENTINEL" ] && git merge-base --is-ancestor "$(cat "$SENTINEL")" HEAD; then
+       ROWS="$(~/.claude/skills/roar/enumerate-merges.py "$(cat "$SENTINEL")" --project "<name>")"
+   fi
+   if [ -n "$ROWS" ]; then
+       # Per-PR path: one telemetry-equivalent record per merged PR.
+       printf '%s\n' "$ROWS" | while IFS= read -r row; do
+           printf '%s\n' "$row" | ~/.claude/skills/roar/log-celebration
+       done
+   else
+       # Aggregate fallback: first roar, rewritten history, squash-merge, or
+       # a no-forge repo where no merge commits exist.
+       echo '{"project":"<name>","branch":"<branch>","commits":<n>,"files_changed":<n>,"ticket":<number|null>}' | ~/.claude/skills/roar/log-celebration
+   fi
    ```
    Then write the current HEAD SHA to the sentinel:
    ```bash

--- a/skills/roar/enumerate-merges.py
+++ b/skills/roar/enumerate-merges.py
@@ -36,7 +36,7 @@ PR_SUBJECT_RE = re.compile(r"^Merge pull request #(\d+) from [^/]+/(.+)$")
 # so a PR with no close commit (Ticket: none, non-erg merge) would otherwise
 # mis-attribute a filing commit's id. If the close format changes, update this.
 CLOSE_COMMIT_RE = re.compile(
-    r"^ticket\((\d+)(?:,\s*\d+)*\): close and archive\b.*PR #\d+$"
+    r"^ticket\((\d+)(?:,\s*\d+)*\): close and archive — PR #\d+$"
 )
 
 

--- a/skills/roar/enumerate-merges.py
+++ b/skills/roar/enumerate-merges.py
@@ -80,21 +80,23 @@ def branch_from_subject(subject: str) -> str | None:
     return m.group(2) if m else None
 
 
-def ticket_from_range(parent1: str, parent2: str, root: str) -> int | None:
+def commits_and_ticket(parent1: str, parent2: str, root: str) -> tuple[int, int | None]:
+    """Return (commit count, ticket id) for a two-dot range in one git call.
+
+    The subject list `git log` returns while scanning for the close commit
+    already has one line per commit, so its length is the commit count — no
+    separate `rev-list --count` spawn needed.
+    """
     subjects = git(
         ["log", "--format=%s", f"{parent1}..{parent2}"], cwd=root
     ).splitlines()
+    ticket = None
     for subject in subjects:
         m = CLOSE_COMMIT_RE.match(subject.strip())
         if m:
-            return int(m.group(1))
-    return None
-
-
-def commits_in_range(parent1: str, parent2: str, root: str) -> int:
-    return int(
-        git(["rev-list", "--count", f"{parent1}..{parent2}"], cwd=root).strip()
-    )
+            ticket = int(m.group(1))
+            break
+    return len(subjects), ticket
 
 
 def files_changed(parent1: str, parent2: str, root: str) -> int:
@@ -115,13 +117,14 @@ def build_records(since_sha: str, project: str, root: str) -> list[dict]:
             # --merges guarantees >= 2 parents; skip defensively otherwise.
             continue
         p1, p2 = parents[0], parents[1]
+        commits, ticket = commits_and_ticket(p1, p2, root)
         records.append(
             {
                 "project": project,
                 "branch": branch_from_subject(subject),
-                "commits": commits_in_range(p1, p2, root),
+                "commits": commits,
                 "files_changed": files_changed(p1, p2, root),
-                "ticket": ticket_from_range(p1, p2, root),
+                "ticket": ticket,
             }
         )
     return records

--- a/skills/roar/enumerate-merges.py
+++ b/skills/roar/enumerate-merges.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Enumerate merged PRs since a sentinel SHA as celebration records (ticket 0331).
+
+Roar's telemetry step logs one celebration per merged PR instead of a single
+aggregate blob. This script enumerates the merge commits in ``<since-sha>..HEAD``
+on the current branch and emits, per merge, one JSON object per line carrying the
+fields roar's ``log-celebration`` expects (that helper stamps ``ts``/``date``):
+
+    {"project": str, "branch": str|null, "commits": int,
+     "files_changed": int, "ticket": int|null}
+
+Branch is parsed from the GitHub-shaped merge subject; ticket is recovered by
+scanning the merge's second-parent commit range for the erg-pr-merge close
+commit, NOT from the branch name (real branch names such as
+``worktree-agent-a31bf6655c104744e`` carry misleading digits).
+
+An empty range prints nothing and exits 0. The sentinel-missing / non-ancestor
+guards live in roar's SKILL.md prose, not here.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# GitHub-shaped merge subject: "Merge pull request #123 from owner/branch-name".
+PR_SUBJECT_RE = re.compile(r"^Merge pull request #(\d+) from [^/]+/(.+)$")
+
+# erg-pr-merge writes its close commit as
+#   ticket(<id>[, <id>...]): close and archive — PR #<n>
+# (skills/merge/erg-pr-merge ~line 228; CLOSED_LIST joins IDs with ", ").
+# If that commit format changes, update this regex to match.
+CLOSE_COMMIT_RE = re.compile(r"^ticket\((\d+)(?:,\s*\d+)*\):")
+
+
+def git(args: list[str], cwd: str | None = None) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    ).stdout
+
+
+def repo_root() -> str:
+    # Resolve at call time — never at import (worktree-safe; see memory
+    # feedback_module_level_git_paths).
+    return git(["rev-parse", "--show-toplevel"]).strip()
+
+
+def merge_commits(since_sha: str, root: str) -> list[str]:
+    out = git(
+        [
+            "log",
+            "--merges",
+            "--first-parent",
+            "--reverse",
+            "--format=%H",
+            f"{since_sha}..HEAD",
+        ],
+        cwd=root,
+    )
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def merge_meta(sha: str, root: str) -> tuple[list[str], str]:
+    """Return (parent SHAs, subject) for a merge commit."""
+    out = git(["show", "-s", "--format=%P%n%s", sha], cwd=root).splitlines()
+    parents = out[0].split() if out else []
+    subject = out[1] if len(out) > 1 else ""
+    return parents, subject
+
+
+def branch_from_subject(subject: str) -> str | None:
+    m = PR_SUBJECT_RE.match(subject)
+    return m.group(2) if m else None
+
+
+def ticket_from_range(parent1: str, parent2: str, root: str) -> int | None:
+    subjects = git(
+        ["log", "--format=%s", f"{parent1}..{parent2}"], cwd=root
+    ).splitlines()
+    for subject in subjects:
+        m = CLOSE_COMMIT_RE.match(subject.strip())
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def commits_in_range(parent1: str, parent2: str, root: str) -> int:
+    return int(
+        git(["rev-list", "--count", f"{parent1}..{parent2}"], cwd=root).strip()
+    )
+
+
+def files_changed(parent1: str, parent2: str, root: str) -> int:
+    out = git(["diff", "--stat", f"{parent1}..{parent2}"], cwd=root)
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    if not lines:
+        return 0
+    # Summary line, e.g. " 3 files changed, 12 insertions(+), 2 deletions(-)".
+    m = re.search(r"(\d+) files? changed", lines[-1])
+    return int(m.group(1)) if m else 0
+
+
+def build_records(since_sha: str, project: str, root: str) -> list[dict]:
+    records = []
+    for sha in merge_commits(since_sha, root):
+        parents, subject = merge_meta(sha, root)
+        if len(parents) < 2:
+            # --merges guarantees >= 2 parents; skip defensively otherwise.
+            continue
+        p1, p2 = parents[0], parents[1]
+        records.append(
+            {
+                "project": project,
+                "branch": branch_from_subject(subject),
+                "commits": commits_in_range(p1, p2, root),
+                "files_changed": files_changed(p1, p2, root),
+                "ticket": ticket_from_range(p1, p2, root),
+            }
+        )
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit one celebration JSON record per merged PR since a SHA."
+    )
+    parser.add_argument(
+        "since_sha",
+        help="sentinel SHA; merges in <since_sha>..HEAD are enumerated",
+    )
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="project name for the record (default: repo directory name)",
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    project = args.project or os.path.basename(root)
+    for record in build_records(args.since_sha, project, root):
+        print(json.dumps(record))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/roar/enumerate-merges.py
+++ b/skills/roar/enumerate-merges.py
@@ -28,11 +28,16 @@ import sys
 # GitHub-shaped merge subject: "Merge pull request #123 from owner/branch-name".
 PR_SUBJECT_RE = re.compile(r"^Merge pull request #(\d+) from [^/]+/(.+)$")
 
-# erg-pr-merge writes its close commit as
+# erg-pr-merge writes its close commit as exactly
 #   ticket(<id>[, <id>...]): close and archive — PR #<n>
 # (skills/merge/erg-pr-merge ~line 228; CLOSED_LIST joins IDs with ", ").
-# If that commit format changes, update this regex to match.
-CLOSE_COMMIT_RE = re.compile(r"^ticket\((\d+)(?:,\s*\d+)*\):")
+# Anchor on the whole "close and archive … PR #<n>" template, NOT just the
+# ticket(...) prefix: ordinary ticket-FILING commits also start "ticket(NNNN):",
+# so a PR with no close commit (Ticket: none, non-erg merge) would otherwise
+# mis-attribute a filing commit's id. If the close format changes, update this.
+CLOSE_COMMIT_RE = re.compile(
+    r"^ticket\((\d+)(?:,\s*\d+)*\): close and archive\b.*PR #\d+$"
+)
 
 
 def git(args: list[str], cwd: str | None = None) -> str:
@@ -96,14 +101,10 @@ def files_changed(parent1: str, parent2: str, root: str) -> int:
     # Three-dot (merge-base relative) so a batched session's intervening PRs,
     # which advanced parent1 but are absent from parent2, do not leak in as
     # phantom changes. This is the PR's own diff — what GitHub's "Files changed"
-    # and a raid's immediate per-PR roar record.
-    out = git(["diff", "--stat", f"{parent1}...{parent2}"], cwd=root)
-    lines = [ln for ln in out.splitlines() if ln.strip()]
-    if not lines:
-        return 0
-    # Summary line, e.g. " 3 files changed, 12 insertions(+), 2 deletions(-)".
-    m = re.search(r"(\d+) files? changed", lines[-1])
-    return int(m.group(1)) if m else 0
+    # and a raid's immediate per-PR roar record. --numstat yields one line per
+    # changed file (locale-independent; no summary-line parse to localize).
+    out = git(["diff", "--numstat", f"{parent1}...{parent2}"], cwd=root)
+    return sum(1 for ln in out.splitlines() if ln.strip())
 
 
 def build_records(since_sha: str, project: str, root: str) -> list[dict]:

--- a/skills/roar/enumerate-merges.py
+++ b/skills/roar/enumerate-merges.py
@@ -93,7 +93,11 @@ def commits_in_range(parent1: str, parent2: str, root: str) -> int:
 
 
 def files_changed(parent1: str, parent2: str, root: str) -> int:
-    out = git(["diff", "--stat", f"{parent1}..{parent2}"], cwd=root)
+    # Three-dot (merge-base relative) so a batched session's intervening PRs,
+    # which advanced parent1 but are absent from parent2, do not leak in as
+    # phantom changes. This is the PR's own diff — what GitHub's "Files changed"
+    # and a raid's immediate per-PR roar record.
+    out = git(["diff", "--stat", f"{parent1}...{parent2}"], cwd=root)
     lines = [ln for ln in out.splitlines() if ln.strip()]
     if not lines:
         return 0

--- a/skills/roar/enumerate-merges.py
+++ b/skills/roar/enumerate-merges.py
@@ -16,6 +16,11 @@ commit, NOT from the branch name (real branch names such as
 
 An empty range prints nothing and exits 0. The sentinel-missing / non-ancestor
 guards live in roar's SKILL.md prose, not here.
+
+Octopus merges (3+ parents) are skipped with a stderr note: the per-PR fields
+are defined for a two-sided PR merge, so an N-way merge is reported rather than
+silently undercounted. The forge's PR-merge path is always 2-parent; octopus
+merges only occur on the standalone/no-forge CLI path.
 """
 
 import argparse
@@ -115,6 +120,14 @@ def build_records(since_sha: str, project: str, root: str) -> list[dict]:
         parents, subject = merge_meta(sha, root)
         if len(parents) < 2:
             # --merges guarantees >= 2 parents; skip defensively otherwise.
+            continue
+        if len(parents) > 2:
+            # Octopus merge: the per-PR fields (branch, commits, files, ticket)
+            # are defined for a two-sided PR merge, so an N-way merge cannot be
+            # reduced to one without silently dropping parents 3..N. Skip it
+            # visibly rather than undercount.
+            print(f"skipping octopus merge {sha} ({len(parents)} parents)",
+                  file=sys.stderr)
             continue
         p1, p2 = parents[0], parents[1]
         commits, ticket = commits_and_ticket(p1, p2, root)

--- a/tests/test_roar_enumerate_merges.py
+++ b/tests/test_roar_enumerate_merges.py
@@ -159,6 +159,46 @@ def test_non_pr_merge_subject_branch_null_still_emitted(repo):
     assert records[0]["project"] == "testproj"
 
 
+def test_files_changed_excludes_interleaved_merges(repo):
+    """files_changed counts only the PR's own diff, not intervening PRs.
+
+    A batched session merges PRs cut from an older main. When PR-A is cut off
+    C0, PR-B lands on main first, then PR-A is merged, a two-dot M^1..M^2 diff
+    charges PR-A with PR-B's files as phantom changes. The PR's own diff (three
+    dot, merge-base relative — what GitHub and a raid's per-PR roar record) must
+    win.
+    """
+    base = head(repo)  # C0
+    # Cut PR-A off C0, but do not merge it yet.
+    git(repo, "switch", "-c", "feat-A")
+    (repo / "a1.txt").write_text("a1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-m", "A: one file")
+    git(repo, "switch", "main")
+    # PR-B lands on main first (three files), advancing main under PR-A.
+    merge_pr(
+        repo,
+        pr=20,
+        owner_branch="ben/three-files",
+        feature_commits=[
+            ("b1.txt", "b1"),
+            ("b2.txt", "b2"),
+            ("b3.txt", "b3"),
+        ],
+    )
+    # Now merge PR-A off the advanced main.
+    git(repo, "merge", "--no-ff", "feat-A", "-m",
+        "Merge pull request #21 from ann/feat-A")
+    records, res = enumerate_merges(repo, base)
+    assert len(records) == 2, res.stderr
+    # records[0] = PR-B (no interleaving), records[1] = PR-A (one own file).
+    assert records[0]["branch"] == "three-files"
+    assert records[0]["files_changed"] == 3
+    assert records[1]["branch"] == "feat-A"
+    assert records[1]["files_changed"] == 1
+    assert records[1]["commits"] == 1
+
+
 def test_commits_and_files_changed_counts(repo):
     base = head(repo)
     merge_pr(

--- a/tests/test_roar_enumerate_merges.py
+++ b/tests/test_roar_enumerate_merges.py
@@ -1,0 +1,173 @@
+"""Tests for skills/roar/enumerate-merges.py (ticket 0331).
+
+Roar's telemetry step must log one celebration per merged PR since the
+roar-last-sha sentinel, not a single aggregate blob. This script enumerates
+the merge commits in <since-sha>..HEAD and emits one JSON record per merge,
+recovering the branch from the GitHub-shaped merge subject and the ticket from
+the erg-pr-merge close commit inside the merge's second-parent range.
+
+The load-bearing case is anti-tautological: a PR whose branch name carries no
+ticket digits but whose range holds a close commit must still recover the
+ticket. A branch-name-regex implementation fails it; the specified commit scan
+passes.
+
+Each test spawns real git via subprocess, so the module is integration-tier.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENUMERATE = REPO_ROOT / "skills" / "roar" / "enumerate-merges.py"
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(shutil.which("git") is None, reason="git required"),
+]
+
+
+def run(args, cwd=None, check=True):
+    return subprocess.run(
+        args, cwd=cwd, check=check, capture_output=True, text=True
+    )
+
+
+def git(repo, *args, check=True):
+    return run(["git", "-C", str(repo), *args], check=check)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real git repo on main with one initial commit."""
+    r = tmp_path / "repo"
+    run(["git", "init", "-b", "main", str(r)])
+    git(r, "config", "user.email", "test@example.com")
+    git(r, "config", "user.name", "Test")
+    git(r, "config", "commit.gpgsign", "false")
+    (r / "README").write_text("hi\n")
+    git(r, "add", "-A")
+    git(r, "commit", "-m", "init")
+    return r
+
+
+def merge_pr(repo, *, pr, owner_branch, feature_commits, subject=None):
+    """Branch off main, add commits, and merge --no-ff back into main.
+
+    owner_branch: the "owner/branch" string used to build a GitHub-shaped
+    merge subject, or None (with an explicit ``subject``) for a non-PR merge.
+    feature_commits: list of (filename, commit_message) tuples committed on the
+    feature branch before the merge.
+    """
+    branch = f"feat-{pr}"
+    git(repo, "switch", "-c", branch)
+    for fname, msg in feature_commits:
+        (repo / fname).write_text(f"{fname} content\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-m", msg)
+    git(repo, "switch", "main")
+    if subject is None and owner_branch is not None:
+        subject = f"Merge pull request #{pr} from {owner_branch}"
+    args = ["merge", "--no-ff", branch]
+    if subject is not None:
+        args += ["-m", subject]
+    git(repo, *args)
+
+
+def enumerate_merges(repo, since, project="testproj"):
+    res = run(
+        ["python3", str(ENUMERATE), since, "--project", project],
+        cwd=str(repo),
+    )
+    records = [json.loads(ln) for ln in res.stdout.splitlines() if ln.strip()]
+    return records, res
+
+
+def head(repo):
+    return git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_ticket_from_close_commit_not_branch_name(repo):
+    """Anti-tautology: ticket comes from the close commit, not the branch name."""
+    base = head(repo)
+    # First PR: ordinary branch, no close commit -> ticket null.
+    merge_pr(
+        repo,
+        pr=6,
+        owner_branch="alice/add-feature",
+        feature_commits=[("a.txt", "add feature")],
+    )
+    # Second PR: branch name has NO ticket digits, but the range carries an
+    # erg-pr-merge close commit -> ticket must come from the commit scan.
+    merge_pr(
+        repo,
+        pr=7,
+        owner_branch="bob/fix-flaky-widget",
+        feature_commits=[
+            ("b.txt", "fix the widget"),
+            ("dummy", "ticket(0042): close and archive — PR #7"),
+        ],
+    )
+    records, res = enumerate_merges(repo, base)
+    assert len(records) == 2, res.stderr
+    assert records[0]["branch"] == "add-feature"
+    assert records[0]["ticket"] is None
+    assert records[1]["branch"] == "fix-flaky-widget"
+    assert records[1]["ticket"] == 42
+
+
+def test_empty_range_emits_nothing(repo):
+    base = head(repo)
+    records, res = enumerate_merges(repo, base)
+    assert records == []
+    assert res.returncode == 0
+    assert res.stdout.strip() == ""
+
+
+def test_multi_ticket_close_takes_first_id(repo):
+    base = head(repo)
+    merge_pr(
+        repo,
+        pr=8,
+        owner_branch="carol/raid-wave",
+        feature_commits=[
+            ("c.txt", "raid work"),
+            ("dummy", "ticket(0042, 0043): close and archive — PR #8"),
+        ],
+    )
+    records, res = enumerate_merges(repo, base)
+    assert len(records) == 1, res.stderr
+    assert records[0]["ticket"] == 42
+
+
+def test_non_pr_merge_subject_branch_null_still_emitted(repo):
+    base = head(repo)
+    merge_pr(
+        repo,
+        pr=9,
+        owner_branch=None,
+        feature_commits=[("d.txt", "some work")],
+        subject="Merge branch 'feat-9'",
+    )
+    records, res = enumerate_merges(repo, base)
+    assert len(records) == 1, res.stderr
+    assert records[0]["branch"] is None
+    assert records[0]["ticket"] is None
+    assert records[0]["project"] == "testproj"
+
+
+def test_commits_and_files_changed_counts(repo):
+    base = head(repo)
+    merge_pr(
+        repo,
+        pr=10,
+        owner_branch="dan/two-commits",
+        feature_commits=[("e.txt", "one"), ("f.txt", "two")],
+    )
+    records, res = enumerate_merges(repo, base)
+    assert len(records) == 1, res.stderr
+    assert records[0]["commits"] == 2
+    assert records[0]["files_changed"] == 2

--- a/tests/test_roar_enumerate_merges.py
+++ b/tests/test_roar_enumerate_merges.py
@@ -222,6 +222,47 @@ def test_files_changed_excludes_interleaved_merges(repo):
     assert records[1]["commits"] == 1
 
 
+def test_octopus_merge_skipped_not_undercounted(repo):
+    """An octopus (3+ parent) merge is skipped visibly, not silently reduced.
+
+    build_records only reads parents[0]/parents[1], so an N-way merge would emit
+    one plausible record while dropping every parent beyond the second (its
+    commits, files, and close-commit ticket vanish). It must be skipped with a
+    stderr note instead. Unreachable via the forge's 2-parent PR merge, but the
+    script is a documented standalone CLI where octopus merges occur.
+    """
+    base = head(repo)
+    # A normal PR that must still be emitted, to prove only the octopus is dropped.
+    merge_pr(
+        repo,
+        pr=29,
+        owner_branch="ivan/normal-pr",
+        feature_commits=[("n.txt", "normal work")],
+    )
+    # Two feature branches off main, then a single 3-parent octopus merge.
+    git(repo, "switch", "-c", "octo-1")
+    (repo / "o1.txt").write_text("o1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-m", "octo one")
+    git(repo, "switch", "main")
+    git(repo, "switch", "-c", "octo-2")
+    (repo / "o2.txt").write_text("o2\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-m", "octo two")
+    git(repo, "switch", "main")
+    git(repo, "merge", "--no-ff", "octo-1", "octo-2", "-m",
+        "Merge pull request #30 from x/octo")
+    octo_sha = head(repo)
+    # Sanity: this really is a 3-parent merge.
+    parents = git(repo, "rev-list", "--parents", "-n", "1", octo_sha).stdout.split()
+    assert len(parents) == 4, parents  # commit + 3 parents
+
+    records, res = enumerate_merges(repo, base)
+    branches = [r["branch"] for r in records]
+    assert branches == ["normal-pr"], res.stderr
+    assert octo_sha[:12] in res.stderr
+
+
 def test_commits_and_files_changed_counts(repo):
     base = head(repo)
     merge_pr(

--- a/tests/test_roar_enumerate_merges.py
+++ b/tests/test_roar_enumerate_merges.py
@@ -143,6 +143,29 @@ def test_multi_ticket_close_takes_first_id(repo):
     assert records[0]["ticket"] == 42
 
 
+def test_filing_commit_not_mistaken_for_close(repo):
+    """A ticket-FILING commit in a PR with no close commit must not attribute.
+
+    Ordinary work commits also start "ticket(NNNN):" (the filing convention).
+    A raid's per-PR roar logs ticket null for a PR that carried no erg-pr-merge
+    close commit; the enumeration must match only the "close and archive — PR #"
+    template, not any ticket(...) subject.
+    """
+    base = head(repo)
+    merge_pr(
+        repo,
+        pr=11,
+        owner_branch="erin/no-close",
+        feature_commits=[
+            ("g.txt", "ticket(0329): file the follow-up ticket"),
+            ("h.txt", "wire up the follow-up"),
+        ],
+    )
+    records, res = enumerate_merges(repo, base)
+    assert len(records) == 1, res.stderr
+    assert records[0]["ticket"] is None
+
+
 def test_non_pr_merge_subject_branch_null_still_emitted(repo):
     base = head(repo)
     merge_pr(

--- a/tickets/0331-roar-per-pr-celebrations-since-last-sha.erg
+++ b/tickets/0331-roar-per-pr-celebrations-since-last-sha.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-14T09:31Z claude created
 
+2026-07-14T11:04Z bump verify-reroll — round 1: octopus-merge silent undercount in build_records
 --- body ---
 ## Context
 Interactive sessions merge PRs one at a time and roar once at the end (per

--- a/tickets/closed/0331-roar-per-pr-celebrations-since-last-sha.erg
+++ b/tickets/closed/0331-roar-per-pr-celebrations-since-last-sha.erg
@@ -2,11 +2,13 @@
 Title: Roar: log one celebration per merged PR since roar-last-sha, not one aggregate blob
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #589
 
 --- log ---
 2026-07-14T09:31Z claude created
 
 2026-07-14T11:04Z bump verify-reroll — round 1: octopus-merge silent undercount in build_records
+2026-07-14T11:07Z Minh Ha-Duong closed — autoclosed — PR #589
 --- body ---
 ## Context
 Interactive sessions merge PRs one at a time and roar once at the end (per


### PR DESCRIPTION
## Summary
A batched interactive session merges several PRs one at a time then roars once at the end. Roar's telemetry step measured "everything since `roar-last-sha`" and wrote a single aggregate `celebrations.jsonl` record, losing the per-ticket attribution that bump tallies and celebration stats feed on (2026-07-13: eleven PRs #538-#548 collapsed into one 51-commit record with ticket null). Raid roars fire per merged PR and never had this problem.

## Changes
- **New `skills/roar/enumerate-merges.py`** — `enumerate-merges.py <since-sha> [--project NAME]`. Enumerates first-parent merge commits in `<sha>..HEAD` and emits one celebration JSON record per merge (`{project, branch, commits, files_changed, ticket}`; no `ts`/`date` — `log-celebration` stamps those). Branch parsed from the GitHub-shaped merge subject; **ticket recovered by scanning the merge's second-parent range for the erg-pr-merge close commit, not from the branch name** (real branch names carry misleading digits). Repo root resolved at call time (worktree-safe). Empty range prints nothing, exits 0.
- **`skills/roar/SKILL.md` step 2** — pipe each enumerated record through `log-celebration` when the sentinel exists, is an ancestor of HEAD, and the enumeration is non-empty; else fall back to the current single aggregate entry (first roar, rewritten history, squash-merge, no-forge repos). Sentinel-write lines unchanged.
- **`tests/test_roar_enumerate_merges.py`** — integration-tier, real-git fixtures. Anti-tautology core case: a no-ticket-digit branch (`fix-flaky-widget`) carrying a close commit `ticket(0042): ...` still recovers ticket 42; plus empty range, multi-ticket close, non-PR merge subject, and count fields.

`log-celebration` and `erg-pr-merge` are untouched. Nothing reads `celebrations.jsonl` programmatically; lair reads only the sentinel SHA.

## Exit criteria
- [x] A batched interactive roar produces per-PR celebration entries telemetry-equivalent to a raid's per-PR roars
- [x] Aggregate fallback preserved where merge commits are absent
- [x] `make check` passes (840 passed)

Pre-PR `/verify-adherence`: PASS (no mechanical or semantic findings).

**Ticket:** tickets/0331-roar-per-pr-celebrations-since-last-sha.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)