### PR TITLE
gaze(0205): wire external reviewer panel — auto request/harvest/scorecard

### DIFF
--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -103,7 +103,7 @@ applied to build outputs.
 # Subagents
 
 - **Don't spawn for simple tasks.** Single-file edits, grep, reading files — work directly.
-- **Reviewers use a different model than the coder.** Sonnet reviews Opus's work; different blind spots catch more.
+- **Reviewer decorrelation.** The verify panel never shares the coding agent's model. Minimum: the sibling tier of the same family. Stronger: a different vendor or harness entirely (forge review bot, independent CLI agent, local model). Prefer the most-decorrelated reviewer available for the change's risk level.
 - **Pin `model` per-invocation on every fan-out launch — frontmatter does not propagate.** A skill's `model:` frontmatter never reaches the agents it spawns (an Agent-tool child resolves to the session model; a Workflow `agent()` inherits it), so for fan-out it is decorative. Set `model` on each launch: reviewers below the coder tier, mechanical lookups at `haiku`, coders at the top tier. Use the short enum token (`sonnet|opus|haiku`) on a launch — a full `claude-*` id is valid only in frontmatter. `effort` is **not** a launch parameter: a spawned child runs at the *session* effort, not pinnable per-call (set the session effort before a fan-out). Enforced by `tests/test_model_rightsizing.py`; mechanics in memory `feedback_subagent_model_effort_levers`.
 - **Max 8 concurrent agents** (authorized 2026-06-08). Beyond that, coordination overhead exceeds the gains. Keep watch: when 3+ agents touch the same file or registry, open a coordination PR first (see Phase 5.0 in raid skill).
 - **One well-prompted agent first.** Only add agents when a single agent clearly can't handle the task.

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -181,7 +181,7 @@ launch and orphans its reviewers (ticket 0250; see **Fork execution
 contract**). Once all return, collect their structured outputs. Pin every
 read-only reviewer to
 **`model: sonnet`** — reviewers stay below the coder tier (rules/workflow.md
-§ "Sonnet reviews Opus's work"), and an unpinned Agent inherits the session
+§ "Reviewer decorrelation"), and an unpinned Agent inherits the session
 model, so on a top-tier session this fan-out is silently a top-model wave.
 
 **Agent A — adherence** (`/verify-adherence <branch> worktree=$primary_root/.claude/worktrees/review-<pr-number>`
@@ -434,14 +434,44 @@ Explicit human override. Usage: `/gaze <pr-number> --force-approve <reason>`.
   `/verify-wave` (not yet drafted) for post-merge integration testing of a batch.
 - **Merging.** Ever. That is the caller's job.
 
-## External reviewer panel (delegation stub)
+## External reviewer panel
 
 The external, decorrelated reviewer panel — sandboxed CI-style seats over
 agnostic CLI reviewers — is managed by the `/reviewers` skill, not inlined
-here. Its findings are **advisory**: the gate dispositions them like any
-panel comment (only verifiable-class may bounce). The full panel-extension
-contract is ticket 0205's deliverable; seat execution is the 0217
-seat-runner. See `skills/reviewers/SKILL.md`.
+here; seat execution is the 0217 seat-runner. See `skills/reviewers/SKILL.md`.
+This section is the panel-extension contract (ticket 0205).
+
+**When seats fire.** Automatically, on **small**- and **full**-tier CODE
+reviews — the decorrelation evidence concentrates ensemble value on
+substantive multi-file code changes. Skip on the **tiny** tier and on prose
+panels (any `*.qmd` changed). Empty roster or `/reviewers` unavailable →
+skip silently: the panel is fail-open and never blocks a gaze run.
+
+**How.** At the phase 2–4 reviewer-battery launch, also invoke
+`/reviewers request <pr>` as a background *shell* job (a Bash call, not an
+agent launch, so the fork-orphan contract does not apply): the sandboxed
+seats (~30–120 s) run concurrently with the internal reviewer battery and
+finish well inside its wall time. Before phase 6, run
+`/reviewers harvest <pr>` synchronously and hand the normalized
+`verifiable:` / `consider:` findings to the gate as panel comments.
+
+**Disposition.** The gate dispositions external findings identically to
+internal ones (0205 rule 1). Seats are **advisory**: only verifiable-class
+findings may bounce. A seat that errors or hangs WARNs and the review
+proceeds — per-seat fail-open; one seat never blocks the verdict.
+
+**Scorecard (the trial).** After the gate verdict, for each seat that
+returned findings, append the trial line:
+`/reviewers scorecard <pr> <seat> "<verdict — N verifiable, M consider, of
+which K adopted>"`. This fills ticket 0207's advisory trial (≥5 MRs across
+≥3 projects per config) passively from normal gaze runs.
+
+**Advisory → required promotion** (0205 rule 2, condensed). A seat runs
+advisory for at least 5 merge requests spanning at least 3 projects before
+promotion. Promotion is flipping its check from optional to required — a
+manual roster edit by the author, never automatic. LLM review is
+non-deterministic: promote only seats whose verifiable-class findings are
+stable across re-runs; advisory is the safe default.
 
 **Forge automated reviewer** (ticket 0206): the gate's comment-validation
 step includes the forge's automated reviewer (e.g. a requested Copilot

--- a/skills/raid/SKILL.md
+++ b/skills/raid/SKILL.md
@@ -32,7 +32,7 @@ launch below pins `model` explicitly:
 
 - **Imagine / Plan / integration-review** agents (read-only judgement — scope
   reasoning, test design, cross-PR composition) → `model: sonnet`. Reviewers stay
-  below the coder tier (rules/workflow.md § "Sonnet reviews Opus's work").
+  below the coder tier (rules/workflow.md § "Reviewer decorrelation").
 - **Verify-feasibility** agents (Phase 4) split by task: mechanical existence
   checks (do these paths/lines/signatures exist) → `model: haiku`; the cross-ticket
   conflict and cross-cutting-registry scan that gates the Phase 5.0 coordination PR

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -47,7 +47,7 @@ skill **never signs** a tag — that is the human's sole responsibility.
 Launch **three background agents in parallel** (single message, all as
 background agents), each pinned to **`model: sonnet`** — these are read-and-audit
 reviewers (security, UX, doc/test coherence), so they stay below the coder tier
-(rules/workflow.md § "Sonnet reviews Opus's work"); left unpinned they inherit
+(rules/workflow.md § "Reviewer decorrelation"); left unpinned they inherit
 the session model and silently run the fan-out at top tier. Wait for all to
 return, then consolidate.
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -28,7 +28,7 @@ context: fork
 
 Spin multiple agents in parallel, each with a distinct perspective. Run all
 agents in fresh contexts, each pinned to **`model: sonnet`** — reviewers stay
-below the coder tier (rules/workflow.md § "Sonnet reviews Opus's work"), and an
+below the coder tier (rules/workflow.md § "Reviewer decorrelation"), and an
 unpinned Agent inherits the session model, so on a top-tier session this fan-out
 silently becomes a top-model wave.
 


### PR DESCRIPTION
Lands ticket 0205's two remaining doc criteria so the external-reviewer advisory trial fills passively from normal gaze runs.

**skills/gaze/SKILL.md** — the "delegation stub" section becomes the panel-extension contract:
- **When**: seats fire automatically on small/full-tier CODE reviews; skip on tiny tier and prose panels; empty roster or `/reviewers` unavailable → silent skip (fail-open, never blocks gaze).
- **How**: `/reviewers request <pr>` at reviewer-battery launch (background shell job, concurrent with the internal agents, ~30-120 s); `/reviewers harvest <pr>` before phase 6 hands normalized `verifiable:`/`consider:` findings to the gate as panel comments.
- **Disposition**: identical to internal findings; seats advisory — only verifiable-class may bounce; erroring seat WARNs, review proceeds.
- **Scorecard**: after the verdict, `/reviewers scorecard <pr> <seat> "<verdict — N verifiable, M consider, of which K adopted>"` per seat that returned findings — this fills 0207's advisory trial (≥5 MRs / ≥3 projects) without manual labor.
- **Promotion**: advisory ≥5 MRs across ≥3 projects; promotion = manual roster edit flipping optional→required; promote only seats stable across re-runs.
- Forge-bot (Copilot) paragraph and its harness-extension-point comment kept intact.

**rules/workflow.md** — the "Sonnet reviews Opus" bullet replaced with design rule 3's decorrelation gradient (sibling tier minimum → different vendor/harness stronger → most-decorrelated for the risk level).

**raid/release/review-pr SKILL.md** — swept the now-dead section anchor `§ "Sonnet reviews Opus's work"` to `§ "Reviewer decorrelation"`.

Tests: `tests/test_reviewers.sh` 55/55, `test_gaze_fork_blocking` + `test_gaze_review_worktree_doc` + `test_model_rightsizing` + `test_skill_descriptions` + `test_check_agnostic` 36/36, `make check-skills-drift` OK.

Ticket-ref: tickets/0205-external-reviewer-panel-for-verify-contr.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)