### PR TITLE
memory: statusLine $HOME lesson + correct stale worktree-exemption note

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,8 @@
 
 ## Entries
 
+- [statusLine command needs $HOME not ~](project_statusline_command_no_tilde_expansion.md) — settings.json command entries must not rely on tilde expansion; gaze caught a blank-statusline risk (PR #648, 2026-07-15)
+- [Memory-write worktree exemption contradicted by live guard](feedback_memory_writes_bypass_worktree_gate.md) — a primary-checkout memory write was blocked despite the documented exemption; write the worktree copy and land via PR until reconfirmed (2026-07-15)
 - [Harness cool-down: stop second-order tooling](feedback_harness_cooldown_stop_second_order_tooling.md) — author is done with nitpick tickets and fixes-to-fixes (2026-07-14); file a harness ticket only if the defect blocks a merge, corrupts state, or bites a science project; sweeps report instead of minting tickets; prefer deleting a misfiring guard to patching it; point throughput at the science repos
 - [BASH_ENV/hook tests must exercise the real invocation path](feedback_bash_env_tests_real_invocation_path.md) — sourcing a BASH_ENV script in the test's own shell misses re-entry, ambient inheritance, and export-boundary bugs (three security defects passed the unit suite); test via `env -i HOME=… BASH_ENV=… bash -c …` (PRs #599/#604, 2026-07-14)
 - [Untrusted .env export is a code-execution class](feedback_untrusted_env_export_is_code_execution.md) — the RCE surface is the interpreter-critical namespace (GCONV_PATH, LD_PRELOAD/LD_AUDIT, BASH_ENV/ENV, PYTHONPATH/NODE_OPTIONS/NODE_PATH/PERL5LIB/RUBYOPT, PATH), not just GUARD_ vars; default-deny, never source (ticket 0345, 2026-07-14)

--- a/projects/-home-haduong--claude/memory/feedback_memory_writes_bypass_worktree_gate.md
+++ b/projects/-home-haduong--claude/memory/feedback_memory_writes_bypass_worktree_gate.md
@@ -1,0 +1,27 @@
+---
+name: feedback-memory-writes-bypass-worktree-gate
+description: Memory-file writes to the primary checkout are blocked by the live tool guard during a worktree session — write the worktree copy and land it via the branch's own PR
+metadata:
+  type: feedback
+---
+
+An earlier version of this note claimed `~/.claude/projects/*/memory/**`
+writes bypass worktree isolation by design, citing an exemption in
+`scripts/pretooluse-worktree-path-guard.sh`. Observed behavior on
+2026-07-15 contradicts that: a `Write` to the primary-checkout memory path
+was blocked with "Edit the worktree copy of this file instead of the
+shared-checkout path" — a different message than that script emits, meaning
+a platform-level Write/Edit gate now enforces worktree isolation on this
+path independent of the custom hook's exemption.
+
+**Why:** trust the live guard's exit behavior over a stored claim about it
+([[feedback_memory_writes_bypass_worktree_gate]] itself, ironically) — the
+hook script's carve-out may be dead code now, or the platform added its own
+stricter check on top. Either way, the write was in fact blocked.
+
+**How to apply:** during a worktree session, write memory files to the
+worktree-rooted path (`<worktree>/projects/*/memory/**`), commit them, and
+land them through that branch's normal PR — do not assume a bare
+primary-checkout write will succeed. If a future session confirms the
+exemption works again (no block), update this note rather than trusting
+either version blindly.

--- a/projects/-home-haduong--claude/memory/project_statusline_command_no_tilde_expansion.md
+++ b/projects/-home-haduong--claude/memory/project_statusline_command_no_tilde_expansion.md
@@ -1,0 +1,12 @@
+---
+name: project_statusline_command_no_tilde_expansion
+description: settings.json statusLine.command must use $HOME, not ~ — some invokers skip shell expansion
+metadata:
+  type: project
+---
+
+`settings.json`'s `statusLine.command` field must use `$HOME/.claude/...`, not `~/.claude/...`, matching every other command entry in the file.
+
+**Why:** `/gaze` round 1 on PR #648 flagged this as a real risk, not a style nit: if the invoker spawns the command without shell interpretation, `~` never expands and the status line silently goes blank — defeating the whole point of the config. Fixed in commit `4a274a9`.
+
+**How to apply:** when adding or editing any `command` entry in `settings.json` (statusLine, hooks, etc.), grep the file for the existing convention first (`$HOME` here) and match it rather than defaulting to `~`.


### PR DESCRIPTION
## Summary
- New memory: settings.json statusLine.command must use $HOME not ~ (gaze caught this as a real blank-statusline risk on PR #648, not a style nit).
- Corrects `feedback_memory_writes_bypass_worktree_gate.md`: this session observed a primary-checkout memory write actually blocked by the live guard, contradicting the note's claim of a standing exemption. Updated to reflect observed behavior and route future memory writes through the worktree + PR.

Ticket: none