### PR TITLE
fix(0335): bash-env.sh robustness — CRLF strip, size cap, realpath set -e safety

### DIFF
--- a/projects/-home-haduong--claude/memory/project_bash_env_secret_loading.md
+++ b/projects/-home-haduong--claude/memory/project_bash_env_secret_loading.md
@@ -8,9 +8,16 @@ Secrets are loaded into Claude Code bash subprocesses via `BASH_ENV`, not `CLAUD
 
 **Why:** `CLAUDE_ENV_FILE` causes Claude Code to inline `KEY=VALUE` pairs as shell assignments before each Bash tool call (visible in `ps -ef` to all local users). Discovered 2026-05-03 when orphaned processes from April 30 were found exposing all API keys.
 
-**How to apply:** 
+**Two .env sources, DIFFERENT trust** (`scripts/bash-env.sh`, sourced on every subprocess):
+- `~/.claude/.env` — user-owned, TRUSTED: **sourced** as shell code (full expansion), inside `set -a`/`set +a`.
+- `$PWD/.env` — project-level, UNTRUSTED (an agent/clone/project write can place it): **strict-parsed** `KEY=VALUE`, never sourced. Values assigned LITERALLY (no eval/`$()`/backticks), one surrounding quote-pair stripped, non-identifier keys skipped. Any guard-namespaced key (substring `GUARD_`, covering `GUARD_*` and the `_GUARD_*` override pair) is REFUSED, so it cannot forge a per-process guard nonce or the worktree-path override.
+
+**Provider secrets load least-privilege via `KEYS=`** (#588/#593): the project `.env` opts in with `KEYS=name,name`; only those validated (`^[a-z0-9-]+$`) providers' user-owned `~/.config/keys/<name>.env` are sourced. Default-deny (no `KEYS` line → no provider secrets); name validation blocks path traversal out of `~/.config/keys/`. This is cooperative scoping (shrinks default exposure), NOT access control against a hostile `.env`.
+
+**Robustness (ticket 0335):** strict parse tolerates CRLF (trailing `\r` dropped), is bounded by a 256 KiB byte cap (oversized project `.env` skipped whole with a stderr warning), and the realpath dedup uses `|| true` so an absent file cannot abort the script under an active `set -e` in the sourcing shell.
+
+**How to apply:**
 - `settings.json` → `env.BASH_ENV` → `scripts/bash-env.sh`
-- `bash-env.sh` uses `set -a` / `set +a` to source `~/.claude/.env` and `$PWD/.env`
-- `bash-env.sh` must NOT have `set -euo pipefail` (it's sourced, not executed — flags would propagate into calling shell)
-- `bash-env.sh` is excluded from the `pipefail-guard` CI check alongside `shell-init.sh`
-- Never write secrets back to `CLAUDE_ENV_FILE` in hooks
+- `bash-env.sh` must NOT have `set -euo pipefail` (it's sourced, not executed — flags would propagate into the calling shell); excluded from the `pipefail-guard` CI check alongside `shell-init.sh`.
+- Never write secrets back to `CLAUDE_ENV_FILE` in hooks.
+- Tests: `tests/test_bash_env_project_env_parse.sh`, `tests/test_bash_env_keys_selection.sh`, `tests/test_bash_env_robustness.sh` (auto-run by `tests/test_bash_suites.py`).

--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -24,7 +24,11 @@
 #
 # The script runs on every bash subprocess, so it stays fast and never aborts on
 # a missing or malformed .env — bad lines in the project file are skipped, never
-# fatal.
+# fatal, and it stays safe under an already-active `set -e` in the sourcing shell
+# (the realpath dedup below is guarded with `|| true`). The strict parse tolerates
+# CRLF (a trailing \r is dropped, for Windows-edited files) and is bounded: a
+# project .env past a generous byte cap is skipped whole, so a pathological or
+# adversarial one cannot tax every subprocess.
 #
 # Provider-secret scoping (KEYS=). A project declares which credential providers
 # it needs by setting KEYS=<name,name,...> in its project .env (parsed by the
@@ -55,10 +59,29 @@ set +a
 # Claude Code sets PWD to the project dir for each subprocess. Skip if it
 # resolves to the same file as the trusted user-level one (already loaded).
 if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
-    _be_proj="$(realpath "$PWD/.env" 2>/dev/null)"
-    _be_user="$(realpath "$HOME/.claude/.env" 2>/dev/null)"
+    # `|| true` so a realpath failure (e.g. ~/.claude/.env absent, so its parent
+    # dir is missing) cannot abort this script under an active `set -e` in the
+    # sourcing shell. An empty result still compares unequal, so dedup is intact:
+    # when the two files resolve to the same path the project parse is skipped;
+    # when either is absent the paths differ and the project file is parsed.
+    _be_proj="$(realpath "$PWD/.env" 2>/dev/null || true)"
+    _be_user="$(realpath "$HOME/.claude/.env" 2>/dev/null || true)"
     if [ "$_be_proj" != "$_be_user" ]; then
+      # This script is sourced on EVERY bash subprocess, so a pathological or
+      # adversarial project .env must not tax each one. Past a generous byte cap
+      # (256 KiB — no legitimate .env approaches it) skip the file entirely
+      # rather than partially parse and risk a desynced read.
+      _be_cap=262144
+      _be_size="$(wc -c < "$PWD/.env" 2>/dev/null || echo 0)"
+      if [ "${_be_size:-0}" -gt "$_be_cap" ]; then
+        printf 'bash-env: project .env exceeds size cap (%s > %s bytes), skipping\n' \
+            "$_be_size" "$_be_cap" >&2
+      else
         while IFS= read -r _be_line || [ -n "$_be_line" ]; do
+            # tolerate CRLF: a Windows-edited .env ends lines with \r\n and `read`
+            # strips only \n, so drop a surviving trailing CR before parsing (this
+            # also cleans a trailing \r on the KEYS= provider list).
+            _be_line="${_be_line%$'\r'}"
             # strip leading whitespace for blank/comment detection
             _be_trim="${_be_line#"${_be_line%%[![:space:]]*}"}"
             [ -z "$_be_trim" ] && continue          # blank line
@@ -98,6 +121,8 @@ if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
             export "$_be_key=$_be_val"
         done < "$PWD/.env"
         unset _be_line _be_trim _be_key _be_val _be_first _be_last
+      fi
+      unset _be_cap _be_size
     fi
     unset _be_proj _be_user
 fi

--- a/tests/test_bash_env_robustness.sh
+++ b/tests/test_bash_env_robustness.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Robustness regressions for scripts/bash-env.sh (ticket 0335) — follow-ups from
+# the #588 (strict-parse) and #593 (KEYS=) gaze reviews. Three nits:
+#
+#   1. CRLF tolerance — a Windows-edited project .env terminates lines with \r\n.
+#      `read` strips only \n, so a trailing \r survives into every value and,
+#      worse, into the last KEYS= provider name (corrupting the ^[a-z0-9-]+$
+#      match). The strict parser must drop a trailing CR.
+#   2. Size cap — bash-env.sh is sourced on EVERY bash subprocess. A pathological
+#      or adversarial project .env must not tax each one: past a generous byte
+#      cap the parse is skipped with a stderr warning, never partially parsed.
+#   3. realpath set -e safety — the dedup `realpath "$HOME/.claude/.env"` fails
+#      (exit 1) when the user file is absent; under an already-active `set -e` in
+#      the sourcing shell that failed command substitution aborts bash-env.sh
+#      mid-way. It must be guarded so the script always reaches its end.
+#
+# Harness idiom: run bash-env.sh in an isolated subprocess with a controlled
+# HOME (so the real ~/.claude/.env is never read) and a controlled project dir
+# as PWD, then assert on the resulting environment / exit code / stderr.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+SCRIPT="$PWD/scripts/bash-env.sh"
+fail=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Load bash-env.sh in a subprocess with $HOME=<home> and PWD=<projdir>, then
+# print the value of environment variable <var> ("" if unset). stderr silenced.
+_load_var() {
+    local home="$1" projdir="$2" var="$3"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+        n="$3"
+        printf "%s" "${!n-}"
+    ' _ "$projdir" "$SCRIPT" "$var" 2>/dev/null
+}
+
+# Load bash-env.sh with `set -e` ALREADY ACTIVE in the sourcing shell, and print
+# a sentinel that is only reached if the source did not abort mid-way. Prints
+# "END" on success, "" if the source aborted. stderr silenced.
+_load_sete_reaches_end() {
+    local home="$1" projdir="$2"
+    HOME="$home" bash -c '
+        set -e
+        cd "$1" || exit 1
+        source "$2"
+        printf "END"
+    ' _ "$projdir" "$SCRIPT" 2>/dev/null || true
+}
+
+# Load bash-env.sh as above but return only the exit code (0 = no shell error).
+_load_rc() {
+    local home="$1" projdir="$2"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+    ' _ "$projdir" "$SCRIPT" >/dev/null 2>&1
+    echo $?
+}
+
+# Load bash-env.sh and capture only its stderr (for warning assertions).
+_load_stderr() {
+    local home="$1" projdir="$2"
+    HOME="$home" bash -c '
+        cd "$1" || exit 1
+        source "$2"
+    ' _ "$projdir" "$SCRIPT" 2>&1 >/dev/null
+}
+
+_assert_eq() {
+    local label="$1" got="$2" want="$3"
+    if [[ "$got" == "$want" ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — got [$got], want [$want]"
+        fail=1
+    fi
+}
+
+_assert_contains() {
+    local label="$1" hay="$2" needle="$3"
+    if [[ "$hay" == *"$needle"* ]]; then
+        echo "PASS: $label"
+    else
+        echo "FAIL: $label — [$needle] not found in stderr"
+        fail=1
+    fi
+}
+
+EMPTY_HOME="$WORK/empty-home"   # no ~/.claude/.env — isolates the project file
+mkdir -p "$EMPTY_HOME"
+
+# Fake HOME with a ~/.config/keys/ provider fixture — NON-secret sentinel only.
+FHOME="$WORK/keys-home"
+mkdir -p "$FHOME/.config/keys"
+printf 'FAKE_HF=hfval\n' > "$FHOME/.config/keys/huggingface.env"
+
+# --- (1) CRLF value: a trailing \r is stripped -------------------------------
+# printf '\r\n' writes a CRLF line terminator (Windows-edited .env). `read`
+# strips only the \n; the parser must drop the surviving \r so the value is clean.
+P1="$WORK/p1"; mkdir -p "$P1"
+printf 'FOO=bar\r\n' > "$P1/.env"
+_assert_eq "(1) CRLF value FOO=bar loses its trailing CR" \
+    "$(_load_var "$EMPTY_HOME" "$P1" FOO)" "bar"
+
+# --- (2) CRLF on the KEYS= line: provider name is not \r-corrupted ------------
+# A trailing \r on 'KEYS=huggingface' would make the provider name
+# 'huggingface\r', failing ^[a-z0-9-]+$ and loading nothing. With CR stripped the
+# provider resolves and its (sentinel) secret loads.
+P2="$WORK/p2"; mkdir -p "$P2"
+printf 'KEYS=huggingface\r\n' > "$P2/.env"
+_assert_eq "(2) CRLF KEYS=huggingface resolves the provider (FAKE_HF=hfval)" \
+    "$(_load_var "$FHOME" "$P2" FAKE_HF)" "hfval"
+
+# --- (3) oversized project .env: parse is skipped, warned, shell survives -----
+# Generate a file well past the 256 KiB cap. It must be skipped (FOO not loaded),
+# a warning emitted to stderr, and the shell must not error or hang.
+P3="$WORK/p3"; mkdir -p "$P3"
+# Build ~600 KiB of filler by doubling a buffer — no pipe, so no SIGPIPE under
+# this suite's `set -o pipefail` (the ticket-0332 trap).
+_be_big="PADDING_LINE=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"$'\n'
+while [ "${#_be_big}" -lt 600000 ]; do _be_big="$_be_big$_be_big"; done
+{ printf 'FOO=bar\n'; printf '%s' "$_be_big"; } > "$P3/.env"
+unset _be_big
+_assert_eq "(3) oversized project .env: parse skipped, FOO not loaded" \
+    "$(_load_var "$EMPTY_HOME" "$P3" FOO)" ""
+_assert_eq "(3) oversized project .env: shell survives (rc 0)" \
+    "$(_load_rc "$EMPTY_HOME" "$P3")" "0"
+_assert_contains "(3) oversized project .env: size-cap warning on stderr" \
+    "$(_load_stderr "$EMPTY_HOME" "$P3")" "exceeds size cap"
+
+# --- (4) realpath safety under an active set -e ------------------------------
+# (4a) A project .env EXISTS but the user ~/.claude/.env is ABSENT: the dedup
+# realpath on the missing user file fails, and under set -e must NOT abort.
+P4="$WORK/p4"; mkdir -p "$P4"
+printf 'AAA=bbb\n' > "$P4/.env"
+_assert_eq "(4a) set -e + missing user .env: source reaches its end" \
+    "$(_load_sete_reaches_end "$EMPTY_HOME" "$P4")" "END"
+_assert_eq "(4a) set -e + missing user .env: project value still loads" \
+    "$(_load_var "$EMPTY_HOME" "$P4" AAA)" "bbb"
+# (4b) Neither file present: source must also reach its end under set -e.
+P4B="$WORK/p4b"; mkdir -p "$P4B"   # no .env at all
+_assert_eq "(4b) set -e + no .env at all: source reaches its end" \
+    "$(_load_sete_reaches_end "$EMPTY_HOME" "$P4B")" "END"
+
+exit "$fail"

--- a/tickets/0335-bash-env-robustness-crlf-sizecap-realpath.erg
+++ b/tickets/0335-bash-env-robustness-crlf-sizecap-realpath.erg
@@ -1,0 +1,19 @@
+%erg 0.1
+Title: bash-env.sh robustness — CRLF strip, size cap, realpath set -e safety
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T00:00Z Minh Ha-Duong created
+
+--- body ---
+## Context
+Follow-ups from the #588 (strict-parse) and #593 (KEYS=) gaze reviews on scripts/bash-env.sh. Non-blocking robustness nits, batched.
+
+## Exit criteria
+- [ ] The project-.env strict parser strips a trailing CR (\r) from values, so a CRLF-terminated project .env (Windows-edited) yields clean values (covers the KEYS= line too — a trailing \r there would corrupt the last provider name)
+- [ ] The project-.env parse is bounded: past a generous cap (e.g. > 5000 lines or > 256 KiB) it stops and warns to stderr, so a pathological/adversarial project .env cannot tax every bash subprocess (this file is sourced on every Bash tool call)
+- [ ] The realpath dedup calls (`_be_proj`/`_be_user="$(realpath …)"`) do not abort bash-env.sh under an already-active `set -e` in the parent shell when $PWD/.env or ~/.claude/.env is absent (guard with `|| true` or an existence check first)
+- [ ] Tests cover: CRLF value strip; the size-cap warning + bounded behavior; realpath-absent safety under `set -e`
+- [ ] Memory projects/-home-haduong--claude/memory/project_bash_env_secret_loading.md refreshed to current reality: user-owned ~/.claude/.env is SOURCED (trusted); project $PWD/.env is STRICT-PARSED never sourced (untrusted), GUARD_*/_GUARD_* keys refused; provider secrets load least-privilege via KEYS= from ~/.config/keys/. Keep it one concept, accurate.
+- [ ] make check and make lint pass

--- a/tickets/closed/0335-bash-env-robustness-crlf-sizecap-realpath.erg
+++ b/tickets/closed/0335-bash-env-robustness-crlf-sizecap-realpath.erg
@@ -2,10 +2,12 @@
 Title: bash-env.sh robustness — CRLF strip, size cap, realpath set -e safety
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #595
 
 --- log ---
 2026-07-14T00:00Z Minh Ha-Duong created
 
+2026-07-14T12:03Z Minh Ha-Duong closed — autoclosed — PR #595
 --- body ---
 ## Context
 Follow-ups from the #588 (strict-parse) and #593 (KEYS=) gaze reviews on scripts/bash-env.sh. Non-blocking robustness nits, batched.


### PR DESCRIPTION
Follow-ups from the #588 (strict-parse) and #593 (KEYS=) gaze reviews on `scripts/bash-env.sh`. Three non-blocking robustness nits, batched (all bash-env.sh-adjacent).

## Fixes
1. **CRLF strip** — the strict parser drops a trailing `\r` from each line, so a Windows-edited project `.env` (CRLF terminators) yields clean values. The `KEYS=` provider list was already covered by its existing whitespace trim (`[:space:]` includes `\r`); the line-level strip makes it belt-and-suspenders and cleans all other values.
2. **Size cap** — a project `.env` past 256 KiB (`wc -c`) is skipped whole with a stderr warning (`bash-env: project .env exceeds size cap …`) rather than parsed, so a pathological or adversarial file cannot tax every bash subprocess. This script is sourced on every Bash tool call, and the byte check is cheap. Skipped whole, never partially parsed (no desynced read).
3. **realpath `set -e` safety** — the dedup `realpath` command substitutions now use `|| true`, so an absent `~/.claude/.env` (its parent dir missing) cannot abort the script under an already-active `set -e` in the sourcing shell. Dedup behavior is unchanged when both files exist; an empty result still compares unequal, so the project file is still parsed when either path is absent.

## Tests
New `tests/test_bash_env_robustness.sh` (auto-discovered and run by `tests/test_bash_suites.py`), 8 assertions:
- CRLF value → `\r` stripped (**RED pre-fix**)
- CRLF `KEYS=` line resolves the provider (green pre-fix — already covered by the KEYS whitespace trim; kept as a regression guard)
- oversized `.env` → parse skipped, warning on stderr, shell survives (**RED pre-fix**: file was parsed, no warning)
- `set -e` + missing user `.env` → source reaches its end (**RED pre-fix**: aborted at the realpath dedup)
- `set -e` + no `.env` at all → source reaches its end (green pre-fix — block was skipped)

The oversize fixture builds ~600 KiB by string-doubling, with no `yes | head` pipe, to avoid the SIGPIPE-under-`pipefail` trap (ticket 0332 class).

## Memory
Refreshes `projects/…/memory/project_bash_env_secret_loading.md` to current reality: two-trust-level sources (user `~/.claude/.env` sourced; project `$PWD/.env` strict-parsed, never sourced, `GUARD_*`/`_GUARD_*` refused), `KEYS=` least-privilege provider loading from `~/.config/keys/`, and these robustness properties.

## Gates
`make lint`, `make check` (847 passed), all three bash-env shell suites, and `erg check` all green.

**Ticket:** tickets/0335-bash-env-robustness-crlf-sizecap-realpath.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)