### PR TITLE
fix(0342): correct gaze doc — review-* is guard-covered, not whitelisted

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -101,7 +101,12 @@ PR_BRANCH=<resolved-branch-name>
 
 # Step 2 — Resolve the primary repo root, then create the worktree under its
 # guarded `.claude/worktrees/` namespace (ticket 0300 — /tmp is outside every
-# guard fast-path; `.claude/worktrees/review-*` is already whitelisted).
+# guard fast-path). `.claude/worktrees/review-*` is not whitelisted by name; it
+# is covered by the same worktree-identity check as every worktree (the
+# worktree-path guard has no review-* allowlist). An Edit/Write is allowed only
+# when the acting process is physically inside that worktree — 0300 moved review
+# worktrees here from /tmp to bring them under that check, not to add a
+# path-pattern allowlist.
 primary_root=$(git rev-parse --show-toplevel)
 primary_root="${primary_root%%/.claude/worktrees/*}"   # strip if we run from a session worktree
 git fetch origin "$PR_BRANCH"
@@ -204,7 +209,11 @@ embedded**: spawn a read-only Agent, cwd pinned to `$primary_root/.claude/worktr
 same containment rails, whose prompt simply invokes `/review` on the PR and
 returns the review summary. (Phase 5 `/simplify` is the other built-in slash
 command; it stays as a direct invocation for now — out of this ticket's scope —
-and would be Agent-WRAPped the same way when converted.)
+and would be Agent-WRAPped the same way when converted. Until it is, `/simplify`
+runs in the fork's own cwd — a sibling worktree, not review-<pr> — so the
+worktree-identity guard denies its Edit/Write and it must apply fixes via Bash;
+the Agent-wrap is what lets those edits execute inside review-<pr>. Tracked at
+ticket 0342's follow-up.)
 
 **Agent C — PR review** (`/review-pr <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`
 or `/review-pr-prose <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`).

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -102,14 +102,12 @@ PR_BRANCH=<resolved-branch-name>
 # Step 2 — Resolve the primary repo root, then create the worktree under its
 # guarded `.claude/worktrees/` namespace (ticket 0300 — /tmp is outside every
 # guard fast-path). `.claude/worktrees/review-*` is not whitelisted by name; it
-# is covered by the same worktree-identity check as every worktree (the
-# worktree-path guard has no review-* allowlist). An Edit/Write into a review
-# worktree is allowed when the acting process is physically inside that worktree;
-# otherwise it is denied like any main-repo path, save the guard's one general
-# escape hatch — a human-set `GUARD_ALLOW_PRIMARY_EDIT` allows any primary-subtree
-# edit, review-* included (the `projects/*/memory/*` exemption cannot match a
-# review-* path). 0300 moved review worktrees here from /tmp to bring them under
-# that check, not to add a path-pattern allowlist.
+# is covered by the same worktree-identity check as every worktree: an Edit/Write
+# is allowed when the acting process is physically inside that worktree, denied
+# otherwise — save the human-set `GUARD_ALLOW_PRIMARY_EDIT` escape hatch (the
+# `projects/*/memory/*` exemption cannot match a review-* path). 0300 moved
+# review worktrees here from /tmp for that coverage, not for a name allowlist;
+# exact semantics live in `scripts/pretooluse-worktree-path-guard.sh`.
 primary_root=$(git rev-parse --show-toplevel)
 primary_root="${primary_root%%/.claude/worktrees/*}"   # strip if we run from a session worktree
 git fetch origin "$PR_BRANCH"

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -107,7 +107,7 @@ PR_BRANCH=<resolved-branch-name>
 # otherwise — save the human-set `GUARD_ALLOW_PRIMARY_EDIT` escape hatch (the
 # `projects/*/memory/*` exemption cannot match a review-* path). 0300 moved
 # review worktrees here from /tmp for that coverage, not for a name allowlist;
-# exact semantics live in `scripts/pretooluse-worktree-path-guard.sh`.
+# exact semantics live in `~/.claude/scripts/pretooluse-worktree-path-guard.sh`.
 primary_root=$(git rev-parse --show-toplevel)
 primary_root="${primary_root%%/.claude/worktrees/*}"   # strip if we run from a session worktree
 git fetch origin "$PR_BRANCH"

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -103,16 +103,21 @@ PR_BRANCH=<resolved-branch-name>
 # guarded `.claude/worktrees/` namespace (ticket 0300 — /tmp is outside every
 # guard fast-path). `.claude/worktrees/review-*` is not whitelisted by name; it
 # is covered by the same worktree-identity check as every worktree (the
-# worktree-path guard has no review-* allowlist). An Edit/Write is allowed only
-# when the acting process is physically inside that worktree — 0300 moved review
-# worktrees here from /tmp to bring them under that check, not to add a
-# path-pattern allowlist.
+# worktree-path guard has no review-* allowlist). An Edit/Write into a review
+# worktree is allowed when the acting process is physically inside that worktree;
+# otherwise it is denied like any main-repo path, save the guard's one general
+# escape hatch — a human-set `GUARD_ALLOW_PRIMARY_EDIT` allows any primary-subtree
+# edit, review-* included (the `projects/*/memory/*` exemption cannot match a
+# review-* path). 0300 moved review worktrees here from /tmp to bring them under
+# that check, not to add a path-pattern allowlist.
 primary_root=$(git rev-parse --show-toplevel)
 primary_root="${primary_root%%/.claude/worktrees/*}"   # strip if we run from a session worktree
 git fetch origin "$PR_BRANCH"
 git worktree add "$primary_root/.claude/worktrees/review-<pr-number>" origin/"$PR_BRANCH"
-# All phases 1–6 and the fix agent run inside $primary_root/.claude/worktrees/review-<pr-number>.
-# The main repo is never switched, never dirtied.
+# The cwd-pinned reviewer agents and the REROLL fix agent run inside
+# $primary_root/.claude/worktrees/review-<pr-number>; the main repo is never
+# switched, never dirtied. (Exception: phase 5 /simplify is still a direct
+# invocation and runs from the fork's own cwd, not review-<pr> — see its note below.)
 ```
 
 On any exit path (APPROVED, REROLL-escalated, ESCALATE, circuit-breaker abort),
@@ -212,8 +217,8 @@ command; it stays as a direct invocation for now — out of this ticket's scope 
 and would be Agent-WRAPped the same way when converted. Until it is, `/simplify`
 runs in the fork's own cwd — a sibling worktree, not review-<pr> — so the
 worktree-identity guard denies its Edit/Write and it must apply fixes via Bash;
-the Agent-wrap is what lets those edits execute inside review-<pr>. Tracked at
-ticket 0342's follow-up.)
+the Agent-WRAP is what lets those edits execute inside review-<pr>. Tracked at
+ticket 0349.)
 
 **Agent C — PR review** (`/review-pr <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`
 or `/review-pr-prose <pr-number> worktree=$primary_root/.claude/worktrees/review-<pr-number>`).

--- a/tests/test_gaze_review_worktree_doc.py
+++ b/tests/test_gaze_review_worktree_doc.py
@@ -27,7 +27,10 @@ SKILL = REPO / "skills" / "gaze" / "SKILL.md"
 
 @pytest.mark.adherence
 def test_review_worktree_not_described_as_whitelisted():
-    text = SKILL.read_text(encoding="utf-8")
+    raw = SKILL.read_text(encoding="utf-8")
+    # Collapse whitespace (incl. the `#`-comment line wraps) so the required
+    # phrases still match if the comment block is reflowed across lines.
+    text = " ".join(raw.replace("#", " ").split())
     assert "already whitelisted" not in text, (
         "skills/gaze/SKILL.md still claims review-* worktrees are 'already "
         "whitelisted' — the guard has no such allowlist (ticket 0342). It "

--- a/tests/test_gaze_review_worktree_doc.py
+++ b/tests/test_gaze_review_worktree_doc.py
@@ -1,0 +1,47 @@
+"""Pin skills/gaze/SKILL.md's account of review-worktree guard coverage (ticket 0342).
+
+The worktree-path guard (`scripts/pretooluse-worktree-path-guard.sh`) has no
+`review-*` allowlist and never did: it allows an Edit/Write only when the acting
+hook process is physically inside the worktree that contains the target path
+(the `_in_worktree` identity predicate plus the `$worktree_root/*` prefix check),
+with the narrow `projects/*/memory/*` exemption and the human-set
+`GUARD_ALLOW_PRIMARY_EDIT` escape hatch. Ticket 0300 MOVED gaze review worktrees
+from `/tmp` (outside every guard fast-path) into `.claude/worktrees/review-*` to
+bring them UNDER that identity check — coverage, not a name-pattern whitelist.
+
+The old SKILL.md comment "`.claude/worktrees/review-*` is already whitelisted"
+overclaimed and contradicted the guard. This adherence test pins the corrected
+account so the doc cannot drift back to the whitelist framing.
+
+RED proof (2026-07-14): against the unmodified SKILL.md this test failed on the
+missing corrected phrase; the correction (ticket 0342 Action 1) turns it green.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SKILL = REPO / "skills" / "gaze" / "SKILL.md"
+
+
+@pytest.mark.adherence
+def test_review_worktree_not_described_as_whitelisted():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "already whitelisted" not in text, (
+        "skills/gaze/SKILL.md still claims review-* worktrees are 'already "
+        "whitelisted' — the guard has no such allowlist (ticket 0342). It "
+        "covers review-* via the same worktree-identity check as every "
+        "worktree; edits are allowed only when the acting process is physically "
+        "inside the worktree, never by path pattern."
+    )
+    # The corrected account must be present so the doc states the real model.
+    assert "is not whitelisted by name" in text, (
+        "skills/gaze/SKILL.md must state that .claude/worktrees/review-* is not "
+        "whitelisted by name but covered by the worktree-identity check "
+        "(ticket 0342)."
+    )
+    assert "physically inside that" in text, (
+        "skills/gaze/SKILL.md must state that edits are allowed only when the "
+        "acting process is physically inside the review worktree (ticket 0342)."
+    )

--- a/tests/test_pretooluse_worktree_path_guard.sh
+++ b/tests/test_pretooluse_worktree_path_guard.sh
@@ -310,4 +310,48 @@ else
     fail=1
 fi
 
+# 18. Cross-worktree deny (ticket 0342): two sibling harness worktrees under one
+# primary — a session worktree `t-session` and a gaze review worktree
+# `review-999`. A process INSIDE t-session that targets a file inside review-999
+# must be DENIED. The guard has no `review-*` allowlist (0300 moved review
+# worktrees under `.claude/worktrees/` for identity COVERAGE, not to whitelist
+# the name); a path is allowed only when the acting worktree physically contains
+# it. This is the exact scenario gaze phase 5 hits while `/simplify` is a direct
+# invocation: the fork's cwd is a sibling worktree, so its Edit into review-999
+# is denied. Case 19 is its silent-allow companion. Real-git fixture (cases
+# 8/9/17 style) so identity resolution runs for real. Case 18 also guards
+# against "fixing" 0342 by adding a review-* allowlist — that would flip it FAIL.
+_case18_primary=$(mktemp -d)
+git -C "$_case18_primary" init -q
+git -C "$_case18_primary" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mkdir -p "$_case18_primary/.claude/worktrees"
+git -C "$_case18_primary" worktree add -q "$_case18_primary/.claude/worktrees/t-session"
+git -C "$_case18_primary" worktree add -q "$_case18_primary/.claude/worktrees/review-999"
+out=$( cd "$_case18_primary/.claude/worktrees/t-session" \
+       && printf '{"tool_name":"Write","tool_input":{"file_path":"%s/.claude/worktrees/review-999/fix.py","content":"x"}}' "$_case18_primary" \
+       | bash "$HOOK" 2>&1 || true)
+if echo "$out" | grep -q "Worktree path guard"; then
+    echo "PASS: denies Edit from one worktree into a sibling review-* worktree"
+else
+    echo "FAIL: expected deny for cross-worktree edit into review-999; got: $out"
+    fail=1
+fi
+
+# 19. Silent-allow companion to case 18: a process INSIDE review-999 editing a
+# file inside review-999 is allowed (exit 0, silent) — the acting worktree
+# contains the target. Confirms the deny in case 18 is about worktree identity,
+# not the `review-*` name.
+rc=$( cd "$_case18_primary/.claude/worktrees/review-999" \
+      && printf '{"tool_name":"Write","tool_input":{"file_path":"%s/.claude/worktrees/review-999/fix.py","content":"x"}}' "$_case18_primary" \
+      | bash "$HOOK" >/dev/null 2>&1; echo $? )
+if [ "$rc" = "0" ]; then
+    echo "PASS: allows Edit inside the review-* worktree the process runs from (exit 0)"
+else
+    echo "FAIL: expected exit 0 editing inside review-999 from review-999; got: $rc"
+    fail=1
+fi
+git -C "$_case18_primary" worktree remove --force "$_case18_primary/.claude/worktrees/t-session" 2>/dev/null || true
+git -C "$_case18_primary" worktree remove --force "$_case18_primary/.claude/worktrees/review-999" 2>/dev/null || true
+rm -rf "$_case18_primary"
+
 exit $fail

--- a/tickets/0342-worktree-path-guard-blocks-review-worktrees.erg
+++ b/tickets/0342-worktree-path-guard-blocks-review-worktrees.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-07-14T13:35Z claude created
 2026-07-14T20:11Z claude note planned by raid — guard correct, doc overclaims; 0300 = coverage not whitelist
 
+2026-07-14T20:45Z bump verify-reroll — round 1: exit criterion 3 (make check) fails — check-agnostic-skills VIOLATION at skills/gaze/SKILL.md:110, self-introduced by /simplify commit fe87ff9's new 'scripts/pretooluse-worktree-path-guard.sh' reference (absent at 9d8da9e); fix by wrapping the path per the pattern's own guidance (~/.claude/scripts/ or a harness-extension-point marker), not by reverting the dedupe
 --- body ---
 ## Context
 

--- a/tickets/0342-worktree-path-guard-blocks-review-worktrees.erg
+++ b/tickets/0342-worktree-path-guard-blocks-review-worktrees.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-07-14T13:35Z claude created
+2026-07-14T20:11Z claude note planned by raid — guard correct, doc overclaims; 0300 = coverage not whitelist
 
 --- body ---
 ## Context

--- a/tickets/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg
+++ b/tickets/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg
@@ -1,0 +1,61 @@
+%erg 0.1
+Title: gaze phase 5 (/simplify) runs as direct invocation — Agent-wrap it so edits execute inside review-<pr>
+Created: 2026-07-14
+Author: Minh Ha-Duong
+
+--- log ---
+2026-07-14T20:10Z Minh Ha-Duong created
+
+--- body ---
+## Context
+
+Follow-up from ticket 0342 (doc/test fix: the worktree-path guard is right,
+the "already whitelisted" claim was wrong). 0342 diagnosed but did not fix the
+real functional gap.
+
+Gaze phase 5 `/simplify` is still a **direct invocation** (skills/gaze/SKILL.md
+notes it "stays as a direct invocation for now"), unlike the read-only review
+fan-out (phases 2–4) and Agent B `/review`, which are Agent-WRAPped with cwd
+pinned to `$primary_root/.claude/worktrees/review-<pr-number>`. Because
+`/simplify` runs directly inside the gaze fork, the PreToolUse hook's `pwd -P`
+is the fork's OWN worktree — a SIBLING of `review-<pr>`, not `review-<pr>`
+itself. `scripts/pretooluse-worktree-path-guard.sh` therefore correctly denies
+`/simplify`'s Edit/Write into `review-<pr>` (the acting worktree does not
+contain the target path — verified live in the #602 gaze, raid 207-325-327),
+and `/simplify` falls back to applying its fixes via Bash. The guard has no
+`review-*` allowlist and should not grow one (that would defeat the identity
+check); the fix is to make `/simplify`'s edits execute from inside
+`review-<pr>`.
+
+## Relevant files
+
+- `skills/gaze/SKILL.md` — phase 5 `/simplify` invocation site (~lines 205–249)
+  and the Agent-WRAP pattern already used for Agent B `/review` (~lines 199–207)
+- `scripts/pretooluse-worktree-path-guard.sh` — the (correct) denying guard
+
+## Actions
+
+1. Convert phase 5 `/simplify` to the same **Agent-WRAP** pattern as Agent B
+   `/review`: spawn a mutator Agent whose cwd is pinned to
+   `$primary_root/.claude/worktrees/review-<pr-number>`, invoking `/simplify` on
+   the PR from inside that worktree, so its Edit/Write pass the identity guard.
+2. Preserve the fork execution contract: `/simplify` mutates, so unlike the
+   read-only reviewers the wrapping Agent needs write capability in the review
+   worktree — but must not push, branch, or open PRs beyond what phase 5 already
+   does. Decide foreground vs isolation:"worktree" against the Fork execution
+   contract (a fork cannot wait on background agents).
+3. Update the SKILL.md note (currently "stays as a direct invocation for now …
+   Tracked at ticket 0342's follow-up") to describe the wrapped invocation.
+
+## Test
+
+- Integration/e2e: run gaze phase 5 on a PR with a simplifiable diff and assert
+  `/simplify`'s edits land via Edit/Write inside `review-<pr>` (no Bash-fallback
+  path), i.e. the guard does not deny.
+
+## Exit criteria
+
+- [ ] Phase 5 `/simplify` executes inside `review-<pr>` and its edits pass the
+      worktree-path guard (no Bash fallback)
+- [ ] SKILL.md note updated to reflect the Agent-WRAP
+- [ ] `make check` passes

--- a/tickets/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg
+++ b/tickets/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg
@@ -29,8 +29,9 @@ check); the fix is to make `/simplify`'s edits execute from inside
 
 ## Relevant files
 
-- `skills/gaze/SKILL.md` — phase 5 `/simplify` invocation site (~lines 205–249)
-  and the Agent-WRAP pattern already used for Agent B `/review` (~lines 199–207)
+- `skills/gaze/SKILL.md` — the phase 5 `/simplify` invocation site (§ 2–4, the
+  built-in-slash-command note) and the Agent-WRAP pattern already used for
+  Agent B `/review` in the same section
 - `scripts/pretooluse-worktree-path-guard.sh` — the (correct) denying guard
 
 ## Actions
@@ -42,7 +43,7 @@ check); the fix is to make `/simplify`'s edits execute from inside
 2. Preserve the fork execution contract: `/simplify` mutates, so unlike the
    read-only reviewers the wrapping Agent needs write capability in the review
    worktree — but must not push, branch, or open PRs beyond what phase 5 already
-   does. Decide foreground vs isolation:"worktree" against the Fork execution
+   does. Decide foreground vs `isolation:"worktree"` against the Fork execution
    contract (a fork cannot wait on background agents).
 3. Update the SKILL.md note (currently "stays as a direct invocation for now …
    Tracked at ticket 0342's follow-up") to describe the wrapped invocation.

--- a/tickets/closed/0342-worktree-path-guard-blocks-review-worktrees.erg
+++ b/tickets/closed/0342-worktree-path-guard-blocks-review-worktrees.erg
@@ -2,12 +2,14 @@
 Title: worktree-path guard blocks Edit/Write in review-* worktrees despite 0300 whitelist claim
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #615
 
 --- log ---
 2026-07-14T13:35Z claude created
 2026-07-14T20:11Z claude note planned by raid — guard correct, doc overclaims; 0300 = coverage not whitelist
 
 2026-07-14T20:45Z bump verify-reroll — round 1: exit criterion 3 (make check) fails — check-agnostic-skills VIOLATION at skills/gaze/SKILL.md:110, self-introduced by /simplify commit fe87ff9's new 'scripts/pretooluse-worktree-path-guard.sh' reference (absent at 9d8da9e); fix by wrapping the path per the pattern's own guidance (~/.claude/scripts/ or a harness-extension-point marker), not by reverting the dedupe
+2026-07-14T21:47Z Minh Ha-Duong closed — autoclosed — PR #615
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0342-worktree-path-guard-blocks-review-worktrees.erg
Related follow-up: tickets/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg

## Verdict

The guard is right; the gaze doc overclaimed. `scripts/pretooluse-worktree-path-guard.sh` has **no** `review-*` allowlist and never did — it allows an Edit/Write only when the acting hook process is physically inside the worktree that contains the target path (the `_in_worktree` identity predicate + `$worktree_root/*` prefix check), plus the narrow `projects/*/memory/*` exemption and the human-set `GUARD_ALLOW_PRIMARY_EDIT` escape hatch.

## 0300 evidence: coverage, not whitelist

Ticket 0300 (`tickets/closed/0300-*.erg`) MOVED gaze review worktrees from `/tmp/review-<pr>` (outside every guard fast-path) into `.claude/worktrees/review-*` to bring them **under** the same worktree-identity check as every worktree — its own title says "Bring gaze review worktrees under guard coverage" and its actions choose "one guarded namespace". Coverage, not a name-pattern allowlist. The `skills/gaze/SKILL.md` "already whitelisted" comment was the losing side of the contradiction.

The practical trigger: gaze phase 5 `/simplify` is still a **direct invocation** (not Agent-wrapped like the review fan-out), so its edits fire from the fork's real cwd — a *sibling* worktree of `review-<pr>` — and are correctly denied. That functional gap is filed as follow-up **0349** (Agent-wrap phase 5); this PR does not implement it.

## Changes

- `skills/gaze/SKILL.md` § Setup: replace the "already whitelisted" wording with the accurate identity-check model (edit confined to the comment block; § Fork execution contract and § Circuit breakers untouched — sibling ticket 0341's turf).
- `skills/gaze/SKILL.md` § phase 5: one sentence noting `/simplify`'s edits are evaluated from the fork's cwd and denied outside `review-<pr>` until Agent-wrapped.
- Guard script **untouched** (no allowlist added — that would defeat the identity check).
- `tests/test_pretooluse_worktree_path_guard.sh` cases 18/19: cross-worktree edit denied (18), same edit from inside `review-999` allowed silently (19). Case 18 also fails if anyone "fixes" 0342 by adding a review-* allowlist.
- `tests/test_gaze_review_worktree_doc.py` (new adherence test): pins the corrected wording — proven RED against the unmodified SKILL.md, GREEN after.
- Follow-up ticket `tickets/0349-...erg` filed (ticket only, not the fix).

## Verification

- `make check` passes (857 tests).
- Adherence RED→GREEN captured for the new doc test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)