### PR TITLE
feat(0352): bash-env lower-sev denylist vars + predicate collapse

### DIFF
--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -125,10 +125,11 @@ _be_is_protected_name() {
     case "$1" in
         *GUARD_*|_be_*) return 0 ;;
         PATH|BASH_ENV|ENV|SHELLOPTS|BASHOPTS|IFS|\
-        PS1|PS2|PS3|PS4|PROMPT_COMMAND|CDPATH|GLOBIGNORE|\
-        LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|\
+        PS0|PS1|PS2|PS3|PS4|PROMPT_COMMAND|CDPATH|GLOBIGNORE|\
+        LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_DEBUG|LD_PROFILE|\
         GCONV_PATH|PYTHONPATH|NODE_OPTIONS|NODE_PATH|PERL5LIB|RUBYOPT|\
         GIT_SSH_COMMAND|GIT_SSH|GIT_ASKPASS|GIT_EXTERNAL_DIFF|LESSOPEN|LESSCLOSE|\
+        TZ|TZDIR|LOCALDOMAIN|TERMINFO|BASH_XTRACEFD|HISTFILE|\
         BASH_FUNC_*|DYLD_*) return 0 ;;
     esac
     return 1
@@ -190,23 +191,16 @@ if [ -n "${PWD:-}" ] && [ -f "$PWD/.env" ]; then
                     _be_val="${_be_val:1:${#_be_val}-2}"
                 fi
             fi
-            # structural refusal: an untrusted file cannot set guard vars.
-            # Match every guard-namespaced key — both the GUARD_* form and the
-            # leading-underscore _GUARD_* override pair (_GUARD_WORKTREE_ROOT /
-            # _GUARD_PRIMARY_ROOT) that pretooluse-worktree-path-guard.sh honors
-            # as an unconditional worktree-path override. Substring match, since
-            # no legitimate project key contains the harness-internal GUARD_ token.
-            if [[ "$_be_key" == *GUARD_* ]]; then
-                printf 'bash-env: refusing guard-namespaced key from project .env: %s\n' \
-                    "$_be_key" >&2
-                continue
-            fi
-            # ticket 0345: an untrusted project .env controls both name and value,
-            # so refuse any shell/process/interpreter-critical export NAME (else
-            # GCONV_PATH / LD_PRELOAD / BASH_ENV → RCE, PATH / PYTHONPATH /
-            # NODE_OPTIONS → interpreter clobber, in EVERY subprocess). Shares the
-            # _be_is_protected_name predicate with the KEYS-selection path below,
-            # so the two denylists cannot drift. Default-deny, skip + warn.
+            # structural + critical-name refusal, ONE predicate (ticket 0352).
+            # _be_is_protected_name covers both the guard-namespaced keys — the
+            # GUARD_* form and the leading-underscore _GUARD_* worktree-path
+            # override pair honored by pretooluse-worktree-path-guard.sh, plus this
+            # script's own _be_* bookkeeping — AND the shell/process/interpreter-
+            # critical set (ticket 0345: an untrusted project .env controls both
+            # name and value, so GCONV_PATH / LD_PRELOAD / BASH_ENV → RCE, PATH /
+            # PYTHONPATH / NODE_OPTIONS → interpreter clobber, in EVERY subprocess).
+            # It is the SINGLE name-policy site, shared with the KEYS-selection
+            # path below, so the two paths cannot drift. Default-deny, skip + warn.
             if _be_is_protected_name "$_be_key"; then
                 printf 'bash-env: refusing protected name from project .env: %s\n' \
                     "$_be_key" >&2
@@ -271,32 +265,29 @@ if [ -n "${KEYS:-}" ]; then
                 IFS=','
                 continue
             fi
-            # structural refusal (mirrors the project-.env line-138 guard): the
-            # untrusted project .env supplies SRC/DST, so it must not name a
-            # guard-namespaced target (GUARD_* / the _GUARD_* worktree-path
-            # override pair honored by pretooluse-worktree-path-guard.sh) nor
-            # this script's own _be_* bookkeeping, which is live in the sourcing
-            # shell and would be corrupted mid-loop. Default-deny, skip + warn.
-            if [[ "$_be_dst" == *GUARD_* ]] || [[ "$_be_dst" == _be_* ]] || \
-               [[ "$_be_src" == *GUARD_* ]]; then
-                printf 'bash-env: ignoring invalid KEYS entry: %s\n' "$_be_entry" >&2
-                IFS=','
-                continue
-            fi
-            # shell/process/interpreter-critical export-name refusal: the export
-            # NAME is DST (== SRC in the no-rename form), chosen by the untrusted
-            # project .env. Refuse names that would subvert every subprocess if a
-            # hostile .env aimed a value at them — PATH/LD_* (code execution),
-            # BASH_ENV/ENV (re-source arbitrary shell), IFS/prompt/CDPATH/GLOBIGNORE
-            # (parse and word-splitting hijack), GCONV_PATH (glibc iconv RCE), the
-            # PYTHONPATH/NODE_OPTIONS/NODE_PATH/PERL5LIB/RUBYOPT interpreter hijacks,
-            # the BASH_FUNC_* exported-function channel, and the DYLD_* macOS
-            # analogue of LD_*. Shares the _be_is_protected_name predicate with the
-            # strict-parse loop above (ticket 0345), so the two denylists cannot
-            # drift. Default-deny, skip + warn.
+            # export-name refusal via the ONE shared predicate (ticket 0352).
+            # The untrusted project .env supplies SRC/DST, so refuse the entry if
+            # EITHER names a protected name. _be_is_protected_name covers, in a
+            # single site shared with the strict-parse loop above (so the two
+            # paths cannot drift): the guard-namespaced keys (GUARD_* / the
+            # _GUARD_* worktree-path override pair / this script's own _be_*
+            # bookkeeping, which is live in the sourcing shell and would be
+            # corrupted mid-loop) AND the shell/process/interpreter-critical set
+            # (PATH/LD_* code execution, BASH_ENV/ENV re-source, IFS/prompt/CDPATH/
+            # GLOBIGNORE parse hijack, GCONV_PATH iconv RCE, the interpreter-var
+            # hijacks, BASH_FUNC_*/DYLD_*). Checking SRC too (not just the export
+            # target DST) closes the earlier asymmetry where SRC got only a GUARD_
+            # substring check. Default-deny, skip + warn.
             if _be_is_protected_name "$_be_dst"; then
+                _be_bad="$_be_dst"
+            elif _be_is_protected_name "$_be_src"; then
+                _be_bad="$_be_src"
+            else
+                _be_bad=""
+            fi
+            if [ -n "$_be_bad" ]; then
                 printf 'bash-env: refusing KEYS export to protected name: %s\n' \
-                    "$_be_dst" >&2
+                    "$_be_bad" >&2
                 IFS=','
                 continue
             fi
@@ -361,7 +352,7 @@ if [ -n "${KEYS:-}" ]; then
     IFS="$_be_ifs"
     [ "$_be_had_noglob" = 1 ] || set +f
     unset _be_ifs _be_entry _be_prov _be_sel _be_sel_mode _be_src _be_dst \
-          _be_val _be_rc _be_keyfile _be_had_noglob
+          _be_val _be_rc _be_keyfile _be_had_noglob _be_bad
 fi
 
 # Drop the shared predicate so it does not leak into every subprocess's shell.

--- a/scripts/bash-env.sh
+++ b/scripts/bash-env.sh
@@ -83,7 +83,8 @@
 # LD_PRELOAD, LD_LIBRARY_PATH, LD_AUDIT, GCONV_PATH, PYTHONPATH, NODE_OPTIONS,
 # NODE_PATH, PERL5LIB, RUBYOPT, the git exec vectors GIT_SSH_COMMAND, GIT_SSH,
 # GIT_ASKPASS, GIT_EXTERNAL_DIFF, the LESSOPEN / LESSCLOSE pager hooks, or the
-# BASH_FUNC_* / DYLD_* prefix families —
+# BASH_FUNC_* / DYLD_* prefix families (plus the lower-severity perturbation vars
+# of ticket 0352 — see the predicate's `case` for the authoritative list) —
 # via the shared _be_is_protected_name predicate (ticket 0345), alongside the
 # existing GUARD_* / _be_* refusal; such an entry warns `refusing KEYS export to
 # protected name: <name>` and is skipped, so an untrusted .env cannot overwrite a
@@ -120,7 +121,13 @@
 #     set one would run its command in every git call) and the pager hooks
 #     LESSOPEN / LESSCLOSE (a `|cmd %s` input pipe runs on every `git log` / `less`),
 #     and the BASH_FUNC_* exported-function and DYLD_* (macOS LD_* analogue) prefix
-#     families.
+#     families;
+#   * lower-severity perturbation vars (ticket 0352) a hostile .env should not be
+#     able to steer, though none is a code-execution vector: PS0, TZ / TZDIR /
+#     LOCALDOMAIN (locale/resolver), TERMINFO, LD_DEBUG / LD_PROFILE (linker
+#     diagnostics), BASH_XTRACEFD, HISTFILE.
+# The `case` block below is the authoritative enumeration; this prose summarises
+# it by category and may lag — read the `case` when in doubt.
 _be_is_protected_name() {
     case "$1" in
         *GUARD_*|_be_*) return 0 ;;

--- a/tests/test_bash_env_keys_protect_critical_names.sh
+++ b/tests/test_bash_env_keys_protect_critical_names.sh
@@ -148,11 +148,13 @@ REAL="REAL_SENTINEL_kept_intact"
 # GIT_EXTERNAL_DIFF, LESSOPEN, LESSCLOSE) were added in the 0345 verify round: the
 # harness runs git constantly, so any of these is a direct command-execution
 # channel if a hostile project .env can aim a value at it.
-for name in PATH BASH_ENV ENV SHELLOPTS BASHOPTS IFS PS1 PS2 PS3 PS4 \
+for name in PATH BASH_ENV ENV SHELLOPTS BASHOPTS IFS PS0 PS1 PS2 PS3 PS4 \
             PROMPT_COMMAND CDPATH GLOBIGNORE LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT \
+            LD_DEBUG LD_PROFILE \
             GCONV_PATH PYTHONPATH NODE_OPTIONS NODE_PATH PERL5LIB RUBYOPT \
             GIT_SSH_COMMAND GIT_SSH GIT_ASKPASS GIT_EXTERNAL_DIFF \
-            LESSOPEN LESSCLOSE; do
+            LESSOPEN LESSCLOSE \
+            TZ TZDIR LOCALDOMAIN TERMINFO BASH_XTRACEFD HISTFILE; do
     proj="$(_mkproj "p1_$name" "KEYS=zzz:EVIL=$name
 ")"
     _assert_contains "(1:$name) warns 'protected name: $name'" \

--- a/tests/test_bash_env_keys_selection_explicit.sh
+++ b/tests/test_bash_env_keys_selection_explicit.sh
@@ -276,6 +276,28 @@ _assert_eq "(9) _be_* dst: not leaked into the env" \
 _assert_eq "(9) _be_* dst: shell survives (rc 0)" \
     "$(_load_rc "$FHOME" "$P9")" "0"
 
+# --- (9b) a protected SRC is refused too, not just DST (ticket 0352) --------------
+# provider:SRC=DST reads SRC from the provider file and exports it as DST. The
+# untrusted project .env picks SRC, so a protected SRC must be refused even when
+# DST is innocuous — closing the earlier asymmetry where SRC got only a GUARD_
+# substring check. The refusal fires before the provider file is even consulted.
+P9B="$(_mkproj p9b 'KEYS=huggingface:LD_PRELOAD=SAFE_DST
+')"
+_assert_eq "(9b) protected SRC: DST not set" \
+    "$(_load_var "$FHOME" "$P9B" SAFE_DST)" ""
+_assert_eq "(9b) protected SRC: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P9B")" "0"
+_assert_contains "(9b) protected SRC: warns 'protected name: LD_PRELOAD'" \
+    "$(_load_stderr "$FHOME" "$P9B")" "refusing KEYS export to protected name: LD_PRELOAD"
+
+# --- (9c) a GUARD_ SRC is refused (was the only SRC check before 0352) -----------
+P9C="$(_mkproj p9c 'KEYS=huggingface:GUARD_ALLOW_PRIMARY_EDIT=SAFE_DST2
+')"
+_assert_eq "(9c) GUARD_ SRC: DST not set" \
+    "$(_load_var "$FHOME" "$P9C" SAFE_DST2)" ""
+_assert_eq "(9c) GUARD_ SRC: shell survives (rc 0)" \
+    "$(_load_rc "$FHOME" "$P9C")" "0"
+
 # --- (10) missing provider file -> warn 'KEYS provider not found' -----------------
 # A valid provider NAME whose file does not exist: the file-existence check fires
 # before any subshell and must warn the file-missing diagnostic.

--- a/tests/test_bash_env_project_env_parse.sh
+++ b/tests/test_bash_env_project_env_parse.sh
@@ -231,6 +231,18 @@ _be0345_case GIT_EXTERNAL_DIFF /evil
 # pager input/close hooks: a `|cmd %s` LESSOPEN runs on every `git log` / `less`.
 _be0345_case LESSOPEN '|evil %s'
 _be0345_case LESSCLOSE '|evil %s'
+# lower-severity perturbation vars (ticket 0352): not code-execution vectors, but
+# a hostile project .env should not be able to steer a child's timezone, terminal
+# database, prompt-0, dynamic-linker diagnostics, xtrace fd, or history file.
+_be0345_case PS0 /evil
+_be0345_case LD_DEBUG all
+_be0345_case LD_PROFILE /evil.so
+_be0345_case TZ /evil
+_be0345_case TZDIR /evil
+_be0345_case LOCALDOMAIN evil
+_be0345_case TERMINFO /evil
+_be0345_case BASH_XTRACEFD 2
+_be0345_case HISTFILE /evil
 
 # (6d) IFS must not be turned into an exported variable by a project .env.
 P6D="$WORK/p6d"; mkdir -p "$P6D"

--- a/tickets/0352-bashenv-lowsev-residuals-predicate-collapse.erg
+++ b/tickets/0352-bashenv-lowsev-residuals-predicate-collapse.erg
@@ -5,6 +5,7 @@ Author: Minh Ha-Duong
 
 --- log ---
 2026-07-14T21:05Z Minh Ha-Duong created
+2026-07-14T21:47Z Minh Ha-Duong note implemented: 9 lower-sev vars added to predicate; both export sites collapsed to the single predicate; KEYS path now checks SRC too (closed the src asymmetry). red-proven, all bash suites + lint green
 
 --- body ---
 ## Context
@@ -27,6 +28,6 @@ tidy-ups.
   (assert each is refused on both the strict-parse and KEYS-selection paths).
 
 ## Exit criteria
-- [ ] New vars refused on both export paths, red-proven
-- [ ] Single predicate is the only name-policy site (no duplicated inline lists)
-- [ ] make check passes
+- [x] New vars refused on both export paths, red-proven
+- [x] Single predicate is the only name-policy site (no duplicated inline lists)
+- [x] make check passes

--- a/tickets/closed/0352-bashenv-lowsev-residuals-predicate-collapse.erg
+++ b/tickets/closed/0352-bashenv-lowsev-residuals-predicate-collapse.erg
@@ -2,11 +2,13 @@
 Title: bash-env.sh — lower-severity env-var residuals and predicate collapse
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #629
 
 --- log ---
 2026-07-14T21:05Z Minh Ha-Duong created
 2026-07-14T21:47Z Minh Ha-Duong note implemented: 9 lower-sev vars added to predicate; both export sites collapsed to the single predicate; KEYS path now checks SRC too (closed the src asymmetry). red-proven, all bash suites + lint green
 
+2026-07-14T22:14Z Minh Ha-Duong closed — autoclosed — PR #629
 --- body ---
 ## Context
 The critical-name denylist in scripts/bash-env.sh (`_be_is_protected_name`) now


### PR DESCRIPTION
## Summary

Closes 0352 — the tail of the bash-env secret-loader hardening.

**Action 1 — lower-severity vars.** Adds nine perturbation vars to the shared `_be_is_protected_name` predicate: `PS0, TZ, TZDIR, LOCALDOMAIN, TERMINFO, LD_DEBUG, LD_PROFILE, BASH_XTRACEFD, HISTFILE`. None is a code-execution vector (the RCE/hijack classes already landed in 0345); each is defence-in-depth so a hostile project `.env` cannot steer a child's timezone, terminal database, prompt-0, dynamic-linker diagnostics, xtrace fd, or history file.

**Action 2 — one predicate, no drift.** Makes `_be_is_protected_name` the single name-policy site at both export paths:
- strict-parse loop: drops the redundant inline `== *GUARD_*` check (the predicate already covers `GUARD_`/`_be_`).
- KEYS-selection: replaces the inline `*GUARD_*`/`_be_*` dst+src check with the predicate applied to **both** dst and src — closing the earlier asymmetry where SRC got only a `GUARD_` substring check. A protected SRC is now refused against the full critical-name set.

**Tests.** The KEYS refusal loop and the strict-parse parametrized cases gain the nine new vars; new cases 9b/9c assert a protected / `GUARD_` SRC is refused. Red-proven — the nine vars were unprotected pre-0352 and the SRC check did not exist. All 29 bash suites and adherence lint pass.

**Ticket:** tickets/0352-bashenv-lowsev-residuals-predicate-collapse.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
