### PR TITLE
dream: consolidate padme memory (10→11)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -1071,7 +1071,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T11:08:32Z",
-      "last_confirmed": "2026-06-08T22:31:08Z",
+      "last_confirmed": "2026-07-22T19:40:49Z",
       "promoted": false
     },
     "padme-llm-backend-llama-server": {
@@ -1079,7 +1079,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T11:08:32Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:49Z",
       "promoted": false
     },
     "project_pending_reboot_kernel_635": {
@@ -1095,7 +1095,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T11:08:32Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     },
     "feedback_languages": {
@@ -1103,7 +1103,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T11:08:32Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     },
     "feedback_no_wrapper_skills": {
@@ -1111,7 +1111,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T11:08:32Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     },
     "feedback_worktree_stale_after_agent": {
@@ -1119,7 +1119,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T11:08:32Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     },
     "project-nvidia-580-hold-posture": {
@@ -1127,7 +1127,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T22:31:11Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     },
     "feedback_host_file_writes": {
@@ -1135,7 +1135,7 @@
         "-home-haduong-padme"
       ],
       "first_seen": "2026-06-08T22:31:11Z",
-      "last_confirmed": "2026-06-08T22:31:11Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     },
     "user_platform": {
@@ -2920,6 +2920,30 @@
       ],
       "first_seen": "2026-07-22T18:30:12Z",
       "last_confirmed": "2026-07-22T18:30:12Z",
+      "promoted": false
+    },
+    "project-systemd-linked-vs-enabled": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-07-22T19:40:49Z",
+      "last_confirmed": "2026-07-22T19:40:49Z",
+      "promoted": false
+    },
+    "project-secureboot-disabled-fwupd-mok": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-07-22T19:40:50Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
+      "promoted": false
+    },
+    "feedback_no_sudo": {
+      "projects": [
+        "-home-haduong-padme"
+      ],
+      "first_seen": "2026-07-22T19:40:50Z",
+      "last_confirmed": "2026-07-22T19:40:50Z",
       "promoted": false
     }
   }

--- a/projects/-home-haduong-padme/memory/MEMORY.md
+++ b/projects/-home-haduong-padme/memory/MEMORY.md
@@ -1,20 +1,19 @@
 ## Key insights
 
-- padme is a layered monitoring system (L0 hardware → L4 planned rust loop) where higher levels can override lower; L3 is observe-only by design. Don't duplicate checks across levels.
-- Deployment is via `/usr/local/bin` symlinks into the **main checkout working tree** — a merge isn't live until `git pull` runs in `/home/haduong/padme`, and if the primary is on a feature branch the cutover is gated on syncing it.
-- Local LLM inference is **llama-server** (llama.cpp), not ollama: reasoning models (Qwen3) need `enable_thinking=false`, ollama GGUF blobs aren't llama.cpp-loadable, and llama-server 400s on context overflow where ollama silently truncated.
-- The user is a KISS homelab sysadmin: bash for system scripts, python for LLM glue, rust for high-frequency infra; uv/apt only; don't wrap self-documenting CLIs in skills.
-- Verify via `git show`/`git -C`, not the working tree, after worktree/isolation agents; long-running GPU/server processes need systemd (Bash-spawned ones get SIGTERM'd when the call returns). Worktree-isolated agents cannot call session-level tools (ExitWorktree) — the parent session must handle worktree lifecycle after agents return.
-- When migrating a `.sh` script to `.py` in padme: critical stale-ref locations are (1) `.service` ExecStart, (2) `tools/README.md` deployment table + symlink + cron example, (3) `main-logbook.md` operational sections (ToC, architecture level, timer table, usage step, quarterly check). Historical bash-vs-python policy rows stay as-is with a "Résolu" annotation. Comment/string mentions (check-system-daily.sh threshold comment, reflect-quarterly.py string) are low-priority — not invocation paths.
+- Deployment is symlinks into the main checkout working tree: a merge is not live until `git pull` runs in `/home/haduong/padme`; systemd units must stay `linked` (never `enable`, disable-before-link).
+- Privileged operations belong to the author: no sudo, ever. Produce the exact command for them to run; snapper's apt pre/post hook and the NVIDIA/kernel apt-mark holds make routine `apt upgrade` self-bracketing and safe.
+- padme is a layered monitoring system (L0 hardware → L4 planned rust loop); higher levels can override lower, L3 is observe-only by design. Don't duplicate checks across levels.
+- A stopped service is not necessarily an incident: the author stops llama-server manually during heatwaves. Confirm intent before restarting or ticketing.
+- Machine state (interventions, upgrades, incidents) is recorded in the padme repo — `intervention-log.txt` + STATE.md via PR — never in the harness repo, which carries only shared rules and skills.
 
 ## Entries
 
 - [systemd linked vs enabled](project-systemd-linked-vs-enabled.md) — deploy order: disable first, then ln -sf, never enable on-demand units; systemctl disable removes ALL symlinks including manual ln -sf ones
-
-- [Server management](project_server_management.md) — padme monitoring architecture: bash L2, python L3, rust L4 planned
-- [LLM backend: llama-server](padme-llm-backend-llama-server.md) — local inference is llama-server (llama.cpp) :8080 serving Qwen3.6-35B-A3B; ollama removed (0010); config + gotchas
+- [Server management](project_server_management.md) — padme monitoring architecture: bash L2, python L3, rust L4 planned; script names verified 2026-07-22
+- [LLM backend: llama-server](padme-llm-backend-llama-server.md) — local inference is llama-server (llama.cpp) :8080 serving Qwen3.6-35B-A3B; ollama removed (0010); config + gotchas; stopped during heatwaves by design
 - [NVIDIA 580 hold posture](project-nvidia-580-hold-posture.md) — why padme pins proprietary 580 + the exact apt-mark hold set the quarterly baseline expects (HWE metas not bare; retire at 26.04)
 - [Secure Boot disabled / fwupd-MOK gotcha](project-secureboot-disabled-fwupd-mok.md) — SB off since 2026-06-10 (ticket 0041); fwupd firmware updates can de-trust the nvidia DKMS MOK → no GUI; MOK Manager renders on the boot GPU
+- [No sudo — ask the user](feedback_no_sudo.md) — never run sudo; give the author the exact command and read the output; reaffirmed 2026-07-22
 - [User profile](user_profile.md) — senior researcher, homelab sysadmin, KISS philosophy, prefers uv/apt-only
 - [Language preferences](feedback_languages.md) — bash for system scripts, python for LLM integration, rust for high-frequency infra
 - [No wrapper skills](feedback_no_wrapper_skills.md) — don't wrap self-documenting CLIs in skills; CLAUDE.md instructions + direct invocation

--- a/projects/-home-haduong-padme/memory/feedback_no_sudo.md
+++ b/projects/-home-haduong-padme/memory/feedback_no_sudo.md
@@ -3,9 +3,10 @@ name: No sudo — ask the user
 description: Never run sudo commands; ask the user to run them and paste output.
 type: feedback
 originSessionId: bac3c7fd-350c-4179-9b07-72ad2c7e85b5
+modified: 2026-07-22T11:28:19.648Z
 ---
 Ne jamais invoquer `sudo` directement. Si une opération requiert root (lire `/etc/snapper/configs/*`, `btrfs quota`, éditer `/etc/cron.d/`, etc.), demander à l'utilisateur d'exécuter la commande et de coller la sortie.
 
-**Why:** l'utilisateur a explicitement rejeté un `sudo -n` et corrigé "You cannot sudo. Ask me." — il garde le contrôle des actions privilégiées.
+**Why:** règle réaffirmée le 2026-07-22 (« You cannot sudo, ever ») après un plan de mise à jour apt proposant des commandes `sudo` à exécuter par Claude. L'utilisateur a explicitement rejeté un `sudo -n` et corrigé "You cannot sudo. Ask me." — il garde le contrôle des actions privilégiées.
 
 **How to apply:** avant toute commande nécessitant root, soit proposer la commande exacte à l'utilisateur (`! sudo ...` pour qu'il la lance dans la session), soit demander la sortie. Les lectures de fichiers sous `/etc/` ou `/root/` qui échouent en non-root tombent sous cette règle.

--- a/projects/-home-haduong-padme/memory/padme-llm-backend-llama-server.md
+++ b/projects/-home-haduong-padme/memory/padme-llm-backend-llama-server.md
@@ -5,6 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: 9c170357-d13b-4620-ba42-63123659fb6a
+  modified: 2026-07-22T19:33:02.125Z
 ---
 
 The local LLM backend is **llama-server** (llama.cpp), serving an
@@ -14,6 +15,11 @@ OpenAI-compatible API. ollama was fully removed in ticket 0010 (2026-06-08).
 - systemd unit `tools/llama-server.service` (symlinked into `/etc/systemd/system/`, so a `git pull` in the main checkout updates it). Runs as `User=haduong` — home is `0750` so a service user can't reach the `~/llama.cpp` binary, and `/dev/nvidia*` is world-accessible so no `video`/`render` group is needed.
 - Serves **Qwen3.6-35B-A3B** (`/data/models/gguf/qwen/`), port **8080**, `--ctx-size 16384`, `--tensor-split 16,12 --n-gpu-layers 999` across A4000 (16 GB) + 3060 (12 GB). GGUF cache lives under `/data/models/gguf/` (qwen, devstral).
 - Binary built with CUDA at `~/llama.cpp/build/bin` (build 9125). Consumer: L3 `reflect-monitoring-history.py` — endpoint/model via `PADME_LLM_URL`/`PADME_REFLECT_MODEL`/`PADME_LLM_CTX`. See [[padme monitoring architecture]].
+
+**Seasonal note:** the author stops llama-server manually during heatwaves
+(GPU thermal load). `inactive (dead)` on the unit with nothing on :8080 in
+summer is normal at-rest state, not an anomaly — check with the author before
+restarting or filing a ticket (2026-07-22).
 
 **Gotchas that cost time (verify before re-tripping):**
 1. **ollama GGUF blobs are NOT loadable by llama.cpp** — gemma4's blob failed `wrong number of tensors; expected 1014, got 658`. ollama uses its own internal layout. Migrate from a clean HF GGUF in the cache, not the ollama blob store.

--- a/projects/-home-haduong-padme/memory/project_server_management.md
+++ b/projects/-home-haduong-padme/memory/project_server_management.md
@@ -3,14 +3,15 @@ name: padme monitoring architecture
 description: Multi-level monitoring stack — bash mechanistic, python reflective (llama-server), rust conscious loop planned
 type: project
 originSessionId: 373c4915-d420-4c58-8931-74f68c620ede
+modified: 2026-07-22T19:40:30.334Z
 ---
 padme has a layered monitoring architecture:
 - **Level 0-1**: Hardware/OS (BIOS, systemd, btrfs, fan2go)
-- **Level 2**: Mechanistic bash scripts (check-resources.sh daily, quarterly-check.sh, backup-restic.sh). Threshold-based, no reasoning.
+- **Level 2**: Mechanistic scripts (`check-system-daily.sh` daily 07:15, `verify-system-baseline.py` quarterly, `backup-to-hetzner.sh` daily 02:30; names verified against main-logbook.md 2026-07-22). Threshold-based, no reasoning.
 - **Level 3**: Reflective python agent (reflect-monitoring-history.py, daily 07:30). Feeds L2 history to local **llama-server** (Qwen3.6-35B-A3B, OpenAI `/v1/chat/completions` on :8080), reasons about trends/correlations. Read-only, never acts. Migrated off Ollama in ticket 0010 (2026-06-08); see [[padme-llm-backend-llama-server]].
 - **Level 4**: High-frequency conscious loop in Rust — planned, not yet implemented. Higher-order reasoning/override capability.
 
 **Why:** Higher levels CAN override lower — cybernetics principle user explicitly endorsed. L3 currently observe-only by design (cautious start).
 **How to apply:** When discussing monitoring, respect the layered architecture. Don't duplicate checks across levels.
 
-Deployment model (verified 2026-06-06): L2 scripts run from `/usr/local/bin/*.sh` symlinks pointing at the **main checkout working tree** (`/home/haduong/padme/tools/`). A merged fix is NOT live until `git pull` runs in `/home/haduong/padme`. Desktop alerts come from `desktop-monitor-notify.sh` via XDG autostart at login (not a timer). Bash checks carry their own smoke tests: `check-resources.sh --smoke-test`, plus the stdin hook in `btrfs_chunk_check` — extend these rather than testing in throwaway shell sessions ([[padme-monitoring-fails-loud]] incident, ticket 0014).
+Deployment model (verified 2026-06-06): L2 scripts run from `/usr/local/bin/*.sh` symlinks pointing at the **main checkout working tree** (`/home/haduong/padme/tools/`). A merged fix is NOT live until `git pull` runs in `/home/haduong/padme`. Desktop alerts come from `notify-desktop-alerts.sh` via XDG autostart at login (not a timer). Bash checks carry their own smoke tests: `check-system-daily.sh --smoke-test`, plus the stdin hook in `btrfs_chunk_check` — extend these rather than testing in throwaway shell sessions ([[padme-monitoring-fails-loud]] incident, ticket 0014).


### PR DESCRIPTION
Ticket: none

## Decision table

| File | Decision | Reason |
|---|---|---|
| project-systemd-linked-vs-enabled.md | NOOP | accurate, matches logbook deployment order |
| project_server_management.md | UPDATE | stale script names corrected (check-resources.sh → check-system-daily.sh, quarterly-check.sh → verify-system-baseline.py, backup-restic.sh → backup-to-hetzner.sh, desktop-monitor-notify.sh → notify-desktop-alerts.sh; verified against main-logbook.md and tools/) |
| padme-llm-backend-llama-server.md | NOOP | refreshed today (heatwave at-rest note) |
| project-nvidia-580-hold-posture.md | NOOP | verified today — holds survived apt upgrade |
| project-secureboot-disabled-fwupd-mok.md | NOOP | ticket 0041 still open |
| feedback_no_sudo.md | ADD (to index) | existed unindexed; reaffirmed 2026-07-22, now in MEMORY.md |
| user_profile.md | NOOP | current |
| feedback_languages.md | NOOP | current |
| feedback_no_wrapper_skills.md | NOOP | current |
| feedback_worktree_stale_after_agent.md | NOOP | current |
| feedback_host_file_writes.md | NOOP | current |

Counts: before=10, after=11 (NOOP 9 + UPDATE 1 + DELETE 0 = 10 ✓; NOOP 9 + UPDATE 1 + ADD 1 = 11 ✓)

## Key insights

- Deployment is symlinks into the main checkout: a merge is live only after git pull in /home/haduong/padme; units stay linked, never enabled.
- No sudo ever; snapper apt hook + NVIDIA/kernel holds make routine apt upgrade self-bracketing.
- Layered monitoring L0→L4; L3 observe-only; no duplicated checks across levels.
- A stopped service may be deliberate (llama-server off during heatwaves) — confirm intent before fixing.
- Machine state is recorded in the padme repo (intervention-log.txt, STATE.md), never in the harness repo.

Promotion candidates: none. Decay flags: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)