### PR TITLE
fix(0332): replace SIGPIPE-class grep|grep pipe in rules-injection suite

### DIFF
--- a/tests/test_harness_rules_injection.sh
+++ b/tests/test_harness_rules_injection.sh
@@ -41,7 +41,7 @@ for needle in "${body_strings[@]}"; do
 done
 
 # 3. on-start.sh must literally contain a `cat ... README.md` invocation.
-if ! grep -F 'cat' scripts/on-start.sh | grep -qF 'README.md'; then
+if ! grep -qE 'cat[^#]*README\.md' scripts/on-start.sh; then
   echo "FAIL: scripts/on-start.sh missing 'cat ... README.md' invocation"
   fail=1
 fi

--- a/tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
+++ b/tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-07-14T12:40Z claude created
 2026-07-14T11:29Z claude note imagine: single grep|grep site confirmed (no siblings in suite); the pipe is a same-line cooccurrence check — on-start.sh:33 pairs cat and README.md on one line, so one anchored `grep -qE 'cat[^#]*README\.md'` against the file replaces it with no pipe; capture-then-[[ ]] dropped as ceremony; mutation check unchanged
 2026-07-14T11:40Z claude note plan+feasibility: imagine output is the plan (file:line-precise, phase-3 absorbed per raid-0252 precedent); anchors verified (suite :44, on-start.sh:33); PASS, no overlap with 0333
+2026-07-14T12:50Z claude note execute: replaced the pipe with single anchored `grep -qE 'cat[^#]*README\.md'` (no pipe, cannot SIGPIPE); sibling sweep re-run — line 44 was the sole grep|grep -q in the suite; mutation on throwaway on-start.sh copy (README.md dropped) makes the converted check FAIL loudly, pristine PASSes; suite green standalone, make check green
 
 --- body ---
 ## Context
@@ -47,6 +48,6 @@ here-string flake); this ticket tracks the residual site.
 - Fail-loud semantics preserved; no retry or `|| true` on the assertion itself.
 
 ## Exit criteria
-- [ ] No `grep | grep -q` pipeline remains in tests/test_harness_rules_injection.sh
-- [ ] Mutation check confirms the converted site still fails on needle removal
-- [ ] `make check` passes
+- [x] No `grep | grep -q` pipeline remains in tests/test_harness_rules_injection.sh
+- [x] Mutation check confirms the converted site still fails on needle removal
+- [x] `make check` passes

--- a/tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
+++ b/tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-07-14T12:40Z claude created
+2026-07-14T11:29Z claude note imagine: single grep|grep site confirmed (no siblings in suite); the pipe is a same-line cooccurrence check — on-start.sh:33 pairs cat and README.md on one line, so one anchored `grep -qE 'cat[^#]*README\.md'` against the file replaces it with no pipe; capture-then-[[ ]] dropped as ceremony; mutation check unchanged
 
 --- body ---
 ## Context

--- a/tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
+++ b/tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-14T12:40Z claude created
 2026-07-14T11:29Z claude note imagine: single grep|grep site confirmed (no siblings in suite); the pipe is a same-line cooccurrence check — on-start.sh:33 pairs cat and README.md on one line, so one anchored `grep -qE 'cat[^#]*README\.md'` against the file replaces it with no pipe; capture-then-[[ ]] dropped as ceremony; mutation check unchanged
+2026-07-14T11:40Z claude note plan+feasibility: imagine output is the plan (file:line-precise, phase-3 absorbed per raid-0252 precedent); anchors verified (suite :44, on-start.sh:33); PASS, no overlap with 0333
 
 --- body ---
 ## Context

--- a/tickets/0333-erg-pr-merge-guard-breaks-under-rtk-rewrite.erg
+++ b/tickets/0333-erg-pr-merge-guard-breaks-under-rtk-rewrite.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-14T13:10Z claude created
 2026-07-14T11:29Z claude note imagine: empirical correction — rtk PreToolUse hook (0.34.3) fires ONCE on the outer Bash-tool command text, never on a script's internal subprocess calls, and ls-tree/rev-parse are not in its rewrite table ("No rewrite for"); the #584 incident's root cause is therefore UNCONFIRMED (misdiagnosis recorded, per diagnosis discipline). Script path is skills/merge/erg-pr-merge, not scripts/. Confirmed live rewrite targets to harden: branch --show-current (erg-pr-merge:76), worktree list --porcelain (sync-local-main.sh:56); L164 ls-tree grep-over-blob hardened as fragility, not confirmed exposure. No generic wrapper layer (YAGNI)
+2026-07-14T11:40Z claude note plan+feasibility: imagine output is the plan (phase-3 absorbed); anchors verified (erg-pr-merge:54,76,164,201; sync-local-main.sh:56; worktree-salvage.sh:22); regression tests extend existing tests/test_erg_pr_merge.sh and tests/test_sync_local_main.sh; PASS, no overlap with 0332
 
 --- body ---
 ## Context

--- a/tickets/0333-erg-pr-merge-guard-breaks-under-rtk-rewrite.erg
+++ b/tickets/0333-erg-pr-merge-guard-breaks-under-rtk-rewrite.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-07-14T13:10Z claude created
+2026-07-14T11:29Z claude note imagine: empirical correction — rtk PreToolUse hook (0.34.3) fires ONCE on the outer Bash-tool command text, never on a script's internal subprocess calls, and ls-tree/rev-parse are not in its rewrite table ("No rewrite for"); the #584 incident's root cause is therefore UNCONFIRMED (misdiagnosis recorded, per diagnosis discipline). Script path is skills/merge/erg-pr-merge, not scripts/. Confirmed live rewrite targets to harden: branch --show-current (erg-pr-merge:76), worktree list --porcelain (sync-local-main.sh:56); L164 ls-tree grep-over-blob hardened as fragility, not confirmed exposure. No generic wrapper layer (YAGNI)
 
 --- body ---
 ## Context

--- a/tickets/closed/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
+++ b/tickets/closed/0332-sigpipe-class-pipe-in-rules-injection-suite.erg
@@ -2,6 +2,7 @@
 Title: SIGPIPE-class grep|grep pipe in test_harness_rules_injection.sh:44
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #594
 
 --- log ---
 2026-07-14T12:40Z claude created
@@ -9,6 +10,7 @@ Author: claude
 2026-07-14T11:40Z claude note plan+feasibility: imagine output is the plan (file:line-precise, phase-3 absorbed per raid-0252 precedent); anchors verified (suite :44, on-start.sh:33); PASS, no overlap with 0333
 2026-07-14T12:50Z claude note execute: replaced the pipe with single anchored `grep -qE 'cat[^#]*README\.md'` (no pipe, cannot SIGPIPE); sibling sweep re-run — line 44 was the sole grep|grep -q in the suite; mutation on throwaway on-start.sh copy (README.md dropped) makes the converted check FAIL loudly, pristine PASSes; suite green standalone, make check green
 
+2026-07-14T12:24Z Minh Ha-Duong closed — autoclosed — PR #594
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

`tests/test_harness_rules_injection.sh:44` asserted that `scripts/on-start.sh` contains a `cat ... README.md` invocation via a two-stage pipe:

```bash
if ! grep -F 'cat' scripts/on-start.sh | grep -qF 'README.md'; then
```

This was a same-line co-occurrence check — `on-start.sh:33` pairs `cat` and `README.md` on one line. Under `set -o pipefail`, the trailing `grep -q` exits on first match and can close the pipe before the upstream `grep -F` finishes writing; the upstream then dies with SIGPIPE (141), which pipefail reports as the pipeline status — a nondeterministic false FAIL. Same defect class fixed suite-wide in PR #575 (printf|grep) and PR #584 (grep-here-string); this site greps a FILE through a filter pipe, so it was out of scope for both.

## Change

One anchored grep, no pipe, asserting the same invariant:

```bash
if ! grep -qE 'cat[^#]*README\.md' scripts/on-start.sh; then
```

## Sweep result

Line 44 was the **only** `grep | grep -q` pipe in `tests/test_harness_rules_injection.sh` (re-verified with a single anchored grep over the suite; no siblings).

## Mutation outcome

On a throwaway copy of `scripts/on-start.sh` with `README.md` dropped from the cat line, the converted check FAILs loudly (`FAIL: scripts/on-start.sh missing 'cat ... README.md' invocation`); against the pristine file it passes. Mutation never committed.

## Verification

- Suite green standalone (`bash tests/test_harness_rules_injection.sh`)
- `make check-fast` green
- `make check` green
- Fail-loud preserved; no retry loop, no `|| true` on the assertion.

**Ticket:** tickets/0332-sigpipe-class-pipe-in-rules-injection-suite.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)