### PR TITLE
feat(reviewers): audition/seat latency tracking + peer-relative SLOW gate

### DIFF
--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -43,6 +43,12 @@ diff (the branch is resolved from the PR, or passed explicitly):
 proceed — one seat never blocks the verdict (0205). Empty roster → no-op,
 exits 0. No secrets in config; seat credentials load via the BASH_ENV path.
 
+**Per-seat latency** (ticket 0353): each `cli-agent`/`local-model` seat is timed
+and its wall-clock seconds written to a `<seat>.latency` sidecar beside the
+findings, whatever the outcome (a slow-then-failed seat is still evidence).
+`scorecard` folds that figure into the seat's trial line. `forge-bot` seats run
+async server-side and get **no** sidecar — there is nothing local to time.
+
 ### `/reviewers harvest <pr>`
 
 Collect every seat's findings and normalize the seat-runner's
@@ -64,8 +70,14 @@ Append a fixed-schema trial line to the seat's trial ticket via `erg log`
 evidence-based:
 
 ```
-MR #42 seat=local-qwen verdict: PASS — 0 verifiable, 2 consider
+MR #42 seat=local-qwen verdict: PASS — 0 verifiable, 2 consider latency=48.7s
 ```
+
+When `request` left a `.latency` sidecar for the seat (a `cli-agent`/
+`local-model` seat — see below), its wall-clock seconds fold into the line as a
+trailing `latency=<s>s` field (ticket 0353). Absent a sidecar the line is
+byte-identical to the pre-latency schema — the field is appended at the end, so
+every existing parser is unaffected.
 
 ### `/reviewers scores [seat-or-candidate]`
 
@@ -84,18 +96,21 @@ card to an archived trial ticket fails "no ticket found". `scores` reads by
 grep, so it is not bound by that.)
 
 ```
-KIND      NAME                 MR/BOARD                   VERIF  CONS  FIND  DUP  UVER  UHAL  OVERLAP   LATENCY     COST
-audition  hy3-free             10MR                           -     -    59   23     0    36      38%   3419.1s      n/a
-scorecard copilot              ImperialDragonHarness#537      0     0     -    -     -     -        -         -        -
+KIND      NAME                 MR/BOARD                   VERIF  CONS  FIND  DUP  UVER  UHAL  OVERLAP   LATENCY      P95     COST  FLAG
+audition  hy3-free             10MR                           -     -    59   23     0    36      38%      9.4s    41.0s      n/a  SLOW
+scorecard copilot              ImperialDragonHarness#537      0     0     -    -     -     -        -     48.7s        -        -     -
 ```
 
 No argument → all seats and candidates. An argument filters to one seat or
 candidate name. A malformed trial line WARNs on stderr, never silently dropped
 (the harvest convention). Only each ticket's `--- log ---` section is read, so
 a card quoted in a ticket body as documentation is never mistaken for a result.
-`scorecard`'s per-MR columns (`VERIF`/`CONS`) and
-`audition`'s per-board columns (`FIND`/`DUP`/`UVER`/`UHAL`/`OVERLAP`/`LATENCY`/
-`COST`) share one table; a `-` marks a column that does not apply to that row.
+`scorecard`'s per-MR columns (`VERIF`/`CONS`) and `audition`'s per-board columns
+(`FIND`/`DUP`/`UVER`/`UHAL`/`OVERLAP`) share one table; a `-` marks a column that
+does not apply to that row. `LATENCY` shows a candidate's `latency-p50` (the
+gate-relevant stat, falling back to the running-sum `latency=` for older cards)
+and a seat's per-MR latency; `P95` is the candidate's tail latency; `FLAG`
+surfaces the peer-relative `SLOW` verdict (ticket 0353).
 
 ### `/reviewers help`
 
@@ -132,7 +147,8 @@ trial ticket via `erg log` (verb `note`):
 ```
 audition candidate=<label> model=<id> board=<N>MR findings=<F> \
   duplicate=<d> unique-verified=<uv> unique-hallucinated=<uh> \
-  overlap=<pct>% latency=<s>s cost=<$x|n/a>
+  overlap=<pct>% latency=<s>s cost=<$x|n/a> \
+  latency-p50=<s>s latency-p95=<s>s [SLOW]
 ```
 
 `overlap%` is the share of the candidate's findings that merely duplicate the
@@ -140,6 +156,22 @@ panel. `cost` is `$ per review` from the token counts the seat reports on its
 `SUMMARY` line, priced via `REVIEWERS_PRICE_IN_PER_M` / `REVIEWERS_PRICE_OUT_PER_M`
 (USD per 1M tokens); it is `n/a` when the seat reports no tokens or no price is
 configured — an honest blank, never a fabricated `$0`.
+
+`latency=` is a running **sum** of wall-clock across the board PRs.
+`latency-p50` / `latency-p95` are the per-PR latency distribution (nearest-rank,
+appended after `cost=` so existing parsers are unaffected; ticket 0353).
+
+**Peer-relative SLOW gate** (ticket 0353): a candidate whose `latency-p50`
+exceeds `REVIEWERS_SLOW_FACTOR` × the cross-candidate median p50 (default factor
+**3**) earns a bare trailing ` SLOW` token, and its verdict becomes
+**eliminate-slow** — it does not proceed to the live advisory trial. The
+comparison is against **other candidates that replayed the same board size**:
+identical work, so the statistic is host- and diff-size-independent. It fires
+only with **≥1 peer** (a lone candidate has no basis for comparison) and is a
+**strict** `>`, so a candidate at exactly `factor × median` is kept. The gate
+only reads peers' logged cards and appends to the new candidate's own card — it
+**never edits a prior candidate's line** (append-only) and never touches the
+roster; roster promotion stays the manual call at 0205's integration review.
 
 **Fail-loud**: unlike `request`'s per-seat fail-open, audition aborts non-zero
 if the seat-runner cannot replay a board PR (unreachable endpoint, sandbox
@@ -162,6 +194,9 @@ tickets/NNNN-...` (where the scorecard is logged; default the 0207 trial ticket)
 `--credential-env NAME` (for an authenticated endpoint; threaded to the
 seat-runner, never written to config), `--name LABEL` (candidate label in the
 scorecard; default the model id).
+
+Environment: `REVIEWERS_SLOW_FACTOR` (default `3`) sets the SLOW threshold as a
+multiple of the cross-candidate median p50.
 
 ## Candidate scouting
 

--- a/skills/reviewers/SKILL.md
+++ b/skills/reviewers/SKILL.md
@@ -193,7 +193,9 @@ local endpoint), `--board FILE` (default `benchmark-board.yml`), `--trial-ticket
 tickets/NNNN-...` (where the scorecard is logged; default the 0207 trial ticket),
 `--credential-env NAME` (for an authenticated endpoint; threaded to the
 seat-runner, never written to config), `--name LABEL` (candidate label in the
-scorecard; default the model id).
+scorecard; default the model id — an **identifier**, so no spaces, `=`, or
+newlines: those are the space-delimited card's field delimiters and would
+corrupt read-back).
 
 Environment: `REVIEWERS_SLOW_FACTOR` (default `3`) sets the SLOW threshold as a
 multiple of the cross-candidate median p50.

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -132,6 +132,58 @@ _card_field() {  # key line
     printf '%s' "${rest%% *}"
 }
 
+# Nearest-rank percentile (1-based) at percentile $1 of the numeric arguments
+# $2..$N. Empty arg list → "0.0". One implementation for audition's per-run
+# p50/p95 AND the peer-relative SLOW median, so the two can never drift apart
+# (ticket 0353).
+_percentile() {  # pct v1 v2 ...
+    local pct="$1"; shift
+    [ "$#" -gt 0 ] || { printf '0.0'; return 0; }
+    printf '%s\n' "$@" | sort -g | awk -v p="$pct" '
+        { a[NR]=$0 }
+        END {
+            x = (p / 100.0) * NR
+            r = int(x); if (r < x) r++      # ceil → nearest-rank
+            if (r < 1) r = 1; if (r > NR) r = NR
+            printf "%.1f", a[r]
+        }'
+}
+
+# Emit every ticket's `--- log ---` section lines across the corpus (tickets/
+# and tickets/closed/). The scan latches at the FIRST `--- log ---`, stops at
+# the next section boundary, and never re-enters, so a body line quoting
+# `--- log ---` cannot fabricate a phantom row (ticket 0348). Shared by `scores`
+# (read-back table) and audition's peer-relative SLOW scan (ticket 0353), so
+# both read the same log-only surface from one implementation.
+_corpus_log_lines() {  # tickets_dir
+    local td="$1"
+    [ -d "$td" ] || return 0
+    find "$td" -name '*.erg' -type f 2>/dev/null | sort | while IFS= read -r f; do
+        awk '
+            done_log        { next }
+            !inlog && /^--- log ---/ { inlog=1; next }
+            inlog && /^--- /         { inlog=0; done_log=1; next }
+            inlog
+        ' "$f" 2>/dev/null
+    done
+}
+
+# Peer p50 latencies: emit the `latency-p50` seconds (`s` stripped) of every
+# OTHER candidate's audition card on the SAME board size, read log-only from the
+# ticket corpus. Feeds the peer-relative SLOW gate (ticket 0353).
+_audition_peer_p50s() {  # tickets_dir board_size self_label
+    local td="$1" bsize="$2" self="$3" line p50 lbl
+    _corpus_log_lines "$td" | while IFS= read -r line; do
+        case "$line" in *"audition candidate="*) ;; *) continue ;; esac
+        [ "$(_card_field board "$line")" = "${bsize}MR" ] || continue
+        p50=$(_card_field latency-p50 "$line")
+        [ -n "$p50" ] || continue
+        lbl=$(_card_field candidate "$line")
+        [ "$lbl" = "$self" ] && continue
+        printf '%s\n' "${p50%s}"
+    done
+}
+
 # Does candidate finding basename $1 + line $2 match any anchor in list $3?
 # Anchor form: basename[:LINE] or basename:* (bare basename == :*).
 _audition_match() {  # cfile cline anchor-string
@@ -219,10 +271,25 @@ case "$subcmd" in
                     # a local, unauthenticated endpoint carries no credential.
                     cred_args=()
                     [ -n "$ce" ] && cred_args=(--credential-env "$ce")
+                    # Time the seat, whatever the outcome — a slow-then-failed
+                    # seat is still evidence. The elapsed seconds land in a
+                    # `.latency` sidecar beside the findings; `scorecard` folds
+                    # it into the seat's trial line (ticket 0353). forge-bot
+                    # seats run async server-side and get no sidecar — there is
+                    # nothing local to time.
+                    t0=$(date +%s.%N)
                     if "$SEAT_RUNNER" --repo "$REPO_ROOT" --branch "$branch" \
                         --endpoint "$ep" --model "$mo" --out "${dest}/${name}.findings" \
                         ${cred_args[@]+"${cred_args[@]}"} \
                         >/dev/null 2>"${dest}/${name}.err"; then
+                        seat_ok=1
+                    else
+                        seat_ok=0
+                    fi
+                    t1=$(date +%s.%N)
+                    awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.1f", b - a}' \
+                        > "${dest}/${name}.latency"
+                    if [ "$seat_ok" = 1 ]; then
                         echo "request: seat '${name}' ok → ${dest}/${name}.findings" >&2
                         ran=$((ran+1))
                     else
@@ -285,6 +352,11 @@ case "$subcmd" in
         tid=$(_ticket_id_from_path "$tt")
         # Fixed schema so 0205's integration review is evidence-based, not vibes.
         line="MR #${pr} seat=${seat} verdict: ${verdict}"
+        # Fold in the seat's per-MR latency when `request` left a sidecar
+        # (ticket 0353). Appended at END so every existing parser is unaffected;
+        # absent sidecar → byte-identical to the pre-0353 line.
+        latfile="${FINDINGS_DIR}/${pr}/${seat}.latency"
+        [ -f "$latfile" ] && line="${line} latency=$(cat "$latfile")s"
         "$ERG" log "$tid" "claude note ${line}"
         ;;
 
@@ -318,6 +390,13 @@ case "$subcmd" in
         dest="${FINDINGS_DIR}/audition-$$"; mkdir -p "$dest"
         trap 'rm -rf "$dest"' EXIT   # reap the scratch dir on every exit path
         n_pr=0; tot=0; dup=0; uv=0; uh=0; ptok=0; ctok=0; lat="0"
+        lat_samples=()
+        # Per-PR elapsed is real wall-clock; REVIEWERS_AUDITION_ELAPSED (a
+        # space-separated list of seconds, one per board PR, indexed by board
+        # position) overrides it so the latency statistics are deterministic
+        # under test — the same override philosophy as SEAT_RUNNER/ERG (0353).
+        _elapsed_ov=()
+        [ -n "${REVIEWERS_AUDITION_ELAPSED:-}" ] && read -ra _elapsed_ov <<<"$REVIEWERS_AUDITION_ELAPSED"
         while IFS='|' read -r pr title base head panel defects; do
             [ -n "$pr" ] || continue
             n_pr=$((n_pr + 1))
@@ -341,7 +420,16 @@ case "$subcmd" in
                 exit 1
             fi
             t1=$(date +%s.%N)
-            lat=$(awk -v s="$lat" -v a="$t0" -v b="$t1" 'BEGIN{printf "%.1f", s + (b - a)}')
+            if [ "${#_elapsed_ov[@]}" -gt 0 ]; then
+                e="${_elapsed_ov[$((n_pr - 1))]:-0.0}"
+            else
+                e=$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.1f", b - a}')
+            fi
+            lat_samples+=("$e")
+            # Existing `latency=` field stays a running SUM across board PRs
+            # (unchanged — do not turn it into a mean); the distribution stats
+            # are appended separately below (ticket 0353).
+            lat=$(awk -v s="$lat" -v e="$e" 'BEGIN{printf "%.1f", s + e}')
             # A seat that exited 0 but wrote nothing contributes zero findings —
             # count the latency (above) and move on rather than crashing on a
             # missing file.
@@ -384,7 +472,33 @@ case "$subcmd" in
                 'BEGIN{ if (pi==0 && po==0) { print "n/a" } else { printf "$%.4f", p/1e6*pi + c/1e6*po } }')
         fi
 
-        card="audition candidate=${label} model=${model} board=${n_pr}MR findings=${tot} duplicate=${dup} unique-verified=${uv} unique-hallucinated=${uh} overlap=${overlap}% latency=${lat}s cost=${cost}"
+        # Per-run latency distribution (nearest-rank) over the replayed board.
+        p50=$(_percentile 50 ${lat_samples[@]+"${lat_samples[@]}"})
+        p95=$(_percentile 95 ${lat_samples[@]+"${lat_samples[@]}"})
+
+        # Peer-relative SLOW gate (ticket 0353). A candidate is compared only
+        # against OTHER candidates that replayed the SAME board size — identical
+        # work, so the comparison is host- and diff-size-independent. Flag when
+        # this p50 exceeds factor × the cross-candidate median p50 (self included
+        # in the median sample, so a mean-based bug on 10/10/35 is caught). Fires
+        # only with ≥1 peer (a lone candidate has no basis for comparison) and is
+        # a STRICT >, so a boundary candidate at exactly factor × median is kept.
+        # Flagged → the verdict is eliminate-slow (no advisory trial); the prior
+        # candidates' logged lines are never touched (append-only).
+        tickets_dir="${REVIEWERS_TICKETS:-${REPO_ROOT}/tickets}"
+        factor="${REVIEWERS_SLOW_FACTOR:-3}"
+        slow=""
+        peer_p50s=()
+        mapfile -t peer_p50s < <(_audition_peer_p50s "$tickets_dir" "$n_pr" "$label")
+        if [ "${#peer_p50s[@]}" -ge 1 ]; then
+            median=$(_percentile 50 "${peer_p50s[@]}" "$p50")
+            if awk -v x="$p50" -v m="$median" -v f="$factor" 'BEGIN{exit !(x > f * m)}'; then
+                slow=" SLOW"
+                echo "audition: candidate '${label}' flagged SLOW — p50 ${p50}s > ${factor}× peer median ${median}s; eliminate-slow (no advisory trial)" >&2
+            fi
+        fi
+
+        card="audition candidate=${label} model=${model} board=${n_pr}MR findings=${tot} duplicate=${dup} unique-verified=${uv} unique-hallucinated=${uh} overlap=${overlap}% latency=${lat}s cost=${cost} latency-p50=${p50}s latency-p95=${p95}s${slow}"
         echo "$card"
 
         # Append the scorecard to the candidate's trial ticket (erg verbs:
@@ -408,9 +522,9 @@ case "$subcmd" in
         # ticket's move to closed/) — but confined to each file's log section.
         filter="${1:-}"
         tickets_dir="${REVIEWERS_TICKETS:-${REPO_ROOT}/tickets}"
-        fmt='%-9s %-20s %-26s %5s %5s %5s %4s %5s %5s %8s %9s %8s\n'
+        fmt='%-9s %-20s %-26s %5s %5s %5s %4s %5s %5s %8s %9s %8s %8s %5s\n'
         # shellcheck disable=SC2059  # $fmt is a fixed local format, not user input
-        printf "$fmt" KIND NAME MR/BOARD VERIF CONS FIND DUP UVER UHAL OVERLAP LATENCY COST
+        printf "$fmt" KIND NAME MR/BOARD VERIF CONS FIND DUP UVER UHAL OVERLAP LATENCY P95 COST FLAG
         [ -d "$tickets_dir" ] || exit 0
         while IFS= read -r line; do
             [ -n "$line" ] || continue
@@ -424,13 +538,20 @@ case "$subcmd" in
                     uh=$(_card_field unique-hallucinated "$line")
                     ov=$(_card_field overlap "$line")
                     lat=$(_card_field latency "$line")
+                    p50=$(_card_field latency-p50 "$line")
+                    p95=$(_card_field latency-p95 "$line")
                     cost=$(_card_field cost "$line")
                     if [ -z "$name" ] || [ -z "$find" ] || [ -z "$dup" ] || [ -z "$uv" ] || [ -z "$uh" ]; then
                         echo "scores: WARN unparseable audition line: ${line}" >&2; continue
                     fi
                     [ -n "$filter" ] && [ "$filter" != "$name" ] && continue
+                    # LATENCY column shows p50 (the gate-relevant stat); older
+                    # cards without p50 fall back to the running-sum `latency=`.
+                    # The bare ` SLOW` token (ticket 0353) surfaces in FLAG.
+                    latshow="${p50:-$lat}"
+                    flag="-"; case "$line" in *" SLOW") flag="SLOW" ;; esac
                     # shellcheck disable=SC2059
-                    printf "$fmt" audition "$name" "${board:--}" - - "$find" "$dup" "$uv" "$uh" "${ov:--}" "${lat:--}" "${cost:--}"
+                    printf "$fmt" audition "$name" "${board:--}" - - "$find" "$dup" "$uv" "$uh" "${ov:--}" "${latshow:--}" "${p95:--}" "${cost:--}" "$flag"
                     ;;
                 *"MR "*"seat="*"verdict:"*)
                     # Extract the counts as one anchored `N verifiable, M consider`
@@ -443,6 +564,7 @@ case "$subcmd" in
                     # (ticket 0348 review, rounds 1–2).
                     seat="${line#*seat=}"; seat="${seat%% *}"
                     mr="${line#*MR }";     mr="${mr%% *}"
+                    lat=$(_card_field latency "$line")   # per-seat latency (0353), if request left one
                     tally=$(grep -oE '[0-9]+ verifiable, [0-9]+ consider' <<<"$line" | head -1 || true)
                     if [ -z "$seat" ] || [ -z "$tally" ]; then
                         echo "scores: WARN unparseable scorecard line: ${line}" >&2; continue
@@ -451,7 +573,7 @@ case "$subcmd" in
                     cons="${tally##*, }"; cons="${cons%% *}"   # → M
                     [ -n "$filter" ] && [ "$filter" != "$seat" ] && continue
                     # shellcheck disable=SC2059
-                    printf "$fmt" scorecard "$seat" "${mr:--}" "$verif" "$cons" - - - - - - -
+                    printf "$fmt" scorecard "$seat" "${mr:--}" "$verif" "$cons" - - - - - "${lat:--}" - - -
                     ;;
             esac
             # Scan only each ticket's `--- log ---` section, where scorecard/
@@ -461,20 +583,11 @@ case "$subcmd" in
             # section boundary that follows, and never re-enters — so a body line
             # quoting `--- log ---` (the %erg template shows one) cannot fabricate
             # a phantom row or spam WARNs (ticket 0348 review, rounds 1–2).
-        done < <(
             # No pre-filter grep here: the `case` above has no default arm, so a
             # log line matching neither pattern is already a silent no-op -- a
             # second regex re-stating the same two patterns would only risk
             # drifting out of sync with the case arms (simplify review, PR 634).
-            find "$tickets_dir" -name '*.erg' -type f 2>/dev/null | sort | while IFS= read -r f; do
-                awk '
-                    done_log        { next }
-                    !inlog && /^--- log ---/ { inlog=1; next }
-                    inlog && /^--- /         { inlog=0; done_log=1; next }
-                    inlog
-                ' "$f" 2>/dev/null
-            done
-        )
+        done < <(_corpus_log_lines "$tickets_dir")
         ;;
 
     help) usage_text ;;

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -139,7 +139,9 @@ _card_field() {  # key line
 _percentile() {  # pct v1 v2 ...
     local pct="$1"; shift
     [ "$#" -gt 0 ] || { printf '0.0'; return 0; }
-    printf '%s\n' "$@" | sort -g | awk -v p="$pct" '
+    # LC_ALL=C so `sort -g` and awk read `.` decimals regardless of the ambient
+    # locale (a fr_FR locale would otherwise mis-parse "10.5" on the comma).
+    printf '%s\n' "$@" | LC_ALL=C sort -g | LC_ALL=C awk -v p="$pct" '
         { a[NR]=$0 }
         END {
             x = (p / 100.0) * NR
@@ -177,10 +179,13 @@ _audition_peer_p50s() {  # tickets_dir board_size self_label
         case "$line" in *"audition candidate="*) ;; *) continue ;; esac
         [ "$(_card_field board "$line")" = "${bsize}MR" ] || continue
         p50=$(_card_field latency-p50 "$line")
-        [ -n "$p50" ] || continue
+        p50="${p50%s}"
+        # Emit only a well-formed numeric p50 — a malformed card must not coerce
+        # to 0.0 and silently drag the peer median down (ticket 0353 review).
+        case "$p50" in ''|*[!0-9.]*|*.*.*) continue ;; esac
         lbl=$(_card_field candidate "$line")
         [ "$lbl" = "$self" ] && continue
-        printf '%s\n' "${p50%s}"
+        printf '%s\n' "$p50"
     done
 }
 
@@ -380,11 +385,15 @@ case "$subcmd" in
             esac
         done
         label="${label:-$model}"
-        # Reject control characters (newlines/CRs) in the values that flow into
-        # the erg-log scorecard card: an embedded newline would forge a second,
-        # well-formed ticket-log line that `erg check` cannot flag.
-        case "$model" in *[$'\n\r']*) echo "error: audition: model must not contain newlines or carriage returns" >&2; exit 1 ;; esac
-        case "$label" in *[$'\n\r']*) echo "error: audition: --name must not contain newlines or carriage returns" >&2; exit 1 ;; esac
+        # Reject control characters (newlines/CRs) AND the card's field delimiters
+        # (space, `=`) in the values that flow into the space-delimited scorecard
+        # card. A newline would forge a second ticket-log line `erg check` cannot
+        # flag; a space or `=` truncates or hijacks the first-match `_card_field`
+        # parse — e.g. `--name "Local Qwen 30B"` would read back as `Local`,
+        # breaking the peer-median self-exclusion and the `scores` NAME column
+        # (ticket 0353 review). Candidate labels are identifiers, not prose.
+        case "$model" in *[$'\n\r'\ =]*) echo "error: audition: model must not contain spaces, '=', or newlines" >&2; exit 1 ;; esac
+        case "$label" in *[$'\n\r'\ =]*) echo "error: audition: --name must not contain spaces, '=', or newlines" >&2; exit 1 ;; esac
         [ -f "$board" ] || { echo "error: benchmark board not found: ${board}" >&2; exit 1; }
 
         dest="${FINDINGS_DIR}/audition-$$"; mkdir -p "$dest"

--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -132,6 +132,14 @@ _card_field() {  # key line
     printf '%s' "${rest%% *}"
 }
 
+# Elapsed seconds (one decimal) between two `date +%s.%N` stamps. One
+# implementation for request's per-seat timing AND audition's per-PR timing,
+# so a change to how wall-clock is measured cannot drift between the two
+# call sites (ticket 0353 simplify review).
+_elapsed() {  # t0 t1
+    awk -v a="$1" -v b="$2" 'BEGIN{printf "%.1f", b - a}'
+}
+
 # Nearest-rank percentile (1-based) at percentile $1 of the numeric arguments
 # $2..$N. Empty arg list → "0.0". One implementation for audition's per-run
 # p50/p95 AND the peer-relative SLOW median, so the two can never drift apart
@@ -160,14 +168,18 @@ _percentile() {  # pct v1 v2 ...
 _corpus_log_lines() {  # tickets_dir
     local td="$1"
     [ -d "$td" ] || return 0
-    find "$td" -name '*.erg' -type f 2>/dev/null | sort | while IFS= read -r f; do
-        awk '
+    # One awk over the whole file list (FNR==1 resets the per-file latch), not
+    # one awk fork per ticket — the corpus is hundreds of files and `audition`
+    # now scans it on every run (ticket 0353 simplify review). -print0/-0 keep
+    # unusual filenames intact; xargs -r skips awk entirely on an empty list.
+    find "$td" -name '*.erg' -type f -print0 2>/dev/null | sort -z | \
+        xargs -0 -r awk '
+            FNR == 1        { inlog = 0; done_log = 0 }
             done_log        { next }
             !inlog && /^--- log ---/ { inlog=1; next }
             inlog && /^--- /         { inlog=0; done_log=1; next }
             inlog
-        ' "$f" 2>/dev/null
-    done
+        ' 2>/dev/null
 }
 
 # Peer p50 latencies: emit the `latency-p50` seconds (`s` stripped) of every
@@ -283,17 +295,12 @@ case "$subcmd" in
                     # seats run async server-side and get no sidecar — there is
                     # nothing local to time.
                     t0=$(date +%s.%N)
-                    if "$SEAT_RUNNER" --repo "$REPO_ROOT" --branch "$branch" \
+                    "$SEAT_RUNNER" --repo "$REPO_ROOT" --branch "$branch" \
                         --endpoint "$ep" --model "$mo" --out "${dest}/${name}.findings" \
                         ${cred_args[@]+"${cred_args[@]}"} \
-                        >/dev/null 2>"${dest}/${name}.err"; then
-                        seat_ok=1
-                    else
-                        seat_ok=0
-                    fi
+                        >/dev/null 2>"${dest}/${name}.err" && seat_ok=1 || seat_ok=0
                     t1=$(date +%s.%N)
-                    awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.1f", b - a}' \
-                        > "${dest}/${name}.latency"
+                    _elapsed "$t0" "$t1" > "${dest}/${name}.latency"
                     if [ "$seat_ok" = 1 ]; then
                         echo "request: seat '${name}' ok → ${dest}/${name}.findings" >&2
                         ran=$((ran+1))
@@ -432,7 +439,7 @@ case "$subcmd" in
             if [ "${#_elapsed_ov[@]}" -gt 0 ]; then
                 e="${_elapsed_ov[$((n_pr - 1))]:-0.0}"
             else
-                e=$(awk -v a="$t0" -v b="$t1" 'BEGIN{printf "%.1f", b - a}')
+                e=$(_elapsed "$t0" "$t1")
             fi
             lat_samples+=("$e")
             # Existing `latency=` field stays a running SUM across board PRs

--- a/tests/test_reviewers.sh
+++ b/tests/test_reviewers.sh
@@ -145,14 +145,37 @@ reviewers:
     endpoint: http://127.0.0.1:9/v1
     model: openai/stub
 YAML
-    ( cd "$WORK" && REVIEWERS_PANEL="$SCROSTER" ERG="$TSTORE/erg" \
+    TF="$TSTORE/0207-agnostic-cli-reviewer-seat-one-config-op.erg"
+    # Point FINDINGS_DIR at a clean dir so no stale sidecar leaks into the
+    # no-sidecar case (default is /tmp/reviewers, shared across runs).
+    SC_FDIR="$WORK/sc-findings"; mkdir -p "$SC_FDIR"
+    ( cd "$WORK" && REVIEWERS_PANEL="$SCROSTER" ERG="$TSTORE/erg" REVIEWERS_FINDINGS_DIR="$SC_FDIR" \
         "$REVIEWERS" scorecard 42 stub-good "PASS — 0 verifiable, 2 consider" ) >/dev/null 2>&1
-    if "$TSTORE/erg" validate "$TSTORE/0207-agnostic-cli-reviewer-seat-one-config-op.erg" >/dev/null 2>&1 \
-       && grep -q 'MR #42 seat=stub-good' "$TSTORE/0207-agnostic-cli-reviewer-seat-one-config-op.erg"; then
+    if "$TSTORE/erg" validate "$TF" >/dev/null 2>&1 \
+       && grep -q 'MR #42 seat=stub-good' "$TF"; then
         echo "PASS: scorecard appends a valid erg log line"; PASS=$((PASS+1))
     else
         echo "FAIL: scorecard did not append a valid erg log line"; FAIL=$((FAIL+1))
     fi
+    # ── ticket 0353: request-path latency folds into the scorecard line ──────
+    # No sidecar → the line is byte-identical to the pre-0353 schema (no latency).
+    line42=$(grep 'MR #42 seat=stub-good' "$TF" | head -1)
+    if [[ "$line42" == *"latency="* ]]; then
+        echo "FAIL: scorecard: no-sidecar line must not carry latency="; FAIL=$((FAIL+1))
+    else
+        echo "PASS: scorecard: no-sidecar line is byte-identical (no latency=)"; PASS=$((PASS+1))
+    fi
+    assert_contains "scorecard: no-sidecar line ends at the verdict" \
+        "MR #42 seat=stub-good verdict: PASS — 0 verifiable, 2 consider" "$line42"
+    # A `.latency` sidecar (left by `request`) → its seconds fold in at END.
+    mkdir -p "$SC_FDIR/43"; printf '12.3' > "$SC_FDIR/43/stub-good.latency"
+    ( cd "$WORK" && REVIEWERS_PANEL="$SCROSTER" ERG="$TSTORE/erg" REVIEWERS_FINDINGS_DIR="$SC_FDIR" \
+        "$REVIEWERS" scorecard 43 stub-good "PASS — 1 verifiable, 0 consider" ) >/dev/null 2>&1
+    line43=$(grep 'MR #43 seat=stub-good' "$TF" | head -1)
+    assert_contains "scorecard: sidecar latency folded into the line" "latency=12.3s" "$line43"
+    "$TSTORE/erg" validate "$TF" >/dev/null 2>&1 \
+        && { echo "PASS: scorecard: ticket still valid after latency-bearing note"; PASS=$((PASS+1)); } \
+        || { echo "FAIL: scorecard: latency-bearing note broke ticket validity"; FAIL=$((FAIL+1)); }
 else
     echo "SKIP: erg binary absent — scorecard erg-integration test"
 fi

--- a/tests/test_reviewers_audition.sh
+++ b/tests/test_reviewers_audition.sh
@@ -335,5 +335,24 @@ else
     echo "SKIP: erg binary absent — 0353 latency/SLOW tests"
 fi
 
+# ── ticket 0353 review: --name/model reject the card's field delimiters ──────
+# A space or `=` in the label would truncate/hijack the first-match
+# `_card_field` read-back (`--name "Local Qwen 30B"` → candidate "Local"),
+# breaking the peer-median self-exclusion and the scores NAME column.
+for bad in "Local Qwen 30B" "foo=bar"; do
+    if "$REVIEWERS" audition openai/toy --board "$BOARD" \
+            --endpoint http://127.0.0.1:9/v1 --name "$bad" >/dev/null 2>&1; then
+        echo "FAIL: 0353: --name '$bad' (space/=) should exit non-zero"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: 0353: --name '$bad' rejected"; PASS=$((PASS+1))
+    fi
+done
+if "$REVIEWERS" audition "openai/toy model" --board "$BOARD" \
+        --endpoint http://127.0.0.1:9/v1 >/dev/null 2>&1; then
+    echo "FAIL: 0353: model with a space should exit non-zero"; FAIL=$((FAIL+1))
+else
+    echo "PASS: 0353: model with a space rejected"; PASS=$((PASS+1))
+fi
+
 echo ""; echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/test_reviewers_audition.sh
+++ b/tests/test_reviewers_audition.sh
@@ -248,5 +248,92 @@ if [ -x "$ERG_BIN" ]; then
     fi
 fi
 
+# ── ticket 0353: per-run latency stats + peer-relative SLOW gate ─────────────
+# Latency is injected via REVIEWERS_AUDITION_ELAPSED so the stats are
+# deterministic (no sleep, no wall-clock dependence). Peers are hand-written
+# audition cards on the SAME board size (2MR), p50=10.0s each — one open, one
+# archived (proving the closed/ reach) — so the median-vs-mean distinction is
+# real: median(10,10,35)=10 ≠ mean(10,10,35)=18.3.
+if [ -x "$ERG_BIN" ]; then
+    PEERDIR="$WORK/peer-tickets"; mkdir -p "$PEERDIR/closed"
+    cat > "$PEERDIR/0400-peer-a.erg" <<'ERG'
+%erg 0.1
+Title: Peer A
+Created: 2026-07-15
+Author: test
+
+--- log ---
+2026-07-15T00:00Z claude note audition candidate=peer-a model=x board=2MR findings=1 duplicate=0 unique-verified=1 unique-hallucinated=0 overlap=0% latency=20.0s cost=n/a latency-p50=10.0s latency-p95=10.0s
+
+--- body ---
+## Context
+Fixture.
+ERG
+    cat > "$PEERDIR/closed/0401-peer-b.erg" <<'ERG'
+%erg 0.1
+Title: Peer B
+Created: 2026-07-15
+Author: test
+Closed: 2026-07-15
+
+--- log ---
+2026-07-15T00:00Z claude note audition candidate=peer-b model=x board=2MR findings=1 duplicate=0 unique-verified=1 unique-hallucinated=0 overlap=0% latency=20.0s cost=n/a latency-p50=10.0s latency-p95=10.0s
+
+--- body ---
+## Context
+Fixture.
+ERG
+
+    run353() {  # elapsed factor tickets-dir label  → echoes the scorecard card
+        local elapsed="$1" factor="$2" tdir="$3" label="$4"
+        ( cd "$TDIR" && REVIEWERS_FINDINGS_DIR="$WORK/f353" SEAT_RUNNER="$STUB" \
+            ERG="$ERG_FIXTURE" REVIEWERS_TICKETS="$tdir" \
+            REVIEWERS_AUDITION_ELAPSED="$elapsed" REVIEWERS_SLOW_FACTOR="$factor" \
+            "$REVIEWERS" audition openai/toy --board "$BOARD" \
+                --endpoint http://127.0.0.1:9/v1 --trial-ticket "$TRIAL" \
+                --name "$label" 2>/dev/null )
+    }
+
+    # p50/p95 fields present, appended after cost=, and correct (35/35 → 35.0).
+    slow_card=$(run353 "35.0 35.0" 3 "$PEERDIR" cand-slow)
+    assert_contains "0353: card carries latency-p50" "latency-p50=35.0s" "$slow_card"
+    assert_contains "0353: card carries latency-p95" "latency-p95=35.0s" "$slow_card"
+    assert_contains "0353: existing running-sum latency preserved" "latency=70.0s" "$slow_card"
+    # 35 > 3×median(10,10,35)=30 → flagged. A mean-based bug (3×18.3=55) would NOT
+    # flag, so this assertion doubles as the median-not-mean guard.
+    assert_contains "0353: slow candidate flagged SLOW" " SLOW" "$slow_card"
+
+    # Boundary: exactly factor×median (30 = 3×10) is NOT flagged (STRICT >).
+    bound_card=$(run353 "30.0 30.0" 3 "$PEERDIR" cand-bound)
+    assert_contains "0353: boundary p50 present" "latency-p50=30.0s" "$bound_card"
+    if [[ "$bound_card" == *" SLOW"* ]]; then
+        echo "FAIL: 0353: boundary candidate (exactly factor×median) must NOT be flagged"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: 0353: boundary candidate not flagged"; PASS=$((PASS+1))
+    fi
+
+    # Lone candidate: no peers on this board size → never flagged, however slow.
+    LONEDIR="$WORK/lone-tickets"; mkdir -p "$LONEDIR"
+    lone_card=$(run353 "999.0 999.0" 3 "$LONEDIR" cand-lone)
+    if [[ "$lone_card" == *" SLOW"* ]]; then
+        echo "FAIL: 0353: lone candidate (no peers) must never be flagged"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: 0353: lone candidate never flagged"; PASS=$((PASS+1))
+    fi
+
+    # REVIEWERS_SLOW_FACTOR raises the bar: factor 5 → 35 > 5×10=50? no → kept.
+    loose_card=$(run353 "35.0 35.0" 5 "$PEERDIR" cand-loose)
+    if [[ "$loose_card" == *" SLOW"* ]]; then
+        echo "FAIL: 0353: REVIEWERS_SLOW_FACTOR=5 must not flag p50=35 (5×median=50)"; FAIL=$((FAIL+1))
+    else
+        echo "PASS: 0353: REVIEWERS_SLOW_FACTOR raises the threshold"; PASS=$((PASS+1))
+    fi
+    # …and lowers it: factor 2 → 35 > 2×10=20 → flagged.
+    tight_card=$(run353 "35.0 35.0" 2 "$PEERDIR" cand-tight)
+    assert_contains "0353: REVIEWERS_SLOW_FACTOR=2 flags p50=35 (2×median=20)" " SLOW" "$tight_card"
+else
+    echo "SKIP: erg binary absent — 0353 latency/SLOW tests"
+fi
+
 echo ""; echo "Results: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tickets/0353-audition-latency-tracking-relative-slow.erg
+++ b/tickets/0353-audition-latency-tracking-relative-slow.erg
@@ -2,13 +2,12 @@
 Title: Audition and seat latency tracking; eliminate slow candidates on peer statistics
 Created: 2026-07-14
 Author: Minh Ha-Duong
-Blocked-by: 0348
-Closed: 2026-07-14
 
 --- log ---
 2026-07-14T21:13Z Minh Ha-Duong created
 2026-07-14T21:59Z Minh Ha-Duong note Blocked-by 0348 header added — 0348 reached main via PR #613, forward reference now legal
 2026-07-14T22:19Z Minh Ha-Duong closed wontfix — harness cool-down (author): not merge-blocking, not state-corrupting, no science-project impact; audition scorecards already expose mean latency per run, sufficient for seat decisions
+2026-07-15T00:00Z Minh Ha-Duong note reopened under the author's 2026-07-15 raid directive, superseding the PR #632 cool-down close; Blocked-by 0348 now satisfied (0348 merged via PR #634, scores verb on main)
 
 --- body ---
 ## Context

--- a/tickets/0353-audition-latency-tracking-relative-slow.erg
+++ b/tickets/0353-audition-latency-tracking-relative-slow.erg
@@ -43,8 +43,9 @@ to what the other candidates demonstrate is achievable.
 
 1. **Capture, audition path**: record wall-clock per board PR; extend
    the scorecard block with distribution figures
-   (`latency-p50=<s>s latency-p95=<s>s` alongside the existing mean, so
-   existing parsers keep working).
+   (`latency-p50=<s>s latency-p95=<s>s` alongside the existing
+   `latency=` field — which is a running SUM across board PRs, not a
+   mean; left unchanged so existing parsers keep working).
 2. **Capture, request path**: time each seat per merge request and put
    the figure in the seat's `scorecard` fixed-schema line, so live-trial
    evidence accumulates the same statistic.

--- a/tickets/closed/0353-audition-latency-tracking-relative-slow.erg
+++ b/tickets/closed/0353-audition-latency-tracking-relative-slow.erg
@@ -2,6 +2,7 @@
 Title: Audition and seat latency tracking; eliminate slow candidates on peer statistics
 Created: 2026-07-14
 Author: Minh Ha-Duong
+Closed: autoclosed — PR #636
 
 --- log ---
 2026-07-14T21:13Z Minh Ha-Duong created
@@ -9,6 +10,7 @@ Author: Minh Ha-Duong
 2026-07-14T22:19Z Minh Ha-Duong closed wontfix — harness cool-down (author): not merge-blocking, not state-corrupting, no science-project impact; audition scorecards already expose mean latency per run, sufficient for seat decisions
 2026-07-15T00:00Z Minh Ha-Duong note reopened under the author's 2026-07-15 raid directive, superseding the PR #632 cool-down close; Blocked-by 0348 now satisfied (0348 merged via PR #634, scores verb on main)
 
+2026-07-15T01:06Z Minh Ha-Duong closed — autoclosed — PR #636
 --- body ---
 ## Context
 


### PR DESCRIPTION
## Summary

Ticket 0353 (reopened under the 2026-07-15 raid directive, superseding the PR #632 cool-down close). Tracks per-review response time on both reviewer paths and eliminates a candidate that is slow *relative to its peers* on the same frozen benchmark board.

**Audition path** (`skills/reviewers/reviewers.sh`):
- Per-PR elapsed collected into an array; nearest-rank `latency-p50` / `latency-p95` appended after `cost=`. The existing `latency=` field stays a running **SUM** across board PRs — deliberately unchanged (it is not the "mean" the ticket prose implied).
- **Peer-relative SLOW gate**: this candidate's p50 is compared against OTHER candidates that replayed the *same board size*. Flagged with a bare trailing ` SLOW` token (verdict → eliminate-slow, no advisory trial) when `p50 > REVIEWERS_SLOW_FACTOR × cross-candidate median p50` (default factor 3, STRICT `>`, self included in the median sample). Fires only with ≥1 peer; never edits a prior card (append-only); never touches the roster.

**Request path**: each `cli-agent`/`local-model` seat is timed (whatever the outcome) into a `<seat>.latency` sidecar; `forge-bot` seats run async server-side and get no sidecar. `scorecard` folds the sidecar seconds into the trial line at END — absent a sidecar the line is byte-identical to the old schema.

**scores**: `LATENCY` column now shows p50 (fallback to the sum for pre-0353 cards); new `P95` and `FLAG` (SLOW) columns; scorecard rows show per-seat latency. The scores/audition corpus log-scan is factored into a shared `_corpus_log_lines` helper, and `_percentile` serves both the per-run stats and the peer median.

**Tests**: real-time-independent via a `REVIEWERS_AUDITION_ELAPSED` injection seam. Hand-written peer cards (p50 10/10/35 → median 10 ≠ mean 18.3) prove median-not-mean; boundary (30 = 3×10) not flagged; lone candidate never flagged; factor override in both directions; scorecard sidecar byte-identity + validity. `make check` green (858 pytest items + agnostic/skills-drift/bash-suite gates).

## Adherence

Self-gated: `make check` (includes the adherence/agnostic gates) exits 0.

## Report-only notes (author's raid directive: NO follow-up tickets)

- **Board identity is inferred from PR count only.** `board=<N>MR` is the only board discriminator, so two different N-PR boards would be treated as peers. One board ships today, so this is inert — noted, not fixed.
- **Request-path latency has no live non-forge-bot seat to exercise it** until one is enrolled in `panel.yml`; the sidecar + scorecard fold are covered by tests, not by a live run.

**Ticket:** tickets/0353-audition-latency-tracking-relative-slow.erg
