### PR TITLE
ticket(0345): strict-parse critical-name/RCE injection hardening (needs policy decision)

### DIFF
--- a/tickets/0345-strict-parse-critical-name-injection.erg
+++ b/tickets/0345-strict-parse-critical-name-injection.erg
@@ -1,0 +1,31 @@
+%erg 0.1
+Title: strict-parse critical-name/RCE injection hardening (needs policy decision)
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T00:00Z Minh Ha-Duong created
+
+--- body ---
+## Context
+The untrusted project `$PWD/.env` strict-parse loop in `scripts/bash-env.sh` exports every non-`GUARD_*` key directly. An agent operating in an attacker-controlled repo (one shipping a malicious `.env`) can therefore inject arbitrary environment variables into every harness bash subprocess — attacker controls both name and value. Confirmed code-execution vectors: `GCONV_PATH` (glibc/iconv module load, RCE), `LD_PRELOAD` / `LD_AUDIT`, `BASH_ENV` / `ENV` (bash re-source), plus interpreter hijacks `PYTHONPATH` / `NODE_OPTIONS` / `NODE_PATH` / `PERL5LIB` / `RUBYOPT`, and `PATH` clobber. Reproduced during PR #604 review. This is the higher-severity sibling of ticket 0343 (which hardened only the KEYS-selection export name, where the value is trusted).
+
+## Severity / exposure
+Code-execution class. Exposure requires the harness to run bash with cwd in a repo carrying a hostile `.env` (autonomous agents cloning/working in untrusted repos). Not the common path (project `.env` files are normally the author's own), but the harness's threat model includes agents operating on untrusted code.
+
+## Policy decision needed
+A denylist on the strict-parse export NAME must balance security against legitimate project config:
+- (a) **Full denylist** — refuse the whole critical set in strict-parse (the 0343 set: PATH, BASH_ENV, ENV, SHELLOPTS, BASHOPTS, IFS, PS1-4, PROMPT_COMMAND, CDPATH, GLOBIGNORE, LD_PRELOAD, LD_LIBRARY_PATH, LD_AUDIT, BASH_FUNC_*, DYLD_*) PLUS GCONV_PATH and interpreter vars (PYTHONPATH, NODE_OPTIONS, NODE_PATH, PERL5LIB, RUBYOPT). Safest; may break a project that sets PATH/PYTHONPATH via `.env`.
+- (b) **RCE-only subset now, config vars deferred** — immediately refuse the vars with NO legitimate `.env` use and direct RCE/hijack impact (GCONV_PATH, LD_PRELOAD, LD_AUDIT, BASH_ENV, ENV, BASH_FUNC_*, DYLD_*), but ALLOW PATH/PYTHONPATH/NODE_OPTIONS/etc. (a project clobbering its own PATH mainly self-DoSes). Lower breakage, residual PATH-hijack risk if the attacker also controls a dir on the new PATH.
+- (c) **Allowlist model** — strict-parse exports only project-declared/expected names; biggest change, strongest guarantee.
+
+Recommend **(b)** as an immediate low-regret hardening (zero legit-use breakage), with (a)/(c) as a follow-up if the threat model warrants.
+
+## Exit criteria
+- [ ] Policy (a/b/c) chosen and recorded
+- [ ] Chosen denylist/allowlist applied to the strict-parse loop export path, refusing with a stderr warning (default-deny), reusing/sharing the 0343 critical-name predicate where sensible
+- [ ] Red tests: a project `.env` setting GCONV_PATH / LD_PRELOAD / BASH_ENV (and, if policy (a), PATH/PYTHONPATH) does NOT export it; legit non-critical keys still load
+- [ ] `make check` + `make lint` pass
+- [ ] Memory `project_bash_env_secret_loading.md` updated
+
+Reference: sibling ticket 0343 (KEYS-selection export-name denylist, closed via PR #604).


### PR DESCRIPTION
## The hole
`scripts/bash-env.sh`'s strict-parse loop for the untrusted project `$PWD/.env` refuses only `*GUARD_*` keys, then `export "$_be_key=$_be_val"` for everything else. An attacker who controls a project `.env` controls BOTH the exported variable name and its value — a code-execution-class hole, strictly worse than the KEYS-selection path hardened in 0343/PR #604 (there the attacker controls only the export NAME; the value comes from a trusted provider file).

Reproduced live during #604's review: a hostile `.env` setting `GCONV_PATH=<dir>` yields arbitrary code execution via glibc/iconv charset-module loading. Also settable: `PATH`, `LD_PRELOAD`, `LD_AUDIT`, `BASH_ENV`, `ENV`, and interpreter vars (`PYTHONPATH`, `NODE_OPTIONS`, `NODE_PATH`, `PERL5LIB`, `RUBYOPT`).

## Why a ticket, not an auto-fix
Some projects legitimately set `PATH`, `PYTHONPATH`, `NODE_OPTIONS`, etc. in their `.env`. A blanket denylist could break those, so the fix needs an author policy decision:

- **(a) Full denylist** — refuse the whole 0343 critical set plus `GCONV_PATH` and interpreter vars. Safest; may break projects that set `PATH`/`PYTHONPATH` via `.env`.
- **(b) RCE-only subset now** — refuse only vars with no legitimate `.env` use and direct RCE/hijack impact (`GCONV_PATH`, `LD_PRELOAD`, `LD_AUDIT`, `BASH_ENV`, `ENV`, `BASH_FUNC_*`, `DYLD_*`); allow `PATH`/`PYTHONPATH`/etc. Lower breakage, residual `PATH`-hijack risk.
- **(c) Allowlist model** — strict-parse exports only project-declared names. Biggest change, strongest guarantee.

**Recommendation: (b)** as an immediate low-regret hardening (zero legit-use breakage), with (a)/(c) as follow-up if the threat model warrants.

Ticket stays open pending the policy decision.

Ticket-ref: tickets/0345-strict-parse-critical-name-injection.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)