### PR TITLE
chore: default new sessions to Sonnet 5 at medium effort

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -97,7 +97,7 @@
       "/home/haduong/CNRS/papiers/actif/AEDIST-technical-report/tickets"
     ]
   },
-  "model": "fable",
+  "model": "sonnet",
   "hooks": {
     "SessionStart": [
       {
@@ -227,7 +227,7 @@
     "Stop": []
   },
   "enabledPlugins": {},
-  "effortLevel": "high",
+  "effortLevel": "medium",
   "tui": "fullscreen",
   "voice": {
     "enabled": true,


### PR DESCRIPTION
Author changed the interactive default (`/model sonnet`) and had a matching local edit sitting dirty in the primary checkout (`effortLevel: high → medium`). Landing both via a proper branch so the primary checkout can go clean.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)