### PR TITLE
doc(0354): guard-worktree-identity verb-in-argument false positive

### DIFF
--- a/scripts/guard-worktree-identity.sh
+++ b/scripts/guard-worktree-identity.sh
@@ -48,6 +48,19 @@ esac
 # SCOPE here: command substitution (`git $(echo commit)`) and git aliases
 # (`git ci` for commit) — a regex cannot see through either without invoking git
 # itself. See ticket 0302 if closing the alias gap ever becomes necessary.
+#
+# Known residual FALSE-POSITIVE gap (ticket 0354, accepted, not fixed): a
+# mutating verb token that appears as literal text INSIDE a quoted argument of a
+# read-only command is misread as a mutation. `grep 'erg close' f`, `echo 'git
+# commit later'` both match ERG_MUT/GIT_MUT. Quote-stripping here then lets the
+# `tr ';&|'` split below cut a grep pattern like `'a|erg close|b'` into a bare
+# `erg close` segment. Consequence is bounded and fail-SAFE: it only ever
+# over-blocks, never mis-allows, and in a HEALTHY worktree it does not even
+# block (the identity check passes; cost is one skipped fast-path). It bites
+# only under a real identity mismatch (husk / deregistered worktree) AND when
+# the read-only command's args literally contain a git/erg verb. Workaround:
+# name the tree with `git -C`, or run from a non-worktree cwd. A robust fix
+# (quote-aware split + verb anchored to command position) is deferred in 0354.
 norm=${cmd//\"/}
 norm=${norm//\'/}
 

--- a/tickets/0354-guard-worktree-identity-verb-in-arg-false-positive.erg
+++ b/tickets/0354-guard-worktree-identity-verb-in-arg-false-positive.erg
@@ -1,0 +1,63 @@
+%erg 0.1
+Title: guard-worktree-identity false-positive on a mutating verb inside a quoted argument
+Created: 2026-07-14
+Author: Minh Ha-Duong
+Label: deferred
+
+--- log ---
+2026-07-14T21:33Z Minh Ha-Duong created
+
+--- body ---
+## Context
+`scripts/guard-worktree-identity.sh` gates a mutating git/erg command when the
+cwd claims a harness worktree but git resolves elsewhere (incident I1). Its
+`GIT_MUT`/`ERG_MUT` regexes match the verb token ANYWHERE in the command text,
+including inside a quoted argument of a read-only command. So a read-only
+`grep -nE '...|erg close|erg pr' f` or `echo 'git commit later'` is misread as a
+mutation: quote-stripping (`norm`) plus the `tr ';&|'` split then cuts a grep
+pattern like `'a|erg close|b'` into a bare `erg close` segment with no `git -C`,
+forcing the identity check.
+
+Found 2026-07-14 (session a645ef77) while inspecting AEDIST/harness workflows
+from an orphaned husk cwd — several read-only `grep`/`gh` inspection commands
+were blocked because their grep patterns literally contained `erg close`.
+
+## Severity — accepted as a documented gap, not urgent
+- Fail-SAFE: it only ever over-blocks; it never mis-allows a real mutation.
+- In a HEALTHY worktree it does not even block — the final identity check passes
+  (basename matches, toplevel != primary); the only cost is a skipped fast-path
+  (~one extra rev-parse). It actually blocks ONLY under a real identity
+  mismatch (husk / deregistered worktree) AND when the read-only command's args
+  contain a git/erg verb token.
+- Workaround is trivial: name the tree with `git -C`, or run from a
+  non-worktree cwd, or reword the pattern.
+
+Documented as a known residual gap in the guard header (this ticket referenced
+there), consistent with the already-documented command-substitution and
+git-alias gaps.
+
+## Reproduction (verified against the real guard)
+cwd = a husk under `.claude/worktrees/`; payload fed as `.tool_input.command`:
+- `grep -nE '...|erg close|erg pr' f`  -> exit 2 (false positive)
+- `grep -nE '...|autoclose' f`         -> exit 0
+- `gh pr list --head foo --state all`  -> exit 0
+- `echo 'remember to git commit later'`-> exit 2 (false positive)
+- real bare `git commit -m x`          -> exit 2 (correct, the I1 invariant)
+- `git -C /tmp log --oneline`          -> exit 0
+
+## Possible fix (deferred)
+Root cause is quote-strip + split-on-`|` destroying the argument boundary. A
+robust fix splits on shell separators WITHOUT splitting inside quotes and
+anchors the verb to command position (segment start, after optional
+`env VAR=val` prefixes), while keeping the I1 replay and the `git "commit"`
+quoting-evasion regressions green. Add two red cases to
+`tests/test_guard_worktree_identity.sh`: `grep 'erg close'` and
+`echo 'git commit'` from a mismatched cwd must ALLOW after the fix.
+
+## Exit criteria
+- [ ] Quote-aware segment split; verb matched only in command position
+- [ ] `grep 'erg close'` / `echo 'git commit'` from a mismatched cwd -> allow
+- [ ] I1 replay + `git "commit"` evasion + compound-bypass tests stay green
+- [ ] Guard header note updated (drop "not fixed" once resolved)
+
+Leave OPEN (deferred) — documented gap; fix is low priority.


### PR DESCRIPTION
## Summary

Documents a low-severity, fail-safe false positive in `scripts/guard-worktree-identity.sh` as a known residual gap (investigation requested; fix deferred).

**Finding.** `GIT_MUT`/`ERG_MUT` match a mutating verb token *anywhere* in the command string, including inside a quoted argument. A read-only inspection command whose quoted argument contains a verb token (a grep pattern, an echo message) is misread as a mutation — quote-stripping plus the separator split then cut a grep pattern into a bare verb segment. Verified against the real guard.

**Severity — accepted, not fixed.** Fail-safe: it only ever over-blocks, never mis-allows. In a healthy worktree it does not even block (the identity check passes; cost is a skipped fast-path). It bites only under a real identity mismatch (husk / deregistered worktree) when a read-only command's args contain a git/erg verb token. Workaround is trivial (`git -C`, or run outside a worktree).

**This PR:**
- Adds a "Known residual FALSE-POSITIVE gap" note to the guard header, next to the existing command-substitution and git-alias gap notes, referencing ticket 0354.
- Files ticket **0354** (`deferred`) with the reproduction table and the proposed quote-aware-split fix, left open.

Comment-only change to the guard — its test suite and `bash -n` stay green.

Ticket-ref: tickets/0354-guard-worktree-identity-verb-in-arg-false-positive.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
