### PR TITLE
feat: add status line showing model, effort, and context usage

### DIFF
--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Status line: model name, reasoning effort, context usage with a progress bar.
+set -euo pipefail
+
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model.display_name')
+EFFORT=$(echo "$input" | jq -r '.effort.level // empty')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+
+BAR_WIDTH=10
+FILLED=$((PCT * BAR_WIDTH / 100))
+EMPTY=$((BAR_WIDTH - FILLED))
+BAR=""
+[ "$FILLED" -gt 0 ] && printf -v FILL "%${FILLED}s" && BAR="${FILL// /▓}"
+[ "$EMPTY" -gt 0 ] && printf -v PAD "%${EMPTY}s" && BAR="${BAR}${PAD// /░}"
+
+LABEL="$MODEL"
+[ -n "$EFFORT" ] && LABEL="$LABEL/$EFFORT"
+
+echo "[$LABEL] $BAR $PCT%"

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,9 @@
 {
   "cleanupPeriodDays": 180,
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/scripts/statusline.sh"
+  },
   "env": {
     "UV_ENV_FILE": "/home/haduong/.claude/.env",
     "BASH_ENV": "/home/haduong/.claude/scripts/bash-env.sh"

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,7 @@
   "cleanupPeriodDays": 180,
   "statusLine": {
     "type": "command",
-    "command": "~/.claude/scripts/statusline.sh"
+    "command": "$HOME/.claude/scripts/statusline.sh"
   },
   "env": {
     "UV_ENV_FILE": "/home/haduong/.claude/.env",


### PR DESCRIPTION
## Summary
- Adds `scripts/statusline.sh`: displays `[Model/effort] ▓▓▓░░░░░░░ NN%` using the documented `context_window.used_percentage` and `effort.level` stdin fields.
- Wires it into `settings.json` via the `statusLine` command field.

There was previously no `statusLine` config at all, which is why the user couldn't find a toggle for it under `/config` — it requires a script, not a settings flag.

## Test plan
- [x] Ran the script with mock JSON (with and without `effort`) and confirmed correct output/progress bar
- [x] Validated `settings.json` remains valid JSON
- [ ] User confirms the status line renders correctly in a live session (requires restart/next interaction to pick up the new config)

Ticket: none