### PR TITLE
feat(0334): per-project least-privilege ~/.config/keys loading via KEYS=

### DIFF
--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -25,6 +25,17 @@
 # The script runs on every bash subprocess, so it stays fast and never aborts on
 # a missing or malformed .env — bad lines in the project file are skipped, never
 # fatal.
+#
+# Least-privilege provider secrets (KEYS=). A project declares which credential
+# providers it needs by setting KEYS=<name,name,...> in its project .env (parsed
+# by the untrusted strict-parse above, so KEYS itself is a plain value). For each
+# declared, VALIDATED provider <name>, and ONLY those, this script sources the
+# user-owned $HOME/.config/keys/<name>.env. Default-deny: no KEYS line means no
+# provider secrets are loaded. Provider names must match ^[a-z0-9-]+$ — anything
+# else (path traversal like ../../x, a slash, uppercase, empty) is ignored with a
+# warning, so KEYS can never source an arbitrary path. The per-provider files are
+# user-owned and TRUSTED, so they are sourced as shell code (contrast the
+# untrusted project .env). A missing provider file warns but is non-fatal.
 
 # --- trusted user-level .env: source as before (full expansion) ---
 set -a  # mark all subsequent assignments for export
@@ -80,4 +91,44 @@ if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
         unset _be_line _be_trim _be_key _be_val _be_first _be_last
     fi
     unset _be_proj _be_user
+fi
+
+# --- least-privilege provider secrets: source only the declared KEYS providers ---
+# $KEYS (if any) was set by the project strict-parse above. Split it on commas and
+# source $HOME/.config/keys/<name>.env for each validated provider name only.
+if [ -n "${KEYS:-}" ]; then
+    # Disable globbing while splitting so a stray '*' in KEYS cannot expand to
+    # filenames; restore the caller's setting afterwards.
+    case "$-" in
+        *f*) _be_had_noglob=1 ;;
+        *)   _be_had_noglob=0 ;;
+    esac
+    set -f
+    set -a  # export vars assigned by the sourced (trusted) provider files
+    _be_ifs="$IFS"
+    IFS=','
+    for _be_prov in ${KEYS}; do
+        IFS="$_be_ifs"
+        # trim surrounding whitespace
+        _be_prov="${_be_prov#"${_be_prov%%[![:space:]]*}"}"
+        _be_prov="${_be_prov%"${_be_prov##*[![:space:]]}"}"
+        [ -z "$_be_prov" ] && { IFS=','; continue; }
+        # validate: lowercase, digits and dashes only — blocks path traversal
+        if [[ ! "$_be_prov" =~ ^[a-z0-9-]+$ ]]; then
+            printf 'bash-env: ignoring invalid KEYS provider name: %s\n' "$_be_prov" >&2
+            IFS=','
+            continue
+        fi
+        _be_keyfile="$HOME/.config/keys/$_be_prov.env"
+        if [ -f "$_be_keyfile" ]; then
+            source "$_be_keyfile"
+        else
+            printf 'bash-env: KEYS provider not found: %s\n' "$_be_prov" >&2
+        fi
+        IFS=','
+    done
+    IFS="$_be_ifs"
+    set +a
+    [ "$_be_had_noglob" = 1 ] || set +f
+    unset _be_ifs _be_prov _be_keyfile _be_had_noglob
 fi

--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -26,16 +26,25 @@
 # a missing or malformed .env — bad lines in the project file are skipped, never
 # fatal.
 #
-# Least-privilege provider secrets (KEYS=). A project declares which credential
-# providers it needs by setting KEYS=<name,name,...> in its project .env (parsed
-# by the untrusted strict-parse above, so KEYS itself is a plain value). For each
+# Provider-secret scoping (KEYS=). A project declares which credential providers
+# it needs by setting KEYS=<name,name,...> in its project .env (parsed by the
+# untrusted strict-parse above, so KEYS itself is a plain value). For each
 # declared, VALIDATED provider <name>, and ONLY those, this script sources the
-# user-owned $HOME/.config/keys/<name>.env. Default-deny: no KEYS line means no
-# provider secrets are loaded. Provider names must match ^[a-z0-9-]+$ — anything
-# else (path traversal like ../../x, a slash, uppercase, empty) is ignored with a
-# warning, so KEYS can never source an arbitrary path. The per-provider files are
-# user-owned and TRUSTED, so they are sourced as shell code (contrast the
-# untrusted project .env). A missing provider file warns but is non-fatal.
+# user-owned $HOME/.config/keys/<name>.env. Default-deny: no KEYS line loads no
+# provider secrets. Provider names must match ^[a-z0-9-]+$ — anything else (path
+# traversal like ../../x, a slash, uppercase, empty) is ignored with a warning.
+# The per-provider files are user-owned and TRUSTED, so they are sourced as shell
+# code (contrast the untrusted project .env). A missing provider file warns but is
+# non-fatal.
+#
+# Guarantee and its limit. Two properties hold even against a hostile project
+# .env: it never sources a path outside ~/.config/keys/ (name validation), and it
+# never executes the project .env (strict-parsed, never sourced) — so a hostile
+# .env can neither run code nor exfiltrate a secret through the .env itself. But
+# the provider SET is self-declared by that untrusted file, which can name any
+# provider to load its secret into the environment. This is cooperative scoping
+# that shrinks default secret exposure, NOT access control against a hostile
+# project .env.
 
 # --- trusted user-level .env: source as before (full expansion) ---
 set -a  # mark all subsequent assignments for export
@@ -104,7 +113,6 @@ if [ -n "${KEYS:-}" ]; then
         *)   _be_had_noglob=0 ;;
     esac
     set -f
-    set -a  # export vars assigned by the sourced (trusted) provider files
     _be_ifs="$IFS"
     IFS=','
     for _be_prov in ${KEYS}; do
@@ -121,14 +129,19 @@ if [ -n "${KEYS:-}" ]; then
         fi
         _be_keyfile="$HOME/.config/keys/$_be_prov.env"
         if [ -f "$_be_keyfile" ]; then
+            # Enable allexport ONLY around the source, so exactly the variables
+            # the trusted provider file assigns get exported — the loop
+            # bookkeeping (IFS, the _be_* temporaries) is assigned outside
+            # allexport and stays unexported.
+            set -a
             source "$_be_keyfile"
+            set +a
         else
             printf 'bash-env: KEYS provider not found: %s\n' "$_be_prov" >&2
         fi
         IFS=','
     done
     IFS="$_be_ifs"
-    set +a
     [ "$_be_had_noglob" = 1 ] || set +f
     unset _be_ifs _be_prov _be_keyfile _be_had_noglob
 fi

--- a/tests/test_bash_env_keys_selection.sh
+++ b/tests/test_bash_env_keys_selection.sh
@@ -49,6 +49,37 @@ _load_rc() {
     echo $?
 }
 
+# Load bash-env.sh as above and print `export -p` (the exported environment) so a
+# caller can assert whether a variable is or is not marked for export.
+_load_exports() {
+    local home="$1" projdir="$2"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+        export -p
+    ' _ "$projdir" "$SCRIPT" 2>/dev/null
+}
+
+_assert_contains() {
+    local label="$1" hay="$2" needle="$3"
+    if [[ "$hay" == *"$needle"* ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — [$needle] not found"
+        fail=1
+    fi
+}
+
+_assert_not_contains() {
+    local label="$1" hay="$2" needle="$3"
+    if [[ "$hay" != *"$needle"* ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — [$needle] unexpectedly present"
+        fail=1
+    fi
+}
+
 _assert_eq() {
     local label="$1" got="$2" want="$3"
     if [[ "$got" == "$want" ]]; then
@@ -122,5 +153,38 @@ _assert_eq "(5) nonexistent provider: shell survives (rc 0)" \
     "$(_load_rc "$FHOME" "$P5")" "0"
 _assert_eq "(5) nonexistent provider: nothing loaded" \
     "$(_load_var "$FHOME" "$P5" FAKE_OPENROUTER)" ""
+
+# --- (6) export hygiene: provider vars export; IFS and _be_* temporaries do NOT --
+# Enabling allexport only around each `source` must export exactly what the
+# provider file assigns. IFS and the loop-bookkeeping temporaries are assigned
+# outside allexport, so they must never leak into the child environment.
+P6="$(_mkproj p6 'KEYS=openrouter
+')"
+P6_EXPORTS="$(_load_exports "$FHOME" "$P6")"
+_assert_contains "(6) provider var IS exported (FAKE_OPENROUTER)" \
+    "$P6_EXPORTS" "FAKE_OPENROUTER"
+_assert_not_contains "(6) IFS is NOT exported" \
+    "$P6_EXPORTS" "declare -x IFS"
+_assert_not_contains "(6) no _be_ temporary is exported" \
+    "$P6_EXPORTS" "declare -x _be_"
+
+# --- (7) glob-safety: KEYS=* stays literal, is rejected, sources nothing ---------
+# A decoy file next to the project must not tempt the '*' to expand: set -f keeps
+# it literal, validation rejects it, and nothing is sourced.
+P7="$(_mkproj p7 'KEYS=*
+')"
+touch "$P7/decoy.env"
+_assert_eq "(7) glob KEYS=*: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P7")" "0"
+_assert_eq "(7) glob KEYS=*: nothing sourced" \
+    "$(_load_var "$FHOME" "$P7" FAKE_OPENROUTER)" ""
+
+# --- (8) uppercase provider names are rejected by ^[a-z0-9-]+$ -------------------
+P8="$(_mkproj p8 'KEYS=OpenRouter
+')"
+_assert_eq "(8) uppercase name: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P8")" "0"
+_assert_eq "(8) uppercase name: nothing loaded" \
+    "$(_load_var "$FHOME" "$P8" FAKE_OPENROUTER)" ""
 
 exit "$fail"

--- a/tests/test_bash_env_keys_selection.sh
+++ b/tests/test_bash_env_keys_selection.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Tests for the KEYS= least-privilege provider-secret loading in scripts/bash-env.sh.
+#
+# A project opts into provider secrets by declaring KEYS=prov1,prov2 in its project
+# $PWD/.env. bash-env.sh then sources ONLY $HOME/.config/keys/<prov>.env for each
+# declared, VALIDATED provider. Default-deny: no KEYS line -> no provider secrets
+# loaded. Provider names are validated against ^[a-z0-9-]+$ so a crafted KEYS value
+# cannot escape ~/.config/keys/ via path traversal (../../etc/passwd, foo/bar, ...).
+#
+# The ~/.config/keys/<name>.env files are user-owned and TRUSTED, so they are sourced
+# as shell code (contrast the untrusted project .env, which is strict-parsed). This
+# suite never touches the real ~/.config/keys — it builds a FAKE HOME temp dir whose
+# fixtures hold NON-secret sentinel values only.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+SCRIPT="$PWD/scripts/bash-env.sh"
+fail=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Fake HOME with ~/.config/keys/ provider fixtures — NON-secret sentinels only.
+FHOME="$WORK/home"
+mkdir -p "$FHOME/.config/keys"
+printf 'FAKE_OPENROUTER=orval\n' > "$FHOME/.config/keys/openrouter.env"
+printf 'FAKE_MISTRAL=mval\n'     > "$FHOME/.config/keys/mistral.env"
+printf 'FAKE_ZENODO=zval\n'      > "$FHOME/.config/keys/zenodo.env"
+
+# Load bash-env.sh in a subprocess with $HOME=<home> and PWD=<projdir>, then print
+# the value of environment variable <var> ("" if unset). stderr silenced.
+_load_var() {
+    local home="$1" projdir="$2" var="$3"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+        n="$3"
+        printf "%s" "${!n-}"
+    ' _ "$projdir" "$SCRIPT" "$var" 2>/dev/null
+}
+
+# Load bash-env.sh as above but return only the exit code (0 = no shell error).
+_load_rc() {
+    local home="$1" projdir="$2"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+    ' _ "$projdir" "$SCRIPT" >/dev/null 2>&1
+    echo $?
+}
+
+_assert_eq() {
+    local label="$1" got="$2" want="$3"
+    if [[ "$got" == "$want" ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — got [$got], want [$want]"
+        fail=1
+    fi
+}
+
+# Make a project dir <name> holding <env-content> as its .env; echo the dir path.
+_mkproj() {
+    local dir="$WORK/$1"
+    mkdir -p "$dir"
+    printf '%s' "$2" > "$dir/.env"
+    printf '%s' "$dir"
+}
+
+# --- (1) only the declared provider loads; undeclared providers do NOT -----------
+P1="$(_mkproj p1 'KEYS=openrouter
+')"
+_assert_eq "(1) declared openrouter loads (FAKE_OPENROUTER=orval)" \
+    "$(_load_var "$FHOME" "$P1" FAKE_OPENROUTER)" "orval"
+_assert_eq "(1) undeclared mistral is NOT loaded" \
+    "$(_load_var "$FHOME" "$P1" FAKE_MISTRAL)" ""
+
+# --- (2) no KEYS line at all -> default-deny, nothing loaded ---------------------
+P2="$(_mkproj p2 'FOO=bar
+')"
+_assert_eq "(2) default-deny: openrouter not loaded" \
+    "$(_load_var "$FHOME" "$P2" FAKE_OPENROUTER)" ""
+_assert_eq "(2) default-deny: mistral not loaded" \
+    "$(_load_var "$FHOME" "$P2" FAKE_MISTRAL)" ""
+
+# --- (3) multiple declared providers all load -----------------------------------
+P3="$(_mkproj p3 'KEYS=openrouter,zenodo
+')"
+_assert_eq "(3) multi: openrouter loads" \
+    "$(_load_var "$FHOME" "$P3" FAKE_OPENROUTER)" "orval"
+_assert_eq "(3) multi: zenodo loads" \
+    "$(_load_var "$FHOME" "$P3" FAKE_ZENODO)" "zval"
+_assert_eq "(3) multi: undeclared mistral not loaded" \
+    "$(_load_var "$FHOME" "$P3" FAKE_MISTRAL)" ""
+
+# --- (3b) whitespace around names is trimmed ------------------------------------
+P3B="$(_mkproj p3b 'KEYS= openrouter , zenodo
+')"
+_assert_eq "(3b) spaced: openrouter loads" \
+    "$(_load_var "$FHOME" "$P3B" FAKE_OPENROUTER)" "orval"
+_assert_eq "(3b) spaced: zenodo loads" \
+    "$(_load_var "$FHOME" "$P3B" FAKE_ZENODO)" "zval"
+
+# --- (4) path-traversal / invalid names are rejected: nothing sourced, no error --
+P4="$(_mkproj p4 'KEYS=../../etc/passwd
+')"
+_assert_eq "(4a) traversal name: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P4")" "0"
+_assert_eq "(4a) traversal name: nothing spurious loaded" \
+    "$(_load_var "$FHOME" "$P4" FAKE_OPENROUTER)" ""
+P4B="$(_mkproj p4b 'KEYS=foo/bar
+')"
+_assert_eq "(4b) slash name: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P4B")" "0"
+_assert_eq "(4b) slash name: nothing loaded" \
+    "$(_load_var "$FHOME" "$P4B" FAKE_OPENROUTER)" ""
+
+# --- (5) declared-but-nonexistent provider -> warns, no error, nothing spurious --
+P5="$(_mkproj p5 'KEYS=nonexistent
+')"
+_assert_eq "(5) nonexistent provider: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P5")" "0"
+_assert_eq "(5) nonexistent provider: nothing loaded" \
+    "$(_load_var "$FHOME" "$P5" FAKE_OPENROUTER)" ""
+
+exit "$fail"

--- a/tickets/0334-wire-config-keys-least-privilege.erg
+++ b/tickets/0334-wire-config-keys-least-privilege.erg
@@ -7,6 +7,8 @@ Author: Minh Ha-Duong
 2026-07-14T10:44Z Minh Ha-Duong created
 2026-07-14T10:44Z Minh Ha-Duong note scoped AEDIST live-secret migration out to destination repo (cross-repo ops rule); harness ticket closes on the wiring mechanism
 
+2026-07-14T11:06Z Minh Ha-Duong note scoping caveat: KEYS is read from the untrusted project .env with no allowlist; a hostile .env can self-declare any provider name to load that secret. Name validation and never-source-.env still hold, so no arbitrary path and no code execution. This is cooperative default-deny scoping, not access control against a hostile project .env.
+2026-07-14T11:06Z Minh Ha-Duong note bump verify-reroll — round 1: IFS/temp export leak (verifiable) + least-privilege claim scoping caveat
 --- body ---
 ## Context
 `scripts/bash-env.sh` sources the user's `~/.claude/.env` (trusted) and strict-parses

--- a/tickets/0334-wire-config-keys-least-privilege.erg
+++ b/tickets/0334-wire-config-keys-least-privilege.erg
@@ -1,0 +1,72 @@
+%erg 0.1
+Title: Wire per-project least-privilege ~/.config/keys loading via KEYS=
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T10:44Z Minh Ha-Duong created
+2026-07-14T10:44Z Minh Ha-Duong note scoped AEDIST live-secret migration out to destination repo (cross-repo ops rule); harness ticket closes on the wiring mechanism
+
+--- body ---
+## Context
+`scripts/bash-env.sh` sources the user's `~/.claude/.env` (trusted) and strict-parses
+the project `$PWD/.env` (untrusted, ticket 0323 / PR #588). Every project that needs
+a provider token still keeps that secret in its own `.env`, so every bash subprocess
+of every project loads every secret — no least-privilege boundary between providers.
+
+Add an opt-in, default-deny mechanism: a project declares the providers it needs with
+`KEYS=provider1,provider2,...` in its project `.env`. bash-env.sh then sources ONLY
+`$HOME/.config/keys/<provider>.env` for each declared, validated provider. A project
+with no `KEYS` line loads no provider secrets. Provider secrets live once, user-owned,
+under `~/.config/keys/`; projects reference them by name, never by copying the value.
+
+This builds on the merged strict parser: `KEYS` is a normal (non-GUARD) key, so it is
+parsed and exported by the untrusted strict-parse before the provider block runs.
+
+## Relevant files
+- `scripts/bash-env.sh` — add the KEYS provider-loading block after the project
+  strict-parse block; document the mechanism in the header.
+- `tests/test_bash_env_keys_selection.sh` — new hermetic suite (fake HOME + fake
+  `~/.config/keys/*.env` sentinels + crafted project `.env`).
+- `tests/test_bash_env_project_env_parse.sh` — must stay green (no regression).
+
+## Actions
+1. After the project `$PWD/.env` strict-parse block (so `$KEYS` is known), if
+   `${KEYS:-}` is non-empty, split it on commas.
+2. For each name: trim whitespace; validate against `^[a-z0-9-]+$` (reject path
+   traversal / slashes / uppercase / empty with a stderr warning and skip); if valid
+   and `$HOME/.config/keys/<name>.env` exists, `source` it (trusted, user-owned); if
+   the file is missing, warn and continue (non-fatal).
+3. Keep the block `set -euo pipefail`-safe: guard `${KEYS:-}`, no `((...))`, never
+   abort the shell on a missing file/dir (this runs on every bash subprocess).
+4. Document the KEYS mechanism in the bash-env.sh header comment.
+
+## Test
+Write `tests/test_bash_env_keys_selection.sh` first (RED): fake HOME, fake
+`~/.config/keys/{openrouter,mistral,zenodo}.env` holding non-secret sentinels, a temp
+project dir with a crafted `.env`, source bash-env.sh in a subshell, assert on env.
+Cases: (1) `KEYS=openrouter` loads openrouter but NOT mistral; (2) no KEYS line loads
+nothing (default-deny); (3) `KEYS=openrouter,zenodo` loads both; (4) `KEYS=foo/bar`
+and `KEYS=../../etc/passwd` are rejected, nothing sourced, shell survives; (5)
+`KEYS=nonexistent` warns, shell survives, nothing spurious loaded.
+
+## Invariants
+- `tests/test_bash_env_project_env_parse.sh` stays green — the trusted/untrusted split
+  and the GUARD_* refusal from PR #588 are untouched.
+- Provider files are sourced as code; only names matching `^[a-z0-9-]+$` reach the
+  filesystem, so `KEYS` can never source an arbitrary path.
+- The script never aborts a subprocess on a missing/invalid provider.
+
+## Exit criteria
+- [ ] `KEYS=` in a project `.env` sources only the named `~/.config/keys/<name>.env`
+      files; no `KEYS` line loads no provider secrets (default-deny).
+- [ ] Provider names are validated (`^[a-z0-9-]+$`); traversal/invalid names are
+      skipped with a warning and never source a path.
+- [ ] `tests/test_bash_env_keys_selection.sh` covers cases 1-5 and is green; RED was
+      demonstrated against pre-fix bash-env.sh.
+- [ ] `tests/test_bash_env_project_env_parse.sh` and the shell-suite wrapper stay green.
+- [ ] `make lint` passes.
+- [ ] (Deferred — cross-repo ops) Live migration of a project's real secrets into
+      ~/.config/keys/ + adding its KEYS= line is a per-project step tracked at the
+      destination repo, not gated here. AEDIST keeps working via strict-parse until
+      migrated.

--- a/tickets/closed/0334-wire-config-keys-least-privilege.erg
+++ b/tickets/closed/0334-wire-config-keys-least-privilege.erg
@@ -2,6 +2,7 @@
 Title: Wire per-project least-privilege ~/.config/keys loading via KEYS=
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #593
 
 --- log ---
 2026-07-14T10:44Z Minh Ha-Duong created
@@ -9,6 +10,7 @@ Author: Minh Ha-Duong
 
 2026-07-14T11:06Z Minh Ha-Duong note scoping caveat: KEYS is read from the untrusted project .env with no allowlist; a hostile .env can self-declare any provider name to load that secret. Name validation and never-source-.env still hold, so no arbitrary path and no code execution. This is cooperative default-deny scoping, not access control against a hostile project .env.
 2026-07-14T11:06Z Minh Ha-Duong note bump verify-reroll — round 1: IFS/temp export leak (verifiable) + least-privilege claim scoping caveat
+2026-07-14T11:13Z Minh Ha-Duong closed — autoclosed — PR #593
 --- body ---
 ## Context
 `scripts/bash-env.sh` sources the user's `~/.claude/.env` (trusted) and strict-parses


### PR DESCRIPTION
## Mechanism

Adds an opt-in, default-deny least-privilege boundary to `scripts/bash-env.sh`. A project declares the credential providers it needs with `KEYS=prov1,prov2,...` in its project `$PWD/.env`. bash-env.sh then sources **only** `$HOME/.config/keys/<prov>.env` for each declared, validated provider — so a project no longer loads every secret on every bash subprocess.

- **Default-deny**: no `KEYS` line → no provider secrets loaded.
- **Name validation**: each provider name must match `^[a-z0-9-]+$` before any filesystem access. Path traversal (`../../etc/passwd`), slashes (`foo/bar`), uppercase, and empty names are skipped with a stderr warning and can never source an arbitrary path. Globbing is disabled during the comma split.
- **Trusted vs untrusted**: the per-provider `~/.config/keys/<name>.env` files are user-owned and TRUSTED, so they are sourced as shell code (full expansion) — in deliberate contrast to the untrusted project `.env`, which stays strict-parsed and never executed (builds on merged #588). `KEYS` itself arrives as a plain non-GUARD value through that strict parser.
- **Non-fatal**: a declared-but-missing provider warns and continues. The block is `set -euo pipefail`-safe (`${KEYS:-}` guarded, no `((...))`).

## Tests — `tests/test_bash_env_keys_selection.sh` (new, hermetic)

Fake `HOME` temp dir + fake `~/.config/keys/*.env` fixtures holding **non-secret sentinels** (`FAKE_OPENROUTER=orval`, etc.) + crafted project `.env`; bash-env.sh is sourced in an isolated subshell and the env is asserted. No real `~/.config/keys` file is ever read.

1. `KEYS=openrouter` → `FAKE_OPENROUTER` set, undeclared `FAKE_MISTRAL` **not** set.
2. No `KEYS` line → neither loaded (default-deny).
3. `KEYS=openrouter,zenodo` → both load (+ a whitespace-trimming variant `KEYS= openrouter , zenodo`).
4. `KEYS=../../etc/passwd` and `KEYS=foo/bar` → rejected by validation, nothing sourced, shell survives (rc 0).
5. `KEYS=nonexistent` → warns, shell survives, nothing spurious loaded.

**Red-proof (honest):** against pre-fix bash-env.sh, cases **1, 3, 3b are RED** (declared providers do not load — got `[]`, want `[orval]`). Cases **2, 4, 5 assert absence/survival**, which trivially holds pre-fix (no KEYS handling exists at all), so they were already green and stay green — matching the expectation that a traversal name is simply ignored when there is no KEYS code path. Post-fix: all 15 assertions green.

## Gates

- `tests/test_bash_env_keys_selection.sh`: green.
- `tests/test_bash_env_project_env_parse.sh`: green (no regression to the #588 trusted/untrusted split or GUARD_* refusal).
- Shell-suite wrapper `tests/test_bash_suites.py`: 24 passed (new suite auto-discovered).
- `make lint`: passed (17 adherence).
- `erg check tickets/`: PASS (329 tickets, no duplicate ID).

## Ticket ID note

Briefed as ticket 0330, but slot **0330 is an unrelated already-closed ticket** (`0330-raid-merge-denial-cure-with-external-review`). Per the optimistic-ID rule ("seat taken, move to the next one"), the KEYS ticket takes the next free ID **0334**. The AEDIST live-secret migration was scoped out to the destination repo (cross-repo ops) in the ticket's exit criteria and log.

**Ticket:** tickets/0334-wire-config-keys-least-privilege.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)