### PR TITLE
chore(0348,0353): close wontfix — harness cool-down, no second-order tooling

### DIFF
--- a/tickets/closed/0348-reviewers-scores-readback-help-verb-stal.erg
+++ b/tickets/closed/0348-reviewers-scores-readback-help-verb-stal.erg
@@ -2,9 +2,11 @@
 Title: /reviewers scores read-back, explicit help verb, stale trial-ticket pointer
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: 2026-07-14
 
 --- log ---
 2026-07-14T19:55Z Minh Ha-Duong created
+2026-07-14T22:19Z Minh Ha-Duong closed wontfix — harness cool-down (author): not merge-blocking, not state-corrupting, no science-project impact; scorecards remain readable in the trial tickets directly
 
 --- body ---
 ## Context

--- a/tickets/closed/0353-audition-latency-tracking-relative-slow.erg
+++ b/tickets/closed/0353-audition-latency-tracking-relative-slow.erg
@@ -3,10 +3,12 @@ Title: Audition and seat latency tracking; eliminate slow candidates on peer sta
 Created: 2026-07-14
 Author: Minh Ha-Duong
 Blocked-by: 0348
+Closed: 2026-07-14
 
 --- log ---
 2026-07-14T21:13Z Minh Ha-Duong created
 2026-07-14T21:59Z Minh Ha-Duong note Blocked-by 0348 header added — 0348 reached main via PR #613, forward reference now legal
+2026-07-14T22:19Z Minh Ha-Duong closed wontfix — harness cool-down (author): not merge-blocking, not state-corrupting, no science-project impact; audition scorecards already expose mean latency per run, sufficient for seat decisions
 
 --- body ---
 ## Context


### PR DESCRIPTION
Closes tickets 0348 (scores read-back / help verb / stale pointer) and 0353 (latency tracking / SLOW elimination) as wontfix, per the author's cool-down doctrine: close-one-open-two follow-up minting is exactly the second-order tooling pattern to stop. Neither ticket blocks a merge, corrupts state, or affects a science project. Tickets pre-closed in the diff (Closed: header + closed log line + archived to tickets/closed/), so this PR itself claims no close.

Ticket-ref: tickets/closed/0348-reviewers-scores-readback-help-verb-stal.erg
Ticket-ref: tickets/closed/0353-audition-latency-tracking-relative-slow.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)