### PR TITLE
memory(rtk): hook-surface scope + exit-code-over-parsing rule (roar #596)

### DIFF
--- a/projects/-home-haduong--claude/memory/feedback_rtk_rewrites_git_output.md
+++ b/projects/-home-haduong--claude/memory/feedback_rtk_rewrites_git_output.md
@@ -1,6 +1,6 @@
 ---
 name: feedback_rtk_rewrites_git_output
-description: rtk rewrites git diff/porcelain output (injects "--- Changes ---" lines); use `rtk proxy git ...` when parsing machine output
+description: rtk rewrites the OUTER Bash-tool git command's diff/porcelain output (not a script's internal git calls); use `rtk proxy git` for machine output you parse yourself, and prefer exit-code/plumbing checks over porcelain parses in scripts
 metadata:
   type: feedback
 ---
@@ -28,3 +28,28 @@ mutation whose success you must trust, bypass the hook with
 Reserve plain `git` for output you read yourself. Bit repeatedly during the
 2026-07-10 merge sessions (file-overlap `comm`, porcelain worktree parse,
 force-push no-op). Related: [[feedback_gh_pr_edit_broken_use_rest]].
+
+**Hook surface — the rewrite fires on the OUTER Bash-tool command only, never
+on a script's internal subprocess git calls** (rtk 0.34.3, verified with
+`rtk hook check`, 2026-07-14). The PreToolUse hook reads the command text you
+hand the Bash tool and rewrites that; a `git` call made *inside* a committed
+script the tool merely launches is untouched, whatever its subcommand. So the
+#584 incident premise — that rtk corrupted `erg-pr-merge`'s internal
+`git ls-tree` — is empirically disproven, and that incident's root cause stays
+unconfirmed. `ls-tree` and `rev-parse` are also absent from the rewrite table;
+only `branch --show-current`, `diff`, and `worktree list --porcelain` are
+confirmed targets. Diagnosis discipline caught a plausible-but-wrong causal
+story a prior session had already written into ticket 0333.
+
+**Design rule — prefer exit codes and plumbing over parsing porcelain in any
+script whose git output a framing hook could reach.** A check that reads no
+stdout is rewrite-proof by construction: `git cat-file -e HEAD:<path>`
+(presence by exit code) over grepping `ls-tree`; `compgen -G '<glob>'` (a
+filesystem read) over listing tree entries; `git symbolic-ref --quiet --short
+HEAD || true` over `git branch --show-current`. Where a porcelain parse is
+unavoidable, filter to known record keys and assert field arity (`NF == 2` on a
+`branch` record) so an injected banner cannot satisfy a match. This is the 0333
+fix (erg-pr-merge branch + existence guards, `sync-local-main.sh`,
+`worktree-gc.sh`) and the durable takeaway even though the rtk exposure it was
+chartered against turned out not to apply — it hardens against *any*
+output-framing hook, present or future.


### PR DESCRIPTION
Roar post-task wrap-up for merged PR #596 (ticket 0333).

Consolidates two durable lessons into the existing
`feedback_rtk_rewrites_git_output` memory entry (one entry, not two thin new
files):

1. **Hook surface** — the rtk PreToolUse rewrite fires on the OUTER Bash-tool
   command only, never on a script's internal subprocess git calls
   (`rtk hook check`, rtk 0.34.3). This empirically disproves the #584 incident
   premise (rtk corrupted `erg-pr-merge`'s internal `git ls-tree`); that root
   cause stays unconfirmed. A diagnosis-discipline catch on a causal story a
   prior session wrote into ticket 0333.
2. **Design rule** — prefer exit-code checks (`cat-file -e`, `compgen`) and
   plumbing (`symbolic-ref`) over parsing porcelain in scripts. Parse-free
   checks are rewrite-proof by construction and harden against any
   output-framing hook.

The description frontmatter is updated so the scope correction is visible at
index level.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)