### PR TITLE
fix(0347): fail loud on reasoning-field models in seat-runner

### DIFF
--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -72,6 +72,10 @@
 #                          /health); empty string skips the reachability probe.
 #
 # Env: SEAT_TIMEOUT (per-seat wall-clock cap, seconds; default 600)
+#      AIDER_API_TIMEOUT (aider/litellm per-request API timeout, seconds; default
+#      120) — a backstop that converts a silent litellm hang into a stderr
+#      exception the failure tail surfaces, instead of a SEAT_TIMEOUT SIGKILL with
+#      empty stderr (ticket 0347).
 set -euo pipefail
 
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -150,6 +154,22 @@ if [[ -n "$CREDENTIAL_ENV" ]]; then
     CRED_ARGS=(-e OPENAI_API_KEY)
 fi
 
+# Scratch dir + cleanup trap are set up EARLY: the reasoning-shape pre-flight
+# probe below writes a mode-600 curl config file here, and the self-test, relay,
+# and clone all reuse it. cleanup reaps the relay, any orphaned seat container,
+# and $WORK on exit (an early probe/health FATAL is reaped too).
+WORK=$(mktemp -d)
+RELAY_PID=""
+SEAT_CONTAINERS=()
+cleanup() {
+    [[ -n "$RELAY_PID" ]] && kill "$RELAY_PID" 2>/dev/null || true
+    for _c in ${SEAT_CONTAINERS[@]+"${SEAT_CONTAINERS[@]}"}; do
+        podman rm -f "$_c" >/dev/null 2>&1 || true
+    done
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
 if [[ "$SELF_TEST_ONLY" -eq 0 ]]; then
     [[ -n "$BRANCH" ]] || { echo "seat-runner: --branch required" >&2; exit 2; }
     # Fail loud if the endpoint is down (0217: unreachable endpoint = non-zero).
@@ -159,6 +179,55 @@ if [[ "$SELF_TEST_ONLY" -eq 0 ]]; then
     if [[ -n "$HEALTH_PATH" ]]; then
         curl -sf --max-time 5 "${SCHEME}://${EP}${HEALTH_PATH}" >/dev/null \
             || { echo "seat-runner: endpoint ${ENDPOINT} unreachable" >&2; exit 1; }
+    fi
+
+    # ── Reasoning-shape pre-flight probe (ticket 0347) ────────────────────────
+    # z-ai/glm-5.2 and moonshotai/kimi-k2.7-code return a `reasoning` /
+    # `reasoning_content` field alongside `content`; the seat's pinned
+    # aider/litellm venv hangs forever waiting for content it never surfaces and
+    # the outer SEAT_TIMEOUT SIGKILL leaves EMPTY stderr — a silent timeout that
+    # burns an audition's wall-clock. Catch that class HERE, host-side, before any
+    # container launch: POST a 1-token completion and fail LOUD if the response
+    # carries a non-empty reasoning field. Only runs when a real credential is
+    # injected (--credential-env). The key never touches curl argv — it goes in a
+    # mode-600 curl config file under $WORK (trap-reaped), and the response body is
+    # parsed IN-MEMORY (piped to python3 stdin), never written to a file the
+    # credential-scrub pass skips. Probe fragility (connect or parse failure) WARNs
+    # and falls through: never block a working model on a flaky probe.
+    if [[ -n "$CREDENTIAL_ENV" ]]; then
+        _probe_model="${MODEL#openai/}"          # the endpoint knows the raw provider id
+        _probe_rc="$WORK/probe.curlrc"
+        ( umask 077; printf 'header = "Authorization: Bearer %s"\n' "$OPENAI_API_KEY" > "$_probe_rc" )
+        _probe_body="$(printf '{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}' "$_probe_model")"
+        _probe_resp=""
+        if _probe_resp="$(curl -sf --max-time 15 -K "$_probe_rc" \
+                -H 'Content-Type: application/json' -X POST -d "$_probe_body" \
+                "${ENDPOINT}/chat/completions" 2>/dev/null)"; then
+            _probe_verdict=0
+            printf '%s' "$_probe_resp" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    msg = (d.get("choices") or [{}])[0].get("message") or {}
+    r = msg.get("reasoning")
+    if r is None:
+        r = msg.get("reasoning_content")
+    present = bool(r.strip()) if isinstance(r, str) else bool(r)
+    sys.exit(0 if present else 1)
+except Exception:
+    sys.exit(2)
+' || _probe_verdict=$?
+            rm -f "$_probe_rc"
+            if [[ "$_probe_verdict" -eq 0 ]]; then
+                echo "seat-runner: FATAL model '${MODEL}' returns a reasoning-field response — known aider/litellm hang class (ticket 0347)" >&2
+                exit 1
+            elif [[ "$_probe_verdict" -eq 2 ]]; then
+                echo "seat-runner: WARN reasoning-shape probe could not parse the response from ${MODEL} — proceeding (probe is advisory)" >&2
+            fi
+        else
+            rm -f "$_probe_rc"
+            echo "seat-runner: WARN reasoning-shape probe could not reach ${ENDPOINT}/chat/completions — proceeding (probe is advisory)" >&2
+        fi
     fi
 fi
 
@@ -200,18 +269,6 @@ fi
 if [[ "$SELF_TEST_ONLY" -eq 0 && -z "$AIDER_REAL" ]]; then
     echo "seat-runner: FATAL aider not found on PATH" >&2; exit 1
 fi
-
-WORK=$(mktemp -d)
-RELAY_PID=""
-SEAT_CONTAINERS=()
-cleanup() {
-    [[ -n "$RELAY_PID" ]] && kill "$RELAY_PID" 2>/dev/null || true
-    for _c in ${SEAT_CONTAINERS[@]+"${SEAT_CONTAINERS[@]}"}; do
-        podman rm -f "$_c" >/dev/null 2>&1 || true
-    done
-    rm -rf "$WORK"
-}
-trap cleanup EXIT
 
 # ── Host-side relay: /relay.sock ⇄ the real endpoint. The container binds the
 #    socket file; under --network=none it has no other route out. ──────────────
@@ -314,7 +371,7 @@ exec ${AIDER_REAL} \\
     --message "\$(cat /prompt.txt)" \\
     --read /review.diff \\
     --yes-always --no-check-update --no-show-model-warnings --no-pretty \\
-    --no-stream --map-tokens 0
+    --no-stream --map-tokens 0 --timeout "${AIDER_API_TIMEOUT:-120}"
 EOF
 )
 review_rc=0

--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -211,16 +211,18 @@ if [[ "$SELF_TEST_ONLY" -eq 0 ]]; then
     if [[ -n "$CREDENTIAL_ENV" ]] && command -v python3 >/dev/null 2>&1; then
         _probe_model="${MODEL#openai/}"          # the endpoint knows the raw provider id
         _probe_rc="$WORK/probe.curlrc"
-        _probe_body="$(python3 -c 'import json,sys; print(json.dumps({"model": sys.argv[1], "max_tokens": 1, "messages": [{"role": "user", "content": "ping"}]}))' "$_probe_model")"
-        _probe_resp=""
-        if ! ( umask 077; printf 'header = "Authorization: Bearer %s"\n' "$OPENAI_API_KEY" > "$_probe_rc" ); then
-            echo "seat-runner: WARN reasoning-shape probe could not write its curl config — proceeding (probe is advisory)" >&2
-        elif _probe_resp="$(curl -sf --max-time 15 -K "$_probe_rc" \
-                -H 'Content-Type: application/json' -X POST -d "$_probe_body" \
-                "${ENDPOINT}/chat/completions" 2>/dev/null)"; then
-            rm -f "$_probe_rc"                    # key file gone before the body is parsed
-            _probe_verdict=0
-            printf '%s' "$_probe_resp" | python3 -c '
+        if ! _probe_body="$(python3 -c 'import json,sys; print(json.dumps({"model": sys.argv[1], "max_tokens": 1, "messages": [{"role": "user", "content": "ping"}]}))' "$_probe_model")"; then
+            echo "seat-runner: WARN reasoning-shape probe could not build its request body — proceeding (probe is advisory)" >&2
+        else
+            _probe_resp=""
+            if ! ( umask 077; printf 'header = "Authorization: Bearer %s"\n' "$OPENAI_API_KEY" > "$_probe_rc" ); then
+                echo "seat-runner: WARN reasoning-shape probe could not write its curl config — proceeding (probe is advisory)" >&2
+            elif _probe_resp="$(curl -sf --max-time 15 -K "$_probe_rc" \
+                    -H 'Content-Type: application/json' -X POST -d "$_probe_body" \
+                    "${ENDPOINT}/chat/completions" 2>/dev/null)"; then
+                rm -f "$_probe_rc"                    # key file gone before the body is parsed
+                _probe_verdict=0
+                printf '%s' "$_probe_resp" | python3 -c '
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -233,17 +235,20 @@ try:
 except Exception:
     sys.exit(2)
 ' || _probe_verdict=$?
-            if [[ "$_probe_verdict" -eq 0 ]]; then
-                echo "seat-runner: FATAL model '${MODEL}' returns a reasoning-field response — known aider/litellm hang class (ticket 0347)" >&2
-                exit 1
-            elif [[ "$_probe_verdict" -eq 2 ]]; then
-                echo "seat-runner: WARN reasoning-shape probe could not parse the response from ${MODEL} — proceeding (probe is advisory)" >&2
+                if [[ "$_probe_verdict" -eq 0 ]]; then
+                    echo "seat-runner: FATAL model '${MODEL}' returns a reasoning-field response — known aider/litellm hang class (ticket 0347)" >&2
+                    exit 1
+                elif [[ "$_probe_verdict" -eq 2 ]]; then
+                    echo "seat-runner: WARN reasoning-shape probe could not parse the response from ${MODEL} — proceeding (probe is advisory)" >&2
+                elif [[ "$_probe_verdict" -ne 1 ]]; then
+                    echo "seat-runner: WARN reasoning-shape probe returned unexpected verdict code ${_probe_verdict} for ${MODEL} — proceeding (probe is advisory)" >&2
+                fi
+                # verdict 1 (no reasoning field): the model is safe — proceed silently.
+            else
+                echo "seat-runner: WARN reasoning-shape probe could not reach ${ENDPOINT}/chat/completions — proceeding (probe is advisory)" >&2
             fi
-            # verdict 1 (no reasoning field): the model is safe — proceed silently.
-        else
-            echo "seat-runner: WARN reasoning-shape probe could not reach ${ENDPOINT}/chat/completions — proceeding (probe is advisory)" >&2
+            rm -f "$_probe_rc"                        # idempotent catch-all (also covers the write-fail branch)
         fi
-        rm -f "$_probe_rc"                        # idempotent catch-all (also covers the write-fail branch)
     fi
 fi
 

--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -189,20 +189,27 @@ if [[ "$SELF_TEST_ONLY" -eq 0 ]]; then
     # burns an audition's wall-clock. Catch that class HERE, host-side, before any
     # container launch: POST a 1-token completion and fail LOUD if the response
     # carries a non-empty reasoning field. Only runs when a real credential is
-    # injected (--credential-env). The key never touches curl argv — it goes in a
-    # mode-600 curl config file under $WORK (trap-reaped), and the response body is
-    # parsed IN-MEMORY (piped to python3 stdin), never written to a file the
-    # credential-scrub pass skips. Probe fragility (connect or parse failure) WARNs
-    # and falls through: never block a working model on a flaky probe.
-    if [[ -n "$CREDENTIAL_ENV" ]]; then
+    # injected (--credential-env), and only when python3 is available (it both
+    # builds the request body — so a $MODEL id with JSON metacharacters cannot
+    # corrupt it — and parses the response). The key never touches curl argv: it
+    # goes in a mode-600 curl config file under $WORK (trap-reaped), and the
+    # response body is parsed IN-MEMORY (piped to python3 stdin), never written to
+    # a file the credential-scrub pass skips. Every fragility — no python3, a curl
+    # config write failure, a connect failure, an unparseable body — WARNs and
+    # falls through: never block a working model on a flaky probe. Verdict codes
+    # from the parser: 0 = reasoning present (FATAL), 1 = absent (proceed), 2 =
+    # unparseable (WARN, proceed).
+    if [[ -n "$CREDENTIAL_ENV" ]] && command -v python3 >/dev/null 2>&1; then
         _probe_model="${MODEL#openai/}"          # the endpoint knows the raw provider id
         _probe_rc="$WORK/probe.curlrc"
-        ( umask 077; printf 'header = "Authorization: Bearer %s"\n' "$OPENAI_API_KEY" > "$_probe_rc" )
-        _probe_body="$(printf '{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}' "$_probe_model")"
+        _probe_body="$(python3 -c 'import json,sys; print(json.dumps({"model": sys.argv[1], "max_tokens": 1, "messages": [{"role": "user", "content": "ping"}]}))' "$_probe_model")"
         _probe_resp=""
-        if _probe_resp="$(curl -sf --max-time 15 -K "$_probe_rc" \
+        if ! ( umask 077; printf 'header = "Authorization: Bearer %s"\n' "$OPENAI_API_KEY" > "$_probe_rc" ); then
+            echo "seat-runner: WARN reasoning-shape probe could not write its curl config — proceeding (probe is advisory)" >&2
+        elif _probe_resp="$(curl -sf --max-time 15 -K "$_probe_rc" \
                 -H 'Content-Type: application/json' -X POST -d "$_probe_body" \
                 "${ENDPOINT}/chat/completions" 2>/dev/null)"; then
+            rm -f "$_probe_rc"                    # key file gone before the body is parsed
             _probe_verdict=0
             printf '%s' "$_probe_resp" | python3 -c '
 import json, sys
@@ -217,17 +224,17 @@ try:
 except Exception:
     sys.exit(2)
 ' || _probe_verdict=$?
-            rm -f "$_probe_rc"
             if [[ "$_probe_verdict" -eq 0 ]]; then
                 echo "seat-runner: FATAL model '${MODEL}' returns a reasoning-field response — known aider/litellm hang class (ticket 0347)" >&2
                 exit 1
             elif [[ "$_probe_verdict" -eq 2 ]]; then
                 echo "seat-runner: WARN reasoning-shape probe could not parse the response from ${MODEL} — proceeding (probe is advisory)" >&2
             fi
+            # verdict 1 (no reasoning field): the model is safe — proceed silently.
         else
-            rm -f "$_probe_rc"
             echo "seat-runner: WARN reasoning-shape probe could not reach ${ENDPOINT}/chat/completions — proceeding (probe is advisory)" >&2
         fi
+        rm -f "$_probe_rc"                        # idempotent catch-all (also covers the write-fail branch)
     fi
 fi
 

--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -58,6 +58,15 @@
 #     start: a blocked write only counts when the probe also proves the
 #     sandbox executes. Run it standalone with --self-test-only (no endpoint,
 #     no diff) to prove containment with podman + the image alone.
+#   - HOST-SIDE PRE-FLIGHT PROBE (0347): the sandbox posture above governs the
+#     SEATED reviewer. One check runs OUTSIDE it, host-side, before any container
+#     launch: the reasoning-shape probe (below) POSTs a 1-token completion to the
+#     SAME endpoint the seat will use, carrying the SAME credential — a direct
+#     host→endpoint call, not routed through the --network=none relay. It reaches
+#     only the one configured endpoint (the health probe already dials it), adds
+#     no destination the seat could exfiltrate through, and keeps the key off argv
+#     (mode-600 curl -K config, trap-reaped). It is the host operator's own
+#     pre-flight, on par with the health probe — not part of the seat's sandbox.
 #
 # Usage:
 #   seat-runner.sh --branch BRANCH [--repo PATH] [--base REF]

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -430,6 +430,26 @@ STUB
     assert_contains "reasoning-probe: diagnostic names the hang class" "reasoning-field response" "$rsn_err"
     assert_absent   "reasoning-probe: blocks before any podman run"    "GUARD-BYPASS"             "$rsn_err"
 
+    # RED case, alternate shape: kimi-k2.7-code returns the field as
+    # `reasoning_content` (not `reasoning`). The probe must block on this shape
+    # too — pins the second half of the ticket's reasoning-response canary.
+    RSNBIN_RC="$WORK/rsnbin_rc"; mkdir -p "$RSNBIN_RC"
+    cat > "$RSNBIN_RC/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '{"choices":[{"message":{"content":"ok","reasoning_content":"step-by-step"}}]}'
+exit 0
+STUB
+    chmod +x "$RSNBIN_RC/curl"
+    cp "$RSNBIN/podman" "$RSNBIN_RC/podman"          # same GUARD-BYPASS screamer
+    rsn_rc_err="$(MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN_RC:$PATH" \
+        bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
+        --model openai/moonshotai/kimi-k2.7-code --endpoint http://127.0.0.1:9/v1 --health-path "" \
+        --credential-env MY_TEST_VAR --out "$WORK/rsn.out.rc" 2>&1 >/dev/null)" && rsn_rc_rc=0 || rsn_rc_rc=1
+    [ "$rsn_rc_rc" -ne 0 ] && pass "reasoning-probe: reasoning_content shape also blocks" \
+        || fail "reasoning-probe: reasoning_content shape also blocks"
+    assert_contains "reasoning-probe: reasoning_content diagnostic names the hang class" "reasoning-field response" "$rsn_rc_err"
+    assert_absent   "reasoning-probe: reasoning_content blocks before any podman run"    "GUARD-BYPASS"             "$rsn_rc_err"
+
     # Negative-space case: an ordinary (content-only) body must NOT block — the
     # review path reaches podman run. Guards against a tautological always-block.
     RSNBIN2="$WORK/rsnbin2"; mkdir -p "$RSNBIN2"

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -379,6 +379,90 @@ else
     echo "SKIP: python3/git/aider absent — credential-scrub exfiltration test"
 fi
 
+# ── tier 2a⁶: reasoning-shape pre-flight probe (ticket 0347) ─────────────────
+# z-ai/glm-5.2 and moonshotai/kimi-k2.7-code return a `reasoning` field alongside
+# `content`; the seat's pinned aider/litellm venv hangs on that shape and the
+# outer SEAT_TIMEOUT SIGKILL leaves EMPTY stderr — a silent timeout. seat-runner
+# must probe the endpoint host-side (max_tokens=1) BEFORE any container launch and
+# fail LOUD when the response carries a non-empty reasoning field. Both cases stub
+# curl (the probe endpoint) and podman; --health-path "" skips the health probe so
+# every curl call here is the reasoning probe. --credential-env activates the probe
+# (it only runs when a real credential is injected). A throwaway repo supplies the
+# non-empty diff the review path needs on the negative (non-blocking) case.
+if command -v python3 >/dev/null && command -v git >/dev/null && command -v aider >/dev/null; then
+    RSN_REPO="$WORK/rsnrepo"; mkdir -p "$RSN_REPO"
+    (
+        cd "$RSN_REPO"
+        git init -q -b main
+        git config user.email t@t; git config user.name t
+        printf 'line one\n' > f.txt
+        git add f.txt; git commit -qm base
+        git checkout -q -b feature
+        printf 'line one\nline two\n' > f.txt
+        git commit -qam change
+    )
+
+    # RED case: curl returns a reasoning-shaped completion body; the podman stub
+    # screams if `run` is reached. seat-runner must exit non-zero with the hang-
+    # class diagnostic and must NOT have reached any podman run.
+    RSNBIN="$WORK/rsnbin"; mkdir -p "$RSNBIN"
+    cat > "$RSNBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+# The reasoning-shape probe endpoint: a non-empty `reasoning` field beside content.
+printf '{"choices":[{"message":{"content":"ok","reasoning":"let me think about it"}}]}'
+exit 0
+STUB
+    chmod +x "$RSNBIN/curl"
+    cat > "$RSNBIN/podman" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+    run) echo "GUARD-BYPASS: podman run reached" >&2; exit 99 ;;
+    *)   exit 0 ;;
+esac
+STUB
+    chmod +x "$RSNBIN/podman"
+    rsn_err="$(MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN:$PATH" \
+        bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
+        --model openai/z-ai/glm-5.2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
+        --credential-env MY_TEST_VAR --out "$WORK/rsn.out" 2>&1 >/dev/null)" && rsn_rc=0 || rsn_rc=1
+    [ "$rsn_rc" -ne 0 ] && pass "reasoning-probe: reasoning-field model exits non-zero" \
+        || fail "reasoning-probe: reasoning-field model exits non-zero"
+    assert_contains "reasoning-probe: diagnostic names the hang class" "reasoning-field response" "$rsn_err"
+    assert_absent   "reasoning-probe: blocks before any podman run"    "GUARD-BYPASS"             "$rsn_err"
+
+    # Negative-space case: an ordinary (content-only) body must NOT block — the
+    # review path reaches podman run. Guards against a tautological always-block.
+    RSNBIN2="$WORK/rsnbin2"; mkdir -p "$RSNBIN2"
+    cat > "$RSNBIN2/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '{"choices":[{"message":{"content":"ok"}}]}'
+exit 0
+STUB
+    chmod +x "$RSNBIN2/curl"
+    cat > "$RSNBIN2/podman" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = run ]; then
+    : > "${PODMAN_RUN_MARKER:-/dev/null}"          # prove run was reached
+    if printf '%s\n' "$@" | grep -q SANDBOX-ALIVE; then
+        printf 'SANDBOX-ALIVE\nWRITE-BLOCKED\nSECRET-BLOCKED\nLOCAL-SCOPED\nNET-BLOCKED\n'
+    else
+        printf 'SUMMARY|findings=0|verdict=approve\n'
+    fi
+fi
+exit 0
+STUB
+    chmod +x "$RSNBIN2/podman"
+    RUN_MARKER="$WORK/rsn.runmarker"
+    PODMAN_RUN_MARKER="$RUN_MARKER" MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN2:$PATH" \
+        bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
+        --model openai/devstral-small-2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
+        --credential-env MY_TEST_VAR --out "$WORK/rsn.out2" >/dev/null 2>&1 || true
+    [ -f "$RUN_MARKER" ] && pass "reasoning-probe: ordinary model reaches podman run (no false block)" \
+        || fail "reasoning-probe: ordinary model reaches podman run (no false block)"
+else
+    echo "SKIP: python3/git/aider absent — reasoning-shape probe tests"
+fi
+
 # ── tier 2b: real containment self-test (podman + image) ─────────────────────
 if ! command -v podman >/dev/null; then
     echo "SKIP: podman absent — containment self-test"

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -484,6 +484,62 @@ STUB
     else
         echo "SKIP: git/aider absent — reasoning-probe negative-space case"
     fi
+
+    # Test A (item 1): a parser verdict OUTSIDE {0,1,2} — e.g. python3 killed,
+    # exit 42 — must fail LOUD, not silently proceed as "safe". Dispatch python3
+    # on the -c script: the body builder (json.dumps) works; the response parser
+    # (json.load) exits 42. The probe is advisory, so the run proceeds — but a
+    # WARN naming the unexpected verdict code must be emitted (fail-open, LOUD).
+    _rp_realpy="$(command -v python3)"
+    _rpA="$(mktemp -d "$WORK/rpA.XXXXXX")"
+    cat > "$_rpA/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '{"choices":[{"message":{"content":"ok"}}]}'
+exit 0
+STUB
+    printf '%s\n' "$_rp_realpy" > "$_rpA/realpy"
+    cat > "$_rpA/python3" <<'STUB'
+#!/usr/bin/env bash
+script=""; [ "${1:-}" = "-c" ] && script="${2:-}"
+case "$script" in
+    *json.load*)  exit 42 ;;                                              # response parser → unexpected verdict
+    *json.dumps*) printf '{"model":"x","max_tokens":1,"messages":[]}'; exit 0 ;;
+    *) exec "$(cat "$(dirname "$0")/realpy")" "$@" ;;
+esac
+STUB
+    chmod +x "$_rpA/curl" "$_rpA/python3"
+    errA="$(MY_TEST_VAR="probe-key-${RANDOM}" PATH="$_rpA:$PATH" \
+        bash "$SR" --base origin/main --branch feature \
+        --model openai/devstral-small-2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
+        --credential-env MY_TEST_VAR --out "$_rpA/out" 2>&1 >/dev/null || true)"
+    assert_contains "reasoning-probe: unexpected verdict code warns loud (not silent-safe)" \
+        "unexpected verdict code" "$errA"
+
+    # Test B (item 2): if the request-body builder (python3 json.dumps) crashes,
+    # the unguarded command substitution used to abort the ENTIRE seat run under
+    # set -euo pipefail. The probe is advisory: a body-build failure must WARN
+    # and fall through to the normal run, not kill the seat for every model.
+    _rpB="$(mktemp -d "$WORK/rpB.XXXXXX")"
+    cat > "$_rpB/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '{"choices":[{"message":{"content":"ok"}}]}'
+exit 0
+STUB
+    cat > "$_rpB/python3" <<'STUB'
+#!/usr/bin/env bash
+script=""; [ "${1:-}" = "-c" ] && script="${2:-}"
+case "$script" in
+    *json.dumps*) echo "boom" >&2; exit 7 ;;                             # body builder crashes
+    *) exit 2 ;;
+esac
+STUB
+    chmod +x "$_rpB/curl" "$_rpB/python3"
+    errB="$(MY_TEST_VAR="probe-key-${RANDOM}" PATH="$_rpB:$PATH" \
+        bash "$SR" --base origin/main --branch feature \
+        --model openai/devstral-small-2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
+        --credential-env MY_TEST_VAR --out "$_rpB/out" 2>&1 >/dev/null || true)"
+    assert_contains "reasoning-probe: body-build failure warns and does not abort the seat" \
+        "could not build its request body" "$errB"
 else
     echo "SKIP: python3 absent — reasoning-shape probe tests"
 fi

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -56,6 +56,15 @@ if grep -Eq 'timeout[^|]*"?\$\{?SEAT_TIMEOUT' <<<"$SRC"; then
 else
     fail "timeout wraps the seat invocation"
 fi
+# The aider/litellm per-request timeout backstop (ticket 0347): the env knob is
+# documented AND the aider invocation actually passes --timeout, so a silent
+# litellm hang becomes a stderr exception instead of a SEAT_TIMEOUT SIGKILL.
+assert_contains "aider timeout backstop env documented" "AIDER_API_TIMEOUT" "$SRC"
+if grep -Eq 'timeout "\$\{AIDER_API_TIMEOUT' <<<"$SRC"; then
+    pass "aider invocation passes --timeout backstop"
+else
+    fail "aider invocation passes --timeout backstop"
+fi
 assert_contains "relay bind-mounted into container"  "relay.sock"      "$SRC"
 # timeout SIGKILLs only the podman client (rootless conmon keeps the container
 # alive), so the seat must be --name'd and force-reaped or it leaks/outlives.
@@ -380,86 +389,79 @@ else
 fi
 
 # ── tier 2a⁶: reasoning-shape pre-flight probe (ticket 0347) ─────────────────
-# z-ai/glm-5.2 and moonshotai/kimi-k2.7-code return a `reasoning` field alongside
-# `content`; the seat's pinned aider/litellm venv hangs on that shape and the
-# outer SEAT_TIMEOUT SIGKILL leaves EMPTY stderr — a silent timeout. seat-runner
-# must probe the endpoint host-side (max_tokens=1) BEFORE any container launch and
-# fail LOUD when the response carries a non-empty reasoning field. Both cases stub
-# curl (the probe endpoint) and podman; --health-path "" skips the health probe so
-# every curl call here is the reasoning probe. --credential-env activates the probe
-# (it only runs when a real credential is injected). A throwaway repo supplies the
-# non-empty diff the review path needs on the negative (non-blocking) case.
-if command -v python3 >/dev/null && command -v git >/dev/null && command -v aider >/dev/null; then
-    RSN_REPO="$WORK/rsnrepo"; mkdir -p "$RSN_REPO"
-    (
-        cd "$RSN_REPO"
-        git init -q -b main
-        git config user.email t@t; git config user.name t
-        printf 'line one\n' > f.txt
-        git add f.txt; git commit -qm base
-        git checkout -q -b feature
-        printf 'line one\nline two\n' > f.txt
-        git commit -qam change
-    )
-
-    # RED case: curl returns a reasoning-shaped completion body; the podman stub
-    # screams if `run` is reached. seat-runner must exit non-zero with the hang-
-    # class diagnostic and must NOT have reached any podman run.
-    RSNBIN="$WORK/rsnbin"; mkdir -p "$RSNBIN"
-    cat > "$RSNBIN/curl" <<'STUB'
+# z-ai/glm-5.2 and moonshotai/kimi-k2.7-code return a `reasoning` /
+# `reasoning_content` field alongside `content`; the seat's pinned aider/litellm
+# venv hangs on that shape and the outer SEAT_TIMEOUT SIGKILL leaves EMPTY stderr
+# — a silent timeout. seat-runner must probe the endpoint host-side (max_tokens=1)
+# BEFORE any container launch and fail LOUD when the response carries a non-empty
+# reasoning field. --health-path "" skips the health probe so every curl call here
+# is the reasoning probe; --credential-env activates it. The RED (blocking) cases
+# FATAL at the probe BEFORE aider resolution or any clone, so they need neither
+# aider nor a git repo — they run in the merge gate (python3 only), where the
+# real-container tier below SKIPs. Only the negative-space case needs the full
+# review path (aider + repo) to reach podman run.
+if command -v python3 >/dev/null; then
+    # _reasoning_probe_red MODEL BODY_JSON LABEL — stub the probe endpoint (curl)
+    # to return BODY_JSON and stub podman to scream if `run` is reached; assert
+    # seat-runner exits non-zero, names the hang class, and never reaches podman.
+    _reasoning_probe_red() {
+        local model="$1" body="$2" label="$3"
+        local bin; bin="$(mktemp -d "$WORK/rsnred.XXXXXX")"
+        cat > "$bin/curl" <<'STUB'
 #!/usr/bin/env bash
-# The reasoning-shape probe endpoint: a non-empty `reasoning` field beside content.
-printf '{"choices":[{"message":{"content":"ok","reasoning":"let me think about it"}}]}'
+printf '%s' "$PROBE_BODY_JSON"      # the reasoning-shape probe response
 exit 0
 STUB
-    chmod +x "$RSNBIN/curl"
-    cat > "$RSNBIN/podman" <<'STUB'
+        cat > "$bin/podman" <<'STUB'
 #!/usr/bin/env bash
 case "${1:-}" in
     run) echo "GUARD-BYPASS: podman run reached" >&2; exit 99 ;;
     *)   exit 0 ;;
 esac
 STUB
-    chmod +x "$RSNBIN/podman"
-    rsn_err="$(MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN:$PATH" \
-        bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
-        --model openai/z-ai/glm-5.2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
-        --credential-env MY_TEST_VAR --out "$WORK/rsn.out" 2>&1 >/dev/null)" && rsn_rc=0 || rsn_rc=1
-    [ "$rsn_rc" -ne 0 ] && pass "reasoning-probe: reasoning-field model exits non-zero" \
-        || fail "reasoning-probe: reasoning-field model exits non-zero"
-    assert_contains "reasoning-probe: diagnostic names the hang class" "reasoning-field response" "$rsn_err"
-    assert_absent   "reasoning-probe: blocks before any podman run"    "GUARD-BYPASS"             "$rsn_err"
-
-    # RED case, alternate shape: kimi-k2.7-code returns the field as
-    # `reasoning_content` (not `reasoning`). The probe must block on this shape
-    # too — pins the second half of the ticket's reasoning-response canary.
-    RSNBIN_RC="$WORK/rsnbin_rc"; mkdir -p "$RSNBIN_RC"
-    cat > "$RSNBIN_RC/curl" <<'STUB'
-#!/usr/bin/env bash
-printf '{"choices":[{"message":{"content":"ok","reasoning_content":"step-by-step"}}]}'
-exit 0
-STUB
-    chmod +x "$RSNBIN_RC/curl"
-    cp "$RSNBIN/podman" "$RSNBIN_RC/podman"          # same GUARD-BYPASS screamer
-    rsn_rc_err="$(MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN_RC:$PATH" \
-        bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
-        --model openai/moonshotai/kimi-k2.7-code --endpoint http://127.0.0.1:9/v1 --health-path "" \
-        --credential-env MY_TEST_VAR --out "$WORK/rsn.out.rc" 2>&1 >/dev/null)" && rsn_rc_rc=0 || rsn_rc_rc=1
-    [ "$rsn_rc_rc" -ne 0 ] && pass "reasoning-probe: reasoning_content shape also blocks" \
-        || fail "reasoning-probe: reasoning_content shape also blocks"
-    assert_contains "reasoning-probe: reasoning_content diagnostic names the hang class" "reasoning-field response" "$rsn_rc_err"
-    assert_absent   "reasoning-probe: reasoning_content blocks before any podman run"    "GUARD-BYPASS"             "$rsn_rc_err"
+        chmod +x "$bin/curl" "$bin/podman"
+        local err rc=0
+        err="$(PROBE_BODY_JSON="$body" MY_TEST_VAR="probe-key-${RANDOM}" PATH="$bin:$PATH" \
+            bash "$SR" --base origin/main --branch feature \
+            --model "$model" --endpoint http://127.0.0.1:9/v1 --health-path "" \
+            --credential-env MY_TEST_VAR --out "$bin/out" 2>&1 >/dev/null)" || rc=1
+        [ "$rc" -ne 0 ] && pass "reasoning-probe: ${label} exits non-zero" \
+            || fail "reasoning-probe: ${label} exits non-zero"
+        assert_contains "reasoning-probe: ${label} names the hang class"        "reasoning-field response" "$err"
+        assert_absent   "reasoning-probe: ${label} blocks before any podman run" "GUARD-BYPASS"            "$err"
+    }
+    # glm-5.2 shape: `reasoning`. kimi-k2.7-code shape: `reasoning_content`.
+    # Both must block — pins both halves of the ticket's reasoning-response canary.
+    _reasoning_probe_red "openai/z-ai/glm-5.2" \
+        '{"choices":[{"message":{"content":"ok","reasoning":"let me think about it"}}]}' \
+        "reasoning field (glm-5.2)"
+    _reasoning_probe_red "openai/moonshotai/kimi-k2.7-code" \
+        '{"choices":[{"message":{"content":"ok","reasoning_content":"step-by-step"}}]}' \
+        "reasoning_content field (kimi-k2.7-code)"
 
     # Negative-space case: an ordinary (content-only) body must NOT block — the
-    # review path reaches podman run. Guards against a tautological always-block.
-    RSNBIN2="$WORK/rsnbin2"; mkdir -p "$RSNBIN2"
-    cat > "$RSNBIN2/curl" <<'STUB'
+    # full review path reaches podman run. Guards against a tautological always-
+    # block. This one needs aider + a real diff (the review path clones + diffs).
+    if command -v git >/dev/null && command -v aider >/dev/null; then
+        RSN_REPO="$WORK/rsnrepo"; mkdir -p "$RSN_REPO"
+        (
+            cd "$RSN_REPO"
+            git init -q -b main
+            git config user.email t@t; git config user.name t
+            printf 'line one\n' > f.txt
+            git add f.txt; git commit -qm base
+            git checkout -q -b feature
+            printf 'line one\nline two\n' > f.txt
+            git commit -qam change
+        )
+        RSNBIN2="$WORK/rsnbin2"; mkdir -p "$RSNBIN2"
+        cat > "$RSNBIN2/curl" <<'STUB'
 #!/usr/bin/env bash
 printf '{"choices":[{"message":{"content":"ok"}}]}'
 exit 0
 STUB
-    chmod +x "$RSNBIN2/curl"
-    cat > "$RSNBIN2/podman" <<'STUB'
+        chmod +x "$RSNBIN2/curl"
+        cat > "$RSNBIN2/podman" <<'STUB'
 #!/usr/bin/env bash
 if [ "${1:-}" = run ]; then
     : > "${PODMAN_RUN_MARKER:-/dev/null}"          # prove run was reached
@@ -471,16 +473,19 @@ if [ "${1:-}" = run ]; then
 fi
 exit 0
 STUB
-    chmod +x "$RSNBIN2/podman"
-    RUN_MARKER="$WORK/rsn.runmarker"
-    PODMAN_RUN_MARKER="$RUN_MARKER" MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN2:$PATH" \
-        bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
-        --model openai/devstral-small-2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
-        --credential-env MY_TEST_VAR --out "$WORK/rsn.out2" >/dev/null 2>&1 || true
-    [ -f "$RUN_MARKER" ] && pass "reasoning-probe: ordinary model reaches podman run (no false block)" \
-        || fail "reasoning-probe: ordinary model reaches podman run (no false block)"
+        chmod +x "$RSNBIN2/podman"
+        RUN_MARKER="$WORK/rsn.runmarker"
+        PODMAN_RUN_MARKER="$RUN_MARKER" MY_TEST_VAR="probe-key-${RANDOM}" PATH="$RSNBIN2:$PATH" \
+            bash "$SR" --repo "$RSN_REPO" --base origin/main --branch feature \
+            --model openai/devstral-small-2 --endpoint http://127.0.0.1:9/v1 --health-path "" \
+            --credential-env MY_TEST_VAR --out "$WORK/rsn.out2" >/dev/null 2>&1 || true
+        [ -f "$RUN_MARKER" ] && pass "reasoning-probe: ordinary model reaches podman run (no false block)" \
+            || fail "reasoning-probe: ordinary model reaches podman run (no false block)"
+    else
+        echo "SKIP: git/aider absent — reasoning-probe negative-space case"
+    fi
 else
-    echo "SKIP: python3/git/aider absent — reasoning-shape probe tests"
+    echo "SKIP: python3 absent — reasoning-shape probe tests"
 fi
 
 # ── tier 2b: real containment self-test (podman + image) ─────────────────────

--- a/tickets/0347-seat-stack-hangs-on-reasoning-field-models.erg
+++ b/tickets/0347-seat-stack-hangs-on-reasoning-field-models.erg
@@ -7,6 +7,7 @@ Author: claude
 2026-07-14T17:55Z claude created
 2026-07-14T20:08Z claude note reimagined+planned by raid — fix at seat-runner layer, aider venv unpinnable from repo
 
+2026-07-14T21:28Z bump verify-reroll — round 1: verdict-switch fallthrough + unguarded probe-body substitution
 --- body ---
 ## Context
 

--- a/tickets/0347-seat-stack-hangs-on-reasoning-field-models.erg
+++ b/tickets/0347-seat-stack-hangs-on-reasoning-field-models.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-07-14T17:55Z claude created
+2026-07-14T20:08Z claude note reimagined+planned by raid — fix at seat-runner layer, aider venv unpinnable from repo
 
 --- body ---
 ## Context
@@ -23,8 +24,8 @@ reasoning-model responses via the `openai/` route — hangs waiting for
 content it never surfaces.
 
 This blocks auditioning reasoning-emitting candidates, which make up
-roughly half of the OpenRouter leaderboard that ticket 0346's audition
-board is designed to scan.
+roughly half of the models on the OpenRouter leaderboard that ticket
+0346's audition board scans.
 
 ## Relevant files
 
@@ -35,14 +36,28 @@ board is designed to scan.
 
 ## Actions
 
-1. Reproduce outside the sandbox: `aider --ask` against OpenRouter
-   `z-ai/glm-5.2` via the `openai/` route; capture where it hangs
-   (litellm streaming? response parse?).
-2. Fix smallest-first: litellm/aider upgrade, or a per-model extra-body
-   param suppressing the reasoning field, or a response-shim in the seat.
-3. Canary: a cheap seat self-test invocation against a reasoning-model
-   stub so the incompatibility class is caught before an audition burns
-   wall-clock.
+The aider/litellm venv is a host-level uv-tool install, unpinnable from
+this repo, so the durable fix lives in `scripts/seat-runner.sh`.
+
+1. Reasoning-shape pre-flight probe (the core fix). In `seat-runner.sh`,
+   right after the `--health-path` probe and only when `--credential-env`
+   is set, POST a one-token chat completion (`max_tokens=1`, the target
+   `$MODEL` with any litellm `openai/` route prefix stripped) to
+   `${ENDPOINT}/chat/completions` and inspect it. If the response carries a
+   non-empty `reasoning` / `reasoning_content` field, exit non-zero with a
+   diagnostic naming the hang class — BEFORE any container launch. The key
+   goes in a mode-600 `curl -K` config file under `$WORK` (never argv); the
+   response body is parsed in-memory, never written to a scrub-skipped file.
+   A probe that cannot connect or parse WARNs and falls through — a working
+   model is never blocked on a flaky probe.
+2. aider `--timeout` backstop. Pass `--timeout "${AIDER_API_TIMEOUT:-120}"`
+   to the seat's aider invocation so any future silent hang becomes a
+   litellm exception on stderr that the existing failure tail surfaces,
+   not a SEAT_TIMEOUT SIGKILL with empty stderr.
+3. Hermetic tests in `tests/test_seat_runner.sh`: a RED case (a canned
+   reasoning-shaped body must fail loud before podman is reached) and a
+   negative-space case (an ordinary body must reach podman run) so the
+   probe neither misses the class nor false-blocks every model.
 
 ## Exit criteria
 

--- a/tickets/closed/0347-seat-stack-hangs-on-reasoning-field-models.erg
+++ b/tickets/closed/0347-seat-stack-hangs-on-reasoning-field-models.erg
@@ -2,12 +2,14 @@
 Title: seat-runner CLI stack hangs on reasoning-field models (glm-5.2, kimi-k2.7-code)
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #618
 
 --- log ---
 2026-07-14T17:55Z claude created
 2026-07-14T20:08Z claude note reimagined+planned by raid — fix at seat-runner layer, aider venv unpinnable from repo
 
 2026-07-14T21:28Z bump verify-reroll — round 1: verdict-switch fallthrough + unguarded probe-body substitution
+2026-07-14T21:52Z Minh Ha-Duong closed — autoclosed — PR #618
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

`z-ai/glm-5.2` and `moonshotai/kimi-k2.7-code` never completed a seat review during the 2026-07-14 audits: the reviewer inside the sandbox produced NO stderr and idled until `SEAT_TIMEOUT` SIGKILLed it (empty stderr — a silent timeout). Both models answer a trivial prompt in 1-3s over the same endpoint/key, and both return a `reasoning` field alongside `content`. The seat's pinned aider/litellm venv hangs on that shape. The venv is a host-level uv-tool install, unpinnable from this repo, so the durable fix lives in `scripts/seat-runner.sh`.

## Action 1 — reasoning-shape pre-flight probe (core fix)

In `scripts/seat-runner.sh`, right after the `--health-path` probe and only when `--credential-env` is set, POST a one-token chat completion (`max_tokens=1`, target `$MODEL` with any litellm `openai/` route prefix stripped) to `${ENDPOINT}/chat/completions` via `curl -sf --max-time 15`, parse in-memory with `python3`, and if the response carries a non-empty `reasoning`/`reasoning_content` field, exit non-zero with a diagnostic naming the hang class — BEFORE any container launch. A probe that cannot connect or parse WARNs and falls through (a working model is never blocked on probe fragility).

Credential discipline: the key never touches curl argv — it goes in a mode-600 `curl -K` config file under `$WORK` (`umask 077` write, `rm -f`'d on every branch, backstopped by the EXIT trap reaping `$WORK`). The response body is parsed by piping to `python3` stdin, never written to a file the credential-scrub pass skips. `WORK`/`cleanup` trap setup moved earlier so the curlrc has a reaped home; the move is safe on early exits (empty `RELAY_PID` short-circuits, empty `SEAT_CONTAINERS` no-ops).

## Action 2 — aider `--timeout` backstop

Added `--timeout "${AIDER_API_TIMEOUT:-120}"` to the seat's aider invocation and documented `AIDER_API_TIMEOUT` next to `SEAT_TIMEOUT`. Converts any future silent litellm hang into a stderr exception the existing `tail -20 raw.err` failure tail surfaces, instead of a SIGKILL with empty stderr.

## Action 3 — hermetic tests (RED + negative-space)

In `tests/test_seat_runner.sh` (reusing the stub-podman / stub-curl idioms):
- **RED case:** a canned reasoning-shaped body must fail loud (`reasoning-field response` diagnostic) before the podman stub's `run` is reached (no `GUARD-BYPASS`). Confirmed RED on the pre-fix script (2 assertions failed: no diagnostic, `GUARD-BYPASS` present).
- **Negative-space case:** an ordinary content-only body must reach `podman run` — guards against a tautological always-block.

Both green after the fix: `tests/test_seat_runner.sh` → 55 passed, 0 failed.

## Action 4 — dropped

Not shipped. Action 1's fail-loud path already satisfies the exit criterion ("fails LOUD with a diagnostic, not a silent timeout"). A model-settings reasoning-suppression shim was descoped; no live OpenRouter probe was run, so no spend and no key handling.

## Verification

- `make check` green (exit 0); `make lint` green (17 passed).
- `/verify-adherence` → PASS (bash rules, credential-sink audit by a sonnet reviewer, `check-agnostic.sh` on `scripts` and `tickets` both clean).
- `bash -n` + `shellcheck -S warning` clean.

**Ticket:** tickets/0347-seat-stack-hangs-on-reasoning-field-models.erg
Ticket-ref: tickets/0207-agnostic-cli-reviewer-seat-one-config-op.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
