### PR TITLE
fix(0341): fix two foreign memory citations in raid SKILL.md

### DIFF
--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -152,7 +152,7 @@ rebase is cheaper than the coordination overhead.
 **Why**: when N parallel PRs each append to the same cross-cutting set, the
 rebase onto sibling-merged main silently drops each PR's own addition. Wave 2
 (SOTA-adapter raid, 2026-05-20) needed a resurrection agent for 3 of 4 merges
-because of this. (memory: feedback_rebase_drop_cascade)
+because of this.
 
 **How**: before opening any Wave-N PR, open one tiny PR that adds ALL of the
 wave's entries to the shared registries at once, and merge it first. Each
@@ -334,7 +334,7 @@ the tree with `git rev-parse --show-toplevel` first (rules/git.md § anchor acro
 a forked-skill boundary); it inspects the salvaged WIP via
 `git show --stat HEAD` before continuing rather than starting from scratch.
 Salvage is the FIRST step of any restart, not an afterthought.
-(memory: feedback_killed_agent_salvage)
+(memory: feedback_agent_stall_watchdog_recovery)
 
 **Agent timeout**: If an agent has not pushed within 10 minutes, salvage its
 worktree (above), then kill it. Split the ticket or relaunch with narrower

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -131,8 +131,8 @@ the execute agent prompt and the agent creates the file as its first step.
 Launch agents by cluster to cross-check plans (`model: haiku` for the mechanical
 existence checks — paths/lines/signatures; `model: sonnet` for the cross-ticket
 conflict and cross-cutting-registry scan, which is judgement across N plans, not
-lookup — missing it cost a resurrection agent for 3 of 4 merges, memory
-`feedback_rebase_drop_cascade`):
+lookup — missing it cost a resurrection agent for 3 of 4 merges, see § Phase 5.0
+below):
 - File paths, line numbers, function signatures
 - Data assumptions, API key requirements
 - Cross-ticket conflicts

--- a/tickets/0341-consolidate-killed-agent-salvage-recipe.erg
+++ b/tickets/0341-consolidate-killed-agent-salvage-recipe.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-07-14T13:35Z claude created
+2026-07-14T20:09Z claude note planned by raid — sweep found 2 foreign citations (337 + 155); gaze and memory already pointer-shaped, criterion 2 is a verified no-op
 
 --- body ---
 ## Context
@@ -33,3 +34,35 @@ citation.
 - [ ] No duplicated salvage-recipe text across gaze SKILL.md, raid SKILL.md,
       and memory entries — one owner, pointers elsewhere
 - [ ] `make check` passes
+
+## Verified findings (plan agent, against HEAD eb7be4e)
+
+The "three drift-prone copies" framing overstated the scope: gaze SKILL.md's
+Fork-liveness clause is a distinct gaze-scoped concern (no salvage-recipe
+text, its memory citation resolves locally), and the memory entry
+`feedback_agent_stall_watchdog_recovery.md` was already trimmed to pointers
+by PR #601. The actual defect was two stale citations in
+`skills/raid/SKILL.md` pointing at memories that exist only in the aedist
+project's store:
+
+- Line 337: `(memory: feedback_killed_agent_salvage)` — foreign; the same
+  content lives locally as `feedback_agent_stall_watchdog_recovery`.
+- Line 155: `(memory: feedback_rebase_drop_cascade)` — foreign; raid's
+  Phase 5.0 prose already inlines the full account, the pointer was vestige.
+
+Fix applied: line 337 now cites `feedback_agent_stall_watchdog_recovery`
+(exists locally); line 155's dangling parenthetical was deleted, keeping
+"because of this." intact. Gaze SKILL.md and memory files were left
+untouched — no genuine duplication was found there to consolidate.
+
+## Sweep command (RED/GREEN evidence, reusable)
+
+```bash
+grep -rEo "memory[: ]*.?\`?feedback_[a-zA-Z_]+" skills/*/SKILL.md rules/*.md rules/*/*.md 2>/dev/null \
+  | grep -oE "feedback_[a-zA-Z_]+" | LC_ALL=C sort -u > /tmp/cited.txt
+ls projects/-home-haduong--claude/memory/ | sed 's/\.md$//' | LC_ALL=C sort -u > /tmp/exist.txt
+LC_ALL=C comm -23 /tmp/cited.txt /tmp/exist.txt
+```
+
+RED (before fix): `feedback_killed_agent_salvage`, `feedback_rebase_drop_cascade`.
+GREEN (after fix): empty.

--- a/tickets/0341-consolidate-killed-agent-salvage-recipe.erg
+++ b/tickets/0341-consolidate-killed-agent-salvage-recipe.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-14T13:35Z claude created
 2026-07-14T20:09Z claude note planned by raid — sweep found 2 foreign citations (337 + 155); gaze and memory already pointer-shaped, criterion 2 is a verified no-op
+2026-07-14T20:19Z claude note review-pr round 1 found a 3rd foreign citation at line 134-135 that the line-oriented sweep missed (citation wrapped across a markdown line break); fixed and re-verified with a line-wrap-safe sweep
 
 --- body ---
 ## Context
@@ -41,21 +42,33 @@ The "three drift-prone copies" framing overstated the scope: gaze SKILL.md's
 Fork-liveness clause is a distinct gaze-scoped concern (no salvage-recipe
 text, its memory citation resolves locally), and the memory entry
 `feedback_agent_stall_watchdog_recovery.md` was already trimmed to pointers
-by PR #601. The actual defect was two stale citations in
+by PR #601. The actual defect was THREE stale citations in
 `skills/raid/SKILL.md` pointing at memories that exist only in the aedist
-project's store:
+project's store (the third was found by review-pr round 1, not the initial
+plan — see round-1 log entry):
 
 - Line 337: `(memory: feedback_killed_agent_salvage)` — foreign; the same
   content lives locally as `feedback_agent_stall_watchdog_recovery`.
 - Line 155: `(memory: feedback_rebase_drop_cascade)` — foreign; raid's
   Phase 5.0 prose already inlines the full account, the pointer was vestige.
+- Line 134-135: `memory` `feedback_rebase_drop_cascade`) — same foreign name
+  as line 155, restating the same "resurrection agent for 3 of 4 merges"
+  fact in Phase 4's prose; missed by the initial line-oriented sweep because
+  the citation wraps across a markdown line break (`memory` ends line 134,
+  the backtick-fenced name is line 135) — the sweep's `grep -E` is
+  line-oriented and never sees the two halves joined.
 
 Fix applied: line 337 now cites `feedback_agent_stall_watchdog_recovery`
 (exists locally); line 155's dangling parenthetical was deleted, keeping
-"because of this." intact. Gaze SKILL.md and memory files were left
-untouched — no genuine duplication was found there to consolidate.
+"because of this." intact; line 134-135's dangling parenthetical was
+replaced with a cross-reference to § Phase 5.0, which carries the full
+account. Gaze SKILL.md and memory files were left untouched — no genuine
+duplication was found there to consolidate.
 
 ## Sweep command (RED/GREEN evidence, reusable)
+
+Line-oriented (misses line-wrapped citations — use the line-wrap-safe
+variant below for a trustworthy sweep):
 
 ```bash
 grep -rEo "memory[: ]*.?\`?feedback_[a-zA-Z_]+" skills/*/SKILL.md rules/*.md rules/*/*.md 2>/dev/null \
@@ -64,5 +77,20 @@ ls projects/-home-haduong--claude/memory/ | sed 's/\.md$//' | LC_ALL=C sort -u >
 LC_ALL=C comm -23 /tmp/cited.txt /tmp/exist.txt
 ```
 
-RED (before fix): `feedback_killed_agent_salvage`, `feedback_rebase_drop_cascade`.
-GREEN (after fix): empty.
+Line-wrap-safe (joins each file's lines before matching):
+
+```bash
+for f in skills/*/SKILL.md rules/*.md rules/*/*.md; do
+  [ -f "$f" ] && tr '\n' ' ' < "$f"
+  echo
+done 2>/dev/null | grep -oE "memory[: ]*\`?feedback_[a-zA-Z_]+" | grep -oE "feedback_[a-zA-Z_]+" \
+  | LC_ALL=C sort -u > /tmp/cited-safe.txt
+LC_ALL=C comm -23 /tmp/cited-safe.txt /tmp/exist.txt
+```
+
+RED (line-oriented sweep, before any fix): `feedback_killed_agent_salvage`,
+`feedback_rebase_drop_cascade`.
+RED (line-wrap-safe sweep, before the round-1 fix, after the initial two-line
+fix): `feedback_rebase_drop_cascade` (line 134-135, missed by the
+line-oriented sweep).
+GREEN (line-wrap-safe sweep, after all three fixes): empty.

--- a/tickets/0341-consolidate-killed-agent-salvage-recipe.erg
+++ b/tickets/0341-consolidate-killed-agent-salvage-recipe.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-07-14T13:35Z claude created
 2026-07-14T20:09Z claude note planned by raid — sweep found 2 foreign citations (337 + 155); gaze and memory already pointer-shaped, criterion 2 is a verified no-op
 2026-07-14T20:19Z claude note review-pr round 1 found a 3rd foreign citation at line 134-135 that the line-oriented sweep missed (citation wrapped across a markdown line break); fixed and re-verified with a line-wrap-safe sweep
+2026-07-14T20:25Z claude note review-pr round 2 approved, no blockers; ticked exit-criteria checkboxes (all satisfied) and refreshed the PR summary to describe all three fixes
 
 --- body ---
 ## Context
@@ -31,10 +32,10 @@ citation.
 
 ## Exit criteria
 
-- [ ] raid SKILL.md cites only memories/contracts that exist in this repo
-- [ ] No duplicated salvage-recipe text across gaze SKILL.md, raid SKILL.md,
+- [x] raid SKILL.md cites only memories/contracts that exist in this repo
+- [x] No duplicated salvage-recipe text across gaze SKILL.md, raid SKILL.md,
       and memory entries — one owner, pointers elsewhere
-- [ ] `make check` passes
+- [x] `make check` passes
 
 ## Verified findings (plan agent, against HEAD eb7be4e)
 

--- a/tickets/closed/0341-consolidate-killed-agent-salvage-recipe.erg
+++ b/tickets/closed/0341-consolidate-killed-agent-salvage-recipe.erg
@@ -2,6 +2,7 @@
 Title: Consolidate the killed-agent salvage recipe — three drift-prone copies
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #614
 
 --- log ---
 2026-07-14T13:35Z claude created
@@ -9,6 +10,7 @@ Author: claude
 2026-07-14T20:19Z claude note review-pr round 1 found a 3rd foreign citation at line 134-135 that the line-oriented sweep missed (citation wrapped across a markdown line break); fixed and re-verified with a line-wrap-safe sweep
 2026-07-14T20:25Z claude note review-pr round 2 approved, no blockers; ticked exit-criteria checkboxes (all satisfied) and refreshed the PR summary to describe all three fixes
 
+2026-07-14T21:45Z Minh Ha-Duong closed — autoclosed — PR #614
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Fixes three stale citations in `skills/raid/SKILL.md` that pointed at memory entries living only in the aedist project's memory store, not this repo's — found by the #601 gaze (raid 207-325-327) plus a third caught by review-pr round 1.

- Line 337: `(memory: feedback_killed_agent_salvage)` → `(memory: feedback_agent_stall_watchdog_recovery)` — the equivalent content already exists locally under this name.
- Line 155: `(memory: feedback_rebase_drop_cascade)` — deleted the dangling parenthetical; raid's own Phase 5.0 prose already inlines the full account it pointed to, so the pointer was vestige.
- Line 134-135: `memory` `feedback_rebase_drop_cascade`) — same foreign name, restating the same fact in Phase 4's prose. Missed by the initial sweep because the citation wraps across a markdown line break, so a line-oriented `grep -E` never joins the two halves. Replaced with a cross-reference to § Phase 5.0.

## Why gaze SKILL.md and memory files are untouched

The ticket's "three drift-prone copies" framing was investigated and found overstated:

- `skills/gaze/SKILL.md`'s "Fork liveness" clause (§ Fork execution contract) is a distinct gaze-scoped concern — no salvage-recipe text is restated there, and its own memory citation already resolves locally. There is nothing to consolidate.
- `feedback_agent_stall_watchdog_recovery.md` was already trimmed to pointers by PR #601 (commit 05f6b0b) — it does not duplicate the raid recipe, it points at it.

So exit criterion 2 ("No duplicated salvage-recipe text across gaze SKILL.md, raid SKILL.md, and memory entries") was already satisfied before this PR — a verified no-op, logged on the ticket rather than producing speculative churn.

## RED/GREEN evidence

Line-oriented sweep (used in the initial round; misses line-wrapped citations):

```bash
grep -rEo "memory[: ]*.?\`?feedback_[a-zA-Z_]+" skills/*/SKILL.md rules/*.md rules/*/*.md 2>/dev/null \
  | grep -oE "feedback_[a-zA-Z_]+" | LC_ALL=C sort -u > /tmp/cited.txt
ls projects/-home-haduong--claude/memory/ | sed 's/\.md$//' | LC_ALL=C sort -u > /tmp/exist.txt
LC_ALL=C comm -23 /tmp/cited.txt /tmp/exist.txt
```

Line-wrap-safe sweep (joins each file's lines before matching — use this one):

```bash
for f in skills/*/SKILL.md rules/*.md rules/*/*.md; do
  [ -f "$f" ] && tr '\n' ' ' < "$f"
  echo
done 2>/dev/null | grep -oE "memory[: ]*\`?feedback_[a-zA-Z_]+" | grep -oE "feedback_[a-zA-Z_]+" \
  | LC_ALL=C sort -u > /tmp/cited-safe.txt
LC_ALL=C comm -23 /tmp/cited-safe.txt /tmp/exist.txt
```

**RED (line-oriented, before any fix):** `feedback_killed_agent_salvage`, `feedback_rebase_drop_cascade`.
**RED (line-wrap-safe, after the first two-line fix, before round-1 fix):** `feedback_rebase_drop_cascade` (line 134-135 — the miss review-pr round 1 caught).
**GREEN (line-wrap-safe, after all three fixes):** empty.

This is intentionally NOT captured as a permanent adherence test — a doc-only citation fix doesn't warrant a standing ratchet (per `feedback_dont_codify_hard_rules`), and it's a mechanical grep any future gaze/raid can rerun ad hoc. The ticket body records both sweep variants for reuse.

## Test plan

- [x] Sweep RED (line-oriented) before edits: 2 foreign citations found.
- [x] Sweep RED (line-wrap-safe) after round-0 fix: 1 more foreign citation found (review-pr round 1 catch).
- [x] Sweep GREEN (line-wrap-safe) after round-1 fix: empty.
- [x] `tickets/erg check tickets/`: PASS (341 tickets).
- [x] `make check`: 856 passed (rerun after each round).
- [x] `/verify-adherence`: PASS, no mechanical/semantic findings.
- [x] review-pr round 1: requested changes (missed 3rd citation) — fixed.
- [x] review-pr round 2: approved, no blockers.

**Ticket:** tickets/0341-consolidate-killed-agent-salvage-recipe.erg