### PR TITLE
fix(0339): scope endpoint credential out of the containment self-test

### DIFF
--- a/scripts/seat-runner.sh
+++ b/scripts/seat-runner.sh
@@ -152,7 +152,9 @@ fi
 #    (NOT a secret), passed inline. With --credential-env NAME: read the secret
 #    from that env var HERE, export it, and pass the BARE `-e OPENAI_API_KEY`
 #    form so podman reads the value from the runner's env — never argv (argv
-#    leaks to `ps -ef`). Fail loud if the named var is empty; never echo it. ────
+#    leaks to `ps -ef`). Fail loud if the named var is empty; never echo it.
+#    The containment self-test omits this credential entirely (run_seat --no-cred,
+#    ticket 0339): it probes only isolation and never needs the endpoint key. ────
 CRED_ARGS=(-e OPENAI_API_KEY=local-dummy)
 if [[ -n "$CREDENTIAL_ENV" ]]; then
     if [[ -z "${!CREDENTIAL_ENV:-}" ]]; then
@@ -324,6 +326,14 @@ fi
 
 # ── The sandboxed seat launcher (timeout-wrapped, reaped; network-denied) ─────
 run_seat() {
+    # --no-cred (first arg) runs the container with NO endpoint credential: the
+    # containment self-test only probes write/secret/network isolation and never
+    # needs the real key (ticket 0339, least-privilege). Only the review run gets it.
+    local cred_args=("${CRED_ARGS[@]}")
+    if [[ "${1:-}" == "--no-cred" ]]; then
+        cred_args=()
+        shift
+    fi
     local cname="seatrun-$$-${RANDOM}"
     local rc=0
     SEAT_CONTAINERS+=("$cname")
@@ -345,7 +355,7 @@ run_seat() {
         -e PATH="/usr/bin:/bin" \
         -e TERM=dumb \
         -e COLUMNS=500 \
-        ${CRED_ARGS[@]+"${CRED_ARGS[@]}"} \
+        ${cred_args[@]+"${cred_args[@]}"} \
         -e OPENAI_API_BASE="$CONTAINER_BASE" \
         -w /repo \
         "$IMAGE" "$@" || rc=$?
@@ -356,7 +366,7 @@ run_seat() {
 
 # ── Containment self-test (0217: proven, not assumed; alive-then-blocked) ─────
 echo "seat-runner: containment self-test..." >&2
-PROBE=$(run_seat bash -c '
+PROBE=$(run_seat --no-cred bash -c '
     echo SANDBOX-ALIVE
     touch /repo/PWNED 2>/dev/null && echo WRITE-ALLOWED || echo WRITE-BLOCKED
     cat '"$HOMEDIR"'/.ssh/id_* '"$HOMEDIR"'/.claude/scripts/bash-env.sh \

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -217,11 +217,16 @@ STUB
         # The secret reaches the container through the process env podman inherits...
         assert_contains "credential-env: secret reaches podman via process env" \
             "OPENAI_API_KEY=${PROBE_VAL}" "$(cat "$ENV_CAP")"
-        # ...as a BARE -e passthrough in argv (a line that is exactly the var name)...
+        # ...but NOT into the containment self-test container: that run is invoked
+        # with `run_seat --no-cred` (ticket 0339, least-privilege), so the endpoint
+        # key must be ABSENT from the self-test argv (this is the only podman run
+        # under --self-test-only). The ENV_CAP assertion above is unaffected: the
+        # runner exports OPENAI_API_KEY into its OWN process env for the review run,
+        # which the stub inherits regardless of the -e argv the container receives.
         if grep -qx 'OPENAI_API_KEY' "$ARGV_CAP"; then
-            pass "credential-env: argv carries bare -e OPENAI_API_KEY passthrough"
+            fail "credential-env: self-test container carries the endpoint key (--no-cred not applied)"
         else
-            fail "credential-env: argv carries bare -e OPENAI_API_KEY passthrough"
+            pass "credential-env: self-test container omits the endpoint key (--no-cred, ticket 0339)"
         fi
         # ...and the VALUE must NEVER appear in argv (that is the ps -ef leak).
         if grep -qF "OPENAI_API_KEY=${PROBE_VAL}" "$ARGV_CAP"; then
@@ -308,13 +313,18 @@ if command -v python3 >/dev/null && command -v git >/dev/null && command -v aide
     # FINDING line (stdout→raw.out) AND to stderr (raw.err), so BOTH scrub paths
     # are exercised. The key is read from the stub's own env — exactly how a
     # compromised seat would obtain it.
+    # This stub also captures per-branch argv (self-test vs review) so the test
+    # can prove least-privilege credential scoping (ticket 0339): the self-test
+    # container must NOT receive the endpoint key, the review run must.
     EXFILBIN="$WORK/exfilbin"; mkdir -p "$EXFILBIN"
     cat > "$EXFILBIN/podman" <<'STUB'
 #!/usr/bin/env bash
 if [ "${1:-}" = run ]; then
     if printf '%s\n' "$@" | grep -q SANDBOX-ALIVE; then
+        [ -n "${PODMAN_SELFTEST_ARGV_CAP:-}" ] && printf '%s\n' "$@" > "$PODMAN_SELFTEST_ARGV_CAP"
         printf 'SANDBOX-ALIVE\nWRITE-BLOCKED\nSECRET-BLOCKED\nLOCAL-SCOPED\nNET-BLOCKED\n'
     else
+        [ -n "${PODMAN_REVIEW_ARGV_CAP:-}" ] && printf '%s\n' "$@" > "$PODMAN_REVIEW_ARGV_CAP"
         printf 'FINDING|severity=verifiable|file=f.txt:1|rationale=leaked %s\n' "${OPENAI_API_KEY:-}"
         printf 'SUMMARY|findings=1|verdict=revise\n'
         printf 'leaked %s\n' "${OPENAI_API_KEY:-}" >&2
@@ -326,9 +336,11 @@ STUB
 
     PROBE_VAL="exfil-secret-${RANDOM}-${RANDOM}-${RANDOM}"
     FINDINGS="$WORK/exfil.findings"
+    SELFTEST_ARGV="$WORK/exfil.selftest.argv"; REVIEW_ARGV="$WORK/exfil.review.argv"
 
     # Success path: findings file is written from raw.out; assert it is scrubbed.
     MY_TEST_VAR="$PROBE_VAL" PATH="$EXFILBIN:$PATH" \
+        PODMAN_SELFTEST_ARGV_CAP="$SELFTEST_ARGV" PODMAN_REVIEW_ARGV_CAP="$REVIEW_ARGV" \
         bash "$SR" --repo "$EXFIL_REPO" --base origin/main --branch feature \
         --endpoint http://127.0.0.1:9/v1 --health-path "" \
         --credential-env MY_TEST_VAR --out "$FINDINGS" \
@@ -336,6 +348,24 @@ STUB
     findings_out="$(cat "$FINDINGS" 2>/dev/null || true)"
     assert_absent   "scrub: injected key absent from findings file" "$PROBE_VAL" "$findings_out"
     assert_contains "scrub: findings carry the redaction marker" "[REDACTED-CREDENTIAL]" "$findings_out"
+
+    # ── 0339 least-privilege: the self-test container omits the endpoint key,
+    # the review run keeps it. Argv is the ONLY discriminating channel — the
+    # runner exports OPENAI_API_KEY into its process env, which BOTH stub runs
+    # inherit regardless of the -e flags, so an env-dump check would be a
+    # tautology (passes before AND after the fix). The bare `-e OPENAI_API_KEY`
+    # passthrough puts the var name on its own argv line. The review-run guard is
+    # green before and after the fix — it catches a blanket-strip wrong fix.
+    if [ -f "$SELFTEST_ARGV" ] && grep -qx 'OPENAI_API_KEY' "$SELFTEST_ARGV"; then
+        fail "no-cred: self-test container carries the endpoint key (should be stripped)"
+    else
+        pass "no-cred: self-test container omits the endpoint key (ticket 0339)"
+    fi
+    if [ -f "$REVIEW_ARGV" ] && grep -qx 'OPENAI_API_KEY' "$REVIEW_ARGV"; then
+        pass "no-cred: review run still carries the endpoint key (invariant)"
+    else
+        fail "no-cred: review run lost the endpoint key (over-strip regression?)"
+    fi
 
     # Failure path: a seat that exits non-zero has raw.err tailed to stderr. A
     # second stub leaks the key to stderr, then exits 1 to drive that tail path.

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -221,8 +221,9 @@ STUB
         # with `run_seat --no-cred` (ticket 0339, least-privilege), so the endpoint
         # key must be ABSENT from the self-test argv (this is the only podman run
         # under --self-test-only). The ENV_CAP assertion above is unaffected: the
-        # runner exports OPENAI_API_KEY into its OWN process env for the review run,
-        # which the stub inherits regardless of the -e argv the container receives.
+        # runner unconditionally exports OPENAI_API_KEY into its OWN process env at
+        # credential setup, which the stub inherits regardless of the -e argv the
+        # container receives — so env-inheritance can't discriminate; argv can.
         if grep -qx 'OPENAI_API_KEY' "$ARGV_CAP"; then
             fail "credential-env: self-test container carries the endpoint key (--no-cred not applied)"
         else

--- a/tickets/0339-seat-self-test-cred-args-scoping.erg
+++ b/tickets/0339-seat-self-test-cred-args-scoping.erg
@@ -5,6 +5,7 @@ Author: claude
 
 --- log ---
 2026-07-14T13:40Z claude created
+2026-07-14T22:02Z claude note planned by raid — --no-cred flag param; argv is the only discriminating test channel (env-dump is tautological)
 
 --- body ---
 ## Context

--- a/tickets/0339-seat-self-test-cred-args-scoping.erg
+++ b/tickets/0339-seat-self-test-cred-args-scoping.erg
@@ -6,6 +6,7 @@ Author: claude
 --- log ---
 2026-07-14T13:40Z claude created
 2026-07-14T22:02Z claude note planned by raid — --no-cred flag param; argv is the only discriminating test channel (env-dump is tautological)
+2026-07-14T22:20Z claude note implemented stricter than exit criterion: --no-cred gives the self-test container NO key at all (cred_args=()), not the dummy key — a superset that satisfies "never receives the real endpoint key"
 
 --- body ---
 ## Context

--- a/tickets/closed/0339-seat-self-test-cred-args-scoping.erg
+++ b/tickets/closed/0339-seat-self-test-cred-args-scoping.erg
@@ -2,12 +2,14 @@
 Title: seat-runner self-test needlessly injects the endpoint credential
 Created: 2026-07-14
 Author: claude
+Closed: autoclosed — PR #630
 
 --- log ---
 2026-07-14T13:40Z claude created
 2026-07-14T22:02Z claude note planned by raid — --no-cred flag param; argv is the only discriminating test channel (env-dump is tautological)
 2026-07-14T22:20Z claude note implemented stricter than exit criterion: --no-cred gives the self-test container NO key at all (cred_args=()), not the dummy key — a superset that satisfies "never receives the real endpoint key"
 
+2026-07-14T22:21Z Minh Ha-Duong closed — autoclosed — PR #630
 --- body ---
 ## Context
 

--- a/tickets/closed/0344-erg-pr-merge-chdir-flag-for-bare-invocation.erg
+++ b/tickets/closed/0344-erg-pr-merge-chdir-flag-for-bare-invocation.erg
@@ -2,11 +2,13 @@
 Title: erg-pr-merge: add a -C PATH flag so the bare rule-matched invocation works from any cwd
 Created: 2026-07-14
 Author: claude
+Closed: merged — PR #617
 
 --- log ---
 2026-07-14T16:40Z claude created
 2026-07-14T20:06Z claude note planned by raid — -C parse lands before any git/gh call; skip trigger is the -d tickets clause, not erg resolution
 
+2026-07-14T22:03Z Minh Ha-Duong closed — merged — PR #617
 --- body ---
 ## Context
 


### PR DESCRIPTION
## What

`run_seat` in `scripts/seat-runner.sh` unconditionally spliced `CRED_ARGS` — the real `-e OPENAI_API_KEY` when `--credential-env` is set — into **every** podman run, including the pre-review containment self-test (`PROBE=$(run_seat …)`). That container only probes write/secret/network isolation and never needs the endpoint key. Latent least-privilege gap (raised by the PR #603 red-team panel; `$PROBE` also bypassed the 0207 scrub, moot once the key never enters that container).

Fix: `run_seat` gains a `--no-cred` first-arg flag that empties a **local** `cred_args` copy for that call; the self-test call site passes it. The global `CRED_ARGS` assignment, the export, the scrub chokepoint, and the review-run call site are untouched — only the local var seen by the self-test changes, so the sandbox posture is unchanged and the review run still receives the key. Chosen over a wrapper/global toggle to match the file's flag-parse + optional-array-splice idioms and keep the change to one function.

## Tests (`tests/test_seat_runner.sh`)

- **tier 2a″** — FLIP the self-test-argv assertion from "carries bare `-e OPENAI_API_KEY`" to "omits it". The `ENV_CAP` assertion is left intact.
- **tier 2a⁗ (exfil block)** — add per-branch argv capture (`PODMAN_SELFTEST_ARGV_CAP` / `PODMAN_REVIEW_ARGV_CAP`). Assert the self-test container **omits** the key (RED before the fix) and the review run still **carries** it (invariant guard, green before and after — catches a blanket-strip wrong fix).

### env-vs-argv precision note

Argv is the **only** discriminating channel. The runner exports `OPENAI_API_KEY` into its own process env for the review run, and the stub podman inherits that env on **both** branches regardless of the container's `-e` flags — so an env-dump assertion would be a tautology (passes before AND after the fix). The `-e OPENAI_API_KEY` passthrough puts the bare var name on its own argv line; that is what the assertions grep.

### RED → GREEN evidence

Against the **unmodified** `seat-runner.sh`, the two new/flipped assertions fail (RED); the invariant guard passes:

```
FAIL: credential-env: self-test container carries the endpoint key (--no-cred not applied)
FAIL: no-cred: self-test container carries the endpoint key (should be stripped)
PASS: no-cred: review run still carries the endpoint key (invariant)
Results: 62 passed, 2 failed
```

After the fix:

```
PASS: credential-env: self-test container omits the endpoint key (--no-cred, ticket 0339)
PASS: no-cred: self-test container omits the endpoint key (ticket 0339)
PASS: no-cred: review run still carries the endpoint key (invariant)
Results: 64 passed, 0 failed
```

`make check`: 858 passed. `/verify-adherence`: PASS (adherence suite 18/18) — `/gaze` may skip the mechanical phase.

## Invariants held

- Review run still receives the real credential (proven by the review-argv guard).
- Scrub chokepoint and all three echo paths untouched; sandbox posture unchanged.
- Tier-1 source assertion `CRED_ARGS=(-e OPENAI_API_KEY)` still matches (global assignment untouched).
- 0347's reasoning-shape probe and `AIDER_API_TIMEOUT` regions untouched.

## Rider commit (no close claim)

This branch also carries a separate chore-close commit for **ticket 0344** (`e509b47`): PR #617 merged with a `**Ticket:**` line but erg-pr-merge ran from a checkout-less husk cwd, so the `[[ -d tickets ]]` guard skipped the close — the exact defect #617 fixes. Closed and archived manually per the rules/git.md recipe (staged the `Closed:` edit before the `git mv`; commit carries 2 insertions, not a bare 100%-rename). No `**Ticket:**` close line for 0344 here — it is already-merged cleanup, not a claim.

**Ticket:** tickets/0339-seat-self-test-cred-args-scoping.erg