### PR TITLE
triage: close 0349 wontfix; severity floor for tooling repos

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -171,7 +171,9 @@ author are for genuinely NEW scope or destructive/irreversible actions the
 batched decisions did not cover — not for progress, not for permission to
 continue (author doctrine, 2026-07-11).
 
-**Sweep results are decisions.** When a skill sweep (roar step 3, healthcheck, etc.) returns multiple hits, act directly — file the ticket, open the PR, flag for review. Don't prompt the user to confirm. The data is the decision. Silent no-op if the sweep is empty.
+**Sweep results are decisions.** When a skill sweep (roar step 3, healthcheck, etc.) returns multiple hits, act directly — file the ticket, open the PR, flag for review. Don't prompt the user to confirm. The data is the decision. Silent no-op if the sweep is empty. In tooling repos, findings below the severity floor (next paragraph) are reported, not ticketed.
+
+**Severity floor for tooling repos.** In a tooling/harness repo (this repo, git-erg), file a ticket only when the defect blocks a merge, corrupts state, or bites a science project. Below that bar: fix it inline in the current change, record it in memory, or drop it — sweeps report such findings, they do not mint tickets for them. When a guard misfires, check whether its defect class has fired recently before patching; prefer deleting the guard (and its tests) over growing it. Science repos keep normal filing. (Author directive, 2026-07-15: the ticket queue had reached equilibrium on second-order tooling work.)
 
 **Loophole found → offer to plug it.** When a gap or loophole is identified (audit, review, user-reported check), don't just report it — immediately offer a concrete fix. Propose either implementing it now or opening a ticket. Reporting without offering leaves the user to ask the obvious follow-up.
 

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -98,7 +98,7 @@ Classify every finding into exactly one of three categories:
 - `fix-now` — trivial, no branch needed, reversible, no design decision: do it in the
   current session immediately after the user says "do it"
 - `open-ticket` — multi-file, needs a branch, requires a design decision, or worth
-  tracking across sessions: create a ticket
+  tracking across sessions: create a ticket. Tooling repos: apply the severity floor (rules/workflow.md § Autonomous Action Rules) — findings that don't block a merge, corrupt state, or bite a science project are reported in the run summary, not ticketed.
 - `skip` — cosmetic, already tracked elsewhere, or not worth acting on now: note why
 
 Format:

--- a/skills/molt/SKILL.md
+++ b/skills/molt/SKILL.md
@@ -151,6 +151,7 @@ Run full repo housekeeping and act on every finding.
      using a specific title. For test failures, the slug must contain `fix-tests`
      (e.g. `0042-fix-tests-module-not-found`).
    - If a ticket already exists, skip.
+   - Tooling repos: apply the severity floor (rules/workflow.md § Autonomous Action Rules) — findings that don't block a merge, corrupt state, or bite a science project are reported in the run summary, not ticketed.
 
 5. **Log `skip` items.** One line each, no action.
 

--- a/skills/roar/SKILL.md
+++ b/skills/roar/SKILL.md
@@ -77,7 +77,7 @@ branch — there are no remote branches nor merge requests to inspect.
    ```bash
    git rev-parse HEAD > "$(git rev-parse --git-common-dir)/roar-last-sha"
    ```
-3. **Sweep for similar patterns**: review the fix just completed. Grep/audit the codebase for the same anti-pattern in other files. File tickets for all instances found: `tickets/erg new "<title>"`, fill the body, `erg validate` it, then COMMIT it — don't skip the commit; an uncommitted draft is destroyed by step 9's worktree exit (see ticket 0174).
+3. **Sweep for similar patterns**: review the fix just completed. Grep/audit the codebase for the same anti-pattern in other files. File tickets for all instances found: `tickets/erg new "<title>"`, fill the body, `erg validate` it, then COMMIT it — don't skip the commit; an uncommitted draft is destroyed by step 9's worktree exit (see ticket 0174). Tooling repos: apply the severity floor (rules/workflow.md § Autonomous Action Rules) — findings that don't block a merge, corrupt state, or bite a science project are reported in the run summary, not ticketed.
 4. **Guard against regression**: if the sweep above was juicy — multiple instances of the same anti-pattern — the bug has a class shape. File a follow-up ticket for a standing regression test covering the class. Do not auto-write the test, do not bundle it into the fix PR. If the sweep found nothing, move on silently. /gaze is a per-PR gate; a standing test is what catches the class coming back in an unrelated future PR.
 5. **Update project docs** if pipeline, data contract, or methodology changed.
 6. **Save persistent memory**: durable lessons from this task. No sweep here — sweeps happen at `/lair`.

--- a/skills/skill-doctor/SKILL.md
+++ b/skills/skill-doctor/SKILL.md
@@ -77,6 +77,8 @@ Assign it when you author the report table — a labeling convention, like the
 
 ## 4. Open tickets
 
+Tooling repos: apply the severity floor (rules/workflow.md § Autonomous Action Rules) — findings that don't block a merge, corrupt state, or bite a science project are reported in the run summary, not ticketed.
+
 For each approved pattern, create a ticket via `tickets/erg new "<title>"`:
 
 - **Title**: `skill-doctor: {signature} — {one-line fix summary}`

--- a/tickets/closed/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg
+++ b/tickets/closed/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg
@@ -2,10 +2,12 @@
 Title: gaze phase 5 (/simplify) runs as direct invocation — Agent-wrap it so edits execute inside review-<pr>
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: wontfix under the 2026-07-15 severity floor: the worktree-path guard is working as designed and /simplify's Bash fallback functions — no observed defect, no blocked merge. Reopen if a gaze-applied simplify edit demonstrably lands wrong.
 
 --- log ---
 2026-07-14T20:10Z Minh Ha-Duong created
 
+2026-07-14T22:06Z Minh Ha-Duong closed — wontfix under the 2026-07-15 severity floor: the worktree-path guard is working as designed and /simplify's Bash fallback functions — no observed defect, no blocked merge. Reopen if a gaze-applied simplify edit demonstrably lands wrong.
 --- body ---
 ## Context
 


### PR DESCRIPTION
Ticket: none
Ticket-ref: tickets/closed/0349-gaze-phase-5-simplify-runs-as-direct-inv.erg

Author cool-down directive 2026-07-15: raise the severity floor for tooling repos — a defect earns a ticket only when it blocks a merge, corrupts state, or bites a science project. This PR closes 0349 wontfix under that floor and codifies the rule in rules/workflow.md plus one-line pointers in the four sweep skills that mint tickets (molt, skill-doctor, roar, healthcheck).

0339's wontfix was superseded mid-flight by PR #630 implementing the fix — that closure was dropped from this branch; arbitration between the fix and the wontfix is left to the author. The 0350 item 1 guard-blind-spot arbitration is also left to the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)