### PR TITLE
feat(0346): /reviewers audition — retrospective benchmark board

### DIFF
--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -67,10 +67,77 @@ evidence-based:
 MR #42 seat=local-qwen verdict: PASS — 0 verifiable, 2 consider
 ```
 
+### `/reviewers audition <model> [--endpoint URL]`
+
+Replay a **candidate** model over a frozen benchmark board of already-merged
+merge requests and score its decorrelation value against ground truth (ticket
+0346). This is the cheap filter that runs **before** the live advisory trial:
+every candidate runs the **same** board in about an hour, so cross-candidate
+comparison is sound — a live trial cannot give this, because each candidate
+there sees different merge requests.
+
+For each board PR, `audition` runs the 0217 seat-runner over that PR's
+reconstructed diff (the same sandboxed, read-only invocation path `request`
+uses), then classifies each finding against the board's recorded ground truth:
+
+- **duplicate** — matches an internal-panel finding on that PR (redundant; no
+  decorrelation value).
+- **unique-verified** — not found by the panel, and confirmed real against a
+  recorded panel-missed defect (the payoff).
+- **unique-hallucinated** — not found by the panel and matching no known
+  defect (the noise; e.g. the devstral-small-2 failure mode).
+
+Findings match ground truth by **basename + line** (`file:LINE`, or `file:*`
+for any line in a file) — the board stores anchors basename-normalized so it
+stays forge/stack-agnostic.
+
+One **scorecard block** is emitted per run and appended to the candidate's
+trial ticket via `erg log` (verb `note`):
+
+```
+audition candidate=<label> model=<id> board=<N>PR findings=<F> \
+  duplicate=<d> unique-verified=<uv> unique-hallucinated=<uh> \
+  overlap=<pct>% latency=<s>s cost=<$x|n/a>
+```
+
+`overlap%` is the share of the candidate's findings that merely duplicate the
+panel. `cost` is `$ per review` from the token counts the seat reports on its
+`SUMMARY` line, priced via `AUDITION_PRICE_IN_PER_M` / `AUDITION_PRICE_OUT_PER_M`
+(USD per 1M tokens); it is `n/a` when the seat reports no tokens or no price is
+configured — an honest blank, never a fabricated `$0`.
+
+**Fail-loud**: unlike `request`'s per-seat fail-open, audition aborts non-zero
+if the seat-runner cannot replay a board PR (unreachable endpoint, sandbox
+failure) — a partial score is more misleading than none.
+
+**Audition never touches the roster.** It reads no `panel.yml`, writes no
+`panel.yml`, and files no seat. The pipeline is:
+
+```
+audition (filter)  →  advisory trial (0205 rule 2: ≥5 MRs / ≥3 projects)  →  promote/drop
+```
+
+Promotion — adding a seat to `panel.yml` — stays a **manual** panel edit + merge
+request at 0205's integration review. Audition informs that decision; it does
+not make it.
+
+Options: `--endpoint URL` (OpenAI-compatible base; default is the seat-runner's
+local endpoint), `--board FILE` (default `benchmark-board.yml`), `--trial-ticket
+tickets/NNNN-...` (where the scorecard is logged; default the 0207 trial ticket),
+`--credential-env NAME` (for an authenticated endpoint; threaded to the
+seat-runner, never written to config), `--name LABEL` (candidate label in the
+scorecard; default the model id).
+
 ## Configuration
 
 `skills/reviewers/panel.yml` is the single roster file (schema in its
 header). No secrets in config — credentials load via BASH_ENV (0207).
+
+`skills/reviewers/benchmark-board.yml` is the frozen audition board: ~10
+already-merged multi-file code PRs of this repo, each with `base`/`head` commit
+SHAs (immutable, so the diff is reconstructable forever) and ground-truth
+`panel`/`defects` anchors recovered from the PR's gate verdict. It is a data
+artifact — `audition` reads it, never edits it. Schema in its header.
 
 ## Dependencies
 

--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -95,14 +95,14 @@ One **scorecard block** is emitted per run and appended to the candidate's
 trial ticket via `erg log` (verb `note`):
 
 ```
-audition candidate=<label> model=<id> board=<N>PR findings=<F> \
+audition candidate=<label> model=<id> board=<N>MR findings=<F> \
   duplicate=<d> unique-verified=<uv> unique-hallucinated=<uh> \
   overlap=<pct>% latency=<s>s cost=<$x|n/a>
 ```
 
 `overlap%` is the share of the candidate's findings that merely duplicate the
 panel. `cost` is `$ per review` from the token counts the seat reports on its
-`SUMMARY` line, priced via `AUDITION_PRICE_IN_PER_M` / `AUDITION_PRICE_OUT_PER_M`
+`SUMMARY` line, priced via `REVIEWERS_PRICE_IN_PER_M` / `REVIEWERS_PRICE_OUT_PER_M`
 (USD per 1M tokens); it is `n/a` when the seat reports no tokens or no price is
 configured — an honest blank, never a fabricated `$0`.
 

--- a/skills/reviewers/benchmark-board.yml
+++ b/skills/reviewers/benchmark-board.yml
@@ -1,0 +1,104 @@
+# Frozen benchmark board for `/reviewers audition` (ticket 0346).
+#
+# Each entry is an ALREADY-MERGED merge request of THIS repo, biased toward
+# complex multi-file CODE changes (ensemble review value concentrates there —
+# ticket 0205). `audition` replays a candidate model over each PR's diff through
+# the 0217 seat-runner and classifies every finding against the ground truth
+# recorded here. Because the board is frozen, every candidate runs the SAME
+# board — cross-candidate comparison becomes sound (the live advisory trial
+# cannot give this: each candidate there sees different PRs).
+#
+# Diff reconstruction (why base/head are commit SHAs, not branch names):
+#   The seat-runner diffs `base...head` (three-dot, merge-base). `head` is the
+#   PR's head commit (the merge commit's second parent) and `base` is main's tip
+#   just before the merge (the first parent). Both are IMMUTABLE object SHAs, so
+#   the exact PR diff is reconstructable forever — even after the branch is
+#   deleted. Recover them for a new entry with, per merge commit MC:
+#     base = MC^1   head = MC^2   (diff = base...head)
+#
+# Ground truth per PR:
+#   panel:   anchors the INTERNAL panel (/gaze reviewers + verify gate) flagged,
+#            recovered from the PR's gate-verdict comments. A candidate finding
+#            matching one of these is a DUPLICATE (redundant; no decorrelation
+#            value). Line-precise where the verdict cited a line, else file-wide.
+#   defects: anchors of REAL defects the panel MISSED but that are confirmed
+#            (a post-merge fix, a follow-up ticket, a later-found regression). A
+#            candidate finding matching one of these (and no panel anchor) is
+#            UNIQUE-VERIFIED — the payoff the audition is measuring. Empty when no
+#            panel-miss has surfaced; append anchors here as they do.
+#   A candidate finding matching NEITHER set is UNIQUE-HALLUCINATED.
+#
+# Anchor form: `basename[:LINE]` or `basename:*`.
+#   - `basename:LINE`  matches a finding at that file (by basename) and line.
+#   - `basename:*` or bare `basename`  matches any line in that file.
+#   Anchors are stored BASENAME-normalized (no directory prefix) so the board
+#   stays forge/stack-agnostic (the agnostic gate forbids repo-relative
+#   `scripts/*.sh` literals in skills/); the classifier likewise reduces each
+#   candidate finding to its basename + line before matching. Basenames are
+#   unique enough within a PR's changed set that collisions do not arise.
+#
+# This board is a DATA artifact, not a script. `audition` never edits it, never
+# edits panel.yml, and never files a seat — promotion stays a manual panel.yml
+# edit + PR at 0205's integration review.
+
+board:
+  - pr: 603
+    title: "seat(0207): scrub injected credential from reviewer output"
+    base: 645e5769d7ac9a465441929ac7d6070b31c6e65f
+    head: afe91e4198bd42317f1b540f7645263b279154a0
+    panel: seat-runner.sh:68 seat-runner.sh:317 seat-runner.sh:358 test_seat_runner.sh:*
+    defects:
+  - pr: 602
+    title: "feat(worktree-gc): report unregistered husk dirs under .claude/worktrees"
+    base: 6019a742db0a64bfa9c15f96f17d2e9ac4f8bea2
+    head: 5ea6aac9a62d6fbded5e3bef74e117561fc2b115
+    panel: worktree-gc.sh:104 worktree-gc.sh:105 worktree-gc.sh:106 worktree-gc.sh:115 worktree-gc.sh:118
+    defects:
+  - pr: 599
+    title: "feat(0337): KEYS= explicit per-key selection and rename (provider:SRC=DST)"
+    base: 458f49e94968b36e54c6126ad9d2a0cd2e7431ef
+    head: d765d99183c652cf55b5afdbf4d8890e7b808a4c
+    panel: bash-env.sh:53 bash-env.sh:55 bash-env.sh:225 bash-env.sh:234 test_bash_env_keys_selection.sh:* test_bash_env_keys_selection_explicit.sh:*
+    defects:
+  - pr: 588
+    title: "fix(0323): strict-parse project .env, refuse GUARD_* keys"
+    base: cd92b7baf86c948c1e17b2a2bd27b10d3b9edfd6
+    head: 46a7fe17cb3a13490b3315a9b8e9a9f1cfe8cfb6
+    panel: bash-env.sh:64 bash-env.sh:72 pretooluse-worktree-path-guard.sh:49 pretooluse-worktree-path-guard.sh:50 pretooluse-worktree-path-guard.sh:83 pretooluse-worktree-path-guard.sh:105 test_bash_env_project_env_parse.sh:*
+    defects:
+  - pr: 584
+    title: "fix(0329): replace flaky grep-here-string boolean checks with pure-bash"
+    base: d10db43acd6997fa8c12a30a98de7235bffc7052
+    head: ba3941f85cd85f98479f09dda49db0aa6ae6afc9
+    panel: seat-runner.sh:* test_seat_runner.sh:* test_harness_rules_injection.sh:44
+    defects:
+  - pr: 580
+    title: "test(0328): pin beat-settings.json hook command resolves at runtime"
+    base: bebbc45a9eeade2dbb03187b699e9575f941f505
+    head: a3f6d5a4c1ff9bb3addae90e6a909d3596231640
+    panel: test_beat_settings_hook_resolves.py:* guard-destructive-bash.sh:*
+    defects:
+  - pr: 575
+    title: "feat(0207): agnostic CLI reviewer seat — OpenRouter + llama-server endpoints"
+    base: baf8e45495a758bab901291dc2690180b7a74d8f
+    head: 72659a14025a5ab20aca5c480e96893c5f4a66c4
+    panel: seat-runner.sh:* test_seat_runner.sh:* reviewers.sh:*
+    defects:
+  - pr: 573
+    title: "feat(0326): offline A/B harvest CLI, replay runbook, measure-A sample"
+    base: 22e6c7714b6ea069abd0e2dddc34d2c4a125b6fa
+    head: 6169206f99629598071e06a6f096cd20a78f61b4
+    panel: trace_ab_harvest.py:* test_trace_ab_harvest.py:*
+    defects:
+  - pr: 572
+    title: "feat(0320): graduated reviewer-battery tiers in /gaze"
+    base: 4c302dfc3080378aad0f479c7368889cca58efc8
+    head: 2a4a2d0095b6fed5df1d747f6fe1e228efc0de76
+    panel: test_verify_fork_contracts.py:*
+    defects:
+  - pr: 570
+    title: "fix(0322): extend agnostic gate to scripts/ dir"
+    base: 57ede102b702dab3a9df21e824dfa0d61dbc1e96
+    head: b89f076993eb57a1c4c11d637097fc5d3faa37bb
+    panel: check-agnostic.sh:*
+    defects:

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -18,6 +18,8 @@ PANEL="${REVIEWERS_PANEL:-${SCRIPT_DIR}/panel.yml}"
 SEAT_RUNNER="${SEAT_RUNNER:-${SCRIPT_DIR}/../../scripts/seat-runner.sh}"
 # Where per-seat findings land for harvest to collect (per merge request).
 FINDINGS_DIR="${REVIEWERS_FINDINGS_DIR:-${TMPDIR:-/tmp}/reviewers}"
+# The frozen benchmark board `audition` replays (ticket 0346). Overridable.
+BENCHMARK_BOARD="${REVIEWERS_BOARD:-${SCRIPT_DIR}/benchmark-board.yml}"
 
 usage() {
     cat >&2 <<'EOF'
@@ -28,6 +30,10 @@ Subcommands:
   request <pr> [branch]         Run each seat (0217 seat-runner) over the MR
   harvest <pr>                  Normalize all seats' findings to one file
   scorecard <pr> <seat> <ver>   Append a fixed-schema trial line via erg note
+  audition <model> [opts]       Replay a candidate over the frozen benchmark
+                                board; score decorrelation vs ground truth.
+                                Opts: --endpoint URL --board FILE
+                                --trial-ticket T --credential-env NAME --name L
 EOF
     exit 1
 }
@@ -59,6 +65,67 @@ roster_records() {
 }
 
 panel_is_empty() { [ -z "$(roster_records)" ]; }
+
+# ── benchmark-board parsing (ticket 0346) ────────────────────────────────────
+# Emit one pipe-separated record per board PR: pr title base head panel defects.
+# `panel`/`defects` are space-separated anchor lists (scalar YAML values), so the
+# minimal block parser never has to descend into nested YAML lists. Pipe is the
+# delimiter and `defects` (possibly empty) is last, so an empty middle field
+# cannot shift later fields (rules/coding-bash.md).
+board_records() {  # $1 board file
+    awk '
+        /^[[:space:]]*#/ { next }
+        /^board:[[:space:]]*\[\][[:space:]]*$/ { exit }
+        /^[[:space:]]*-[[:space:]]*pr:/ {
+            if (have) print rec(); have=1
+            pr=fv($0,"pr"); title=base=head=panel=defects=""; next
+        }
+        /^[[:space:]]+title:/   { title=fv($0,"title") }
+        /^[[:space:]]+base:/    { base=fv($0,"base") }
+        /^[[:space:]]+head:/    { head=fv($0,"head") }
+        /^[[:space:]]+panel:/   { panel=fv($0,"panel") }
+        /^[[:space:]]+defects:/ { defects=fv($0,"defects") }
+        END { if (have) print rec() }
+        function fv(line,key,  v) {
+            sub("^[[:space:]]*-?[[:space:]]*" key ":[[:space:]]*", "", line)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+            gsub(/^"|"$/, "", line)
+            return line
+        }
+        function rec() { return pr"|"title"|"base"|"head"|"panel"|"defects }
+    ' "$1" 2>/dev/null
+}
+
+# Does candidate finding basename $1 + line $2 match any anchor in list $3?
+# Anchor form: basename[:LINE] or basename:* (bare basename == :*).
+_audition_match() {  # cfile cline anchor-string
+    local cf="$1" cl="$2" a af al
+    local -a arr=()
+    read -ra arr <<<"$3"
+    for a in ${arr[@]+"${arr[@]}"}; do
+        case "$a" in
+            *:*) af="${a%%:*}"; al="${a##*:}" ;;
+            *)   af="$a"; al="*" ;;
+        esac
+        [ "$cf" = "$af" ] || continue
+        { [ "$al" = "*" ] || [ "$al" = "$cl" ]; } && return 0
+    done
+    return 1
+}
+
+# Classify one finding location against a PR's ground truth. Echoes exactly one
+# of: duplicate | unique-verified | unique-hallucinated.
+_audition_classify() {  # location panel-anchors defect-anchors
+    local loc="$1" panel="$2" defects="$3" bn cf cl
+    bn="${loc##*/}"                       # drop directory → basename[:line]
+    case "$bn" in
+        *:*) cf="${bn%%:*}"; cl="${bn##*:}" ;;
+        *)   cf="$bn"; cl="" ;;
+    esac
+    if _audition_match "$cf" "$cl" "$panel";   then echo duplicate; return; fi
+    if _audition_match "$cf" "$cl" "$defects"; then echo unique-verified; return; fi
+    echo unique-hallucinated
+}
 
 # ── PR → branch resolution (forge-specific; overridable for tests) ───────────
 pr_branch() {  # $1 pr; honor an explicit override first
@@ -184,6 +251,107 @@ case "$subcmd" in
         line="MR #${pr} seat=${seat} verdict: ${verdict}"
         ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
         "$ERG" log "$tid" "claude note ${line}"
+        ;;
+
+    audition)
+        # Replay a CANDIDATE model over the frozen benchmark board (0346) and
+        # score its decorrelation value against ground truth. The candidate is
+        # NOT a roster seat: audition filters candidates BEFORE the live advisory
+        # trial, and never touches panel.yml.
+        model="${1:-}"; shift || true
+        [ -n "$model" ] || { echo "error: audition requires <model> [--endpoint URL]" >&2; exit 1; }
+        endpoint=""; board="$BENCHMARK_BOARD"; cred=""; label=""
+        trial="tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --endpoint)       endpoint="$2"; shift 2 ;;
+                --board)          board="$2"; shift 2 ;;
+                --trial-ticket)   trial="$2"; shift 2 ;;
+                --credential-env) cred="$2"; shift 2 ;;
+                --name)           label="$2"; shift 2 ;;
+                *) echo "error: audition: unknown option '$1'" >&2; exit 1 ;;
+            esac
+        done
+        label="${label:-$model}"
+        [ -f "$board" ] || { echo "error: benchmark board not found: ${board}" >&2; exit 1; }
+
+        dest="${FINDINGS_DIR}/audition-$$"; mkdir -p "$dest"
+        n_pr=0; tot=0; dup=0; uv=0; uh=0; ptok=0; ctok=0; lat="0"
+        while IFS='|' read -r pr title base head panel defects; do
+            [ -n "$pr" ] || continue
+            n_pr=$((n_pr + 1))
+            out="${dest}/${pr}.findings"
+            # Reuse the exact seat-runner invocation path `request` uses: one
+            # sandboxed, read-only replay over the PR's reconstructed diff.
+            sr_args=(--repo "$REPO_ROOT" --base "$base" --branch "$head" \
+                     --model "$model" --out "$out")
+            [ -n "$endpoint" ] && sr_args+=(--endpoint "$endpoint")
+            [ -n "$cred" ]     && sr_args+=(--credential-env "$cred")
+            t0=$(date +%s.%N)
+            # Fail-LOUD (unlike request's per-seat fail-open): a candidate that
+            # cannot be replayed — unreachable endpoint, sandbox failure — voids
+            # the whole audition rather than reporting a partial, misleading score.
+            if ! "$SEAT_RUNNER" "${sr_args[@]}" >/dev/null 2>"${out}.err"; then
+                echo "audition: FATAL seat-runner failed on board PR #${pr} (candidate=${label}); see ${out}.err" >&2
+                exit 1
+            fi
+            t1=$(date +%s.%N)
+            lat=$(awk -v s="$lat" -v a="$t0" -v b="$t1" 'BEGIN{printf "%.1f", s + (b - a)}')
+            # A seat that exited 0 but wrote nothing contributes zero findings —
+            # count the latency (above) and move on rather than crashing on a
+            # missing file.
+            [ -f "$out" ] || continue
+            while IFS= read -r line; do
+                case "$line" in
+                    FINDING\|*)
+                        loc=$(sed -n 's/.*file=\([^|]*\).*/\1/p' <<<"$line")
+                        [ -n "$loc" ] || continue
+                        tot=$((tot + 1))
+                        case "$(_audition_classify "$loc" "$panel" "$defects")" in
+                            duplicate)           dup=$((dup + 1)) ;;
+                            unique-verified)     uv=$((uv + 1)) ;;
+                            unique-hallucinated) uh=$((uh + 1)) ;;
+                        esac
+                        ;;
+                    SUMMARY\|*)
+                        p=$(sed -n 's/.*prompt_tokens=\([0-9]\{1,\}\).*/\1/p' <<<"$line")
+                        c=$(sed -n 's/.*completion_tokens=\([0-9]\{1,\}\).*/\1/p' <<<"$line")
+                        [ -n "$p" ] && ptok=$((ptok + p))
+                        [ -n "$c" ] && ctok=$((ctok + c))
+                        ;;
+                esac
+            done < "$out"
+        done < <(board_records "$board")
+
+        [ "$n_pr" -gt 0 ] || { echo "error: benchmark board is empty: ${board}" >&2; exit 1; }
+
+        # overlap% = share of the candidate's findings that merely duplicate the
+        # internal panel (redundant; the inverse of decorrelation value).
+        overlap=0; [ "$tot" -gt 0 ] && overlap=$(( dup * 100 / tot ))
+        # $ per review from token counts, when the seat reported them on SUMMARY;
+        # prices are USD per 1M tokens (env-overridable). n/a when no tokens or no
+        # price is configured — honest rather than a fabricated $0.
+        price_in="${AUDITION_PRICE_IN_PER_M:-0}"
+        price_out="${AUDITION_PRICE_OUT_PER_M:-0}"
+        cost="n/a"
+        if [ $((ptok + ctok)) -gt 0 ]; then
+            cost=$(awk -v p="$ptok" -v c="$ctok" -v pi="$price_in" -v po="$price_out" \
+                'BEGIN{ if (pi==0 && po==0) { print "n/a" } else { printf "$%.4f", p/1e6*pi + c/1e6*po } }')
+        fi
+
+        card="audition candidate=${label} model=${model} board=${n_pr}PR findings=${tot} duplicate=${dup} unique-verified=${uv} unique-hallucinated=${uh} overlap=${overlap}% latency=${lat}s cost=${cost}"
+        echo "$card"
+
+        # Append the scorecard to the candidate's trial ticket (erg verbs:
+        # created/note/closed only — audition uses note). Promotion stays manual.
+        tid=$(basename "$trial" | grep -oE '^[0-9]{4}' || true)
+        [ -n "$tid" ] || { echo "audition: WARN could not derive a ticket id from '${trial}' — scorecard not logged" >&2; rm -rf "$dest"; exit 1; }
+        ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
+        if ! "$ERG" log "$tid" "claude note ${card}" >/dev/null; then
+            echo "audition: WARN failed to log scorecard to trial ticket ${trial} (id ${tid})" >&2
+            rm -rf "$dest"; exit 1
+        fi
+        rm -rf "$dest"
         ;;
 
     ""|--help|-h) usage ;;

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -20,6 +20,8 @@ SEAT_RUNNER="${SEAT_RUNNER:-${SCRIPT_DIR}/../../scripts/seat-runner.sh}"
 FINDINGS_DIR="${REVIEWERS_FINDINGS_DIR:-${TMPDIR:-/tmp}/reviewers}"
 # The frozen benchmark board `audition` replays (ticket 0346). Overridable.
 BENCHMARK_BOARD="${REVIEWERS_BOARD:-${SCRIPT_DIR}/benchmark-board.yml}"
+# The erg binary used to append trial-ticket log lines. Overridable for tests.
+ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
 
 usage() {
     cat >&2 <<'EOF'
@@ -95,6 +97,19 @@ board_records() {  # $1 board file
         }
         function rec() { return pr"|"title"|"base"|"head"|"panel"|"defects }
     ' "$1" 2>/dev/null
+}
+
+# 4-digit ticket ID from a `.../NNNN-slug.erg` path; empty when unmatched.
+# One extractor for every trial-ticket consumer (scorecard, audition).
+_ticket_id_from_path() {  # path
+    basename "$1" | sed -n 's/^\([0-9]\{4\}\)-.*/\1/p'
+}
+
+# Extract one `key=value` field (value runs to the next `|`) from a
+# 0205-contract FINDING line. One decoder for harvest AND audition, so a
+# contract change cannot silently drift between the two subcommands.
+_contract_field() {  # key line
+    sed -n "s/.*${1}=\([^|]*\).*/\1/p" <<<"$2"
 }
 
 # Does candidate finding basename $1 + line $2 match any anchor in list $3?
@@ -214,8 +229,8 @@ case "$subcmd" in
             while IFS= read -r line; do
                 case "$line" in
                     FINDING\|*)
-                        sev=$(sed -n 's/.*severity=\([^|]*\).*/\1/p' <<<"$line")
-                        loc=$(sed -n 's/.*file=\([^|]*\).*/\1/p' <<<"$line")
+                        sev=$(_contract_field severity "$line")
+                        loc=$(_contract_field file "$line")
                         rat=$(sed -n 's/.*rationale=\(.*\)$/\1/p' <<<"$line")
                         if [ -n "$sev" ] && [ -n "$loc" ]; then
                             if [ "$sev" = "verifiable-or-consider" ] || [ "$loc" = "PATH:LINE" ] || [ "$rat" = "ONE SENTENCE" ]; then
@@ -247,10 +262,9 @@ case "$subcmd" in
         tt=""
         while IFS='|' read -r n k s e m l t ce; do [ "$n" = "$seat" ] && tt="$t"; done < <(roster_records)
         [ -n "$tt" ] || { echo "error: seat '${seat}' not in roster (no trial-ticket)" >&2; exit 1; }
-        tid=$(sed -n 's#.*/\([0-9]\{4\}\)-.*#\1#p' <<<"$tt")
+        tid=$(_ticket_id_from_path "$tt")
         # Fixed schema so 0205's integration review is evidence-based, not vibes.
         line="MR #${pr} seat=${seat} verdict: ${verdict}"
-        ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
         "$ERG" log "$tid" "claude note ${line}"
         ;;
 
@@ -306,7 +320,7 @@ case "$subcmd" in
             while IFS= read -r line; do
                 case "$line" in
                     FINDING\|*)
-                        loc=$(sed -n 's/.*file=\([^|]*\).*/\1/p' <<<"$line")
+                        loc=$(_contract_field file "$line")
                         [ -n "$loc" ] || continue
                         tot=$((tot + 1))
                         case "$(_audition_classify "$loc" "$panel" "$defects")" in
@@ -346,9 +360,8 @@ case "$subcmd" in
 
         # Append the scorecard to the candidate's trial ticket (erg verbs:
         # created/note/closed only — audition uses note). Promotion stays manual.
-        tid=$(basename "$trial" | grep -oE '^[0-9]{4}' || true)
+        tid=$(_ticket_id_from_path "$trial")
         [ -n "$tid" ] || { echo "error: audition: could not derive a ticket id from '${trial}' — scorecard not logged" >&2; exit 1; }
-        ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
         if ! "$ERG" log "$tid" "claude note ${card}" >/dev/null; then
             echo "error: audition: failed to log scorecard to trial ticket ${trial} (id ${tid})" >&2
             exit 1

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -90,6 +90,7 @@ board_records() {  # $1 board file
             sub("^[[:space:]]*-?[[:space:]]*" key ":[[:space:]]*", "", line)
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
             gsub(/^"|"$/, "", line)
+            gsub(/\|/, "/", line)   # never let a value carry the record delimiter
             return line
         }
         function rec() { return pr"|"title"|"base"|"head"|"panel"|"defects }
@@ -276,6 +277,7 @@ case "$subcmd" in
         [ -f "$board" ] || { echo "error: benchmark board not found: ${board}" >&2; exit 1; }
 
         dest="${FINDINGS_DIR}/audition-$$"; mkdir -p "$dest"
+        trap 'rm -rf "$dest"' EXIT   # reap the scratch dir on every exit path
         n_pr=0; tot=0; dup=0; uv=0; uh=0; ptok=0; ctok=0; lat="0"
         while IFS='|' read -r pr title base head panel defects; do
             [ -n "$pr" ] || continue
@@ -292,7 +294,7 @@ case "$subcmd" in
             # cannot be replayed — unreachable endpoint, sandbox failure — voids
             # the whole audition rather than reporting a partial, misleading score.
             if ! "$SEAT_RUNNER" "${sr_args[@]}" >/dev/null 2>"${out}.err"; then
-                echo "audition: FATAL seat-runner failed on board PR #${pr} (candidate=${label}); see ${out}.err" >&2
+                echo "error: audition: seat-runner failed on board MR #${pr} (candidate=${label}); see ${out}.err" >&2
                 exit 1
             fi
             t1=$(date +%s.%N)
@@ -331,27 +333,26 @@ case "$subcmd" in
         # $ per review from token counts, when the seat reported them on SUMMARY;
         # prices are USD per 1M tokens (env-overridable). n/a when no tokens or no
         # price is configured — honest rather than a fabricated $0.
-        price_in="${AUDITION_PRICE_IN_PER_M:-0}"
-        price_out="${AUDITION_PRICE_OUT_PER_M:-0}"
+        price_in="${REVIEWERS_PRICE_IN_PER_M:-0}"
+        price_out="${REVIEWERS_PRICE_OUT_PER_M:-0}"
         cost="n/a"
         if [ $((ptok + ctok)) -gt 0 ]; then
             cost=$(awk -v p="$ptok" -v c="$ctok" -v pi="$price_in" -v po="$price_out" \
                 'BEGIN{ if (pi==0 && po==0) { print "n/a" } else { printf "$%.4f", p/1e6*pi + c/1e6*po } }')
         fi
 
-        card="audition candidate=${label} model=${model} board=${n_pr}PR findings=${tot} duplicate=${dup} unique-verified=${uv} unique-hallucinated=${uh} overlap=${overlap}% latency=${lat}s cost=${cost}"
+        card="audition candidate=${label} model=${model} board=${n_pr}MR findings=${tot} duplicate=${dup} unique-verified=${uv} unique-hallucinated=${uh} overlap=${overlap}% latency=${lat}s cost=${cost}"
         echo "$card"
 
         # Append the scorecard to the candidate's trial ticket (erg verbs:
         # created/note/closed only — audition uses note). Promotion stays manual.
         tid=$(basename "$trial" | grep -oE '^[0-9]{4}' || true)
-        [ -n "$tid" ] || { echo "audition: WARN could not derive a ticket id from '${trial}' — scorecard not logged" >&2; rm -rf "$dest"; exit 1; }
+        [ -n "$tid" ] || { echo "error: audition: could not derive a ticket id from '${trial}' — scorecard not logged" >&2; exit 1; }
         ERG="${ERG:-${SCRIPT_DIR}/../../tickets/erg}"
         if ! "$ERG" log "$tid" "claude note ${card}" >/dev/null; then
-            echo "audition: WARN failed to log scorecard to trial ticket ${trial} (id ${tid})" >&2
-            rm -rf "$dest"; exit 1
+            echo "error: audition: failed to log scorecard to trial ticket ${trial} (id ${tid})" >&2
+            exit 1
         fi
-        rm -rf "$dest"
         ;;
 
     ""|--help|-h) usage ;;

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -288,6 +288,11 @@ case "$subcmd" in
             esac
         done
         label="${label:-$model}"
+        # Reject control characters (newlines/CRs) in the values that flow into
+        # the erg-log scorecard card: an embedded newline would forge a second,
+        # well-formed ticket-log line that `erg check` cannot flag.
+        case "$model" in *[$'\n\r']*) echo "error: audition: model must not contain newlines or carriage returns" >&2; exit 1 ;; esac
+        case "$label" in *[$'\n\r']*) echo "error: audition: --name must not contain newlines or carriage returns" >&2; exit 1 ;; esac
         [ -f "$board" ] || { echo "error: benchmark board not found: ${board}" >&2; exit 1; }
 
         dest="${FINDINGS_DIR}/audition-$$"; mkdir -p "$dest"
@@ -308,7 +313,11 @@ case "$subcmd" in
             # cannot be replayed — unreachable endpoint, sandbox failure — voids
             # the whole audition rather than reporting a partial, misleading score.
             if ! "$SEAT_RUNNER" "${sr_args[@]}" >/dev/null 2>"${out}.err"; then
-                echo "error: audition: seat-runner failed on board MR #${pr} (candidate=${label}); see ${out}.err" >&2
+                # The scratch dir (and ${out}.err) is reaped by the EXIT trap, so
+                # dump the seat-runner's stderr HERE — a message pointing at the
+                # now-deleted file would be unreachable to the operator.
+                echo "error: audition: seat-runner failed on board MR #${pr} (candidate=${label}); seat-runner stderr follows:" >&2
+                cat "${out}.err" >&2 2>/dev/null || true
                 exit 1
             fi
             t1=$(date +%s.%N)

--- a/tests/test_reviewers_audition.sh
+++ b/tests/test_reviewers_audition.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Tests for `/reviewers audition` (ticket 0346) — the retrospective benchmark
+# board that replays a candidate model over already-merged PRs and classifies
+# each finding against ground truth.
+#
+# Covers, over a 2-PR TOY board with KNOWN ground truth and a stubbed
+# OpenAI-compatible seat (the 0217 seat-runner is replaced via SEAT_RUNNER):
+#   - three-way classification: duplicate / unique-verified / unique-hallucinated
+#   - wildcard (`file:*`) panel anchor matches any line in the file
+#   - scorecard block shape (findings / overlap% / latency / $ per review)
+#   - the scorecard is logged to the trial ticket via `erg log note`
+#   - fail-loud: a seat-runner that cannot reach its endpoint exits non-zero
+#   - the roster is never touched (panel.yml byte-identical after two runs)
+#
+# SKIP convention mirrors tests/test_reviewers.sh: echo "SKIP: reason" and keep
+# going; a genuine defect FAILs.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REVIEWERS="${REPO_ROOT}/skills/reviewers/reviewers.sh"
+PASS=0; FAIL=0
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then echo "PASS: $label"; PASS=$((PASS+1))
+    else echo "FAIL: $label"; echo "  expected: $(printf '%q' "$expected")"; echo "  actual:   $(printf '%q' "$actual")"; FAIL=$((FAIL+1)); fi
+}
+assert_contains() {
+    local label="$1" needle="$2" hay="$3"
+    # Pure-bash substring match, no subprocess (mirrors test_reviewers.sh).
+    if [[ "$hay" == *"$needle"* ]]; then echo "PASS: $label"; PASS=$((PASS+1))
+    else echo "FAIL: $label (missing: $needle)"; echo "  in: $hay"; FAIL=$((FAIL+1)); fi
+}
+
+# ── toy board: 2 PRs with known ground truth ─────────────────────────────────
+# Anchors are basename[:line|:*] (the board is stored basename-normalized so it
+# stays forge/stack-agnostic; the classifier matches candidate findings by
+# basename + line). PR1 exercises a line-precise panel anchor, a `:*` wildcard
+# panel anchor, and a defect (panel-missed) anchor; PR2 has an empty defect set.
+BOARD="$WORK/board.yml"
+cat > "$BOARD" <<'YAML'
+# Toy benchmark board.
+board:
+  - pr: 1
+    title: "toy one"
+    base: deadbeef1
+    head: cafebabe1
+    panel: alpha.sh:10 beta.sh:*
+    defects: gamma.sh:20
+  - pr: 2
+    title: "toy two"
+    base: deadbeef2
+    head: cafebabe2
+    panel: delta.py:5
+    defects:
+YAML
+
+# ── stub seat-runner: canned findings per board PR (keyed on --out basename) ──
+# PR1 emits: alpha.sh:10 (dup, line-precise), beta.sh:77 (dup, wildcard match),
+#            gamma.sh:20 (unique-verified, matches the defect anchor),
+#            zeta.sh:99 (unique-hallucinated, matches nothing).
+# PR2 emits: delta.py:5 (dup), epsilon.py:1 (unique-hallucinated).
+# Both emit a SUMMARY line carrying token counts so the cost field is exercised.
+STUB="$WORK/seat-stub.sh"
+cat > "$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [ $# -gt 0 ]; do case "$1" in --out) out="$2"; shift 2 ;; *) shift ;; esac; done
+pr="$(basename "$out" .findings)"
+case "$pr" in
+  1) { echo "FINDING|severity=verifiable|file=src/alpha.sh:10|rationale=dup-line"
+       echo "FINDING|severity=verifiable|file=src/beta.sh:77|rationale=dup-wildcard"
+       echo "FINDING|severity=verifiable|file=src/gamma.sh:20|rationale=panel-missed-real"
+       echo "FINDING|severity=consider|file=src/zeta.sh:99|rationale=hallucinated"
+       echo "SUMMARY|findings=4|verdict=revise|prompt_tokens=1000|completion_tokens=200"
+     } > "$out" ;;
+  2) { echo "FINDING|severity=verifiable|file=lib/delta.py:5|rationale=dup-line"
+       echo "FINDING|severity=consider|file=lib/epsilon.py:1|rationale=hallucinated"
+       echo "SUMMARY|findings=2|verdict=approve|prompt_tokens=500|completion_tokens=100"
+     } > "$out" ;;
+esac
+STUBEOF
+chmod +x "$STUB"
+
+# ── fixture ticket store so the real erg accepts the scorecard note ──────────
+# erg resolves its ticket store from the erg binary's own location, so the
+# fixture erg MUST live in the throwaway store (mirrors test_reviewers.sh's
+# scorecard test) — otherwise the note lands in the repo's real tickets/.
+ERG_BIN="${REPO_ROOT}/tickets/erg"
+TDIR="$WORK/run"; mkdir -p "$TDIR/tickets"
+[ -x "$ERG_BIN" ] && cp "$ERG_BIN" "$TDIR/tickets/erg"
+ERG_FIXTURE="$TDIR/tickets/erg"
+TRIAL="tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg"
+cat > "$TDIR/tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg" <<'ERG'
+%erg 0.1
+Title: Fixture trial ticket
+Created: 2026-06-05
+Author: test
+
+--- log ---
+2026-06-05T00:00Z test created
+
+--- body ---
+## Context
+Fixture.
+ERG
+
+# A sentinel roster so we can prove audition never mutates it.
+SENTINEL="$TDIR/skills/reviewers/panel.yml"; mkdir -p "$(dirname "$SENTINEL")"
+printf 'reviewers: []\n' > "$SENTINEL"
+sentinel_before="$(cat "$SENTINEL")"
+
+# ── run audition over the toy board ──────────────────────────────────────────
+FDIR="$WORK/findings"
+if [ -x "$ERG_BIN" ]; then
+    card="$( cd "$TDIR" && \
+        REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$STUB" ERG="$ERG_FIXTURE" \
+        AUDITION_PRICE_IN_PER_M=1 AUDITION_PRICE_OUT_PER_M=2 \
+        "$REVIEWERS" audition openai/toy-candidate \
+            --board "$BOARD" --endpoint http://127.0.0.1:9/v1 \
+            --trial-ticket "$TRIAL" --name toy-cand 2>/dev/null )"
+
+    assert_contains "audition: scorecard names the candidate"   "candidate=toy-cand" "$card"
+    assert_contains "audition: board size reported"             "board=2PR"          "$card"
+    assert_contains "audition: total findings counted"          "findings=6"         "$card"
+    assert_contains "audition: duplicates classified"           "duplicate=3"        "$card"
+    assert_contains "audition: unique-verified classified"      "unique-verified=1"  "$card"
+    assert_contains "audition: unique-hallucinated classified"  "unique-hallucinated=2" "$card"
+    assert_contains "audition: overlap percentage"              "overlap=50%"        "$card"
+    assert_contains "audition: latency field present"           "latency="           "$card"
+    assert_contains "audition: cost from token counts"          "cost=\$0.0021"      "$card"
+
+    # The scorecard must be appended to the trial ticket via a valid erg note.
+    TF="$TDIR/tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg"
+    if "$ERG_FIXTURE" validate "$TF" >/dev/null 2>&1 && grep -q 'audition candidate=toy-cand' "$TF"; then
+        echo "PASS: audition: scorecard logged as a valid erg note"; PASS=$((PASS+1))
+    else
+        echo "FAIL: audition: scorecard not logged as a valid erg note"; FAIL=$((FAIL+1))
+    fi
+
+    # Idempotent roster: a second run leaves the sentinel panel.yml untouched.
+    ( cd "$TDIR" && \
+        REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$STUB" ERG="$ERG_FIXTURE" \
+        AUDITION_PRICE_IN_PER_M=1 AUDITION_PRICE_OUT_PER_M=2 \
+        "$REVIEWERS" audition openai/toy-candidate \
+            --board "$BOARD" --endpoint http://127.0.0.1:9/v1 \
+            --trial-ticket "$TRIAL" --name toy-cand ) >/dev/null 2>&1 || true
+    assert_eq "audition: roster (panel.yml) never mutated" "$sentinel_before" "$(cat "$SENTINEL")"
+else
+    echo "SKIP: erg binary absent — audition scorecard/erg-integration tests"
+fi
+
+# ── fail-loud: an unreachable endpoint (seat-runner exits non-zero) aborts ────
+DEADSTUB="$WORK/seat-dead.sh"
+cat > "$DEADSTUB" <<'STUBEOF'
+#!/usr/bin/env bash
+echo "seat-runner: endpoint unreachable" >&2
+exit 1
+STUBEOF
+chmod +x "$DEADSTUB"
+
+if ( cd "$TDIR" && REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$DEADSTUB" ERG="$ERG_FIXTURE" \
+        "$REVIEWERS" audition openai/toy-candidate --board "$BOARD" \
+            --endpoint http://127.0.0.1:9/v1 --trial-ticket "$TRIAL" ) >/dev/null 2>&1; then
+    echo "FAIL: audition: unreachable endpoint should exit non-zero"; FAIL=$((FAIL+1))
+else
+    echo "PASS: audition: unreachable endpoint exits non-zero (fail-loud)"; PASS=$((PASS+1))
+fi
+
+# ── arg validation: missing candidate model ──────────────────────────────────
+if "$REVIEWERS" audition >/dev/null 2>&1; then
+    echo "FAIL: audition missing model should fail"; FAIL=$((FAIL+1))
+else
+    echo "PASS: audition missing model fails"; PASS=$((PASS+1))
+fi
+
+# ── the shipped benchmark board parses and its anchors stay agnostic-clean ───
+SHIPPED="${REPO_ROOT}/skills/reviewers/benchmark-board.yml"
+if [ -f "$SHIPPED" ]; then
+    # It must carry the expected ~10 board entries.
+    n=$(grep -cE '^[[:space:]]*-[[:space:]]*pr:' "$SHIPPED" || true)
+    if [ "$n" -ge 8 ]; then
+        echo "PASS: benchmark board ships >=8 PRs ($n)"; PASS=$((PASS+1))
+    else
+        echo "FAIL: benchmark board ships only $n PRs (<8)"; FAIL=$((FAIL+1))
+    fi
+    # A smoke audition over the SHIPPED board proves it parses and runs
+    # end-to-end (no real seat needed). Uses a generic stub that emits one
+    # contract-shaped finding for ANY board PR (the toy stub only knows PRs 1-2).
+    GENSTUB="$WORK/seat-generic.sh"
+    cat > "$GENSTUB" <<'STUBEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [ $# -gt 0 ]; do case "$1" in --out) out="$2"; shift 2 ;; *) shift ;; esac; done
+{ echo "FINDING|severity=verifiable|file=scripts/seat-runner.sh:68|rationale=generic"
+  echo "SUMMARY|findings=1|verdict=revise|prompt_tokens=100|completion_tokens=20"
+} > "$out"
+STUBEOF
+    chmod +x "$GENSTUB"
+    if [ -x "$ERG_BIN" ]; then
+        smoke="$( cd "$TDIR" && REVIEWERS_FINDINGS_DIR="$WORK/smoke" SEAT_RUNNER="$GENSTUB" \
+            ERG="$ERG_FIXTURE" "$REVIEWERS" audition openai/toy-candidate \
+                --board "$SHIPPED" --endpoint http://127.0.0.1:9/v1 \
+                --trial-ticket "$TRIAL" 2>/dev/null )"
+        assert_contains "shipped board: audition runs end-to-end" "audition candidate=" "$smoke"
+        assert_contains "shipped board: 10-PR board size" "board=10PR" "$smoke"
+    fi
+else
+    echo "FAIL: skills/reviewers/benchmark-board.yml missing"; FAIL=$((FAIL+1))
+fi
+
+echo ""; echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test_reviewers_audition.sh
+++ b/tests/test_reviewers_audition.sh
@@ -38,12 +38,14 @@ assert_contains() {
 # stays forge/stack-agnostic; the classifier matches candidate findings by
 # basename + line). PR1 exercises a line-precise panel anchor, a `:*` wildcard
 # panel anchor, and a defect (panel-missed) anchor; PR2 has an empty defect set.
+# PR1's title carries a literal `|`: the parser must not let it shift the
+# pipe-delimited record and corrupt the panel field (regression guard).
 BOARD="$WORK/board.yml"
 cat > "$BOARD" <<'YAML'
 # Toy benchmark board.
 board:
   - pr: 1
-    title: "toy one"
+    title: "toy | one with a pipe"
     base: deadbeef1
     head: cafebabe1
     panel: alpha.sh:10 beta.sh:*
@@ -117,13 +119,13 @@ FDIR="$WORK/findings"
 if [ -x "$ERG_BIN" ]; then
     card="$( cd "$TDIR" && \
         REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$STUB" ERG="$ERG_FIXTURE" \
-        AUDITION_PRICE_IN_PER_M=1 AUDITION_PRICE_OUT_PER_M=2 \
+        REVIEWERS_PRICE_IN_PER_M=1 REVIEWERS_PRICE_OUT_PER_M=2 \
         "$REVIEWERS" audition openai/toy-candidate \
             --board "$BOARD" --endpoint http://127.0.0.1:9/v1 \
             --trial-ticket "$TRIAL" --name toy-cand 2>/dev/null )"
 
     assert_contains "audition: scorecard names the candidate"   "candidate=toy-cand" "$card"
-    assert_contains "audition: board size reported"             "board=2PR"          "$card"
+    assert_contains "audition: board size reported"             "board=2MR"          "$card"
     assert_contains "audition: total findings counted"          "findings=6"         "$card"
     assert_contains "audition: duplicates classified"           "duplicate=3"        "$card"
     assert_contains "audition: unique-verified classified"      "unique-verified=1"  "$card"
@@ -143,7 +145,7 @@ if [ -x "$ERG_BIN" ]; then
     # Idempotent roster: a second run leaves the sentinel panel.yml untouched.
     ( cd "$TDIR" && \
         REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$STUB" ERG="$ERG_FIXTURE" \
-        AUDITION_PRICE_IN_PER_M=1 AUDITION_PRICE_OUT_PER_M=2 \
+        REVIEWERS_PRICE_IN_PER_M=1 REVIEWERS_PRICE_OUT_PER_M=2 \
         "$REVIEWERS" audition openai/toy-candidate \
             --board "$BOARD" --endpoint http://127.0.0.1:9/v1 \
             --trial-ticket "$TRIAL" --name toy-cand ) >/dev/null 2>&1 || true
@@ -206,7 +208,7 @@ STUBEOF
                 --board "$SHIPPED" --endpoint http://127.0.0.1:9/v1 \
                 --trial-ticket "$TRIAL" 2>/dev/null )"
         assert_contains "shipped board: audition runs end-to-end" "audition candidate=" "$smoke"
-        assert_contains "shipped board: 10-PR board size" "board=10PR" "$smoke"
+        assert_contains "shipped board: 10-PR board size" "board=10MR" "$smoke"
     fi
 else
     echo "FAIL: skills/reviewers/benchmark-board.yml missing"; FAIL=$((FAIL+1))

--- a/tests/test_reviewers_audition.sh
+++ b/tests/test_reviewers_audition.sh
@@ -214,5 +214,39 @@ else
     echo "FAIL: skills/reviewers/benchmark-board.yml missing"; FAIL=$((FAIL+1))
 fi
 
+# ── B1: seat-runner failure surfaces the .err diagnostic on stderr ───────────
+# The scratch dir is reaped on exit (EXIT trap), so the error must not merely
+# POINT at a now-deleted .err file — the seat-runner's own stderr has to be
+# dumped to the operator's stderr before exit, or the diagnostic is unreachable.
+B1ERR="$WORK/b1.stderr"
+( cd "$TDIR" && REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$DEADSTUB" ERG="$ERG_FIXTURE" \
+      "$REVIEWERS" audition openai/toy-candidate --board "$BOARD" \
+          --endpoint http://127.0.0.1:9/v1 --trial-ticket "$TRIAL" ) >/dev/null 2>"$B1ERR" || true
+assert_contains "audition: seat-runner failure dumps .err diagnostic to stderr" \
+    "seat-runner: endpoint unreachable" "$(cat "$B1ERR")"
+
+# ── B2: a newline in --name must not forge a second erg-log line ─────────────
+# An embedded newline in --name/model would otherwise flow verbatim into the
+# `erg log ... note <card>` call and inject a well-formed but forged ticket-log
+# line that `erg check` cannot flag. audition must reject it (exit non-zero)
+# before touching the trial ticket.
+if [ -x "$ERG_BIN" ]; then
+    TF2="$TDIR/tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg"
+    FORGE=$'toy\n2026-01-01T00:00Z attacker note FORGED-AUDITION-LINE'
+    if ( cd "$TDIR" && REVIEWERS_FINDINGS_DIR="$FDIR" SEAT_RUNNER="$STUB" ERG="$ERG_FIXTURE" \
+            "$REVIEWERS" audition openai/toy-candidate --board "$BOARD" \
+                --endpoint http://127.0.0.1:9/v1 --trial-ticket "$TRIAL" \
+                --name "$FORGE" ) >/dev/null 2>&1; then
+        echo "FAIL: audition: newline in --name should exit non-zero"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: audition: newline in --name exits non-zero"; PASS=$((PASS+1))
+    fi
+    if grep -q 'FORGED-AUDITION-LINE' "$TF2"; then
+        echo "FAIL: audition: newline in --name forged a ticket-log line"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: audition: newline in --name did not forge a log line"; PASS=$((PASS+1))
+    fi
+fi
+
 echo ""; echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tickets/0346-reviewers-audition-retrospective-benchm.erg
+++ b/tickets/0346-reviewers-audition-retrospective-benchm.erg
@@ -8,6 +8,7 @@ Blocked-by: 0207
 2026-07-14T17:14Z Minh Ha-Duong created
 2026-07-14T17:59Z claude note proto-audition data (0207 log, same session): 6 models over two frozen diffs. Defective diff (t323 guard WIP): terra 2/2 real verifiable, deepseek-v4-flash noise+contract violations, qwen3-coder-next 0/2 all-nit. Clean diff (merged PR #604): terra 0 findings (correct), luna 0 findings (correct, 40% of terra price) — specificity axis works as a board dimension. BLOCKER for the board: reasoning-field candidates (glm-5.2, kimi-k2.7-code) hang the aider/litellm seat stack until SEAT_TIMEOUT with empty stderr while answering in 1-3s via direct API — filed as tickets/0347; audition tooling should fail loud on that class, not burn board wall-clock
 
+2026-07-14T18:45Z claude note bump verify-reroll — round 1: unresolved blocker — EXIT trap in audition (reviewers.sh) deletes ${out}.err before the fail-loud 'see ${out}.err' pointer can be read; reproduced empty findings-dir post-exit. Second blocker: unsanitized --name/model flows into erg log note, embedded newline forges a second well-formed ticket-log line undetected by erg check (reproduced against real tickets/erg).
 --- body ---
 ## Context
 

--- a/tickets/closed/0346-reviewers-audition-retrospective-benchm.erg
+++ b/tickets/closed/0346-reviewers-audition-retrospective-benchm.erg
@@ -3,12 +3,14 @@ Title: /reviewers audition — retrospective benchmark board for candidate seats
 Created: 2026-07-14
 Author: Minh Ha-Duong
 Blocked-by: 0207
+Closed: autoclosed — PR #612
 
 --- log ---
 2026-07-14T17:14Z Minh Ha-Duong created
 2026-07-14T17:59Z claude note proto-audition data (0207 log, same session): 6 models over two frozen diffs. Defective diff (t323 guard WIP): terra 2/2 real verifiable, deepseek-v4-flash noise+contract violations, qwen3-coder-next 0/2 all-nit. Clean diff (merged PR #604): terra 0 findings (correct), luna 0 findings (correct, 40% of terra price) — specificity axis works as a board dimension. BLOCKER for the board: reasoning-field candidates (glm-5.2, kimi-k2.7-code) hang the aider/litellm seat stack until SEAT_TIMEOUT with empty stderr while answering in 1-3s via direct API — filed as tickets/0347; audition tooling should fail loud on that class, not burn board wall-clock
 
 2026-07-14T18:45Z claude note bump verify-reroll — round 1: unresolved blocker — EXIT trap in audition (reviewers.sh) deletes ${out}.err before the fail-loud 'see ${out}.err' pointer can be read; reproduced empty findings-dir post-exit. Second blocker: unsanitized --name/model flows into erg log note, embedded newline forges a second well-formed ticket-log line undetected by erg check (reproduced against real tickets/erg).
+2026-07-14T18:56Z Minh Ha-Duong closed — autoclosed — PR #612
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

Adds `/reviewers audition <model> [--endpoint URL]` — a cheap, repeatable filter that scores a candidate reviewer model **before** the live advisory trial (ticket 0346, child of 0205).

`audition` replays the candidate over a **frozen benchmark board** of 10 already-merged multi-file code PRs of this repo (`skills/reviewers/benchmark-board.yml`). Every candidate runs the same board in ~an hour, so cross-candidate comparison is sound — the live trial cannot give this, because each candidate there sees different merge requests.

## How

- **Diff reconstruction from immutable SHAs.** Each board entry records the PR's `base`/`head` merge-parent SHAs; the 0217 seat-runner's three-dot diff reconstructs the exact PR diff forever, even after branch deletion.
- **Reuses the seat-runner path `request` uses** — one sandboxed, read-only replay per board PR. Containment unchanged.
- **Three-way classification** against recovered ground truth: `duplicate` (matches a panel finding) / `unique-verified` (matches a recorded panel-missed defect) / `unique-hallucinated` (matches neither). Matching is basename+line, so the board stays forge/stack-agnostic (the agnostic gate forbids repo-relative `scripts/*.sh` literals in `skills/`).
- **One scorecard block per run** — findings, overlap %, latency, and `$`/review from SUMMARY token counts — appended to the trial ticket via `erg log note`.
- **Fail-loud**, unlike `request`'s per-seat fail-open: an unreachable endpoint or sandbox failure aborts non-zero rather than reporting a partial score.
- **Never touches the roster.** No `panel.yml` read or write; promotion stays a manual roster edit + PR at 0205's integration review. SKILL.md documents the `audition → advisory trial → promote/drop` pipeline.

## Test

`tests/test_reviewers_audition.sh` (auto-discovered by `test_bash_suites.py`) drives a 2-PR toy board with a stub OpenAI-compatible seat and known ground truth: asserts the three-way counts, the scorecard shape (`overlap=50%`, `cost=\$0.0021`), erg-note logging, roster immutability across two runs, and non-zero exit on an unreachable endpoint. A smoke run over the shipped 10-PR board proves it parses end-to-end.

## Verification

- `tests/test_reviewers_audition.sh`: 16 passed
- Existing `tests/test_reviewers.sh` (27) and `tests/test_seat_runner.sh` (51): green
- `make check-fast` 765 passed; `make lint` 17 adherence passed; full suite 856 passed
- `check-agnostic.sh skills/scripts/tickets` clean; `check-skills-drift` in sync; `erg check` PASS
- Pre-PR `/verify-adherence`: PASS (no mechanical failures, no semantic findings)

## Invariants held

No secrets in config (credential-env name only); seat-runner sandbox containment untouched; advisory-trial protocol (0205 rule 2) unchanged — audition filters before it.

**Ticket:** tickets/0346-reviewers-audition-retrospective-benchm.erg