### PR TITLE
ticket(0346): /reviewers audition — retrospective benchmark board for candidate seats

### DIFF
--- a/tickets/0205-external-reviewer-panel-for-verify-contr.erg
+++ b/tickets/0205-external-reviewer-panel-for-verify-contr.erg
@@ -15,6 +15,7 @@ Blocked-by: 0207
 2026-06-05T11:07Z claude note corrective: the 06:41Z ACP-client architecture decision was superseded the same day by ticket 0217 (sandbox-runner spinoff, PR #289 panel + deep-research evidence) — OS-level sandbox (rootless podman) is the load-bearing containment, ACP demoted to optional plumbing. Current seat mechanism: 0217 seat-runner + /reviewers skill (0208, closed). Do not orient from the 06:41Z note
 2026-06-05T11:08Z MinhHaDuong note blocker 0208 closed — Blocked-by removed.
 2026-07-14T05:05Z Minh Ha-Duong note blocker 0206 closed — Blocked-by removed.
+2026-07-14T17:14Z Minh Ha-Duong note child 0346 filed — /reviewers audition subcommand (frozen benchmark board, duplicate/unique-verified/unique-hallucinated classification); audition filters candidates before the advisory trial, never replaces it
 --- body ---
 ## Context
 
@@ -31,6 +32,7 @@ stays open until children merge + integration review (roar step 7).
 - tickets/0207 — agnostic CLI reviewer seat (OpenRouter + llama-server configs)
 - tickets/0208 — reviewer-management surface (roster, harvest, scorecard)
 - tickets/0217 — sandbox seat-runner (the seat execution mechanism; foundational)
+- tickets/0346 — /reviewers audition: retrospective benchmark board for candidate seats
 
 ## Architecture: review is CI (decided 2026-06-05, supersedes the ACP draft)
 

--- a/tickets/0346-reviewers-audition-retrospective-benchm.erg
+++ b/tickets/0346-reviewers-audition-retrospective-benchm.erg
@@ -1,0 +1,115 @@
+%erg 0.1
+Title: /reviewers audition — retrospective benchmark board for candidate seats
+Created: 2026-07-14
+Author: Minh Ha-Duong
+Blocked-by: 0207
+
+--- log ---
+2026-07-14T17:14Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Child of tickets/0205 (external-reviewer panel tracker). Auditioning a
+candidate model for a roster seat today requires a live advisory trial:
+at least 5 merge requests across at least 3 projects (0205 rule 2). That
+takes days of wall-clock per candidate and makes cross-candidate
+comparison unsound — each candidate sees different PRs. Meanwhile the
+author scouts candidates from the OpenRouter weekly rankings (2026-07-14:
+Hy3 free, MiMo-V2.5, DeepSeek V4 Flash/Pro, MiniMax M3, GLM 5.2,
+Nemotron 3 Ultra free), which measure usage, not error-decorrelation —
+the panel's actual selection criterion.
+
+Decided design (author-approved, 2026-07-14 session): ONE new subcommand
+`/reviewers audition <model> [--endpoint URL]`, not separate skills for
+leaderboard-fetching / promotion / correlation / cost-plotting. Audition
+replays the candidate over a FROZEN benchmark board of already-merged
+PRs, so every candidate runs the same board in about an hour. The live
+advisory trial remains the confirmation stage for seats that pass
+audition; promotion stays a human decision at 0205's integration review.
+
+Per-PR finding classification (this is the decorrelation metric,
+operationalized):
+- duplicate — matches an internal-panel finding on the same PR
+  (redundant; no decorrelation value)
+- unique-verified — not found by the internal panel, confirmed real
+  against the PR's ground truth (the payoff)
+- unique-hallucinated — not found by the panel, refuted (the
+  devstral-small-2 failure mode: 13/13 hallucinations = disqualifier)
+
+## Relevant files
+
+- `skills/reviewers/SKILL.md` — add the `audition` subcommand section
+- `skills/reviewers/reviewers.sh` — implement `audition` (reuses the
+  0217 seat-runner invocation path that `request` already uses)
+- `skills/reviewers/panel.yml` — schema comment: audition scorecard
+  fields (overlap %, unique-verified, unique-hallucinated, latency,
+  $ per review)
+- `scripts/seat-runner.sh` — invoked per benchmark PR; no changes
+  expected (read-only replay is its normal mode)
+- `tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg` — trial
+  ticket where audition scorecard blocks are logged via `erg log`
+- `docs/research/ensemble-decorrelation-evidence.md` — the selection
+  rules audition operationalizes (cap 2-4 seats, composition over count)
+
+## Actions
+
+1. Select and freeze the benchmark board: ~10 merged PRs in this repo,
+   biased toward complex multi-file CODE changes (ensemble value
+   concentrates there — 0205), each with recoverable ground truth
+   (internal-panel findings from the PR thread, gate verdict, any
+   post-merge defect). Record the board as a list of PR numbers + ground
+   truth summaries in `skills/reviewers/benchmark-board.yml`.
+2. Implement `audition` in `reviewers.sh`: for each board PR, run the
+   candidate through the seat-runner over that PR's diff, harvest to the
+   0205 contract shape, classify each finding (duplicate /
+   unique-verified / unique-hallucinated) against the board's ground
+   truth.
+3. Emit one scorecard block per audition run (hit rates, overlap %,
+   latency, $ per review from token counts) and append it to the trial
+   ticket via `erg log` (verbs: `created`, `note`, `closed` only —
+   audition lines use `note`).
+4. Document the subcommand in `skills/reviewers/SKILL.md`, including the
+   audition → advisory trial → promote/drop pipeline and the rule that
+   audition never touches the roster (filing the seat stays a manual
+   panel.yml edit + PR).
+
+## Test
+
+- Extend `tests/test_reviewer_seat.sh` pattern: stub OpenAI-compatible
+  endpoint emitting canned findings; run `audition` against a 2-PR toy
+  board with known ground truth; assert the three-way classification,
+  the scorecard block shape, and non-zero exit when the endpoint is
+  unreachable (fail-loud).
+
+## Verification
+
+- [ ] Audition of the stub candidate over the toy board reproduces the
+      expected duplicate/unique-verified/unique-hallucinated counts
+- [ ] Scorecard block appends to the trial ticket via `erg log note` and
+      passes `erg check`
+- [ ] A second audition run of the same candidate is idempotent on the
+      roster (audition writes no panel.yml change)
+
+## Invariants
+
+- No secrets in any config: credential-env name only, key loads via the
+  BASH_ENV path (0207)
+- Containment unchanged: audition runs candidates only through the 0217
+  seat-runner sandbox (read-only repo, minimal env, network
+  deny-by-default plus the endpoint bridge)
+- Advisory-trial protocol (0205 rule 2) is unchanged — audition filters
+  candidates before it, never replaces it
+- `make check` passes
+
+## Exit criteria
+
+- [ ] Frozen benchmark board committed (`benchmark-board.yml`, ~10 PRs
+      with ground truth)
+- [ ] `/reviewers audition <model>` runs the board end-to-end through
+      the seat-runner and prints one scorecard block
+- [ ] Findings classified duplicate / unique-verified /
+      unique-hallucinated against board ground truth
+- [ ] Scorecard logged to the candidate's trial ticket; SKILL.md
+      documents the audition → trial → promote pipeline
+- [ ] Toy-board test green; `make check` passes


### PR DESCRIPTION
Files ticket 0346, a new child of tracker 0205, and registers it in the tracker's children list.

**What it specifies:** one `/reviewers audition <model>` subcommand that replays a candidate seat over a frozen benchmark board of ~10 already-merged PRs through the 0217 seat-runner, classifies every finding as duplicate / unique-verified / unique-hallucinated against recorded ground truth, and logs one scorecard block (overlap %, hit rates, latency, $ per review) to the trial ticket. Audition filters candidates before the 0205 advisory trial; it never touches the roster — promotion stays a manual panel.yml edit decided at the 0205 integration review.

**Why one subcommand, not five skills:** author decision (2026-07-14 session) — leaderboard fetching, correlation comparison, and cost plotting are inputs/metrics of the audition, not separate surfaces to maintain.

Ticket-ref: tickets/0346-reviewers-audition-retrospective-benchm.erg
Ticket-ref: tickets/0205-external-reviewer-panel-for-verify-contr.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)