### PR TITLE
rules: PDF finishing standard (automate pagination, scripted checklist)

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -12,6 +12,7 @@ files on demand when their scope signal applies to your task.
 | [edm.md](./edm.md) | skill-list: `zotero-import`, `index-source` | EDM discipline — Zotero is the system of record; `docs/` and `.bib` are git-ignored staging, synced and purged on archival. |
 | [coding-python.md](./coding-python.md) | edit of `*.py` (alias: `format/python`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
 | [coding-bash.md](./coding-bash.md) | edit of `*.sh` (alias: `format/bash`) | Bash `set -euo pipefail` discipline: arithmetic-zero abort, unbound associative-array key. |
+| [pdf-finishing.md](./pdf-finishing.md) | finishing pass of any PDF deliverable (submission, deposit, personal page) | Automate pagination (titlesec, widow penalties, dash-ratio widths); scripted pdftotext checklist; variants as archived transform layers. |
 | [prose/_all.md](./prose/_all.md) | edit of any prose file (`*.tex` `*.qmd` `*.md` `*.txt`) | Universal prose rules: LLMism guards, Elements of Style. |
 | [doctype/techreport.md](./doctype/techreport.md) | edit of a `techreport` file (`\documentclass{report}` or manifest) | Report conventions: standalone abstract, numbered floats with takeaway captions, label cross-references. |
 | [doctype/slides.md](./doctype/slides.md) | edit of a `slides` file (`\documentclass{beamer}` or manifest) | Slide conventions: one idea per slide, takeaway titles, fragments not paragraphs. |

--- a/rules/pdf-finishing.md
+++ b/rules/pdf-finishing.md
@@ -2,7 +2,11 @@
 
 Quality bar for any PDF deliverable that leaves the workshop — journal
 submission, preprint deposit (HAL, Zenodo), personal page, report handoff.
-Applies at the *finishing pass*, after content is frozen.
+
+**Keyword: « finition ».** This pass runs when the author asks for it, and the
+agent *proposes* it when a deliverable enters finalization (submission, deposit,
+upload imminent). Never during drafts: while content moves, pagination polish
+is churn — the finishing pass presupposes frozen content.
 
 ## Automate first, paginate by hand never
 

--- a/rules/pdf-finishing.md
+++ b/rules/pdf-finishing.md
@@ -1,0 +1,50 @@
+# PDF finishing standard
+
+Quality bar for any PDF deliverable that leaves the workshop — journal
+submission, preprint deposit (HAL, Zenodo), personal page, report handoff.
+Applies at the *finishing pass*, after content is frozen.
+
+## Automate first, paginate by hand never
+
+Layout intent belongs in the header/config, declared once — not in
+hand-inserted `\newpage` rounds that any upstream edit re-opens (cost of
+skipping: 8 interactive re-render rounds on the Œconomia page-perso variant,
+2026-07-22). For a Quarto/LaTeX build, the standard knobs:
+
+- **Sections on fresh pages** (long-form ≥ 20 pp):
+  `\usepackage{titlesec}` + `\newcommand{\sectionbreak}{\clearpage}`.
+- **Widows and orphans**: `\widowpenalty=10000 \clubpenalty=10000`.
+- **Pipe-table column widths**: pandoc maps the delimiter-row dash counts to
+  relative widths — set the ratios there; narrow the label columns, give the
+  analytic columns the room. Only if a longtable still splits, one `\newpage`
+  before it.
+- **Bibliography density**:
+  `\AtBeginEnvironment{CSLReferences}{\small\setlength{\parskip}{0.3em}}`.
+
+## The finishing checklist — verified by script, not by eyeballing
+
+Run a `pdftotext` sweep over the rendered PDF and check mechanically:
+
+1. No table or figure split across pages; caption on the same page as its float.
+2. No heading as the last line of a page; no 1–2-line widow above a heading
+   at a page top.
+3. No missing glyphs (grep the extraction for `�` / check `pdffonts`) —
+   math-mode symbols, not text-mode Unicode, for ≈/≤/… in Latin Modern.
+4. Page size intentional (A4 unless the venue says otherwise), page count and
+   metadata (title, author) match the variant.
+5. Identity matches the variant: anonymous builds carry zero de-anonymizing
+   strings (grep author name, repo URLs, DOIs); named builds carry the
+   restored links.
+6. Links resolve: spot-check DOIs and URLs added at finishing time.
+
+Eyeballing the PDF stays mandatory for what scripts can't see
+(`feedback_visual_verify_citations`), but the pagination sweep is script work.
+
+## Variants are transform layers
+
+A named/deposit variant (HAL, page perso) is a script that applies string
+transforms to the shared source, renders, and reverts (`apply → render →
+git checkout --`). The script is archived beside the release artifacts, so
+the variant is reproducible. Reference implementation:
+`papiers/sent/Oeconomia_Inventing_Climate_Finance/releases/hal_variant.py`
+(climate-finance-het, 2026-07-22).


### PR DESCRIPTION
Ticket: none

Author-directed standing rule from the 2026-07-22 Œconomia finishing session: PDF pagination polish must be automated (titlesec \sectionbreak, widow/club penalties, pandoc dash-ratio column widths, CSLReferences sizing) rather than hand-paginated; the finishing checklist (unsplit floats, no orphan headings, no missing glyphs, variant-correct identity, resolving links) is verified by a pdftotext script sweep; deposit variants are archived transform-layer scripts. Index row added to rules/README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)