### PR TITLE
ticket(0348): file /reviewers scores read-back, help verb, stale trial-ticket pointer

### DIFF
--- a/tickets/0205-external-reviewer-panel-for-verify-contr.erg
+++ b/tickets/0205-external-reviewer-panel-for-verify-contr.erg
@@ -16,6 +16,7 @@ Blocked-by: 0207
 2026-06-05T11:08Z MinhHaDuong note blocker 0208 closed — Blocked-by removed.
 2026-07-14T05:05Z Minh Ha-Duong note blocker 0206 closed — Blocked-by removed.
 2026-07-14T17:14Z Minh Ha-Duong note child 0346 filed — /reviewers audition subcommand (frozen benchmark board, duplicate/unique-verified/unique-hallucinated classification); audition filters candidates before the advisory trial, never replaces it
+2026-07-14T19:55Z Minh Ha-Duong note child 0348 filed — scores read-back (the integration review's reading surface), explicit help verb, stale copilot trial-ticket pointer (0206 archived to closed/)
 --- body ---
 ## Context
 
@@ -33,6 +34,7 @@ stays open until children merge + integration review (roar step 7).
 - tickets/0208 — reviewer-management surface (roster, harvest, scorecard)
 - tickets/0217 — sandbox seat-runner (the seat execution mechanism; foundational)
 - tickets/0346 — /reviewers audition: retrospective benchmark board for candidate seats
+- tickets/0348 — /reviewers scores read-back, help verb, stale trial-ticket pointer
 
 ## Architecture: review is CI (decided 2026-06-05, supersedes the ACP draft)
 

--- a/tickets/0348-reviewers-scores-readback-help-verb-stal.erg
+++ b/tickets/0348-reviewers-scores-readback-help-verb-stal.erg
@@ -1,0 +1,97 @@
+%erg 0.1
+Title: /reviewers scores read-back, explicit help verb, stale trial-ticket pointer
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T19:55Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Child of tickets/0205. Three discoverability gaps surfaced while presenting
+the /reviewers CLI (author session, 2026-07-14), just after 0346 landed
+audition:
+
+1. Scorecards are write-only. Trial lines (`scorecard`) and audition blocks
+   accrue as `erg log` lines in each seat's trial ticket, and comparing two
+   candidates means opening the ticket files and eyeballing lines. 0205's
+   integration review ("trial scorecards reviewed; promote/drop decided") has
+   no reading surface.
+2. No explicit `help` subcommand. `reviewers.sh` prints usage only via the
+   unknown-subcommand fallback, which exits 1; a conventional `help` verb
+   exits 0.
+3. Stale roster pointer. `panel.yml`'s copilot seat names
+   `tickets/0206-copilot-review-in-the-verify-panel-on-demand.erg`, but 0206
+   closed and the file moved to `tickets/closed/`. `list` displays the dead
+   path; whether `scorecard` still resolves it depends on how the erg-log
+   step addresses the ticket (by path or ID) — establish that before fixing.
+
+## Relevant files
+
+- `skills/reviewers/reviewers.sh` — add `scores` and `help`; check the
+  scorecard erg-log resolution for item 3
+- `skills/reviewers/SKILL.md` — document both subcommands
+- `skills/reviewers/panel.yml` — refresh or retire the copilot trial-ticket
+  pointer (the seat's trial concluded; its 0205 promote-or-drop review is due
+  and may retire the pointer anyway)
+- `tests/test_reviewers.sh` (and `tests/test_reviewers_audition.sh` for the
+  audition-line parsing) — existing patterns to extend
+
+## Actions
+
+1. `scores [seat-or-candidate]` — read-only. Grep the fixed-schema trial
+   lines (`MR #N seat=… verdict: …`) and audition blocks
+   (`audition candidate=… overlap=…`) out of the trial tickets (searching
+   `tickets/` AND `tickets/closed/`), print one sortable table: candidate/
+   seat, MRs or board size, verifiable/consider or duplicate/unique-verified/
+   unique-hallucinated, overlap %, latency, $ per review. No argument → all
+   seats and candidates. Unparseable line → WARN on stderr, never silently
+   dropped (harvest convention).
+2. `help` — print the usage block, exit 0. Keep the no-arg/unknown-verb
+   fallback at exit 1.
+3. Resolve item 3: determine how `scorecard`'s erg-log step addresses the
+   trial ticket; fix the copilot pointer accordingly (path refresh, or seat
+   retirement if the 0205 review drops it — that decision is the author's,
+   record it in the roster comment either way).
+
+## Candidate extension (author to confirm before implementing)
+
+A read-only `models [endpoint]` verb querying `GET <base>/v1/models` on each
+known endpoint (panel.yml seats + commented examples; key names from
+`~/.config/keys/*.env` via BASH_ENV, never echoed) would answer "what can I
+audition here?" from the CLI. Deferred — not part of this ticket's exit
+criteria unless the author opts in.
+
+## Test
+
+- Extend `tests/test_reviewers.sh`: fixture trial ticket with two scorecard
+  lines and one audition block → `scores` prints both rows with correct
+  fields; a malformed line WARNs; `help` exits 0 and names every subcommand
+  (guards drift when verbs are added).
+
+## Verification
+
+- [ ] `scores` with no args lists copilot's trial lines and the 0346-era
+      audition blocks from the archived 0207/0206 tickets
+- [ ] `scores <candidate>` filters to one candidate
+- [ ] `help` exits 0; no-arg still exits 1
+- [ ] `list` no longer shows a dead trial-ticket path
+
+## Invariants
+
+- `scores`, `help`, and `list` stay read-only — no roster edits, no erg log
+  writes
+- No secrets in config or output; credential handling unchanged (BASH_ENV)
+- Existing subcommand contracts unchanged (`request` fail-open, `audition`
+  fail-loud, audition never touches the roster)
+- `make check` passes
+
+## Exit criteria
+
+- [ ] `scores [seat-or-candidate]` prints the comparison table from trial
+      tickets in `tickets/` and `tickets/closed/`
+- [ ] `help` verb exits 0 with the full usage block
+- [ ] Copilot trial-ticket pointer resolved (refreshed or retired, decision
+      logged)
+- [ ] SKILL.md documents both verbs; tests green; `make check` passes

--- a/tickets/0348-reviewers-scores-readback-help-verb-stal.erg
+++ b/tickets/0348-reviewers-scores-readback-help-verb-stal.erg
@@ -55,13 +55,25 @@ audition:
    retirement if the 0205 review drops it — that decision is the author's,
    record it in the roster comment either way).
 
+4. SKILL.md "Candidate scouting" section (author opt-in, 2026-07-14):
+   document the discovery mechanics so a fresh session need not reinvent
+   them — endpoint inventory (`~/.config/keys/*.env` = authenticated
+   providers; panel.yml seat examples; probe local llama-server), models
+   per endpoint via `GET <base>/v1/models` (OpenRouter catalog is public,
+   with per-token pricing that feeds `REVIEWERS_PRICE_*`), rankings are
+   website-only (openrouter.ai/rankings, fetched not API'd). Include the
+   privacy asymmetry: audition on free tiers is risk-free (the board
+   replays merged PRs of a public repo) while live advisory trials ship
+   unmerged diffs. Mechanics only — model CHOICE stays judgment, per the
+   no-hard-rules-for-judgment-calls directive.
+
 ## Candidate extension (author to confirm before implementing)
 
 A read-only `models [endpoint]` verb querying `GET <base>/v1/models` on each
-known endpoint (panel.yml seats + commented examples; key names from
-`~/.config/keys/*.env` via BASH_ENV, never echoed) would answer "what can I
-audition here?" from the CLI. Deferred — not part of this ticket's exit
-criteria unless the author opts in.
+known endpoint would answer "what can I audition here?" from the CLI. Still
+deferred — the SKILL.md scouting section (action 4) covers the need
+documentation-first; promote to a verb only if the manual mechanics prove
+tiresome in practice.
 
 ## Test
 
@@ -94,4 +106,6 @@ criteria unless the author opts in.
 - [ ] `help` verb exits 0 with the full usage block
 - [ ] Copilot trial-ticket pointer resolved (refreshed or retired, decision
       logged)
-- [ ] SKILL.md documents both verbs; tests green; `make check` passes
+- [ ] SKILL.md documents both verbs plus the "Candidate scouting" section
+      (endpoint inventory, /v1/models, rankings fetch, privacy asymmetry)
+- [ ] Tests green; `make check` passes


### PR DESCRIPTION
Files ticket 0348 (child of tracker 0205, registered in its children list): a read-only `scores [seat-or-candidate]` comparison table extracted from trial-ticket scorecard/audition lines, an explicit `help` verb (exit 0), and resolution of the copilot seat's trial-ticket pointer left dangling when 0206 archived to `tickets/closed/`. A `models` endpoint-discovery verb is recorded as a deferred candidate extension pending author opt-in.

Ticket-ref: tickets/0348-reviewers-scores-readback-help-verb-stal.erg
Ticket-ref: tickets/0205-external-reviewer-panel-for-verify-contr.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)