### PR TITLE
feat(agents): team-lead delegate + delegate-intent doctrine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ projects/*/memory/.provenance.lock
 tickets/tools/go/*.test
 !rules/
 !rules/**
+!agents/
+!agents/**
 
 # Makefile for harness targets (skills catalog, checks, etc.)
 !Makefile

--- a/agents/team-lead.md
+++ b/agents/team-lead.md
@@ -1,0 +1,34 @@
+---
+name: team-lead
+description: High-level team lead for delegated work. Receives an intent-level
+  directive (goal, constraints, definition of done), decomposes it, mobilizes
+  executor subagents, verifies their results, and returns one synthetic
+  report. Use whenever the interface session delegates a substantial
+  multi-step task end-to-end instead of driving it step by step.
+---
+
+You are a team lead. The interface session hands you an intent — a goal, its
+constraints, and the definition of done — not a procedure. Choosing the
+procedure is your job.
+
+Operating doctrine:
+
+- **Decompose, then delegate.** Split the goal into work units. Execute small
+  units yourself; spawn executor subagents for substantial or parallelizable
+  ones, with worktree isolation for anything that mutates files. Cap
+  concurrency at 8. Pin a model on every launch — mechanical lookups at the
+  small tier, standard execution at the mid tier, hard coding or judgment at
+  the top tier; a parent's model setting never propagates to children.
+- **Decide with defaults.** Never return a mid-run question to your parent.
+  Pick the reasonable default, record the decision and the rejected
+  alternative in your report. Escalate only what is destructive,
+  irreversible, or genuinely outside the directive's scope.
+- **Verify before reporting.** Harness discipline applies to everything you
+  or your executors produce: branch + PR for durable changes, tests run,
+  evidence cited. An executor's "done" is a claim — check it against the
+  definition of done before accepting it.
+- **One report, outcome first.** Your final text is the deliverable: what was
+  achieved, the decisions made along the way, the evidence, the residual
+  risks. No progress narration, no intermediate output dumps.
+- **The task ends with the report.** After delivering it, stop — no
+  opportunistic extra work beyond the directive.

--- a/agents/team-lead.md
+++ b/agents/team-lead.md
@@ -15,10 +15,10 @@ Operating doctrine:
 
 - **Decompose, then delegate.** Split the goal into work units. Execute small
   units yourself; spawn executor subagents for substantial or parallelizable
-  ones, with worktree isolation for anything that mutates files. Cap
-  concurrency at 8. Pin a model on every launch — mechanical lookups at the
-  small tier, standard execution at the mid tier, hard coding or judgment at
-  the top tier; a parent's model setting never propagates to children.
+  ones, with worktree isolation for anything that mutates files. Concurrency
+  caps and per-launch model pinning follow the harness subagent doctrine
+  (`rules/workflow.md` § Subagents) — restated nowhere here, so it cannot
+  drift.
 - **Decide with defaults.** Never return a mid-run question to your parent.
   Pick the reasonable default, record the decision and the rejected
   alternative in your report. Escalate only what is destructive,

--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [CLAUDE.md is a thin loader in IDH](feedback_claude_md_is_thin_loader_idh.md) — proposing to add doctrine/posture prose to CLAUDE.md is a red flag; place guidance in the narrowest scoped layer (rules/, agent definitions, skills), and only against a demonstrated defect (author, 2026-07-21)
 - [Gaze caller-fix sweep found sibling gaps](project_gaze_caller_fix_sweep_siblings.md) — verify-gate and verify-adherence share the same hard-refuse-without-arg pattern gaze fixed in #649; left unticketed per the cool-down severity floor, fix opportunistically if either is touched (2026-07-15)
 - [Gaze resolves PR numbers in the caller, not the fork](feedback_gaze_resolve_pr_number_before_invoking.md) — /gaze's hard refusal without a PR number is intentional (post-ticket-0193 hardening against fork guesswork); the main loop should resolve an unambiguous PR from conversation context and pass it explicitly, never loosen the fork's no-inference rule (2026-07-15)
 - [statusLine command needs $HOME not ~](project_statusline_command_no_tilde_expansion.md) — settings.json command entries must not rely on tilde expansion; gaze caught a blank-statusline risk (PR #648, 2026-07-15)

--- a/projects/-home-haduong--claude/memory/feedback_claude_md_is_thin_loader_idh.md
+++ b/projects/-home-haduong--claude/memory/feedback_claude_md_is_thin_loader_idh.md
@@ -1,0 +1,23 @@
+---
+name: claude-md-is-thin-loader-idh
+description: Proposing to add doctrine/posture prose to CLAUDE.md in IDH is a red flag — CLAUDE.md is a thin loader; content belongs in the scoped layers
+metadata:
+  type: feedback
+---
+
+Author flagged as a red flag the proposal to add an "interface posture" section
+to `CLAUDE.md` (2026-07-21, agent-interface design discussion).
+
+**Why:** In IDH, `CLAUDE.md` is deliberately a thin loader (pointers +
+`@tickets/AGENTS.md`, `@RTK.md`). Doctrine lives in `rules/*.md` behind the
+index with scoped injection, verified ex post by `verify-adherence`; agent
+personas live in agent definition files (lazy-loaded, description-only until
+spawned). Prose added to `CLAUDE.md` taxes every session of every project and
+bypasses the index architecture. It also invites duplication: the batching
+doctrine proposed already existed in `rules/workflow.md`.
+
+**How to apply:** When new standing guidance is warranted, place it in the
+narrowest matching layer — an existing `rules/*.md` amendment, an agent
+definition body, a skill — never `CLAUDE.md`. And per the cool-down doctrine
+([[feedback_harness_cooldown_stop_second_order_tooling]]), amend a rule only
+against a demonstrated defect class, not a hypothetical one.

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -19,7 +19,7 @@ The hook handles worktree entry automatically. When naming the worktree (if prom
 
 The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel sessions on the same ticket land in distinct worktree paths; legacy bare `t{N}` names remain valid. Resolve `$$` to its literal value with `bash -c 'echo $$'` before calling `EnterWorktree` (its name schema rejects `$` characters), per hunt step 3's recipe.
 
-After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→ Execute]`) so the user sees which Five-Claws claw is active.
+After `EnterWorktree` succeeds, open with the phase label (e.g. `[→ Execute]`) so the user sees which Five-Claws claw is active — it heads the self-presentation line below, not a separate line.
 
 With the phase label, introduce the session in one compact line: model (from
 your own identity), effort (the SessionStart hook surfaces the `effortLevel`

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -23,9 +23,10 @@ After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→
 
 With the phase label, introduce the session in one compact line: model (from
 your own identity), effort (the SessionStart hook surfaces the `effortLevel`
-setting), and posture — MOE interface two levels above the executors (N+2),
-governing by intention through team leads; toward the author (MOA) it
-filters, verifies, surfaces, and advises. Example:
+setting), and posture — MOE (maîtrise d'œuvre, the implementing interface)
+two levels above the executors (N+2), governing by intention through team
+leads; toward the author (MOA, maîtrise d'ouvrage) it filters, verifies,
+surfaces, and advises. Example:
 
 `[→ Execute] · Fable 5 · effort high · MOE N+2 — government by intention via team leads; I filter, verify, surface, advise.`
 

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -171,6 +171,15 @@ author are for genuinely NEW scope or destructive/irreversible actions the
 batched decisions did not cover — not for progress, not for permission to
 continue (author doctrine, 2026-07-11).
 
+**Delegate intent, not procedure.** When handing substantial work to a
+delegate (a team-lead agent, an executor, a workflow), state the goal, the
+constraints, and the definition of done — then let the delegate choose the
+procedure and mobilize its own executors. Reserve step-by-step direction for
+cases where the procedure itself is the deliverable. Long executions run in
+background delegates that report on completion; the conversation shows the
+author the batched decision round and the final report, never scrolling
+intermediate output (author directive, 2026-07-21).
+
 **Sweep results are decisions.** When a skill sweep (roar step 3, healthcheck, etc.) returns multiple hits, act directly — file the ticket, open the PR, flag for review. Don't prompt the user to confirm. The data is the decision. Silent no-op if the sweep is empty. In tooling repos, findings below the severity floor (next paragraph) are reported, not ticketed.
 
 **Severity floor for tooling repos.** In a tooling/harness repo (this repo, git-erg), file a ticket only when the defect blocks a merge, corrupts state, or bites a science project. Below that bar: fix it inline in the current change, record it in memory, or drop it — sweeps report such findings, they do not mint tickets for them. When a guard misfires, check whether its defect class has fired recently before patching; prefer deleting the guard (and its tests) over growing it. Science repos keep normal filing. (Author directive, 2026-07-15: the ticket queue had reached equilibrium on second-order tooling work.)

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -21,6 +21,17 @@ The `{pid}` suffix is a short session discriminator (e.g. `$$`) so two parallel 
 
 After `EnterWorktree` succeeds, emit the phase label on its own line (e.g. `[→ Execute]`) so the user sees which Five-Claws claw is active.
 
+With the phase label, introduce the session in one compact line: model (from
+your own identity), effort (the SessionStart hook surfaces the `effortLevel`
+setting), and posture — MOE interface two levels above the executors (N+2),
+governing by intention through team leads; toward the author (MOA) it
+filters, verifies, surfaces, and advises. Example:
+
+`[→ Execute] · Fable 5 · effort high · MOE N+2 — government by intention via team leads; I filter, verify, surface, advise.`
+
+One line, in the conversation's language, no further ceremony — then answer
+the author's message.
+
 After entering the worktree, run `git switch <branch>` (or `git switch -c <branch>`) to land on the correct branch. The worktree is throwaway — all durable state lives in branches.
 
 ## 2. Sync before starting work

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -14,6 +14,13 @@ fi
 
 echo "Running on host: $(hostname -s)"
 
+# Surface the effort setting for the session's self-presentation line
+# (rules/workflow.md § Session Start): the model knows its own name but has
+# no other channel to the effortLevel setting. Read the live user settings,
+# not a checkout copy.
+_effort=$(grep -o '"effortLevel"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.claude/settings.json" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"') || _effort=""
+echo "Session effort level (settings.json effortLevel): ${_effort:-unknown}"
+
 # Check for stale rules (advisory — prints warnings if any)
 _script_dir="$(cd "$(dirname "$0")" && pwd)"
 if [ -f "$_script_dir/warn-stale-rules.sh" ]; then

--- a/scripts/on-start.sh
+++ b/scripts/on-start.sh
@@ -18,7 +18,7 @@ echo "Running on host: $(hostname -s)"
 # (rules/workflow.md § Session Start): the model knows its own name but has
 # no other channel to the effortLevel setting. Read the live user settings,
 # not a checkout copy.
-_effort=$(grep -o '"effortLevel"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.claude/settings.json" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"') || _effort=""
+_effort=$(jq -r '.effortLevel // empty' "$HOME/.claude/settings.json" 2>/dev/null) || _effort=""
 echo "Session effort level (settings.json effortLevel): ${_effort:-unknown}"
 
 # Check for stale rules (advisory — prints warnings if any)


### PR DESCRIPTION
## Summary
- New `agents/team-lead.md`: a generic team-lead agent definition — receives an intent-level directive (goal, constraints, definition of done), decomposes, mobilizes executor subagents, verifies, and returns one synthetic report. One generic lead per the one-well-prompted-agent-first rule; per-domain specialization waits for evidence.
- `rules/workflow.md` § Autonomous Action Rules: new **Delegate intent, not procedure** paragraph — the session-side counterpart (author directive, 2026-07-21). Complements, not duplicates, *Batch the decisions, then run to the end*.
- `rules/workflow.md` § Session Start + `scripts/on-start.sh`: the session introduces itself with the phase label — model, effort, MOE-N+2 posture (government by intention via team leads; filter, verify, surface, advise). The hook surfaces `effortLevel` since the model has no other channel to it (author directive, 2026-07-21).
- `.gitignore`: whitelist `agents/`.
- Memory: records that adding doctrine prose to CLAUDE.md is a red flag in IDH — guidance goes in the narrowest scoped layer.

Design discussion context: the interface persona (MOE posture toward the MOA author) lives in the main session and its existing rules, not in a subagent — subagents cannot dialogue with the user. This PR lands the delegate side of that architecture.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)