### PR TITLE
memory(harness): erg ready reads the current branch's tree

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -8,6 +8,7 @@
 
 ## Entries
 
+- [erg ready reads the current branch's tree](feedback_erg_ready_reads_current_branch_tree.md) — a stale branch lists tickets already merged and archived on main; fetch and check `tickets/closed/` before re-implementing (0357 near-duplicate, 2026-07-24)
 - [CLAUDE.md is a thin loader in IDH](feedback_claude_md_is_thin_loader_idh.md) — proposing to add doctrine/posture prose to CLAUDE.md is a red flag; place guidance in the narrowest scoped layer (rules/, agent definitions, skills), and only against a demonstrated defect (author, 2026-07-21)
 - [Gaze caller-fix sweep found sibling gaps](project_gaze_caller_fix_sweep_siblings.md) — verify-gate and verify-adherence share the same hard-refuse-without-arg pattern gaze fixed in #649; left unticketed per the cool-down severity floor, fix opportunistically if either is touched (2026-07-15)
 - [Gaze resolves PR numbers in the caller, not the fork](feedback_gaze_resolve_pr_number_before_invoking.md) — /gaze's hard refusal without a PR number is intentional (post-ticket-0193 hardening against fork guesswork); the main loop should resolve an unambiguous PR from conversation context and pass it explicitly, never loosen the fork's no-inference rule (2026-07-15)

--- a/projects/-home-haduong--claude/memory/feedback_erg_ready_reads_current_branch_tree.md
+++ b/projects/-home-haduong--claude/memory/feedback_erg_ready_reads_current_branch_tree.md
@@ -1,0 +1,33 @@
+---
+name: feedback_erg_ready_reads_current_branch_tree
+description: "erg ready lists tickets from the current branch's working tree, so a stale branch reports tickets already closed on main — fetch and re-check before acting on the list"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: bb7d1a1f-202d-45bc-94f6-3ab7979c2dd9
+  modified: 2026-07-24T20:12:39.898Z
+---
+
+`erg ready` reads `tickets/` from the **current branch's tree**, not from
+`origin/main`. On a stale feature branch it happily lists a ticket that a
+parallel session already implemented, merged, and archived to
+`tickets/closed/` on main. Its header line names the branch it read
+(`erg: branch t0357-… (tickets)`) — that line is the tell, and it is easy to
+skim past.
+
+**Why:** on 2026-07-24 a session sat on `t0357-cut-before-condense`,
+`erg ready` listed 0357, and the session began re-implementing the rule from
+scratch. PR #667 had already landed the identical work (`rules/prose/cutting.md`
++ a one-line pointer in `_all.md` + a README row + an adherence ratchet). The
+duplicate edit collided with leftover conflict markers in `_all.md` and wasted
+the turn. This is the same class as [[feedback_pipeline_presentation_overlays_raids]]
+— a "ready" ticket may already be claimed or done elsewhere.
+
+**How to apply:** before acting on `erg ready`, run
+`git fetch origin && git log --oneline HEAD..origin/main` and re-run the picker
+on a current tree — or read the branch name in erg's own header and distrust
+the list if it is not the default branch. When the task is "finalize ticket N",
+check `tickets/closed/` and the merged PR list first; finalization is often
+already done. Use `rtk proxy ls` / `rtk proxy git` for these probes — the rtk
+hook rewrites plain `git status`/`diff` output and can make a clean tree look
+ambiguous (see [[feedback_rtk_rewrites_git_output]]).


### PR DESCRIPTION
Ticket: none

Records the 0357 near-duplicate as a durable feedback memory.

A session sitting on the stale `t0357-cut-before-condense` branch ran `erg ready`, saw 0357 listed, and began re-implementing the rule — while PR #667 had already landed the identical work and archived the ticket to `tickets/closed/` on main. `erg ready` reads `tickets/` from the *current branch's* tree; its header line names that branch, which is the tell.

The entry records the concrete tell and the finalize-time check (`tickets/closed/` + merged PRs) rather than proposing a new guard — the sync-before-work rule in `rules/workflow.md` already carries the discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)