### PR TITLE
revert: back out #657 — machine-local state does not belong in the harness

### DIFF
--- a/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
@@ -15,13 +15,9 @@
 ## Entries
 - [Preprint target is main.md](project_preprint_target_main_md.md) — report.tex internal only; 0255-0262 deferred (pre-registered, never close-silently); H5 wiki count in Annex C (5/20 optimised violations); Annex E = recognition matrix
 - [Reference v2.1 adopted](project_reference_v2_adopted.md) — 173 plants PR #780 (extensions standalone); master replay pending (0458); ratchet 0447
-- [Plan-agent test inversion](feedback_plan_agent_test_inversion.md) — reframing plans can sign-flip the original red test while exit criteria stay intact; diff the Test section too (raid 0544)
 - [Async agent continuation](feedback_async_agent_continuation.md) — no SendMessage here; original agent may self-resume; fresh agents need isolation:worktree
-- [Gaze fork async reviewers vs auto-merge](feedback_gaze_fork_async_reviewers_automerge_race.md) — gaze can return mid-flight; never queue auto-merge before all 3 reviewer reports arrive (PR #983 merged 1 min before two real blockers; fix-forward #986)
 - [Peek/kill sibling sessions](reference_peek_kill_sibling_sessions.md) — no cross-session viewer; peek via `tail -f` of `~/.claude/projects/<proj>/*.jsonl`; map PID→worktree with `readlink /proc/<pid>/cwd` (the one matching your cwd is YOU — don't kill it); kill only idle+merged+no-lock; remove worktree after process dead
 
-- [Light review for mechanical diffs](feedback_light_review_for_mechanical_diffs.md) — user CO2 remark (raid 0558): scale review depth to diff risk; pure-substitution diffs get one reviewer, not the gaze panel
-- [Chore-close staging + late close](feedback_chore_close_staging_and_late_close.md) — git add after erg close (git mv stages pre-edit content); re-check closed/ before chore-closing (hunts close late)
 - [Phase build layout](project_phase_build_layout.md) — one .mk per phase since 2026-06-04 (acquire/score/render + root staleness/world); old root verbs tables/figures/census/measurements DELETED
 - [Make stamp discipline](feedback_make_stamp_discipline.md) — dynamic multi-output stamps (armN_flat) are CORRECT; single-output-dressed-as-stamp is the hack (exp1_cross_eval, 0460); pair conversion with .DELETE_ON_ERROR (was build-wide missing; 0461 generalizes)
 - [Greedy-glob class](project_greedy_glob_class.md) — CLOSED (0495/0496/0499); run-dir consumers skip reconciliation_ PREFIX + _filtered.csv SUFFIX (the real filtered artifact is a suffix not a filtered_ prefix); standing test test_no_colocated_output_leak.py; verify artifact name against the writer not the ticket premise
@@ -29,7 +25,6 @@
 - [Concurrent author-session raids](feedback_concurrent_author_session_raids.md) — re-verify ticket open/closed on origin/main before every execute launch; never touch sibling-session worktrees; don't bundle whole tickets/ snapshots into content PRs
 - [Pre-commit hook commit ordering](feedback_precommit_hook_commit_ordering.md) — adherence hook runs working-tree tests against the index; order multi-commit series green, slice with `git commit -- <paths>`
 - [Optimistic concurrency for ticket IDs](feedback_optimistic_concurrency_ticket_ids.md) — no reservation machinery (wontfix 0427, git-erg#282); collision = renumber; CI detects (0418)
-- [Ratchet race + dropped close](feedback_ratchet_ceiling_race_and_dropped_close.md) — ceiling files race parallel prose merges (re-init OK); post-queue rebase can drop erg-pr-merge close commit — check origin/main closed/ before re-closing
 - [erg close bookkeeping conflict](feedback_erg_close_bookkeeping_conflict.md) — parallel closes of sibling blockers conflict in the THIRD ticket's Blocked-by lines; keep both notes, drop both headers
 - [quickpr limitations](feedback_quickpr_limitations.md) — no renames/deletions; restoring the starting branch reverts working-tree edits
 - [Parallel push during investigation](feedback_parallel_push_during_investigation.md) — always branch from `origin/main` after fetch, not local HEAD; user may push directly while agent investigates
@@ -96,9 +91,6 @@
 - [Beamer plain frame sizing](feedback_beamer_plain_frame_sizing.md) — [plain] full-page figure frames need width=\paperwidth AND height=\paperheight with keepaspectratio
 - [size_class per-record split](feedback_size_class_per_record_split.md) — model attrs in measurements.jsonl can vary across reps; resolve once per model before sorting, not per record
 - [/merge leaves worktree on main](feedback_merge_leaves_worktree_on_main.md) — after merge, worktree's HEAD is on local main; branch BEFORE the next Edit or stray commits land on main
-- [Gaze fork orphans reviewers](feedback_gaze_fork_orphans_reviewers.md) — forked /gaze may end mid-flight; its reviewers still deliver via task-notifications; wait a beat before relaunching; if fork bails twice, run /verify-gate directly once reviews are in
-- [Human sign-off criterion not waivable](feedback_human_signoff_criterion_not_waivable.md) — classifier blocks self-waiving "author approves" via STATE override mode; prep everything, needs-input the author
-- [PYTEST_ADDOPTS breaks uv pytest](feedback_pytest_addopts_env_breaks_uv_pytest.md) — bg-job env injects --cache-dir pytest rejects; `env -u PYTEST_ADDOPTS make check`
 - [Main repo on foreign branch](feedback_main_repo_on_foreign_branch.md) — during a raid the main checkout may be on another session's feature branch; ticket-closure/STATE commits meant for main land wrong — switch a worktree to main instead
 - [pathlib with_suffix on dotted stems](feedback_pathlib_with_suffix_dotted_stems.md) — `Path("foo.bar-baz").with_suffix(".x")` returns `foo.x`; use string slicing when input stem may contain dots
 - [make rebuild-measurements destroys records](feedback_make_rebuild_measurements_destroys_records.md) — deletes ALL .record.json before regenerating; if downstream fails you lose cohort records, restore from git
@@ -107,7 +99,6 @@
 - [claude-code-cli route](reference_claude_cli_route.md) — ticket 0160 / PR #395; runs Claude via user's CC session, no ANTHROPIC_API_KEY; suggest for capability checks (NOT controlled sweeps — no T=0/seed/max_tokens)
 - [Run adherence tests locally before push](feedback_run_adherence_locally_before_push.md) — `pytest -m adherence` catches plot-color/import violations in 30s; saves a CI round-trip
 - [erg-pr-merge partial success](feedback_erg_pr_merge_partial_success.md) — if ticket-close push succeeded but merge failed, ticket already closed; skip to `gh api .../merge` directly
-- [Merge classifier blocks autonomous raid](feedback_merge_classifier_blocks_autonomous_raid.md) — classifier ignores STATE standing merge authorization; end raid with needs-input merge handoff; killed erg-pr-merge leaves stale pre-rebase INDEX in PR worktree (reset --hard before gc)
 - [CI chore-bypass via workflow path-filter](project_ci_chore_bypass_workflow.md) — DONE (#458): CI.yml skips lint/tests on ticket/STATE-only diffs (dorny/paths-filter, predicate-quantifier every, fail-safe)
 - [gh pr merge --delete-branch in worktree](feedback_gh_pr_merge_delete_branch_worktree.md) — drop `--delete-branch` from a worktree (main-lock error); merge succeeds server-side; auto-merge now enabled repo-wide
 - [Agent identity separation](project_agent_identity_separation.md) — post-conference: give Copilot/HDMX-coding-agent a non-admin GitHub identity so `enforce_admins: true` actually protects against agent red-merges

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_optimistic_concurrency_ticket_ids.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_optimistic_concurrency_ticket_ids.md
@@ -12,5 +12,3 @@ Author decision (2026-06-04, after three same-day ID collisions): no reservation
 **Why:** Collisions are rare and cheap to fix (rename to next free ID, one commit); a reservation system (remote refs, push side effects) adds failure modes worse than the disease. git-erg#282 closed wontfix; ticket 0427 closed wontfix.
 
 **How to apply:** Keep allocating optimistically (`erg new` after a fetch — the interim fetch-first habit stays, see [[feedback-ticket-id-collision-check]]). On collision at merge time: renumber, don't redesign. Detection belongs to `erg check` in CI (ticket 0418). Do not re-propose reservation/locking for ticket IDs.
-
-**Wrinkles from raid 541+543 (2026-06-12, double collision 0549→0550→0552):** (1) `git commit -am` does NOT stage a freshly-created untracked `.erg` — the ticket reference then points at a phantom file (caught by verify-gate as a REROLL); `git add` the new ticket explicitly. (2) Scanning origin/main is not enough on a busy night — sibling sessions' unmerged branches hold claimed IDs; scan all remote branches (`git branch -r` + `ls-tree`) before renumbering, and expect `erg check` in CI to be the final arbiter after rebase.

--- a/settings.json
+++ b/settings.json
@@ -91,57 +91,7 @@
       "Read(//home/haduong/CNRS/papiers/actif/AEDIST-technical-report/**)",
       "Bash(rtk git *)",
       "Bash(rtk grep *)",
-      "Bash(~/.claude/skills/merge/erg-pr-merge:*)",
-      "Bash(ssh -f -N -L 11434:127.0.0.1:11434 padme)",
-      "Bash(cp __TRACKED_VAR__/ADR.md .)",
-      "Bash(cp -r __TRACKED_VAR__/diagrams report/)",
-      "Bash(mkdir -p tools/pdfOCR2md)",
-      "Bash(cp __TRACKED_VAR__/pdfOCR2md/Makefile __TRACKED_VAR__/pdfOCR2md/pdfOCR2md.py tools/pdfOCR2md/)",
-      "Bash(mkdir -p publications/journal-article)",
-      "Bash(mv src/aedist/select_top.py src/aedist/select_models.py)",
-      "Bash(mv tests/test_select_top.py tests/test_select_models.py)",
-      "Edit(*/.git/hooks/*)",
-      "Bash(git fetch:*)",
-      "Bash(gh repo:*)",
-      "Bash(git -C /home/haduong/.claude status -s)",
-      "Bash(git -C /home/haduong/.claude diff)",
-      "Bash(git -C /home/haduong/.claude log --oneline -5)",
-      "Bash(CLAUDE_PROJECT_DIR=/home/haduong/aedist-technical-report bash -c 'source /home/haduong/.claude/hooks/on-start.sh')",
-      "Bash(bash ~/.claude/hooks/on-start.sh)",
-      "Bash(gh pr:*)",
-      "Bash(make preflight:*)",
-      "Bash(gh issue:*)",
-      "Bash(python -m pytest tests/test_pdf2md_*.py -v)",
-      "Bash(ls:*)",
-      "Bash(wc -l /home/haduong/aedist-technical-report/experiments/data/converter_test/*/Decision-1509.md)",
-      "Bash(nvidia-smi)",
-      "Bash(ps -o pid,ppid,etime,stat,cmd --ppid 241855)",
-      "Bash(ps -o pid,ppid,etime,cmd --ppid 346009)",
-      "Bash(uv run:*)",
-      "Bash(curl -sf http://localhost:11434/api/tags)",
-      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\('\\\\n'.join\\(m['name'] for m in d.get\\('models',[]\\) if 'qwen3.5' in m['name']\\)\\)\")",
-      "Bash(mkdir -p /tmp/0021)",
-      "Bash(echo \"launched pid $!\")",
-      "Bash(nvidia-smi --query-gpu=index,memory.used,utilization.gpu --format=csv,noheader)",
-      "Bash(kill -0 350276)",
-      "Bash(ps -o etime= -p 350276)",
-      "Bash(echo \"python 350276 STILL RUNNING \\($\\(ps -o etime= -p 350276)",
-      "Bash(ps -o pid,etime,start_time,cmd -p 350276)",
-      "Bash(curl -s http://localhost:11434/api/ps)",
-      "Bash(python3 -m json.tool)",
-      "Bash(curl -s http://localhost:11434/api/show -d '{\"name\":\"qwen3.5:2b\"}')",
-      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\('parameters:', d.get\\('parameters',''\\)\\); print\\('template_len:', len\\(d.get\\('template',''\\)\\)\\); print\\('details:', d.get\\('details',{}\\)\\); print\\('model_info keys:', list\\(d.get\\('model_info',{}\\).keys\\(\\)\\)[:20]\\)\")",
-      "Bash(chmod +x /tmp/0021/apply.sh)",
-      "Bash(head -6 tickets/0054* tickets/archive/0054*)",
-      "Bash(wc -l tickets/0060* tickets/0069* tickets/0073*)",
-      "Bash(git stash:*)",
-      "Bash(git checkout:*)",
-      "Bash(git restore:*)",
-      "Bash(git add:*)",
-      "Bash(git commit -m ':*)",
-      "Bash(git worktree:*)",
-      "Bash(git push:*)",
-      "Bash(grep -E \"\\\\.\\(csv|record\\\\.json\\)$\")"
+      "Bash(~/.claude/skills/merge/erg-pr-merge:*)"
     ],
     "defaultMode": "auto",
     "additionalDirectories": [
@@ -151,7 +101,7 @@
       "/home/haduong/CNRS/papiers/actif/AEDIST-technical-report/tickets"
     ]
   },
-  "model": "fable",
+  "model": "sonnet",
   "hooks": {
     "SessionStart": [
       {
@@ -280,19 +230,14 @@
     ],
     "Stop": []
   },
-  "worktree": {
-    "baseRef": "fresh"
-  },
   "enabledPlugins": {},
-  "effortLevel": "low",
+  "effortLevel": "medium",
   "tui": "fullscreen",
   "voice": {
     "enabled": true,
     "mode": "hold"
   },
   "skipDangerousModePermissionPrompt": true,
-  "editorMode": "normal",
   "teammateMode": "auto",
-  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
Ticket: none

Reverts merge 1995349 (PR #657). That PR committed one machine's live drift — session-accreted permission allowlist entries in settings.json and per-machine memory index lines — into the shared repo. Author flagged it ("storing machine state in the harness rule?"). Machine-local state stays on the machine; the drift remains archived on branch local-state-2026-07-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)