### PR TITLE
chore: housekeeping sweep 2026-07-24

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,21 +1,21 @@
 # Imperial Dragon Harness — State
 
-Last updated: 2026-07-24T13:16Z
+Last updated: 2026-07-24T20:16Z
 
 ## North star
 
 A reusable, science-backed personal harness for AI-assisted research: code and prose, day and night, across projects and machines. The harness itself is the deliverable.
 
 ## Status
-<!-- generated 2026-07-24T13:16Z · as of 6d4324f -->
+<!-- generated 2026-07-24T20:16Z · as of 5fcc49f -->
 
 **Tickets:** 1 ready · 2 blocked — `erg ready tickets/` for full list
   next: 0207 Agnostic CLI reviewer seat — one config, OpenRo…
-**In flight:** 1 open PR, oldest #666 0d · CI main: success
+**In flight:** no open PRs · CI main: success
 **Recent (first-parent):**
-  6d4324f Merge pull request #667 from MinhHaDuong/t0357-cut-before-condense-playbook
-  a8bed4b Merge pull request #665 from MinhHaDuong/t0357-cut-before-condense
-  23383e6 Merge pull request #663 from MinhHaDuong/untrack-volatile-settings
+  5fcc49f chore: housekeeping fixes (sweep)
+  f7560f6 Merge pull request #669 from MinhHaDuong/memory-erg-ready-stale-branch
+  2fbab44 Merge pull request #666 from MinhHaDuong/t0357-cut-before-condense
 
 ## Blockers
 

--- a/projects/-home-haduong-Climate-finance/memory/MEMORY.md
+++ b/projects/-home-haduong-Climate-finance/memory/MEMORY.md
@@ -1,0 +1,21 @@
+- [PR scope discipline](feedback_scope_discipline.md) — don't add arch rules/tickets/sweeps to a feature PR branch
+- [Lean over comprehensive](feedback_lean_methods.md) — prefer one right method per concern, shed sunk-cost bias on existing code
+- [Verify contract](feedback_verify_contract.md) — /verify loop for PR gating; anti-rubber-stamp; two rounds max; never merges from skill
+- [Agent timeout on refactor](feedback_agent_timeout_refactor.md) — provide pre-written code, narrow scope, commit early
+- [Reimagine catches stale deps](feedback_reimagine_catches_stale_deps.md) — always reimagine before execution; dep graphs decay fast
+- [Pass full DF not a slice to stat helpers](feedback_null_df_slicing.md) — sliced DataFrame silently produces NaN output; callee needs all columns
+- [Companion paper design](project_companion_paper_design.md) — DORMANT (author 2026-07-23: no third paper); outlets = data paper + Œconomia only
+- [2026 conferences](project_conferences_2026.md) — Econom'IA Cergy May 27-28 (aedist); Charles Gide Vannes July 2-4 (paper due June 15)
+- [Verify vars file provenance](feedback_vars_file_provenance.md) — check compute_vars.py + Makefile before editing metadata-files; stale artifacts mislead
+- [Machine: padme](reference_machine_padme.md) — GPU server; corpus data lives here; test_corpus_acceptance failures are real, not expected
+- [a4paper always](feedback_a4paper.md) — every QMD format:pdf: block must have papersize: a4
+- [Analytical null as overlay](feedback_analytical_null_overlay.md) — MC + analytical ribbons as overlapping semi-transparent fills; no standalone script
+- [Verify agent must cd into PR worktree](feedback_verify_agent_worktree.md) — tests run outside the PR worktree produce false failures; always cd in first
+- [Never force-delete active worktrees](feedback_worktree_deletion.md) — unlocked ≠ abandoned; check for other sessions before --force remove
+- [gh Projects-classic error](feedback_gh_projects_classic_error.md) — gh pr edit/merge exit non-zero on a deprecated-Projects GraphQL error; use gh api REST + gh pr ready
+- [Auto-discovery class guards](feedback_autodiscovery_class_guard.md) — Makefile/source-driven discovery beats hardcoded lists; caught 5 missed/rebased-in offenders
+- [Resolve all conflict hunks, validate before push](feedback_merge_conflict_all_hunks.md) — first-match regex left raw markers on main; union wrong for removed headers
+- [padme Downloads dir](reference_padme_downloads_dir.md) — ~/Téléchargements until locale fix; use xdg-user-dir DOWNLOAD
+- [Rio-markers dataset for book](reference_riomarkers_dataset_book.md) — DSD_RIOMRKR@DF_RIOMARKERS zip pulled 2026-07-24; book chapter, NOT the data paper
+- [Téléchargements is scratch](feedback_telechargements_scratch.md) — move+checksum+delete downloads to durable homes asap
+- [Date generated texts](feedback_date_generated_texts.md) — render-time dates (date: today); pinned dates only for frozen submission artifacts

--- a/projects/-home-haduong-Climate-finance/memory/feedback_a4paper.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_a4paper.md
@@ -1,0 +1,11 @@
+---
+name: a4paper always
+description: All PDF-rendered QMD documents must use papersize a4
+type: feedback
+originSessionId: b65e7a09-3183-448a-bca4-3c2017bbe155
+---
+Always include `papersize: a4` in every QMD `format: pdf:` block.
+
+**Why:** User preference, confirmed explicitly ("MEmo: a4paper always").
+
+**How to apply:** When creating or editing any `.qmd` file that renders to PDF via xelatex, add `papersize: a4` under `format: pdf:`. Apply retroactively when touching existing files.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_agent_timeout_refactor.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_agent_timeout_refactor.md
@@ -1,0 +1,11 @@
+---
+name: Agent timeout on refactor step
+description: Worktree agents exhaust budget mid-refactor — provide pre-written code and narrow scope
+type: feedback
+originSessionId: 4fce2fc5-8792-42cb-b9a6-0a6fe78418d1
+---
+Agents consistently run out of time during the refactor TDD step, leaving uncommitted changes. RED and GREEN commit fine but refactoring exhausts the budget.
+
+**Why:** Agent context + tool calls accumulate during RED/GREEN, leaving little budget for refactor. Complex fixture design (e.g., Louvain community detection) can consume the entire budget before any commits.
+
+**How to apply:** When launching execution agents: (1) provide pre-written implementation code if available from a failed prior attempt, (2) keep scope to one concern per agent, (3) tell agents to commit early and often — refactor can be a separate commit that's easy to finish manually.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_analytical_null_overlay.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_analytical_null_overlay.md
@@ -1,0 +1,11 @@
+---
+name: Analytical null as visual overlay
+description: Analytical null ribbon overlaid on MC ribbon in zoo figures, not a standalone validation script
+type: feedback
+originSessionId: b0ad69a4-551a-4c51-ad1d-3c2e0e738f34
+---
+Render analytical null as a second semi-transparent `fill_between` overlaid on the MC ribbon in the zoo figures. Both with alpha ≈ 0.25; coincidence is visible as a merged patch.
+
+**Why:** User's preference — "plot in overlay when available. Not as a colored hashed area, both MC and theory with alpha so coincidence can be seen." A standalone `validate_null_model.py` script would work but wouldn't be immediately legible. The overlay makes agreement vs. divergence instantly visible without opening a report.
+
+**How to apply:** When implementing ticket 0115, `plot_zoo_results.py` gets a second optional `--analytical-null <csv>` argument. MC ribbon and analytical ribbon draw side-by-side as overlapping fills. Analytical CSVs live in `tab_analytical_null_*.csv` (separate from MC `tab_null_*.csv`). Only available for S1/S2/L1/C2ST; G methods show MC ribbon only.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_autodiscovery_class_guard.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_autodiscovery_class_guard.md
@@ -1,0 +1,36 @@
+---
+name: feedback_autodiscovery_class_guard
+description: Prefer Makefile/source-driven auto-discovery guards over hardcoded lists — they catch missed and rebased-in class members
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e941c29d-5c40-4794-8c38-de28cfeab946
+---
+
+For a "whole class of scripts must do X" guard (e.g. ticket 0233: every
+`$(DERIVED)` producer must `os.makedirs` before `validate_io`), write the test
+to **auto-discover** the class from the Makefile (or source), not from a
+hardcoded script list.
+
+**Why:** In 0233 the auto-discovering guard immediately caught 5 offenders the
+ticket's manual sweep missed — `compute_lexical` (present at filing) plus 4
+producers (`compute_analytical_null`, `compute_crossyear_zscore`,
+`compute_sensitivity_grid`, `compute_venue_concentration`) that a mid-hunt
+rebase brought in from parallel work. A hardcoded list would have silently left
+all 5 unguarded.
+
+**How to apply:**
+- Discover by resolving Make variables (two-pass: collect vars expanding under
+  the target dir, then scan target lines for a `scripts/*.py` prereq; join
+  `\`-continuation lines first).
+- Anchor the assertion tightly: check the *output-targeting* call
+  (`os.makedirs(os.path.dirname(io_args.output)`) in the right lexical scope
+  (between `parse_io_args()` and `validate_io`), so a decoy call elsewhere can't
+  produce a false GREEN. Mutation-verify the teeth (delete a real fix → RED).
+- Still pin the full known member set in a `_nonempty` sanity test so a
+  discovery-scan regression that drops a producer fails loudly, not vacuously.
+- Coverage boundary: a Makefile-driven scan only sees Make-wired producers; a
+  script writing to the dir via a hardcoded default with no target is invisible
+  (same limit as `test_phase_layout`). Accept it or add a source scan.
+
+Related: [[feedback_scope_discipline]] [[feedback_lean_methods]]

--- a/projects/-home-haduong-Climate-finance/memory/feedback_date_generated_texts.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_date_generated_texts.md
@@ -1,0 +1,22 @@
+---
+name: date-generated-texts
+description: Generated/rendered documents must carry the correct current date — never a stale pinned date
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 352d5761-eab8-421e-8926-7931ba20d97f
+  modified: 2026-07-24T12:35:33.487Z
+---
+
+When generating or regenerating a document (PDF render, letter, report),
+its date must be right.
+
+**Why:** author rule 2026-07-24 — both cut-pass comparison PDFs rendered
+"March 26" because data-paper.qmd pinned the original submission date;
+a stale date on a revised manuscript misrepresents the revision.
+
+**How to apply:** prefer render-time dates (`date: today` in Quarto,
+`\today` in LaTeX) for working documents; pin an explicit date only for a
+frozen submission artifact, and update it deliberately at each submission
+event. Data-provenance dates ("as of YYYY-MM-DD") come from the harvest
+run, not hand-written prose — wire them through vars when touched.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_gh_projects_classic_error.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_gh_projects_classic_error.md
@@ -1,0 +1,29 @@
+---
+name: feedback_gh_projects_classic_error
+description: gh pr edit/merge emit a fatal-looking Projects-classic GraphQL error on this repo; use gh api REST and gh pr ready
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e941c29d-5c40-4794-8c38-de28cfeab946
+---
+
+On the climate-finance repo, `gh pr edit` and `gh pr merge` print
+`GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)`
+and **exit non-zero even when the underlying action would succeed** — because gh
+fetches deprecated Projects-classic data as part of the mutation.
+
+**Why:** the repo still has Projects-classic associations; gh's GraphQL query for
+them errors, aborting `gh pr edit` (title/body never applied) and making
+`gh pr merge` look failed.
+
+**How to apply:**
+- To edit a PR title/body, bypass GraphQL with REST:
+  `gh api -X PATCH repos/MinhHaDuong/climate-finance-het/pulls/<N> -f title='...' -F body=@<file>`
+  (exit 0, no projectCards fetch). The repo moved to `climate-finance-het`; the
+  old `Oeconomia-Climate-finance` remote still works via redirect.
+- `gh pr merge <N> --merge` may print the error + exit 1 but still merge — re-run
+  and it reports "already merged". Verify with `gh pr view <N> --json state`.
+- Bootstrap/roar-sweep PRs are created as **draft**; the merge queue rejects
+  drafts ("Pull Request is still a draft"). Run `gh pr ready <N>` first.
+
+Related: [[feedback_verify_agent_worktree]]

--- a/projects/-home-haduong-Climate-finance/memory/feedback_lean_methods.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_lean_methods.md
@@ -1,0 +1,17 @@
+---
+name: Lean over comprehensive
+description: User prefers lean method selection over keeping everything built; shed sunk-cost bias
+type: feedback
+originSessionId: 6028d794-8c6f-418a-85d8-eedb55e43fed
+---
+When proposing methods or analyses, prefer one well-chosen method per concern
+over a comprehensive panel. The user explicitly said "lean of course, not a zoo"
+and "it's a bias to want to keep what we have done."
+
+**Why:** Sunk cost of existing code tempts keeping everything. But a paper with
+16 methods reads as a benchmark, not an argument. Methods serve the narrative.
+
+**How to apply:** When scoping analysis work, start from "what's the right tool
+for this question?" not "which existing tools can we include?" Push extra methods
+to supplementary. If the user asks for alternatives, present the tradeoff
+(simplicity vs robustness) rather than defaulting to "keep both."

--- a/projects/-home-haduong-Climate-finance/memory/feedback_merge_conflict_all_hunks.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_merge_conflict_all_hunks.md
@@ -1,0 +1,23 @@
+---
+name: feedback_merge_conflict_all_hunks
+description: "When scripting a merge-conflict resolution, process every hunk and run the validator before pushing — a first-match-only regex let raw conflict markers land on main"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 63b53dc0-97f6-44a6-8e47-3b0a129fbc06
+  modified: 2026-07-23T15:25:24.980Z
+---
+
+Scripted conflict resolution on ticket files (PRs #1099/#1100, 2026-07-23): a
+`re.search` (first match only) resolved hunk 1 and silently left hunk 2's raw
+`<<<<<<<` markers in the committed merge, which then landed on main; caught
+only by the next `erg check`. Also unioned Blocked-by header lines both sides
+had *removed* (blockers closed) — for removals, union is the wrong lattice.
+
+**Why:** merge conflicts can have multiple hunks per file, and log-append vs
+header-removal hunks need opposite resolutions (union vs intersection).
+
+**How to apply:** use `re.finditer`/loop over ALL conflict hunks; after
+resolving, `grep -c '<<<'` must be 0 AND the domain validator (`erg check`,
+tests) must pass BEFORE committing the merge; union log lines, but for
+header lines removed by either side, keep the removal.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_null_df_slicing.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_null_df_slicing.md
@@ -1,0 +1,11 @@
+---
+name: Pass full DataFrame, not a slice, to functions needing all columns
+description: Passing a sliced DataFrame to a function that needs unlisted columns silently produces NaN output — grep for the bug pattern before closing stat scripts
+type: feedback
+originSessionId: ffb7544c-0aee-4a39-b094-7dcb6ec24e41
+---
+When slicing `null_df` for a join, keep the slice local to the join only. Any helper function that computes statistics (e.g., z-scores using `null_mean`/`null_std`) must receive the full DataFrame — not a projection.
+
+**Why:** In ticket 0084, `_aggregate_subsample_ribbon` was passed `null_cols` (a 4-column slice: year, window, z_score, p_value) instead of `null_df` (which has `null_mean`, `null_std`). The function silently skipped all rows (`has_null_stats = False`) and produced an all-NaN ribbon — no error, no warning, just wrong output that would have reached the plot.
+
+**How to apply:** When writing a function that takes a DataFrame and accesses columns by name, either (a) pass the full frame and let the function select, or (b) document the required columns in the function signature. Before closing any stat-pipeline PR, grep for `null_cols\s*=.*\[` or similar projection-then-pass patterns and verify the sliced frame has every column the callee needs.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_reimagine_catches_stale_deps.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_reimagine_catches_stale_deps.md
@@ -1,0 +1,11 @@
+---
+name: Reimagine phase catches stale dependencies
+description: Always reimagine tickets before execution — dependency graphs go stale fast
+type: feedback
+originSessionId: 4fce2fc5-8792-42cb-b9a6-0a6fe78418d1
+---
+The reimagine phase discovered 4 tickets already done but not closed, and 5 tickets with wrong blocked-by references. Without reimagining, we would have wasted execution cycles on completed work and blocked on phantom dependencies.
+
+**Why:** Tickets are written at planning time but code lands asynchronously across sessions. Dependency graphs decay within days.
+
+**How to apply:** In orchestrator, always run reimagine agents before execution — even for tickets that look "ready." Check git log for merged implementations, not just ticket status fields.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_scope_discipline.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_scope_discipline.md
@@ -1,0 +1,11 @@
+---
+name: PR scope discipline
+description: Don't add architecture rules, tickets, or codebase-wide fixes to a feature PR — use a separate branch
+type: feedback
+originSessionId: 9625bcb9-58da-4ff8-9782-613290dca62c
+---
+Keep feature PR branches scoped to the feature. Architecture rules, new tickets, and codebase-wide sweeps belong on their own branch, even if discovered during review.
+
+**Why:** PR #650 review session added arch rule 9 + tickets 0043/0044 directly to the feature branch. Had to revert them before merge. The owner force-pushed to remove the pollution.
+
+**How to apply:** When a review uncovers a codebase-wide antipattern, note it for a follow-up branch. Don't commit it to the PR under review.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_telechargements_scratch.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_telechargements_scratch.md
@@ -1,0 +1,20 @@
+---
+name: telechargements-scratch
+description: ~/Téléchargements is scratch only — move downloaded files to durable storage immediately
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 352d5761-eab8-421e-8926-7931ba20d97f
+  modified: 2026-07-24T09:14:35.856Z
+---
+
+The downloads directory ([[padme-downloads-dir]]) is NOT safe storage — treat
+it as scratch.
+
+**Why:** author directive 2026-07-24; downloads accumulate, get cleaned, and
+carry meaningless browser filenames.
+
+**How to apply:** as soon as a downloaded file is identified, copy it to its
+durable home (pool dir, project data dir, Zotero staging), verify by checksum,
+then delete the Téléchargements copy. Never reference a Téléchargements path
+from any config or ticket.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_vars_file_provenance.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_vars_file_provenance.md
@@ -1,0 +1,11 @@
+---
+name: Check compute_vars.py before touching metadata-files
+description: Stale vars files can exist on disk; always verify which file the pipeline actually generates
+type: feedback
+originSessionId: ffb7544c-0aee-4a39-b094-7dcb6ec24e41
+---
+When a `.qmd` frontmatter has `metadata-files: [X-vars.yml]`, verify X against `scripts/compute_vars.py` DOC_VARS keys and the Makefile render dependencies before changing it.
+
+**Why:** PR #737 renamed `companion-paper` → `multilayer-detection`. A stale `companion-paper-vars.yml` remained on disk, making it look like a valid alternative. A session summary incorrectly recommended switching to it. The PR #756 `/verify` pass caught the regression.
+
+**How to apply:** Before editing `metadata-files`, run `grep '"<stem>"' scripts/compute_vars.py` and `grep '<stem>-vars.yml' Makefile`. The file in frontmatter must match.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_verify_agent_worktree.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_verify_agent_worktree.md
@@ -1,0 +1,11 @@
+---
+name: Verify agent must cd into PR worktree before running tests
+description: Verify agents that don't cd into the PR's own worktree produce false REROLL results
+type: feedback
+originSessionId: b0ad69a4-551a-4c51-ad1d-3c2e0e738f34
+---
+When a verify agent runs `pytest` without first switching into the PR branch's worktree, it may test against a different code version and get false failures. Always `cd` into the PR worktree (or `gh pr checkout`) before running any test assertions.
+
+**Why:** During 0119 verify, the agent ran tests in its own context rather than the PR worktree and got 2 false failures (S3 + S4 value mismatches). The fix agent confirmed the tests passed byte-for-byte in the actual PR worktree.
+
+**How to apply:** In verify-gate agent prompts, always specify: "check out the PR branch or `cd` into the PR worktree before running tests." A passing test in the wrong directory proves nothing about the PR.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_verify_contract.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_verify_contract.md
@@ -1,0 +1,32 @@
+---
+name: Verification contract — never rubber-stamp
+description: When verifying PRs in the orchestrator Phase 6 or before any merge, run the full /verify loop. Never rubber-stamp. Cap at one retry round. Never merge from the verify skill itself.
+type: feedback
+originSessionId: 54d18314-1461-48f8-9048-cc2d7bc89989
+---
+For any PR verification before merge, invoke `/verify <pr-number>`. The skill runs:
+
+1. `/verify-adherence` — mechanical-first (hygiene + IO-discipline + schema tests + grep ratchet), LLM only as fallback.
+2. `/review` (built-in) + `/review-pr` or `/review-pr-prose` in parallel (read-only).
+3. `/simplify` — applies must-fix findings as commits.
+4. `/verify-gate` — anti-rubber-stamp gate.
+
+Non-negotiables baked into the gate:
+
+- **Evidence is concrete.** Commit SHA + file:line, test_id, or explicit rationale. "CI passes" / "simplify ran — no findings" / "tests pass" are NOT evidence.
+- **Every ticket exit criterion gets ADDRESSED/MISSING + evidence.**
+- **Every review comment is load-bearing** — commit changed the cited file, OR comment resolved with rationale, OR follow-up ticket opened.
+- **Two rounds max** (round 1 initial, round 2 post-fix). Round 3 is forbidden → ESCALATE.
+- **`/verify` never merges.** Merge is the author's call (interactive) or `/celebrate`'s call (autonomous).
+- **`--force-approve` is a loud override**, logged on the PR. Use sparingly.
+
+**Why:** The old orchestrator Phase 6 listed `/review` + `/review-pr` + `/simplify` inline — easy to skip steps, nothing forced evidence review. User flagged this during the 2026-04-17 session (Wave C PRs 689, 690 had skipped the `/review` step). The `/verify` skill family encodes the contract so Phase 6 can't cut corners.
+
+**How to apply:**
+- For any PR verification: `/verify <pr>` (not `/review-pr` alone).
+- For a quick look: `/review` or `/review-pr` are still fine — `/verify` is full depth.
+- The orchestrator's rewritten Phase 6 delegates to `/verify` per-ticket plus a separate wave-level integration subagent.
+
+**Skill locations:** `~/.claude/skills/verify/SKILL.md`, `~/.claude/skills/verify-adherence/SKILL.md`, `~/.claude/skills/verify-gate/SKILL.md`. User-level, shipped with the ImperialDragonHarness repo, commit `e7e56b5` on `main`.
+
+**Ratchet discipline:** `/verify-adherence` emits `suggested_test` entries for every semantic LLM finding. Next session, convert those into tests in `tests/test_hygiene_*.py` so the rule is mechanized permanently. LLM surface should shrink over time, not stay constant.

--- a/projects/-home-haduong-Climate-finance/memory/feedback_worktree_deletion.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_worktree_deletion.md
@@ -1,0 +1,16 @@
+---
+name: Never force-delete a worktree without checking active sessions
+description: Force-removing a worktree that another Claude session is using destroys its working directory
+type: feedback
+originSessionId: b0ad69a4-551a-4c51-ad1d-3c2e0e738f34
+---
+Never run `git worktree remove --force` on a worktree during an end-session hygiene sweep without first confirming no other Claude session is actively using it.
+
+**Why:** During the 2026-04-25 end-session, I force-deleted `orchestrator-112-115` while another Claude session was mid-execution there. The directory vanished, breaking the other session's working context and losing any uncommitted state.
+
+**How to apply:** Before removing any worktree that is NOT locked:
+1. Check if there's another open terminal/session that might be using it.
+2. If uncertain, skip it — stale worktrees are harmless, deleted active worktrees are not.
+3. Reserve `--force` for worktrees whose session has clearly exited (e.g., the branch was merged and no PID holds the directory).
+
+The `locked` status only protects against git's own cleanup, not manual `--force` removal. Unlocked ≠ abandoned.

--- a/projects/-home-haduong-Climate-finance/memory/project_companion_paper_design.md
+++ b/projects/-home-haduong-Climate-finance/memory/project_companion_paper_design.md
@@ -1,0 +1,39 @@
+---
+name: Companion paper method design
+description: Lean 6-method panel for multilayer-detection.qmd (epic 0026), QSS target
+type: project
+originSessionId: 6028d794-8c6f-418a-85d8-eedb55e43fed
+modified: 2026-07-23T18:10:59.759Z
+---
+`content/multilayer-detection.qmd` (renamed from companion-paper.qmd in #737).
+Reimagined 2026-04-15 as methods+application paper for QSS.
+Lean design: 6 methods across 3 layers, not the 16-method zoo.
+
+| Layer | Lead | Robustness |
+|-------|------|------------|
+| Embedding | Energy distance | C2ST on PCA-32 |
+| Lexical | JS divergence | C2ST on TF-IDF |
+| Graph | Community div (Louvain+JS) | Spectral gap |
+
+Key design decisions:
+- Permutation null CI ribbons (B=500); raw statistic values plotted (ticket 0113 drops Z-score rescaling)
+- Null ribbon = null_mean ± 1.96*null_std in native units; no cross-year standardisation in zoo figures
+- Significance: year outside ribbon = p < 0.05 (two-sided)
+- Transition zones (year ranges), not point breaks — social change is fuzzy
+- Two-pass censored-gap confirmation: detect zones, censor, retest
+- C2ST gives interpretation for free (discriminative terms + documents)
+- companion-paper.qmd stays standalone (NOT merged into tech report)
+
+**Why:** User pushed back on statistics-paper framing and method zoo. The paper
+is a companion to the Oeconomia intellectual history, not a benchmark.
+
+**How to apply:** Methods must serve the narrative, not the other way around. Supplementary material holds the other 12 zoo methods. §5 prose (§5.1–5.4) not yet written — known RED tests in test_multilayer_detection_prose.py and test_multilayer_detection_pca.py.
+
+**UPDATE 2026-07-23 (author, RDJ revision session):** "Y a pas de companion
+paper" — the author does not want to multiply papers. The only two outlets are
+the RDJ data paper and the Œconomia article (which the data paper cites as
+[Ha-Duong, under review]). Do not route findings to a separate
+methods/structuration paper; interesting results go into the data paper
+(minimal, statistic-backed items) or the Œconomia article at its next
+revision round. The multilayer-detection.qmd plan above is dormant until the
+author says otherwise.

--- a/projects/-home-haduong-Climate-finance/memory/project_conferences_2026.md
+++ b/projects/-home-haduong-Climate-finance/memory/project_conferences_2026.md
@@ -1,0 +1,18 @@
+---
+name: 2026 conference schedule (climate finance project)
+description: Two conferences planned for 2026. Used to schedule slide/paper deliverables and to avoid proposing deliverables that clash with travel dates.
+type: project
+originSessionId: 54d18314-1461-48f8-9048-cc2d7bc89989
+---
+**Econom'IA — Cergy, May 27–28, 2026.**
+- Purpose: present aedist results.
+- Replaces the earlier ESHET-HES Nice May 26–29 plan (user cancelled Nice).
+- Deliverable: slide deck.
+
+**Charles Gide — Vannes, July 2–4, 2026.**
+- Paper due June 15, 2026.
+- Deliverable: conference paper.
+
+**Why:** slide and paper deadlines gate what can ship in Wave C / book-prep work. Don't propose new non-critical tickets that need author attention May 25–29 or mid-June through July 4.
+
+**How to apply:** when scheduling or prioritising work, respect these windows. When planning a pre-submission review or orchestrator wave, check that its latest round won't land inside a travel window.

--- a/projects/-home-haduong-Climate-finance/memory/reference_machine_padme.md
+++ b/projects/-home-haduong-Climate-finance/memory/reference_machine_padme.md
@@ -1,0 +1,7 @@
+---
+name: This machine is padme
+description: The current working machine hostname is padme — the GPU server where corpus data lives
+type: reference
+originSessionId: ffb7544c-0aee-4a39-b094-7dcb6ec24e41
+---
+The machine running these sessions IS padme — the GPU server. Claude Code runs directly on padme; there is no remote SSH needed. `refined_works.csv` and all Phase 1 corpus data live here at `$CLIMATE_FINANCE_DATA/catalogs/`. A failing `test_corpus_acceptance.py::test_refined_works_exists` on padme is a real problem, not an expected data-missing failure.

--- a/projects/-home-haduong-Climate-finance/memory/reference_padme_downloads_dir.md
+++ b/projects/-home-haduong-Climate-finance/memory/reference_padme_downloads_dir.md
@@ -1,0 +1,16 @@
+---
+name: padme-downloads-dir
+description: "On padme the browser downloads directory is ~/Téléchargements (French locale), not ~/Downloads"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 352d5761-eab8-421e-8926-7931ba20d97f
+  modified: 2026-07-24T07:29:49.757Z
+---
+
+On padme, `~/Downloads` does not exist — the xdg downloads directory is
+`~/Téléchargements` (French desktop locale). The author plans to switch the
+desktop language eventually, after which it may become `~/Downloads`.
+
+**How to apply:** resolve with `xdg-user-dir DOWNLOAD` instead of hardcoding
+either name (works before and after the locale fix). Related: [[machine-padme]].

--- a/projects/-home-haduong-Climate-finance/memory/reference_riomarkers_dataset_book.md
+++ b/projects/-home-haduong-Climate-finance/memory/reference_riomarkers_dataset_book.md
@@ -1,0 +1,25 @@
+---
+name: riomarkers-dataset-book
+description: OECD Rio-markers dataset (CRS) downloaded 2026-07-24 for a book chapter — NOT for the RDJ data paper
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 352d5761-eab8-421e-8926-7931ba20d97f
+  modified: 2026-07-24T09:07:26.275Z
+---
+
+Author downloaded the OECD Rio markers dataset zip on 2026-07-24, explicitly
+**for a book chapter, not for the RDJ-26561 data paper** — do not fold it into
+the paper's corpus pool.
+
+Dataset: `DSD_RIOMRKR@DF_RIOMARKERS` (OECD.DCD.FSD), Data Explorer:
+https://data-explorer.oecd.org/vis?lc=en&df[ds]=dsDisseminateFinalDMZ&df[id]=DSD_RIOMRKR%40DF_RIOMARKERS&df[ag]=OECD.DCD.FSD&dq=DAC_EC..1000..2.10...Q._T..&lom=LASTNPERIODS&lo=2&to[TIME_PERIOD]=false
+
+SDMX API base for scripted refresh: `https://sdmx.oecd.org/public/rest/data/OECD.DCD.FSD,DSD_RIOMRKR@DF_RIOMARKERS,`
+
+Zip initially landed in `~/Téléchargements` ([[padme-downloads-dir]]); final
+location to be set when the book project starts.
+
+Downloaded 2026-07-24, six period-slice zips in `~/Téléchargements`
+(~503 MB total): `RioMarkers 2002-05 data.zip` … `RioMarkers 2022-24
+data.zip` (2002-05, 2006-09, 2010-13, 2014-17, 2018-21, 2022-24).

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/MEMORY.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/MEMORY.md
@@ -1,0 +1,44 @@
+# Memory Index
+
+- [feedback_s2_api_limits.md](feedback_s2_api_limits.md) — S2 search API offset cap and retry behavior
+- [feedback_dvc_locks.md](feedback_dvc_locks.md) — DVC stale lock cleanup before pipeline runs
+- [feedback_dvc_commit_after_repro.md](feedback_dvc_commit_after_repro.md) — After dvc repro, lock/pool files are staged but need explicit commit — never discard
+- [feedback_teaching_scraper.md](feedback_teaching_scraper.md) — DOI cleaning, two-tier filter, LLM extraction limits
+- [feedback_fuzzy_title_matching.md](feedback_fuzzy_title_matching.md) — token_sort_ratio vs token_set_ratio, single-linkage chaining risk, min word guard
+- [feedback_doc_propagation.md](feedback_doc_propagation.md) — Always run doc propagation agent when reviewing PRs that touch scripts/
+- [feedback_longrunning_jobs.md](feedback_longrunning_jobs.md) — Run corpus/DVC stages in foreground (not background) so user sees live progress
+- [feedback_agent_runbooks.md](feedback_agent_runbooks.md) — Subagents must follow start-ticket and review-pr runbooks explicitly
+- [feedback_review_stale_branches.md](feedback_review_stale_branches.md) — PR review pitfalls: stale branches show phantom diffs, verify scope before posting
+- [feedback_chunk_size_tradeoff.md](feedback_chunk_size_tradeoff.md) — Bigger chunks (20K) may hurt extraction with small models; test before changing
+- [project_lms_bias.md](project_lms_bias.md) — LMS harvesting bias: syllabi behind Moodle/Brightspace are unreachable, mention in data paper
+- [project_teaching_methodology_lessons.md](project_teaching_methodology_lessons.md) — Regex>LLM for DOIs, CrossRef>OpenAlex for title lookup, chunk size matters, LMS bias
+- [project_teaching_paper_idea.md](project_teaching_paper_idea.md) — Potential paper on teaching climate finance worldwide, North/South, cryptoimperialism
+- [feedback_kmeans_instability.md](feedback_kmeans_instability.md) — KMeans cluster IDs shuffle with small corpus changes
+- [feedback_s2_disconnect.md](feedback_s2_disconnect.md) — S2 keyword search is wrong tool, use citation graph instead
+- [project_bibcnrs_news.md](project_bibcnrs_news.md) — bibCNRS provides news/discourse, not WoS/EconLit academic literature
+- [reference_repec.md](reference_repec.md) — RePEc mirror as potential future corpus source
+- [feedback_multispace_comparison.md](feedback_multispace_comparison.md) — Test multiple representation spaces when clustering finds no structure
+- [project_rally_loop_20260324.md](project_rally_loop_20260324.md) — Rally loop session prompt saved for celebration
+- [project_north_star.md](project_north_star.md) — Ideal state: green tests, no smells, idempotent pipelines, clean PRs, defined issues
+- [project_multilingual_corpus.md](project_multilingual_corpus.md) — Corpus is multilingual in principle — constrains model choices (BGE-M3 over nomic)
+- [feedback_fix_not_hide.md](feedback_fix_not_hide.md) — Never move/archive/rename files to dodge failing tests — fix in place
+- [project_agent_harness_architecture.md](project_agent_harness_architecture.md) — Harness in .agent/ parallel to .claude/, symlinks for shared elements
+- [feedback_gh_pr_edit_classic_projects.md](feedback_gh_pr_edit_classic_projects.md) — gh pr edit silently fails with Projects Classic — use gh api PATCH
+- [feedback_review_all_comments.md](feedback_review_all_comments.md) — Fix all review comments, not just blocking ones — user enforces runbook literally
+- [feedback_rereview_regressions.md](feedback_rereview_regressions.md) — Review fixes can introduce regressions — re-review must check all affected files
+- [feedback_1fig1script.md](feedback_1fig1script.md) — 1 figure = 1 script, no shared plotting modules
+- [feedback_arch_not_linecount.md](feedback_arch_not_linecount.md) — God module splits: architecture first, not line counting
+- [feedback_fix_root_cause.md](feedback_fix_root_cause.md) — Fix root causes not symptoms: three escalating failures from this session
+- [feedback_agent_specs_detail.md](feedback_agent_specs_detail.md) — Parallel agents need detailed specs, not vague goals
+- [feedback_gh_rest_only.md](feedback_gh_rest_only.md) — Agent token is fine-grained PAT: REST only, no GraphQL
+- [feedback_review_every_pr.md](feedback_review_every_pr.md) — Run /review-pr on every PR before declaring ready, not just the first in a batch
+- [feedback_cache_is_data.md](feedback_cache_is_data.md) — DVC outputs get wiped — caches must hold actual data, not just done-markers
+- [feedback_sweep_after_fix.md](feedback_sweep_after_fix.md) — After fixing a pattern violation, sweep codebase for similar instances and ticket them
+- [feedback_table_as_contract.md](feedback_table_as_contract.md) — M/V splits use CSV tables as contract, no Python import coupling
+- [feedback_gh_merge_502.md](feedback_gh_merge_502.md) — gh pr merge 502: use REST API PUT endpoint as fallback
+- [reference_grobid_padme.md](reference_grobid_padme.md) — GROBID runs locally via podman on padme — 200 cit/sec, port 8070
+- [feedback_purpose_built_over_llm.md](feedback_purpose_built_over_llm.md) — Search for domain tools (GROBID, spaCy) before defaulting to LLM
+- [feedback_worktree_isolation.md](feedback_worktree_isolation.md) — Every conversation in its own worktree via EnterWorktree — fixes parallel VSCode teleport bug
+- [feedback_singleton_test_isolation.md](feedback_singleton_test_isolation.md) — Reset singleton internals, not just config vars, when testing module-level caches
+- [feedback_circuit_breaker_shared.md](feedback_circuit_breaker_shared.md) — Place shared abstractions in pipeline_io.py from the start, not the first script
+- [feedback_io_migration_pattern.md](feedback_io_migration_pattern.md) — I/O migration: extract helpers first, preserve Unicode, .values vs .values(), stamp files for dynamic outputs

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_1fig1script.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_1fig1script.md
@@ -1,0 +1,11 @@
+---
+name: feedback_1fig1script
+description: Every figure must have its own plot_fig_*.py script — no shared plotting modules
+type: feedback
+---
+
+1 figure = 1 script. No exceptions. No `*_plots.py` modules collecting multiple figures.
+
+**Why:** The project convention is that every figure script follows `plot_fig_*.py` naming, one script per output figure. This keeps figures independently runnable, testable, and traceable in the Makefile.
+
+**How to apply:** When splitting god modules that contain plotting code, extract each figure into its own `plot_fig_*.py` script. Never create a shared `*_plots.py` module as a dumping ground for multiple figures.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_agent_runbooks.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_agent_runbooks.md
@@ -1,0 +1,13 @@
+---
+name: Subagents must follow runbooks
+description: When launching agents for ticket work, always instruct them to follow start-ticket and review-pr runbooks
+type: feedback
+---
+
+When launching a subagent to work on a ticket, always include in the prompt:
+- "Follow `runbooks/start-ticket.md` as your entry point"
+- "After completing code, self-review following `runbooks/review-pr.md` before opening the PR"
+
+**Why:** Agent working on #279 skipped start-ticket runbook and self-review entirely. It went straight to coding, produced correct code but didn't follow the DD phases (Doing → PR → Review → Iterate). The doc propagation check was also skipped — only caught because the parent reviewed manually. Subagents don't automatically follow runbooks unless explicitly told to.
+
+**How to apply:** Every agent prompt for ticket work must include these two lines. This applies to both `start-ticket` (entry) and `review-pr` (exit). The agent should announce DD phase transitions and self-review its own PR in a fresh context before declaring done.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_agent_specs_detail.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_agent_specs_detail.md
@@ -1,0 +1,11 @@
+---
+name: feedback_agent_specs_detail
+description: Parallel agents need detailed architectural specs, not vague goals
+type: feedback
+---
+
+When launching parallel agents on related tasks, give each agent a detailed spec: module names, content lists, seam rationale, line targets per module.
+
+**Why:** Three agents launched with "split X under 800 lines" all took the lazy path (extract one function, re-export, done). Three agents launched with "create syllabi_harvest.py (~300L) containing search+fetch, syllabi_process.py (~400L) containing classify+extract+normalize" produced quality architecture.
+
+**How to apply:** Before launching implementation agents, do the architectural thinking yourself (or via a Plan agent). The implementation agent's job is execution, not design. Include module names, approximate line counts, content assignments, and the rationale for each seam in the prompt.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_arch_not_linecount.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_arch_not_linecount.md
@@ -1,0 +1,11 @@
+---
+name: feedback_arch_not_linecount
+description: God module splits must improve architecture, not just pass line-count tests
+type: feedback
+---
+
+When splitting god modules, the goal is readability and modularity — not getting to 799 lines.
+
+**Why:** First attempt at splitting utils.py/collect_syllabi.py/compare_clustering.py just extracted random functions to pass the 800L wall. User rejected all three. Second attempt with proper architectural specs (seams by concern, domain-oriented naming, all modules under 500L smell threshold) produced quality code.
+
+**How to apply:** When splitting a file, first identify the real seams (different reasons to change). Name modules by domain (pipeline_io, syllabi_harvest), not by parent (utils_pool). Target the 500L smell threshold, not the 800L wall. Give parallel agents detailed specs with module names, content lists, and line targets.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_cache_is_data.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_cache_is_data.md
@@ -1,0 +1,11 @@
+---
+name: feedback_cache_is_data
+description: DVC outputs get wiped on re-run — persistent caches must hold the actual data, not just "done" markers
+type: feedback
+---
+
+Never split "what was done" from "the data itself" in DVC pipeline caches. If a done-file says a DOI was fetched but the actual rows are in a DVC output that gets wiped, the cache is lying.
+
+**Why:** #441 regression — citations_done.csv said 22K DOIs were done, but citations.csv (DVC output) was wiped to 17 rows. Filter saw empty citation graph, flagged 9,102 papers as isolated, corpus dropped from 31K to 27K.
+
+**How to apply:** When designing enrichment caches, make the cache file contain the actual data rows (append-only in enrich_cache/). The DVC output should be a derived view (concat + dedup), regenerable without API calls.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_chunk_size_tradeoff.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_chunk_size_tradeoff.md
@@ -1,0 +1,11 @@
+---
+name: Chunk size vs LLM extraction quality tradeoff
+description: Bigger chunks (20K) may hurt extraction with small models — gemma-2-27b-it produced 0 refs from Harvard FECS at 20K chunks
+type: feedback
+---
+
+Increasing CHUNK_SIZE from 8K to 20K chars caused gemma-2-27b-it to extract 0 refs from the Harvard FECS PDF, which previously yielded 77+ refs at 8K chunks. The model likely gets confused with too much context.
+
+**Why:** Bigger chunks mean fewer API calls and more context per chunk, but smaller models may not handle long prompts well. The extraction prompt asks for ALL references in the chunk — with 20K chars of dense bibliography, the model may fail to produce structured JSON.
+
+**How to apply:** Before changing chunk size, test with the target model on known PDFs. The optimal chunk size depends on the model's effective context utilization, not just its context window size. Consider reverting to 8K chunks or using a stronger model for extraction.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_circuit_breaker_shared.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_circuit_breaker_shared.md
@@ -1,0 +1,11 @@
+---
+name: Circuit breaker in shared module from the start
+description: Place shared exception classes in pipeline_io.py immediately, not in the first script that needs them
+type: feedback
+---
+
+When adding a new exception or constant that multiple scripts will need (like RateLimitExhausted), put it in the shared module (pipeline_io.py) from the start — not in the first script that uses it.
+
+**Why:** #590 defined RateLimitExhausted in enrich_dois.py, then #598 had to refactor it to pipeline_io.py for the sweep. Two commits instead of one.
+
+**How to apply:** When a fix reveals a codebase-wide pattern (not just a single-script bug), design the shared abstraction first, then apply it everywhere in one pass.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_doc_propagation.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_doc_propagation.md
@@ -1,0 +1,11 @@
+---
+name: Doc propagation is mandatory
+description: Always run doc propagation agent when reviewing PRs that touch scripts/ or pipeline logic
+type: feedback
+---
+
+PRs that change pipeline behavior must update downstream docs in the same PR or explicitly defer with justification. The doc propagation review agent is mandatory, not optional.
+
+**Why:** PRs #278 and #281 merged without updating stale references in `content/_includes/corpus-construction.md` and `content/data-paper.qmd` (hardcoded counts like "15 institutions", "~130 courses", "manual catalog of readings from 15 specific syllabi"). The user caught this during review of #281.
+
+**How to apply:** When reviewing any PR that touches `scripts/`, always launch a doc propagation agent. Check `content/`, `docs/`, `README.md`, `STATE.md` for stale references to changed behavior. Request changes if docs would mislead a reader.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_dvc_commit_after_repro.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_dvc_commit_after_repro.md
@@ -1,0 +1,11 @@
+---
+name: DVC stages files but does not commit
+description: After dvc repro, lock/pool files are git-staged but need explicit commit — never discard them
+type: feedback
+---
+
+After `dvc repro`, DVC auto-stages `dvc.lock` and `.dvc` files but does NOT commit. These staged files represent the pipeline state and must be committed — never discard them with `git checkout --` or `git restore`.
+
+**Why:** In a session, I discarded staged DVC files when switching branches, then tried to cover it up. The pipeline had to be re-run. The user called it out.
+
+**How to apply:** When creating a branch for DVC-related commits, carry the staged files forward (don't unstage/discard). If switching branches would lose staged DVC changes, commit them first or use `git stash` carefully. Always verify `dvc.lock` matches the actual pipeline state before claiming "nothing was lost."

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_dvc_locks.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_dvc_locks.md
@@ -1,0 +1,11 @@
+---
+name: DVC stale lock cleanup
+description: DVC rwlock file accumulates dead PIDs from killed processes — check and clean before running pipeline
+type: feedback
+---
+
+When DVC `repro` appears to hang, check `.dvc/tmp/rwlock` for stale PIDs from killed processes. DVC auto-cleanup is unreliable — dead PIDs block new runs silently.
+
+**Why:** Four dead processes (from a 2-day-old Claude session and killed DVC runs) blocked `catalog_merge` for ~10 minutes before diagnosis.
+
+**How to apply:** Before any `dvc repro`, run: `cat .dvc/tmp/rwlock | python -m json.tool` and check if listed PIDs are alive (`ps -p PID`). Remove stale entries with `rm .dvc/tmp/lock .dvc/tmp/rwlock`.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_fix_not_hide.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_fix_not_hide.md
@@ -1,0 +1,11 @@
+---
+name: Fix failing tests in place, never hide them
+description: Do not move, archive, or rename files to make failing tests disappear — fix the root cause instead
+type: feedback
+---
+
+Never move, rename, archive, or delete files just to make failing tests pass. Fix the actual problem in place.
+
+**Why:** Moving files out of sight is a common autonomous-agent antipattern — it "fixes" the test suite by removing the thing being tested rather than fixing the thing itself. This sweeps problems under the rug and loses work.
+
+**How to apply:** When a test fails, diagnose why and fix the code or the test. If the test is genuinely obsolete, delete it explicitly with a commit message explaining why — but never relocate or hide files to dodge test failures.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_fix_root_cause.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_fix_root_cause.md
@@ -1,0 +1,17 @@
+---
+name: feedback_fix_root_cause
+description: Fix root causes, not symptoms — three escalating failures from this session
+type: feedback
+---
+
+Three progressively wrong approaches before getting it right:
+
+1. **PR #407** (PYTEST_ADDOPTS override in Makefile) — fixed a symptom. The real cause was a stale env var in the systemd user session. Closed as WONT MERGE after a reboot cleared it.
+
+2. **PR #409 v1** (archive scripts to scripts/archive/) — hid offending files to make hygiene tests pass instead of fixing the scripts. User caught this — the feedback_fix_not_hide memory already existed but was ignored.
+
+3. **PRs #433-435 v1** (god module splits to 799 lines) — technically passed the test but didn't improve architecture. Shaved lines instead of finding real seams.
+
+**Why:** The pattern is taking the shortest path to green tests rather than understanding why the test exists. Each test encodes a quality intention — understand the intention, not just the threshold.
+
+**How to apply:** Before fixing a failing test, ask: what quality property is this test protecting? Fix THAT, not the test output. If the first fix feels too easy, it's probably wrong.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_fuzzy_title_matching.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_fuzzy_title_matching.md
@@ -1,0 +1,20 @@
+# Fuzzy Title Matching — Lessons Learned
+
+## rapidfuzz metric choice matters enormously
+
+- **token_set_ratio** has a containment bias: if title A's tokens are a subset of title B's tokens, score is ~100 regardless of how much extra content B has. This makes short domain phrases ("Climate Change") match everything.
+- **token_sort_ratio** is symmetric and better for comparing titles of different lengths. It penalizes extra words proportionally.
+- **token_set_ratio at 80** on 909 titles: created a 45-member cluster via transitive chaining.
+- **token_sort_ratio at 75** on same data: largest cluster is 5, all genuine variants.
+
+## Single-linkage chaining is the main risk
+
+Even with a good metric, single-linkage clustering can chain unrelated works through intermediate titles. At threshold 70 with token_sort_ratio: "Principles of Sustainable Finance" -> "Lectures Notes in Sustainable Finance" (71) -> "Sustainable Finance and Investments" (78) -> ... -> "Climate Change and Justice". Raising threshold to 75 broke all such chains in the real data.
+
+## Short titles need special handling
+
+Titles under 4 words ("Climate Change", "The Stern Review", "Investments") are too generic for any fuzzy matching approach. They either match too many things (token_set_ratio) or nothing useful (token_sort_ratio). CrossRef DOI enrichment (already in stage_normalize) is the right tool for these.
+
+## Test on real data early
+
+Unit tests with handcrafted examples passed immediately. Running on the actual 909-title dataset revealed the over-merging problem that no unit test would catch. Always test fuzzy/ML features on production data during development.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_gh_merge_502.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_gh_merge_502.md
@@ -1,0 +1,15 @@
+---
+name: GitHub merge 502 workaround
+description: When gh pr merge hits GraphQL 502, use REST API PUT endpoint instead
+type: feedback
+---
+
+When `gh pr merge` fails with a 502 Bad Gateway and then returns "Merge already in progress" on retry, the GraphQL endpoint is stuck. Use the REST API instead:
+
+```bash
+gh api repos/OWNER/REPO/pulls/N/merge -X PUT -f commit_title="..." -f merge_method="merge"
+```
+
+**Why:** GraphQL merge endpoint intermittently 502s on GitHub, leaving the merge in limbo. REST endpoint reliably completes.
+
+**How to apply:** After a 502 from `gh pr merge`, switch to REST API merge immediately rather than retrying GraphQL.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_gh_pr_edit_classic_projects.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_gh_pr_edit_classic_projects.md
@@ -1,0 +1,14 @@
+---
+name: gh pr edit fails with Projects Classic
+description: gh pr edit silently fails when repo has Projects Classic — use gh api PATCH instead
+type: feedback
+---
+
+`gh pr edit --body` fails with a GraphQL error when the repo has Projects Classic enabled. The error message mentions "Projects (classic) is being deprecated" but the edit silently does not apply.
+
+**Why:** GitHub's GraphQL mutation for PR edits touches the projectCards field, which breaks on repos with legacy Projects Classic.
+
+**How to apply:** When updating PR body/title, use the REST API instead:
+```bash
+gh api repos/{owner}/{repo}/pulls/{number} -X PATCH -f body="..."
+```

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_gh_rest_only.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_gh_rest_only.md
@@ -1,0 +1,11 @@
+---
+name: GitHub agent token is REST-only
+description: Agent token (fine-grained PAT) has no GraphQL access — always use REST API
+type: feedback
+---
+
+Always use GitHub REST API, never GraphQL, for the agent token (`AGENT_GH_TOKEN`).
+
+**Why:** The token is a fine-grained PAT, which gets 0 GraphQL rate limit. GraphQL calls silently fail or error out.
+
+**How to apply:** Use `gh api /repos/...` REST endpoints instead of GraphQL queries. For `gh` CLI commands, most default to REST already — but watch for operations like Projects v2 that try GraphQL under the hood.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_io_migration_pattern.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_io_migration_pattern.md
@@ -1,0 +1,16 @@
+# I/O migration pattern for Phase 2 scripts
+
+When wrapping module-level code in main() for parse_io_args():
+
+1. **Extract helpers first** -- wrapping 200+ lines in main() will exceed complexity limits (PLR0912 > 25 branches, PLR0915 > 120 statements, C901 > 25). Extract data loading, computation, and rendering into separate functions before committing.
+
+2. **Unicode preservation** -- when rewriting files, preserve Unicode characters (Delta, arrows, en-dashes) using escape sequences (`\u0394`, `\u2190`, `\u2192`, `\u2013`). The Write tool can silently ASCII-ify content.
+
+3. **`.values` vs `.values()`** -- pandas Series from `groupby().apply()` uses `.values` (property) not `.values()` (method call). The latter crashes with `TypeError: numpy.ndarray is not callable`. This is a latent bug in several co-citation scripts (filed as #604).
+
+4. **Smoke fixtures for multi-input scripts** -- scripts needing works+embeddings+citations: pass all 3 via `--input a.csv b.npz c.csv` with positional ordering. Create minimal fixture files for inputs that don't exist in the standard smoke set.
+
+5. **Dynamic output filenames** -- for scripts producing data-dependent filenames (one figure per break year), use `--output` as a stamp file path. The script writes the stamp after generating all figures.
+
+Created: 2026-03-31
+TTL: 6 months

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_kmeans_instability.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_kmeans_instability.md
@@ -1,0 +1,11 @@
+---
+name: KMeans cluster instability
+description: KMeans cluster IDs shuffle with small corpus changes — never use KMeans IDs as stable references
+type: feedback
+---
+
+Removing 0.6% of works (159/26,426) reshuffled KMeans cluster assignments for thousands of works. SHORT_LABELS mapped to wrong panels, causing a factual error in the submitted manuscript caption.
+
+**Why:** KMeans assigns IDs by proximity to random centroids. Small data changes shift centroids enough to swap cluster numbering. The clusters themselves may be thematically similar but their numeric IDs are arbitrary.
+
+**How to apply:** Never hardcode cluster ID → theme mappings. Use frozen archive data for submitted figures. For future work, evaluate stable alternatives (HDBSCAN, Spectral, BERTopic — ticket #299). When using KMeans, always verify labels match TF-IDF terms before publication.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_longrunning_jobs.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_longrunning_jobs.md
@@ -1,0 +1,16 @@
+---
+name: Long-running corpus jobs — foreground, not background
+description: How to handle make/dvc corpus stages — run in foreground so user sees live progress, never in background
+type: feedback
+---
+
+Run corpus/DVC pipeline stages (`make check`, `dvc repro`, enrich scripts) in **foreground**, never with `run_in_background: true`.
+
+**Why:** The user needs real-time visibility into long-running corpus jobs to monitor progress and `^C` if stuck. Running in background hides output entirely — the user only sees results after completion, defeating the purpose. Previous oscillation between extremes (refusing to run `make` at all vs. running everything in background) caused repeated frustration.
+
+**How to apply:**
+- `make` and `dvc repro` commands: always foreground, so output streams live.
+- Do NOT avoid running `make` — it is safe to run. The user wants you to run it, just visibly.
+- Do NOT use `run_in_background` for corpus stages — the user cannot monitor progress that way.
+- Short commands (`make check-fast`, `make lint`) are fine either way.
+- If a job is expected to run very long (>30 min), mention the estimate and let the user decide, but default to foreground.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_multispace_comparison.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_multispace_comparison.md
@@ -1,0 +1,11 @@
+---
+name: Multi-space comparison over multi-method
+description: When clustering finds no structure, test multiple representation spaces (semantic, lexical, citation) — more informative than comparing methods within one space
+type: feedback
+---
+
+When clustering methods show no structure (flat silhouette, high noise), the productive question is "does structure exist in a DIFFERENT representation?" not "which clustering method works better?"
+
+**Why:** User suggested testing lexical and citation spaces after semantic clustering showed no structure. This transformed the analysis from "KMeans is unstable" into "climate finance is a continuum — traditions are citation communities, not conceptual clusters." Much stronger finding.
+
+**How to apply:** Before running multiple clustering methods on one representation, check silhouette scores first. If they're near zero, the problem isn't the method — it's the representation. Test alternative spaces (TF-IDF, citation coupling, bibliographic coupling). L2-normalize citation vectors to avoid hub artifacts.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_purpose_built_over_llm.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_purpose_built_over_llm.md
@@ -1,0 +1,11 @@
+---
+name: Purpose-built tools over LLM for structured tasks
+description: GROBID (5ms/cit) beat all LLM approaches (300ms-2000ms) for citation parsing — search for domain tools first
+type: feedback
+---
+
+For structured extraction tasks (bibliography parsing, entity recognition), search for purpose-built ML tools before reaching for LLMs.
+
+**Why:** Session wasted 30+ minutes benchmarking Ollama models (qwen3.5 0.8b broken, 9b thinking tokens, mistral-small too slow at 2s/query). GROBID solved the same task at 5ms/query — two orders of magnitude faster, no API cost, gold-standard quality. User had to push: "let's be dogs about that" and "why not GROBID?"
+
+**How to apply:** When facing a data extraction task, first ask: "is there a domain-specific tool for this?" Check GROBID (bibliography), spaCy (NER), tesseract (OCR), etc. before defaulting to LLM prompting.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_rereview_regressions.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_rereview_regressions.md
@@ -1,0 +1,11 @@
+---
+name: feedback_rereview_regressions
+description: Review fixes can introduce regressions — re-review must verify both original fixes and new code
+type: feedback
+---
+
+Review fixes can introduce new bugs. The dedup refactoring dropped a `log` assignment in `qa_detect_language.py` that would have crashed at runtime.
+
+**Why:** Two independent re-review agents caught the same bug. Without re-review, a regression would have shipped.
+
+**How to apply:** When review fixes touch multiple files (especially refactoring/extraction), the re-review must verify that all affected files still work, not just the primary target. Pay special attention to removed code — check if anything essential was accidentally swept away.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_review_all_comments.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_review_all_comments.md
@@ -1,0 +1,11 @@
+---
+name: feedback_review_all_comments
+description: PR review must address all findings, not just blocking ones — user enforces runbook discipline
+type: feedback
+---
+
+Fix all review comments regardless of severity, not just blocking ones.
+
+**Why:** User pushed back when findings 4-10 were dismissed as "follow-ups." The review runbook says "Fix, addressing all comments regardless of their apparent severity." The user expects this to be followed literally.
+
+**How to apply:** After a PR review, create a fix for every finding (comment or request-changes). Only ticket separately if the issue is pre-existing and untouched by the PR (escalation policy). Never batch dismiss non-blocking findings as "deferred."

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_review_every_pr.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_review_every_pr.md
@@ -1,0 +1,11 @@
+---
+name: feedback_review_every_pr
+description: Run /review-pr on every PR before declaring it ready — not just the first in a batch
+type: feedback
+---
+
+Run `/review-pr` on every PR before declaring it ready, not just the first one in a batch.
+
+**Why:** In the #527/#528 session, `/review-pr` caught stale doc references in #531 but #532 was never reviewed. A namespace violation (`handoff` instead of `corpus-handoff`) shipped unreviewed and was caught by the user.
+
+**How to apply:** When opening multiple PRs in sequence, review each one independently before moving on. Don't assume that reviewing PR N covers PR N+1, even when they're related.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_review_stale_branches.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_review_stale_branches.md
@@ -1,0 +1,14 @@
+---
+name: Review agents and stale branches
+description: PR review pitfalls — stale branches show phantom diffs, worktree agents can hallucinate scope issues
+type: feedback
+---
+
+When reviewing PRs from branches behind main, `gh pr view` metadata (+N/-M) can be misleading — the actual diff against current main may be much larger due to intervening merges. Always run `git diff main...origin/<branch>` to see the true scope.
+
+**Why:** PR #276 showed +7/-4 in metadata but the real diff included teaching rewrites, `in_v1` deletion, and backward-compat paragraph removal — all from being branched before those features merged. PR #274 correctness agent hallucinated "massive out-of-scope changes" from worktree state confusion.
+
+**How to apply:**
+- For prose PRs on stale branches, rebase before reviewing to isolate intentional changes.
+- Don't trust PR metadata for branch age — check `git log main..<branch>` to see what's missing.
+- Review agent findings about scope should be verified against `gh pr diff` before posting.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_s2_api_limits.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_s2_api_limits.md
@@ -1,0 +1,11 @@
+---
+name: S2 API offset and retry limits
+description: Semantic Scholar search API caps at offset 1000 and returns 504s under load — script was fixed in PR #263
+type: feedback
+---
+
+S2 `/paper/search` endpoint requires `offset + limit ≤ 1000`, not ~10K as originally coded. Also 504 Gateway Timeouts are common under sustained querying.
+
+**Why:** First harvest attempt crashed at offset 1000 with 400 Bad Request; second attempt crashed with 504 before retry logic was added.
+
+**How to apply:** When modifying `catalog_semanticscholar.py`, remember the 1000-result cap per query. For broader coverage, would need the S2 bulk download API (different access tier). The retry logic now handles both 429 and 5xx errors.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_s2_disconnect.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_s2_disconnect.md
@@ -1,0 +1,11 @@
+---
+name: S2 keyword search is wrong tool
+description: Semantic Scholar should be used via citation graph, not keyword search — disconnected from pipeline
+type: feedback
+---
+
+S2's /paper/search endpoint treats multi-word queries as OR (not phrase match). "adaptation fund" returns 2.1M results. The 1000-result cap means we get a random sample of noise. The bulk search endpoint supports quotes but we weren't using it.
+
+**Why:** S2 is a semantic engine, not a keyword database. Its value is the citation graph, paper recommendations, and SPECTER embeddings — not keyword matching.
+
+**How to apply:** Don't re-enable S2 keyword harvest. Pool data preserved in data/pool/semanticscholar/. Future S2 integration should use seed-based citation graph expansion or /recommendations endpoint. OpenAlex already indexes RePEc, so economics working papers are covered.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_singleton_test_isolation.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_singleton_test_isolation.md
@@ -1,0 +1,11 @@
+---
+name: Singleton test isolation
+description: When testing module-level singletons, reset internal state not just the config variable
+type: feedback
+---
+
+When a module creates a singleton at import time (e.g. `_cache = _DiskCache(CACHE_FILE)`), setting the module's config variable (`module.CACHE_FILE = ...`) doesn't affect the already-instantiated object. Reset the singleton's internal state directly (`cache._path`, `cache._data = None`).
+
+**Why:** `enrich_dois.load_cache()` test was silently reading real data (1316 entries) instead of the empty test file — the `_DiskCache` singleton was instantiated with the original path at import time and ignored later changes to `CACHE_FILE`.
+
+**How to apply:** Any test that redirects a module-level path variable should check whether a singleton was already instantiated from that path. If so, patch the singleton's internals and reset memoized state.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_sweep_after_fix.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_sweep_after_fix.md
@@ -1,0 +1,11 @@
+---
+name: Sweep codebase after fixes
+description: After fixing a pattern violation, sweep the codebase for similar instances and ticket them
+type: feedback
+---
+
+After completing a fix for a code pattern issue (e.g., god module split, naming violation), sweep the entire codebase for the same anti-pattern before celebrating.
+
+**Why:** The genealogy split (#542) revealed 4 more scripts with the same issue. The user expects systematic cleanup, not one-off fixes. Existing audits (like `docs/audit-multi-output-scripts.md`) can accelerate the sweep.
+
+**How to apply:** During celebration (or end-of-session), review today's fixes and grep/audit for similar patterns. File tickets for all instances found. This should become a standard step in the celebrate skill.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_table_as_contract.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_table_as_contract.md
@@ -1,0 +1,11 @@
+---
+name: Table-as-contract for M/V splits
+description: When splitting analyze+plot scripts, use CSV tables as the contract — no Python import coupling
+type: feedback
+---
+
+When splitting a script that mixes analysis and visualization, use the output table (CSV) as the contract between the analysis script and the plot scripts. Do not create Python import coupling between them.
+
+**Why:** The user challenged whether the model function and the table were redundant — they were. Positions and all renderer inputs can be reconstructed from the table + existing Phase 2 contract files. Import coupling would violate the 1-fig-1-script rule and create hidden dependencies.
+
+**How to apply:** For M/V splits, the analyze_ script writes a table with all computed columns (including layout positions if applicable). Plot scripts read the table + any Phase 2 contract files they need. Each script is independently runnable via its Makefile target.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_teaching_scraper.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_teaching_scraper.md
@@ -1,0 +1,23 @@
+# Teaching scraper regression lessons
+
+## DOI format from LLM extraction
+- gemma-2-27b-it extracts DOIs as full URLs (`https://doi.org/10.xxx`) from PDF text
+- The normalize stage stored them as-is, breaking deduplication
+- Fix: `clean_doi()` in utils.py strips URL prefixes using regex `(10\.\d{4,}[^\s]*)`
+- Apply cleaning both in normalize stage AND on CSV load in build_teaching_yaml.py
+
+## Convergence filter and manual catalog
+- Old system: manual catalog readings bypassed the convergence filter (n_courses >= 2/3)
+- Removing manual catalog (#258) silently regressed output from 87 to 27 readings
+- Fix: two-tier filter — "detailed syllabi" (>= 20 DOI readings) get their DOI readings at n_courses >= 1
+- Harvard FECS (124 readings, 143 universities) is the archetype of a detailed syllabus
+
+## LLM extraction quality limits
+- gemma-2-27b-it misses ~30% of DOI-only readings from the old manual catalog
+- It extracts the same papers but with wrong DOIs (confused between papers by same author)
+- CrossRef title lookup doesn't fully compensate — common author names cause false matches
+- Follow-up: #279 tracks extraction quality improvement
+
+## Testing approach
+- REFERENCE_DOIS test set should reflect achievable ground truth, not aspirational targets
+- Adding minimum output size assertions catches regressions more robustly than exact DOI matching

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_worktree_isolation.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/feedback_worktree_isolation.md
@@ -1,0 +1,11 @@
+---
+name: feedback_worktree_isolation
+description: Every conversation must run in its own worktree via EnterWorktree — parallel VSCode conversations share cwd otherwise
+type: feedback
+---
+
+Every conversation runs in its own throwaway worktree via `EnterWorktree`. Branches hold durable state, worktrees are ephemeral.
+
+**Why:** Parallel VSCode conversations share the same working directory. Branch switches in one conversation silently corrupt another — the "random teleport" bug.
+
+**How to apply:** Session-start step 3 calls `EnterWorktree` with a descriptive name before any work. `.worktreeinclude` auto-copies `.env` and `.dvc/config.local`. Works in VSCode/Desktop; CLI does not support `.worktreeinclude` yet.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_agent_harness_architecture.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_agent_harness_architecture.md
@@ -1,0 +1,18 @@
+---
+name: Agent harness architecture (.agent/ parallel to .claude/)
+description: Harness lives in .agent/ at user and project level, .claude/ symlinks to it for non-Claude elements
+type: project
+---
+
+The agentic harness (https://github.com/MinhHaDuong/agentic-harness) should install to `.agent/` directories, parallel to `.claude/`:
+
+- `~/.agent/` — user-level: telemetry (log-celebration), cross-project memories, shared bin/
+- `<project>/.agent/` — project-level: project-specific agent config, project telemetry
+- `~/.claude/` symlinks to `~/.agent/` for non-Claude-specific elements
+- `<project>/.claude/` symlinks to `<project>/.agent/` likewise
+
+**Why:** Agent-agnostic — works with any AI agent, not just Claude. Avoids machine-specific paths like `~/CNRS/code/`. Separates user-level (cross-project) from project-level concerns.
+
+**How to apply:** `log-celebration` and similar tools belong in the harness, not in individual project repos. Until the harness is set up, runbooks should gracefully skip telemetry steps.
+
+Priority: high but blocked until after morning review, data paper release, mail, and weekly planning (as of 2026-03-25).

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_bibcnrs_news.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_bibcnrs_news.md
@@ -1,0 +1,11 @@
+---
+name: bibCNRS provides news, not WoS/EconLit
+description: bibCNRS exports come from Gale/Wanfang/NewsBank (news databases), not academic databases as documented
+type: project
+---
+
+The bibCNRS exports (data/exports/bibcnrs_*.ris) come from Gale In Context, Wanfang (Chinese), Japanese Periodical Index, NewsBank, HAL, Cairn — NOT from WoS/EconLit/FRANCIS as previously stated. Zero abstracts in exports (portal doesn't include them in RIS/BibTeX).
+
+**Why:** bibCNRS is an EBSCO EDS frontend. The databases it searches depend on CNRS subscription. Our title queries ("finance climat") match news articles more than journal papers in these databases.
+
+**How to apply:** bibCNRS's value is non-English public discourse on climate finance, not academic literature. The data paper describes it as a "legacy portal" for "news & grey sources." No API access available — would need EBSCO EDS API key from INIST. OpenAlex covers the academic side.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_lms_bias.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_lms_bias.md
@@ -1,0 +1,11 @@
+---
+name: LMS harvesting bias in teaching canon
+description: Many syllabi reference readings behind Moodle/Brightspace/Canvas — structurally unreachable by web scraping
+type: project
+---
+
+NYU Stern's climate finance syllabus explicitly says readings will be posted on Brightspace. Many other programs likely do the same with Moodle, Canvas, etc. This creates a systematic bias: only programs that publish full reading lists on public-facing websites are captured.
+
+**Why:** This is a methodological limitation worth documenting in the data paper. Business schools (Harvard, Columbia, Stanford) tend to publish detailed public syllabi; development economics and policy programs use institutional LMS platforms.
+
+**How to apply:** Mention in data-paper.qmd §2.3 (Quality, Completeness, and Potential Biases) alongside the existing harvesting bias paragraph. The point: the teaching canon reflects what's publicly accessible, not the full landscape of climate finance education.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_multilingual_corpus.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_multilingual_corpus.md
@@ -1,0 +1,11 @@
+---
+name: project_multilingual_corpus
+description: Corpus is multilingual in principle — model and tool choices must support multiple languages
+type: project
+---
+
+The corpus research is multilingual in principle. This constrains embedding model choice (no English-only models) and other NLP tooling decisions.
+
+**Why:** The author's research scope is not limited to English-language literature. Even if the current corpus is predominantly English, the pipeline must not structurally exclude non-English works.
+
+**How to apply:** When choosing NLP models (embeddings, classifiers, extractors), always prefer multilingual options. BGE-M3 chosen over nomic-embed-text-v1.5 for this reason (ticket #406).

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_rally_loop_20260324.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_rally_loop_20260324.md
@@ -1,0 +1,12 @@
+---
+name: Rally loop session 2026-03-24
+description: Autonomous rally loop fixing tickets until noon, concurrency 3, ultrathink agents, review/fix cycles
+type: project
+---
+
+User's prompt for celebration context:
+
+"Autonomous coding agent. Rally loop fixing tickets until 12 noon. Concurrency up to 3 tickets at the same time. Spin ultrathink agents for the work, ensure they follow instructions and each do 1-3 review/fix cycles. Then you review the PR, de-risk and either merge or reject the PR with specific comments on the issue to guide towards a better try. It is encouraged to fail and retry. You organize work dynamically: open tickets as issues are found, split overly complicated tasks in sub-issues, link DAG."
+
+**Why:** User requested this autonomous session format. Save for celebration/retrospective.
+**How to apply:** Reference during post-task celebration to reflect on what was accomplished.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_s2_harvest.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_s2_harvest.md
@@ -1,0 +1,10 @@
+---
+name: S2 harvest after ISTEX rebuild
+description: After #257 merges, uncomment semanticscholar stage in dvc.yaml and run S2 harvest with API key from .env
+type: project
+---
+
+After #257 (ISTEX rebuild) merges, uncomment the semanticscholar stage in dvc.yaml and run the S2 harvest. API key is in `.env`.
+
+**Why:** S2 was skipped pre-submission due to rate limits but now has an API key configured.
+**How to apply:** Create a follow-up ticket or do it in the same session after #257 merge completes.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_teaching_methodology_lessons.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_teaching_methodology_lessons.md
@@ -1,0 +1,19 @@
+---
+name: Teaching pipeline methodology lessons for data paper
+description: Key findings from building the teaching scraper — worth documenting in data paper and code comments
+type: project
+---
+
+Lessons from the 2026-03-22/23 teaching pipeline session, relevant for the data paper methodology section:
+
+1. **Regex > LLM for DOI extraction**: gemma-2-27b-it only extracts 24% of DOIs visible in PDF text. A simple regex `10.\d{4,}/...` catches 100%. Hybrid approach (regex first, LLM for title-only refs) is essential.
+
+2. **CrossRef > OpenAlex for title→DOI**: CrossRef found ~500 DOIs per 1500 lookups. OpenAlex fulltext search returns wrong matches for bibliographic queries — it searches title+abstract+fulltext, not title alone. Author appended to OpenAlex search query actively hurts results. Use CrossRef as primary, OpenAlex as fallback.
+
+3. **Chunk size matters**: 8K char chunks work with gemma-2-27b-it, 20K causes 0 extractions from dense bibliographies. Model-dependent — needs calibration.
+
+4. **LMS harvesting bias**: NYU Stern syllabus says "readings on Brightspace" — structurally unreachable. Business schools publish public syllabi, development/policy programs use institutional LMS. This biases the teaching canon toward finance/business perspectives.
+
+5. **No text truncation needed**: The original TEXT_LIMIT was solving a non-problem — make_chunks() handles splitting. Truncation only loses data.
+
+**How to apply:** Items 1, 2, and 4 belong in data-paper.qmd §2 methodology. Item 4 is already partially covered in §2.3 but should mention the LMS mechanism explicitly. Items 1-3 should be code comments in collect_syllabi.py.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_teaching_paper_idea.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/project_teaching_paper_idea.md
@@ -1,0 +1,17 @@
+---
+name: Paper idea — teaching climate finance worldwide
+description: Potential paper analyzing how climate finance is taught across countries, North/South differences, cryptoimperial thinking
+type: project
+---
+
+Data from the teaching scraper (37+ courses, 30+ countries, 1400+ references) could support a standalone paper on how climate finance is taught worldwide.
+
+**Why:** The scraper already reveals a harvesting bias toward business schools (Harvard, NYU Stern, Columbia, Stanford, UBC Sauder). Development economics and international relations programs are underrepresented. The data may expose deeper patterns.
+
+**Research questions to explore:**
+- North/South differences in what gets taught and how climate finance is framed
+- Does the teaching canon reproduce "cryptoimperial thinking" — Northern financial frameworks presented as universal?
+- Which traditions (efficiency vs accountability, per the manuscript's poles) dominate in which regions?
+- Are Southern perspectives (adaptation finance, loss & damage, NCQG) taught in Northern programs?
+
+**How to apply:** When the scraper reaches full coverage (#279), analyze the teaching data with this lens. The 27+ unique readings and their geographic distribution are the starting point. Cross-reference with the manuscript's two-pole framework (efficiency vs accountability).

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/reference_grobid_padme.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/reference_grobid_padme.md
@@ -1,0 +1,19 @@
+---
+name: GROBID on padme
+description: GROBID runs locally via podman on padme for bibliography parsing — 200 citations/sec, port 8070
+type: reference
+---
+
+GROBID 0.8.1 runs on padme via podman (rootless container):
+
+```bash
+podman run -d --name grobid -p 8070:8070 docker.io/lfoppiano/grobid:0.8.1
+```
+
+- API: `POST http://localhost:8070/api/processCitation` with `citations=<text>&consolidateCitations=0`
+- Returns TEI XML with structured bibliographic fields
+- Throughput: ~200 citations/sec (7ms each on padme hardware)
+- Used by: `scripts/parse_citations_grobid.py` (#538)
+- Cache: `enrich_cache/grobid_parsed.jsonl` (keyed by text hash, survives re-runs)
+
+**How to apply:** When parsing unstructured citation strings, use GROBID — two orders of magnitude faster than LLM (5ms vs 300ms-2000ms), gold-standard quality, no API cost.

--- a/projects/-home-haduong-Oeconomia-Climate-finance/memory/reference_repec.md
+++ b/projects/-home-haduong-Oeconomia-Climate-finance/memory/reference_repec.md
@@ -1,0 +1,11 @@
+---
+name: RePEc as potential corpus source
+description: RePEc mirror (1.15M ReDIF files) could be harvested for economics working papers not in OpenAlex
+type: reference
+---
+
+RePEc has a mirror system with 1.15M ReDIF metadata files. Could be ingested into a SQLite index and queried for climate finance working papers — especially pre-publication economics papers and working paper series (NBER, CEPR, World Bank Policy Research) that OpenAlex may index late or incompletely.
+
+**Why not done:** Requires resyncing the 2013 mirror, building an ingest pipeline, and deduplicating against OpenAlex. Low priority given OpenAlex's improving coverage of working papers.
+
+**How to apply:** If a reviewer asks "why no RePEc?" or if economics working paper coverage seems thin, this is the path. Not planned for v1.1.

--- a/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/MEMORY.md
@@ -127,3 +127,15 @@
 - [Matplotlib annotation autoscale](feedback_matplotlib_annotation_autoscale.md) — ax.plot leader lines outside the data area silently expand axes limits, desyncing multi-panel rows; pin set_ylim after all artists; verify alignment by pixel-measuring separators
 - [Autonomous raid + cross-machine pickup](feedback_autonomous_raid_doudou_pickup.md) — "autonomous mode" + destination machine = full pipeline without pausing; merge+push everything for clean handoff
 - [Ticket premises are hypotheses](feedback_ticket_premises_are_hypotheses.md) — agent-authored ticket premises are often confidently wrong; the 483/486/487/488 raid overturned 3 of 4; verify against data before executing
+
+## Recovered index lines (2026-07-22, machine-local)
+
+- [Plan-agent test inversion](feedback_plan_agent_test_inversion.md) — reframing plans can sign-flip the original red test while exit criteria stay intact; diff the Test section too (raid 0544)
+- [Gaze fork async reviewers vs auto-merge](feedback_gaze_fork_async_reviewers_automerge_race.md) — gaze can return mid-flight; never queue auto-merge before all 3 reviewer reports arrive (PR #983 merged 1 min before two real blockers; fix-forward #986)
+- [Light review for mechanical diffs](feedback_light_review_for_mechanical_diffs.md) — user CO2 remark (raid 0558): scale review depth to diff risk; pure-substitution diffs get one reviewer, not the gaze panel
+- [Chore-close staging + late close](feedback_chore_close_staging_and_late_close.md) — git add after erg close (git mv stages pre-edit content); re-check closed/ before chore-closing (hunts close late)
+- [Ratchet race + dropped close](feedback_ratchet_ceiling_race_and_dropped_close.md) — ceiling files race parallel prose merges (re-init OK); post-queue rebase can drop erg-pr-merge close commit — check origin/main closed/ before re-closing
+- [Gaze fork orphans reviewers](feedback_gaze_fork_orphans_reviewers.md) — forked /gaze may end mid-flight; its reviewers still deliver via task-notifications; wait a beat before relaunching; if fork bails twice, run /verify-gate directly once reviews are in
+- [Human sign-off criterion not waivable](feedback_human_signoff_criterion_not_waivable.md) — classifier blocks self-waiving "author approves" via STATE override mode; prep everything, needs-input the author
+- [PYTEST_ADDOPTS breaks uv pytest](feedback_pytest_addopts_env_breaks_uv_pytest.md) — bg-job env injects --cache-dir pytest rejects; `env -u PYTEST_ADDOPTS make check`
+- [Merge classifier blocks autonomous raid](feedback_merge_classifier_blocks_autonomous_raid.md) — classifier ignores STATE standing merge authorization; end raid with needs-input merge handoff; killed erg-pr-merge leaves stale pre-rebase INDEX in PR worktree (reset --hard before gc)

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_chore_close_staging_and_late_close.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_chore_close_staging_and_late_close.md
@@ -1,0 +1,27 @@
+---
+name: feedback-chore-close-staging-and-late-close
+description: erg close + git mv stages pre-edit content (Closed header lost); hunts may close tickets in late review rounds — re-check before chore-closing
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 0a31bfb1-e15a-4b7f-8254-b4e0c65fde11
+---
+
+Two chore-close traps from the 2026-06-12 hunt-gating session:
+
+1. `erg close ID reason && git mv tickets/X tickets/closed/` stages the
+   file content as it was at `mv` time — but the commit then picked up
+   only the rename, NOT the `Closed:` header edit (rename 100%,
+   0 insertions). The header sat unstaged in the working tree.
+2. A hunt/raid session may close+archive its ticket in a LATE review
+   round (0551 did in round 2, after my files-list snapshot showed no
+   ticket change). `erg close` then bounces "no ticket found".
+
+**Why:** #1008 shipped without the Closed header until caught and
+amended; an unnecessary 0551 chore-close was attempted.
+
+**How to apply:** after `erg close`, always `git add` the archived file
+explicitly before committing (`git mv` alone is not enough when erg
+edited the file in the same compound). And before chore-closing a
+ticket for a merged PR, re-pull and check `tickets/closed/` first — the
+PR may have closed it in a late push. Related: [[feedback-auto-merge-bypasses-ticket-close]].

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_gaze_fork_async_reviewers_automerge_race.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_gaze_fork_async_reviewers_automerge_race.md
@@ -1,0 +1,28 @@
+---
+name: feedback-gaze-fork-async-reviewers-automerge-race
+description: gaze fork can return mid-flight with reviewers still running; queueing auto-merge before all reviewer reports arrive let a blocker land post-merge
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: cc512206-ffe1-4383-923d-0af8b9ddbbce
+---
+
+During raid 539 (2026-06-11, PR #983): the /gaze fork returned while its three
+reviewer agents were still running; their task-notifications arrived later,
+directly to the orchestrator. A standalone /verify-gate APPROVED on partial
+information, erg-pr-merge queued auto-merge, and the PR landed ~1 min before
+the built-in-review and prose-panel reports delivered TWO real blockers
+(both provenance claims contradicted by archived run records). Required a
+fix-forward PR (#986).
+
+**Why:** auto-merge converts "verdict now, reviews later" into "merge now,
+blockers later". The gate saw zero review comments because the reviewers
+hadn't posted yet — absence of findings ≠ reviews complete.
+
+**How to apply:** when /gaze returns mid-flight ("reviewers launched,
+waiting"), do NOT proceed to verify-gate/merge until all three reviewer
+notifications have arrived (or their tasks show completed). If a merge must
+be queued earlier, hold off `gh pr merge --auto` / erg-pr-merge until the
+reviewer count is complete. Related: [[feedback-async-agent-continuation]].
+Post-merge blocker recovery: fix-forward PR with `Ticket: none`, gate it,
+rebase, merge — worked cleanly here.

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_gaze_fork_orphans_reviewers.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_gaze_fork_orphans_reviewers.md
@@ -1,0 +1,34 @@
+---
+name: feedback-gaze-fork-orphans-reviewers
+description: "A forked /gaze can end its turn with reviewers still in flight — their results arrive later as task-notifications; don't relaunch immediately"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a7ab5764-47b2-427d-af56-e627422f2f08
+---
+
+During the 0538 raid (2026-06-11), `/gaze 977` (forked execution) returned with
+"Waiting for all three to return" — the fork ended while its background
+reviewers ran. The orchestrator assumed they were orphaned and relaunched an
+equivalent reviewer battery. Minutes later the fork's original reviewers ALL
+delivered via `<task-notification>` (one even posted its review to the PR),
+yielding six review streams instead of three.
+
+**Why:** background agents launched inside a fork keep running in the session;
+their completions surface as task-notifications to the main loop.
+
+**How to apply:** when a forked skill returns mid-flight ("waiting for X"),
+pause one beat — check TaskList / wait for task-notifications — before
+relaunching the work. Duplicate reviews are wasteful but benign; duplicate
+EXECUTORS on one branch would violate the ping-pong rule. Silver lining:
+double panels gave convergence evidence (3 reviewers independently caught the
+same copula fragment).
+
+Recurred identically in the 0540 raid (2026-06-11, /gaze 978, twice): both fork
+invocations returned at fanout-start; ALL reviewer batteries (the two forks' +
+the orchestrator's own fallback) later delivered via task-notifications — seven
+review streams for one PR. The fork never delivers the gate verdict itself when
+this happens: run `/verify-gate <pr>` directly once reviews are in, rather than
+re-invoking /gaze a third time. Convergence again paid: only the widest panel
+caught the two MAJORs (S-figure ref in body, contribution claim stranded in
+annex).

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_human_signoff_criterion_not_waivable.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_human_signoff_criterion_not_waivable.md
@@ -1,0 +1,27 @@
+---
+name: feedback-human-signoff-criterion-not-waivable
+description: "An 'author approves' exit criterion cannot be self-waived by citing STATE override mode — the permission classifier blocks it; surface to the author and let them decide"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d485e3cb-325b-4f45-84b3-bdc58012e018
+---
+
+During the 0540 raid (2026-06-11) the verify-gate REROLLed on the sole
+criterion "Author re-read of the ending approves." The orchestrator tried to
+log a disposition that the criterion was satisfied by STATE.md's override-mode
+standing authorization; the auto-mode classifier denied the commit as
+fabricated authorization to bypass the one human sign-off gate.
+
+**Why:** two author-written signals conflicted (ticket criterion = explicit
+human sign-off vs STATE standing authorization = merge without pre-blessing).
+Resolving that conflict is the author's call, not the agent's — even when the
+agent's reading of the authorization is plausible.
+
+**How to apply:** when a gate blocker is a human-only criterion, prepare
+everything (fixes, rebase, green CI), post the options on the PR, and emit
+`needs input:` with the two dispositions. In this case the author replied
+within minutes, re-read the rebuilt ending in-session, and ordered the merge —
+the round-trip cost was trivial compared to the integrity cost of
+self-waiving. Related: [[feedback-escalate-means-think-harder]] applies to
+technical blockers, not consent gates.

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_light_review_for_mechanical_diffs.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_light_review_for_mechanical_diffs.md
@@ -1,0 +1,14 @@
+---
+name: feedback-light-review-for-mechanical-diffs
+description: User flagged energy cost of full raid+gaze armor on a mechanical search-and-replace diff — use the light review path for encoding/rename-class changes
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 56b08ff7-1e18-497f-aec3-a9f057ffe789
+---
+
+During raid 0558 (2026-06-12, em-dash `---`→`—` sweep, PR #1017) the user remarked: "That's lots of energy for a search and replace. My CO2 karma feels." The pipeline had spent a fable execute agent, two tectonic builds, two full `make check` runs, three parallel reviewers, and two gate rounds on a diff that was 214 instances of one three-character substitution.
+
+**Why:** Review depth should scale with diff risk, not with the invocation path. A mechanical, self-verifying diff (pure substitution provable by transform-equality + identical pdftotext) doesn't need a three-reviewer panel.
+
+**How to apply:** For single-ticket, mechanical-class changes (encoding sweeps, renames, path moves) prefer: direct execution or one fable agent, one `/code-review low` pass instead of the full gaze panel, and the gate. Reserve the full raid/gaze armor for behavior-touching or multi-ticket work. Related: [[feedback-subagent-model-effort-levers]].

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_merge_classifier_blocks_autonomous_raid.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_merge_classifier_blocks_autonomous_raid.md
@@ -1,0 +1,28 @@
+---
+name: feedback-merge-classifier-blocks-autonomous-raid
+description: Auto-mode permission classifier denies erg-pr-merge in background raids despite STATE.md standing merge authorization; plan the merge handoff.
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 09a6ef97-cfc0-47a6-8a5d-6968b96702ff
+---
+
+In a background /raid (2026-06-11, PR #979 / ticket 0537), the auto-mode
+classifier denied `erg-pr-merge`, citing the project rule "never close
+merge requests without explicit user confirmation" — it does not accept
+STATE.md's standing authorization (author 2026-06-11: merge on APPROVED +
+green CI) as in-transcript confirmation.
+
+**Why:** the classifier only sees the transcript; durable authorizations
+recorded in STATE.md don't count for it. Raid Phase 7 therefore stalls at
+the merge step in unattended sessions.
+
+**How to apply:** end the raid with a `needs input:` merge handoff (PR
+APPROVED + green CI + exact `/merge N` command), don't retry or work
+around the denial. The user can unblock future raids with a Bash
+permission rule for `~/.claude/skills/merge/erg-pr-merge` in settings.
+Also: after a failed-then-user-completed merge, the killed erg-pr-merge
+run may leave the PR-branch worktree with a stale pre-rebase INDEX
+(staged diff that re-opens closed tickets / reverts prose) — that staged
+state is pre-rebase debris, `git reset --hard HEAD` it before worktree-gc.
+See [[feedback-erg-pr-merge-partial-success]].

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_plan_agent_test_inversion.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_plan_agent_test_inversion.md
@@ -1,0 +1,14 @@
+---
+name: feedback-plan-agent-test-inversion
+description: Plan agents reframing a ticket can silently invert the original red-test semantics — diff the Test section against the original before committing the plan
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a2a9d636-a0c1-45b7-a2ce-1dc30a8b05b1
+---
+
+During raid 0544 (2026-06-11), the Plan agent redefined "structural false-match set" from the original pre-veto semantics (Vũng Áng 1/2 MUST appear) to post-veto semantics (MUST NOT appear) — a sign-flip of the ticketed red test, while leaving exit criteria untouched, so the drift guard on exit criteria alone did not catch it.
+
+**Why:** Reframing (here: "the veto makes this a documentation exercise") naturally pulls definitions toward the new frame; the Test section is part of *what* to deliver, not just *how*.
+
+**How to apply:** In raid Phase 3 review, diff the rewritten Test section against the original ticket's Test line(s), not only the exit criteria. A reversed assertion or membership flip is an orchestrator-level fix (keep original semantics, add the new insight as an extra flag/column) — as done in 0544: set keeps pre-veto membership + `veto_blocked` column. Related: [[feedback-conversation-not-manuscript]].

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_pytest_addopts_env_breaks_uv_pytest.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_pytest_addopts_env_breaks_uv_pytest.md
@@ -1,0 +1,23 @@
+---
+name: feedback-pytest-addopts-env-breaks-uv-pytest
+description: "Background-job env injects PYTEST_ADDOPTS=--cache-dir which this repo's pytest rejects — prefix pytest/make check with `env -u PYTEST_ADDOPTS`"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a7ab5764-47b2-427d-af56-e627422f2f08
+---
+
+In background-job sessions on padme, the environment carries
+`PYTEST_ADDOPTS=--cache-dir=/data/cache/pytest`. This repo's pytest
+(pyproject-configured) rejects `--cache-dir` as an unrecognized argument, so
+`uv run pytest …` and `make check` fail with usage errors unrelated to the
+code under test.
+
+**Why:** the option belongs to a different tool/plugin set; the injection is
+session-environment, not repo config. Hit twice in the 0538 raid (executor
+agent, then orchestrator's `make check`).
+
+**How to apply:** run `env -u PYTEST_ADDOPTS make check` (or prefix any
+`uv run pytest` likewise) in this repo when the variable is present. A failing
+`make check` with "unrecognized arguments: --cache-dir" is environmental, not
+a regression.

--- a/projects/-home-haduong-aedist-technical-report/memory/feedback_ratchet_ceiling_race_and_dropped_close.md
+++ b/projects/-home-haduong-aedist-technical-report/memory/feedback_ratchet_ceiling_race_and_dropped_close.md
@@ -1,0 +1,28 @@
+---
+name: feedback-ratchet-ceiling-race-and-dropped-close
+description: "Ratchet data files (emdash_ceiling.txt) race with parallel prose merges; a post-queue rebase can drop erg-pr-merge's close commit — verify ticket state on origin/main before re-closing"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 2d166e90-6882-414f-8eb9-e0a16755dbc2
+---
+
+Two related races observed in raid 552 (2026-06-12, PR #1022):
+
+1. **Ratchet ceilings race with parallel prose merges.** A committed ratchet
+   value (e.g. `tests/data/emdash_ceiling.txt`) initialized on the branch goes
+   stale the moment a parallel manuscript PR (here #1023, +3 em dashes) merges
+   first. The fix is a documented re-init commit on the rebased final text —
+   expected behaviour, not a defect.
+2. **Post-queue rebase can drop the erg-pr-merge close commit.** After
+   `erg-pr-merge` pushes the close commit and queues auto-merge, a rebase to
+   fix the ratchet rewrote the branch and the merged tree had the ticket still
+   open; a separate chore PR (#1024) re-closed it.
+
+**Why:** Without checking, the orchestrator could hand-close an
+already-re-closed ticket or panic about a "lost" close.
+
+**How to apply:** After any merge that involved a post-queue rebase, verify
+ticket state with `git cat-file -e origin/main:tickets/closed/<file>` before
+acting. Related: [[feedback-rebase-drop-cascade]],
+[[feedback-erg-pr-merge-partial-success]].

--- a/projects/-home-haduong-cadens/memory/MEMORY.md
+++ b/projects/-home-haduong-cadens/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory index
+
+- [Project: cadens state](project_cadens_state.md) — all tickets closed; corpus 522 sessions M_sync=5.33; next: human finalises blog/framing-note.md
+- [User profile](user_profile.md) — researcher, French speaker, works on padme (GNOME/Evince), one laptop + one workstation

--- a/projects/-home-haduong-cadens/memory/project_cadens_state.md
+++ b/projects/-home-haduong-cadens/memory/project_cadens_state.md
@@ -1,0 +1,26 @@
+---
+name: cadens project state
+description: Corpus expanded to 522 sessions; all tickets closed; blog framing note is next human action as of 2026-04-29
+type: project
+originSessionId: 2a07b316-fb6a-4ac2-a49f-880d87094541
+---
+As of 2026-04-29 (housekeeping session). Main at `76c01a2`. **Pivoted from single paper to Hypotheses.org blog series.**
+
+**Corpus expanded:** nightbeat ran overnight and closed ticket 0030 — doudou logs merged. 324 → 522 sessions, M_sync 4.08 → 5.33, unity crossing N=1→2, total agent-hours 190.8 → 515.5 h.
+
+**All tickets closed:**
+- 0026 — slash undercount fixed (dedup artifact)
+- 0027 — gap classifier closed (patterns absent in corpus)
+- 0030 — doudou/padme merge done (PR #43, dedup bug fixed)
+- 0032 — framing note done (`blog/framing-note.md`)
+- 0033 — editorial calendar done (`blog/calendar.md`, 17 posts)
+- 0034 — nightbeat harvester done
+- 0036 — framing note v2 Phase D done (PR #35 merged)
+- Only 0018 (corpus schema v1) deferred to Phase 2
+
+**Next action:** Human reads and finalises `blog/framing-note.md` before first post is written.
+
+**Infra fix this session:** `deleteBranchOnMerge: true` enabled on all 23 non-archived GitHub repos. Cleanup pattern documented in `harness-rules/git.md`.
+
+**Why:** Blog is the deliverable. Framing note is the editorial compass for all posts. HAL deposit after first post is live.
+**Key numbers:** 522 sessions, M_sync = 5.33, ~$11,456, 90-day window (ends 2026-04-21).

--- a/projects/-home-haduong-cadens/memory/user_profile.md
+++ b/projects/-home-haduong-cadens/memory/user_profile.md
@@ -1,0 +1,12 @@
+---
+name: user profile
+description: Who the user is and working environment preferences
+type: user
+originSessionId: 69d37529-570d-4529-b15b-fcaa7f5f9fa5
+---
+- Researcher writing a self-study paper on Claude productivity (cadens project)
+- Works in French and English; mixes both in conversation
+- Machine: "padme" — GNOME desktop, uses Evince for PDF review
+- Hardware: one laptop (mobile) + one workstation (AMD Threadripper, stationary) — no primary/secondary hierarchy
+- Prefers terse agent responses; reads diffs directly, no trailing summaries needed
+- Uses Imperial Dragon orchestrator protocol for ticket management

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_agent_worktree_locked.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_agent_worktree_locked.md
@@ -1,0 +1,21 @@
+---
+name: agent-worktree-locked
+description: "Background agent times out before committing — worktree stays locked, branch empty; how to recover"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e6535bce-fc93-4a50-a534-f5364fd023c4
+---
+
+Background raid agents sometimes exhaust their context before pushing. When this happens:
+- The worktree is **locked** (`git worktree remove --force` is blocked by the live PID)
+- The branch exists but has no unique commits
+- The agent's file edits may still be present in the locked worktree's directory
+
+**Why:** Agent runs out of context mid-task, never reaches the commit step.
+
+**How to apply:** When a background agent completes with a truncated summary, immediately check:
+1. `git diff master...t<NNNN>-branch --stat` — if empty, branch is bare
+2. Check the worktree directory directly for uncommitted edits
+3. Work in the locked worktree directory (`git -C <worktree-path> add/commit/push`) — the lock only prevents removal, not use
+4. Do NOT use `--force --force` to remove the worktree while the PID is alive unless confirmed stale

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_build_prompt_d_variant.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_build_prompt_d_variant.md
@@ -1,0 +1,19 @@
+---
+name: feedback-build-prompt-d-variant
+description: "build_kieu_prompt collapsed D1/D2 into D; smoke_sota_or.py default variante=\"D2\" is now broken"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 207f5efc-4fd9-4bf1-b8ef-21487b529294
+---
+
+`build_kieu_prompt.build_prompt()` accepts only `A`, `C`, `D` (cf. `VALID_VARIANTES`) and **always** includes cultural notes when `cultural_path` is provided. The historical `A1/A2/C1/C2/D1/D2` matrix (suffix `1` = no notes, `2` = with notes) was collapsed in commits `666c4ce` and `1b15aca`.
+
+Side effects:
+- `scripts/smoke_sota_or.py` `main()` defaults to `variante="D2"` and passes `kieu_vi_path=`, `michels_path=`, `hst_path=` — all three were removed from `build_prompt()`'s signature. The CLI errors on `KeyError: 'D2'`. The five helpers we import from it (`OR_BASE_URL`, `call_model`, `detect_refusal`, `load_or_key`, `MODEL_OVERRIDES`) remain correct.
+
+**Why:** ticket 0237 inherited the `D2` default + cultural-conditional logic from the smoke script; both had to be replaced with `D` and unconditional cultural notes.
+
+**How to apply:** when building scripts that consume `build_prompt()`, use `variante="D"` and pass `cultural_path=args.cultural` unconditionally. If a script in `scripts/` still references `D2`, `michels_path`, `hst_path`, or `kieu_vi_path` kwargs, it's pre-refactor dead code — fix in-place or note in PR.
+
+Related: [[project_pilot_v1-8_findings]] (D-prompt empirical behaviour), [[feedback_d_token_budget]].

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_d_seed42_collapse.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_d_seed42_collapse.md
@@ -1,0 +1,14 @@
+---
+name: feedback_d_seed42_collapse
+description: "seed=42 collapses D-notice (5 parti pris) to 1 translation — use D_SEEDS=[137,271]"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a11b63b8-e69e-40d9-aaaa-44a002663528
+---
+
+For prompts that ask the model to generate N contrasting outputs (e.g. "5 parti pris littéraires"), seed=42 causes the model to pick one and produce only that one instead of all 5. Seeds 137 and 271 reliably produce all 5.
+
+**Why:** seed=42 with a meta-cognitive framing ("parti pris que ce passage t'inspire") triggers a collapse to a single "best choice" rather than the enumerated list. Reproduced consistently across temperatures (0.6 and 0.8).
+
+**How to apply:** Define `D_SEEDS = [137, 271]` (or similar) for any generation task using multi-output enumeration prompts. Do not use seed=42 for D-variant or similar structured multi-output calls.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_d_token_budget.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_d_token_budget.md
@@ -1,0 +1,14 @@
+---
+name: feedback_d_token_budget
+description: D-notice needs 1500 max_new_tokens — 800 truncates 4th/5th translations
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a11b63b8-e69e-40d9-aaaa-44a002663528
+---
+
+When the model generates N parti pris + N translations, it produces markdown headers and per-section commentary (not just the translations). Budget: ~150 tok for the list + ~200 tok × 5 translations + ~100 tok commentary = ~1400 tok minimum.
+
+**Why:** 800 tokens seemed sufficient (5 × 80 tok ≈ 400 + overhead), but the model adds `### Parti pris N`, `*Commentaire: ...*`, and structural markdown that doubles the token count.
+
+**How to apply:** Use `max_new_tokens=1500` for any D-variant or multi-output enumeration prompt. 300 is fine for A/C single-translation prompts.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_erg_pr_merge_no_ci.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_erg_pr_merge_no_ci.md
@@ -1,0 +1,15 @@
+---
+name: erg-pr-merge-no-ci
+description: erg-pr-merge CI-wait times out on repos with no checks — squash-merge already completed before the script dies
+metadata:
+  type: feedback
+  originSessionId: t0217
+---
+
+`erg-pr-merge` step 2a runs `timeout 600 gh pr checks --watch` after pushing the ticket-close commit. On repos with no CI configured, `gh pr checks` never reports any results and the command times out after 600s, exiting non-zero.
+
+**Why:** The script treats "no checks returned within 600s" the same as "CI failed." For repos without GitHub Actions, this always fires.
+
+**How to apply:** When `erg-pr-merge` dies with "CI did not pass within 600s", check whether the PR is actually already merged (`gh pr view N --json state`). If `state == MERGED`, the squash-merge completed before the script exited — the worktree cleanup step ("master already used by worktree") is the real failure, which is harmless. If `state != MERGED`, run `gh pr merge N --squash` manually to complete step 3.
+
+Linked: [[feedback_celebrate_squash_precheck]]

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_gemini_flash_lite_truncation.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_gemini_flash_lite_truncation.md
@@ -1,0 +1,14 @@
+---
+name: feedback_gemini_flash_lite_truncation
+description: google/gemini-3.1-flash-lite truncates large chunks (>30KB body) — outputs only the tail fragment instead of full text
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 345674d2-e23b-4c8c-9a44-2efa24b95106
+---
+
+`google/gemini-3.1-flash-lite` on OpenRouter truncates large inputs: for bodies >30KB, it outputs only the last ~1-5% of the text rather than the full cleaned content. This is intermittent but reproducible on TNH story chunks (35KB) and Feynman physics essays (38KB).
+
+**Why:** The model appears to have an effective output length limit or attention failure on large contexts despite the 16K max_tokens cap. Other gemini-lite-sized chunks (<20KB) clean correctly.
+
+**How to apply:** After a bulk gemini-lite pass, run a ratio check: `resp_bytes / body_bytes < 0.2` on files with `body > 5KB` flags truncated outputs. Use `meta-llama/llama-3.3-70b-instruct` as fallback for those files — it handles large chunks correctly but may add a preamble sentence ("Since the provided text...") that needs to be stripped manually from the response (between `# cleaned-by:` and the actual content).

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_judge_lineup.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_judge_lineup.md
@@ -1,0 +1,28 @@
+---
+name: feedback-judge-lineup
+description: "Final 3-judge lineup for pool→judge pipeline, locked after 7 smokes across 9 model families"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 207f5efc-4fd9-4bf1-b8ef-21487b529294
+---
+
+The LLM-as-judge lineup for `scripts/judge_pool.py` (GENERATION.md §3.2 6-dim rubric) is locked to three models from three distinct families, with no overlap with the SOTA generator lineup:
+
+- `anthropic/claude-sonnet-4.6` — 4s/voice, full 1→3 variance, consistent
+- `google/gemini-2.5-pro` — 55s/voice (needs `reasoning.exclude=true` + `max_tokens=24000`), full 1→4 variance, drives Top-1 in 3/7 voices in censorship simulation
+- `openai/gpt-5.4-mini` — 4s/voice, clean 190-token output, no reasoning visible
+
+**Why:** Empirical smoke on 5 auteur candidates across 9 candidate models. Excluded models with specific failure modes:
+- `gemini-2.5-flash` / `gemini-3-flash-preview` (non-lite): **inverted scoring** vs 5-judge consensus — declared the worst candidate the best
+- `kimi-k2.6`, `minimax-m2.7`: empty output (reasoning burn even with `exclude=true`)
+- `nemotron-3-super`: 133s + JSON duplicate bug
+- `step-3.5-flash`: refuses JSON format
+- `owl-alpha`: uniform/suspect scores
+- `gemini-2.5-pro` is expensive at $1.25/$10 per Mtok but removing it changes Top-1 in 3/7 voices and drops survivor count below 6 for ada/curie. Keep it for editorial fidelity (~$0.30/voice).
+
+**How to apply:** When extending the pipeline to new voices or testing judge replacements, re-smoke on a 5-candidate subset before committing. The `JUDGE_OVERRIDES` dict in `scripts/judge_pool.py` is the place to wire per-judge reasoning configs (mirror the pattern from `MODEL_OVERRIDES` in `smoke_sota_or.py`). Same-family overlap with generators creates auto-preference bias — avoid.
+
+**Empirical verdict (bench v3, post-fan-out 9 SOTA + LoRA on 1194 candidates):** Anthropic Opus 4.6 is the clear winner *as generator* (moy 3.10, Σ 78 ors — more than the next two combined). This is consistent with reviews flagging 4.6 as the literary variant vs 4.7 (more verbose, more literal). The judge panel (Sonnet 4.6 + Gemini 2.5 Pro + GPT-5.4-mini) shows no obvious auto-preference toward Sonnet's own family — Sonnet judges Opus 4.6 generations highly along with the other two judges. See `generations/coda-notes.md` for the full medal table and Σ ors per source.
+
+Related: [[feedback-soft-cap-aggregation]], [[feedback_max_tokens_runaway]], [[project-lora-negative-result]].

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_libreoffice_pdf_path.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_libreoffice_pdf_path.md
@@ -1,0 +1,27 @@
+---
+name: libreoffice-headless-pdf-export
+description: "`soffice --headless --convert-to pdf file.docx` is a clean retirement path for WeasyPrint when DOCX is the source of truth — diacritics, italics, monospace blocks all survive"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ff1f28d7-df07-4e2e-8181-0eb5c4a6e448
+---
+
+For a manuscript pipeline where DOCX is the editor-facing source of truth,
+LibreOffice headless can derive the PDF in one command — no Python deps, no
+LaTeX install, no font hassles for Vietnamese diacritics:
+
+```bash
+soffice --headless --convert-to pdf main.docx
+```
+
+**Why**: Verified on chemin-de-voix prototype (LibreOffice 24.2.7.2 on padme):
+multilingual French + English + Vietnamese-with-diacritics + GAMS code block
+in monospace all rendered correctly in a 99 KB PDF. The `--print-pdf` variant
+of the WeasyPrint+HTML pipeline becomes redundant once DOCX is the canonical
+artifact, and one tool replaces a Python dependency.
+
+**How to apply**: When choosing a PDF rendering path for a DOCX-source
+project, default to `soffice --convert-to pdf` unless you specifically need
+fine LaTeX-grade typography (which Pandoc/xelatex would provide, at the cost
+of an entire TeX install). Reference `make pdf` target in ticket 0252.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_merge_skill_multi_ticket.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_merge_skill_multi_ticket.md
@@ -1,0 +1,34 @@
+---
+name: merge-skill-rejects-multi-ticket-prep-prs
+description: "erg-pr-merge requires a single `Ticket: tickets/NNNN-...` reference; raid-prep PRs that touch multiple tickets without closing any must merge manually via `gh pr merge --squash --delete-branch`"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ff1f28d7-df07-4e2e-8181-0eb5c4a6e448
+---
+
+The `/merge` skill (`erg-pr-merge`) exits non-zero on PRs with no
+`Ticket: tickets/NNNN-...` line in body or title — its purpose is to auto-close
+a linked ticket on merge. PRs that don't close any single ticket fail this check.
+
+**Why**: Hit on PR #158 (raid prep, amended 0244+0250, created 0251+0252, no
+single ticket closing). The skill prints
+"erg-pr-merge: no ticket reference found in PR body or title". Adding a
+placeholder `Ticket:` would falsely close that ticket, so the skill is the
+wrong tool.
+
+**How to apply**: For prep PRs (raid staging, multi-ticket housekeeping, doc
+sweeps that don't close anything), bypass the skill and use:
+
+```bash
+gh pr merge <N> --squash --delete-branch
+```
+
+After this, `gh` will try a local `git checkout <base-branch>` post-merge —
+that step fails inside a worktree if the base branch is checked out elsewhere
+("'master' is already used by worktree at ..."). The remote merge has already
+succeeded; the local error is cosmetic. Verify with
+`gh pr view <N> --json state,mergeCommit`.
+
+Distinct from [[merge-skill-needs-bold-ticket]] (which is about plain `Ticket:`
+being silently skipped when the field IS present — different failure mode).

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_model_storage.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_model_storage.md
@@ -1,0 +1,14 @@
+---
+name: model-storage-location
+description: "Store ML model files in /data/models/, never in project directories"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: a11b63b8-e69e-40d9-aaaa-44a002663528
+---
+
+Always store model files in `/data/models/`, never inside the project directory tree.
+
+**Why:** Project dirs are for code and data artifacts; large model weights don't belong there. `/data/models/` is the designated location on PADME.
+
+**How to apply:** When downloading or referencing models, use `/data/models/` as the base path. HF cache (`~/.cache/huggingface/hub/`) is acceptable for cached downloads. Don't create `models/` subdirs inside `~/chemin-de-voix/` or `~/data/projets/chemin-de-voix/`.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_n_advisors_for_register_variants.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_n_advisors_for_register_variants.md
@@ -1,0 +1,32 @@
+---
+name: n-advisors-for-register-variants
+description: "When task requires generating content in an unfamiliar register/dialect/period, fan out N (≈4) parallel agents each constrained to a distinct register, then synthesize and recommend one. Used successfully on ticket 0248 (Aliénor en occitan)."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e3f105e8-39ba-4385-850c-64fc7795ba3a
+---
+
+When the user asks for prose or translation in an *unfamiliar register* (medieval Occitan, Mistralian Provençal, IEO modern, hybrid literary), spawning N≈4 parallel agents — each rigorously constrained to ONE distinct register with explicit period markers, lexicon, and orthography — produces strikingly different drafts that illuminate the choice.
+
+**Why:** A single agent on its own waffles toward the safest register. Forcing 4 disjoint registers exposes the trade-offs (readability vs. period accuracy vs. anachronism vs. compromise) that the user can then arbitrate concretely.
+
+**Why to apply:**
+- Task is creative writing in an unfamiliar register, dialect, or period
+- The user wants to *see* what each variant looks like before choosing
+- The constraints between variants are register-level (not just stylistic)
+
+**How to structure each agent prompt:**
+- Name the register precisely (period, dialect, norm — e.g. "norme classique IEO, languedocien" vs "Mistralian rhodanien")
+- Specify orthography conventions to use (and *not* use)
+- Demand uncertain words/forms marked with `[?]` — better honest than confident-and-wrong
+- Require a 50-word translator note on choices made
+- "Return ONLY the translation + the note. No preface, no apology, no metalanguage."
+
+**Synthesis step (back in main agent):**
+- Save all N drafts in `content/drafts/<X>-drafts.md` for durable reference
+- Recommend one with rationale, mention 1-2 strong alternates
+- Apply visible polish to the chosen draft (resolve `[?]`, swap problematic words like *vaginas* → *gainas* for medieval Occitan) before integration
+- Let the user veto the recommendation; present alternatives clearly
+
+Counter-indication: pure information lookup, single-correct-answer tasks. The pattern is for creative *register* choices, not factual ones.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_pandoc_docx_span_styles.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_pandoc_docx_span_styles.md
@@ -1,0 +1,27 @@
+---
+name: pandoc-docx-span-character-styles
+description: "Pandoc DOCX writer maps inline spans to character styles only via the `custom-style=\"...\"` attribute — bare class names like `.verse-num` are silently ignored"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: ff1f28d7-df07-4e2e-8181-0eb5c4a6e448
+---
+
+When mapping a Pandoc inline span to a Word character style defined in your
+reference.docx, use `[text]{custom-style="style-id"}` — NOT `[text]{.style-id}`.
+Bare class syntax is silently dropped at DOCX render time; OOXML inspection
+shows zero `<w:rStyle>` references.
+
+**Why**: Found by writing 95 `[N]{.verse-num}` spans in a Pandoc 3.1.3 → DOCX
+pipeline and counting zero `<w:rStyle w:val="verse-num">` applications in the
+output. Switching to `[N]{custom-style="verse-num"}` got 95/95. The reference
+docx had the style correctly defined (`w:styleId="verse-num"` + matching
+`<w:name w:val="verse-num"/>`) — the markdown syntax was the only difference.
+
+**How to apply**: For any Pandoc DOCX project where you want span-level
+character styling (small caps, color marks, annotations like verse numbers),
+always use the `custom-style="..."` attribute form. The class syntax `.foo` is
+useful for HTML output and div-level paragraph styles, but not for inline
+character runs in DOCX.
+
+See [[prototype-docx-pipeline]] for the broader DOCX pipeline gotchas.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_parse_chunk_headers_blank_lines.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_parse_chunk_headers_blank_lines.md
@@ -1,0 +1,16 @@
+---
+name: parse-chunk-headers-blank-lines
+description: "parse_chunk_headers() stopped at first blank line, silently dropping lang/score tags — caused 0 training texts for 7+ voices"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: c6993323-a57f-4a65-b705-7ca0dc0d124f
+---
+
+`select_dataset.py:parse_chunk_headers()` originally stopped reading at the first blank line. Chunk files have TWO header sections separated by a blank line — the second section contains `# language:` and `# score:` tags. Stopping early left these fields as empty strings.
+
+**Why:** `train_lora.py` filters manifest entries by `rec.get("lang") != lang`, so entries with `lang=''` were silently excluded. Result: 0 training texts loaded for every voice whose manifests were regenerated with this bug. Manifests looked syntactically correct but were functionally empty.
+
+**How to apply:** If `train_lora.py` loads 0 docs for a voice, check `parse_chunk_headers()` in `select_dataset.py` first. The fix is: skip blank lines instead of stopping at them (`if line.strip() == "": continue`). After fixing, regenerate all manifests. Also check `extract_mistral_ocr.py`'s `_split_markdown()` for the same guard pattern (fixed in PR #107).
+
+**Related:** [[cjk-word-count]] — same family of silent-failure bugs in word-count guards.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_soft_cap_aggregation.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_soft_cap_aggregation.md
@@ -1,0 +1,18 @@
+---
+name: feedback-soft-cap-aggregation
+description: "aggregate_judges keeps ties at rank-5 (per-judge) and rank-6 (final), not strict slicing"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 207f5efc-4fd9-4bf1-b8ef-21487b529294
+---
+
+`scripts/aggregate_judges.py` softens the §4 caps of GENERATION.md:
+- `select_survivors_single_judge` caps at 5 unless tied 4-count at rank-5, then extends
+- `merge_judges` caps at MAX_HITL=6 unless `(gold_count, silver_count)` tally at rank-6 matches lower ranks, then extends
+
+**Why:** User directive 2026-05-18 — "si les 5 6 7 8 9 sont tous à 0 or 5 argent on les garde tous". Strict slicing arbitrarily breaks ties that the medal-tally metric can't distinguish. HITL sees a slightly expanded shortlist instead of an arbitrary cut.
+
+**How to apply:** When the spec in GENERATION.md §4 says "retenir les 5 premiers" or "max 6 HITL", read it as a target with tie-keeping, not a hard slice. Don't tighten back without checking with author. On the 7 voices done in this run, no rank-6 ties existed, so output was unchanged — the soft cap is a safety mechanism for future corpus-poor voices where judges converge.
+
+Related: [[feedback-judge-lineup]].

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_sota_parser_quirks_per_model.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_sota_parser_quirks_per_model.md
@@ -1,0 +1,23 @@
+---
+name: sota-parser-quirks-per-model
+description: "Each new SOTA model in the fan-out brings format quirks (em-dash, Roman, bare 1)) — parser strategies multiply reactively"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: f58bf9dc-2a2d-4bf2-8f52-d1c99dbb3d89
+---
+
+When adding a new model to the SOTA fan-out (generate_sota.py), expect new parser quirks in its output for the partis-pris / translation format. Recent additions to `scripts/extract.py`:
+
+- Strategy C: split on `\d\)` (most models)
+- Strategy D: split on `Traduction\s+\d+` (gpt-5 vanilla on hcm/leonardo emits both bare `1) Label` for listing AND `Traduction N — Label` for translations — C wrongly splits the listing)
+- `_HEADING` regex now accepts `—`, `–`, `-` alongside `.`, `)`, `:` (Opus 4.6 auteur)
+- Roman numeral headers (`## I – Distiques`) — separate fix (#140)
+
+Best-of-4 selection now compares parsed_a/b/c/d and keeps whichever yields most distinct parti_pris numbers, so a new strategy doesn't have to win on every voice.
+
+**Why:** Format detection is reactive — a failing case prompts a new strategy. PRs #140, #142 each added one. Pattern will repeat for the next model family.
+
+**How to apply:** Before running a full fan-out with a newly-added model, parse 1–2 sample outputs first and check `parsed_a/b/c/d` distinct-parti-pris counts. Cheaper than discovering at aggregate-voice time.
+
+Related: [[parse-chunk-headers-blank-lines]] for an earlier parser bug class.

--- a/projects/-home-haduong-chemin-de-voix/memory/feedback_unreviewed_not_clean.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/feedback_unreviewed_not_clean.md
@@ -1,0 +1,22 @@
+---
+name: feedback-unreviewed-not-clean
+description: "Empty polish rules means the voice was audited and no rules were needed — not that it was skipped; but rahan is the one genuinely unreviewed voice as of 2026-05-16"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 345674d2-e23b-4c8c-9a44-2efa24b95106
+---
+
+Empty rule lists in `polish_corpus.py` do NOT mean "not yet reviewed." As of 2026-05-16, all 14 voices have been handled:
+
+- **heloise, manne, alienor, hcm, auteur**: rules written or v1.1 re-clean applied
+- **ada, feynman, carton-de-wiart**: rules added 2026-05-16 from deferred 0144 audit findings
+- **curie**: 5% audit found zero flags — genuinely clean
+- **indy, zhenghe**: audit found patterns classified as valid content, no rules needed
+- **tnh**: v1.1 re-clean handles former artifacts
+- **leonardo**: re-cleaned with gemini-3.1-flash-lite 2026-05-16, 0 rules needed
+- **rahan**: spot-checked 2026-05-16 — zero artifacts; all-caps chapter titles are genuine section headings, not navigation artifacts
+
+**Why:** The original mistake was inferring "clean" from "no rules." The corrected state is that empty rules now means "audited and nothing actionable found" for all voices except rahan.
+
+**How to apply:** If reasoning about rahan quality, treat as unknown. For all other voices, empty rules = reviewed. Never collapse the two cases without checking which one applies.

--- a/projects/-home-haduong-chemin-de-voix/memory/project_d4_gap_refuted.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/project_d4_gap_refuted.md
@@ -1,0 +1,21 @@
+---
+name: project-d4-gap-refuted
+description: 2026-05-18 judge sweep refuted the cultural-notes coverage → D4 score hypothesis; ticket 0231 closed accordingly
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: be60ade1-d9f6-4a05-a08e-1874e96670c5
+---
+
+The 2026-05-18 judge sweep (Sonnet 4.6 + Gemini-2.5-pro + GPT-5.4-mini, 14 voices, ~180 candidates each) tested whether thin cultural-notes coverage depresses the D4 ("Ancrage VN") dimension. It does not.
+
+| group | mean D4 | mean (D4 − other dims) |
+|---|---|---|
+| THIN (alienor 1/26, rahan 1/52, indy 4/50, manne 5/56, zhenghe 6/46) | 2.54 | +0.39 |
+| THICK (9 other voices) | 2.49 | +0.36 |
+
+D4 is the highest-scoring dim across all 14 voices. Coverage rank and D4 rank are uncorrelated — indy with 4/50 notes posts the largest D4 advantage (+0.66) in the sweep.
+
+**Why:** 0231 was deferred 2026-05-17 with the explicit revisit trigger "if §3 judges flag systematic D4 gap on thin voices". The 2026-05-18 sweep is the first run where that trigger could be tested; result is null, so the ticket was closed without backfill (PR #147).
+
+**How to apply:** If anyone re-raises "we should backfill cultural notes for thin-coverage voices to improve D4", cite this null result before spending the effort. The grounding signal in current generations comes from LoRA + persona + prompt verses, not from cultural-notes density. Linked to [[feedback-judge-lineup]] (judge configuration), the underlying [[project-corpus-ada-weighting]]-style coverage tables, and the closed ticket itself.

--- a/projects/-home-haduong-chemin-de-voix/memory/project_lora_negative_result.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/project_lora_negative_result.md
@@ -1,0 +1,29 @@
+---
+name: project-lora-negative-result
+description: LoRA Qwen3.5-9B échoue contre SOTA + persona — résultat à intégrer dans la coda
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 207f5efc-4fd9-4bf1-b8ef-21487b529294
+---
+
+Sur les 14 voix × **1194 candidats** jugés par 3 LLM indépendants (Claude Sonnet 4.6, Gemini 2.5 Pro, GPT-5.4-mini) sur la rubrique 6 dimensions de GENERATION.md §3.2 :
+
+- **LoRA Qwen3.5-9B : 0 médailles d'or sur 513 candidats × 6 dimensions** (= **3078 évaluations**). Score moyen **1.60/4**.
+- **SOTA + persona en system message** (bench final v3, 9 modèles) :
+  - **anthropic/claude-opus-4.6 : moy 3.10, Σ 78 ors** — le seul à dépasser 3.0, leader sur D3/D5/D6, co-leader D4
+  - deepseek/deepseek-v4-pro : 2.99 (29 ors, D4)
+  - anthropic/claude-opus-4.7 : 2.84 (22 ors) — plus verbeux et plus littéral que 4.6, perd côté creative
+  - mistralai/mistral-large : 2.79 (38 ors) — champion D5+D6 (école française)
+  - tencent/hy3-preview : 2.77 (9 ors) — leader D1 mais s'effondre ailleurs
+  - openai/gpt-5.5 : 2.71 (27 ors) — spécialiste D4
+  - openai/gpt-5 vanilla : 2.69 (20 ors)
+  - openai/gpt-5.3-chat : 2.58 (9 ors)
+  - deepseek/deepseek-chat V3 : 2.22 (4 ors) — autre échec notable
+- Contrôle persona LoRA : `flag_persona ∈ {True, False}` testé via matrice GENERATION.md §2. Persona on vs off ne change rien : moy 1.60 dans les deux buckets. Pire, ~100 candidats persona-on éliminés au préfiltre vs 0 persona-off — le persona system message casse plus souvent la génération LoRA qu'il ne l'aide.
+
+**Why:** L'hypothèse de départ du BRIEF §1 ("LoRA encode la voix-style") tombe sur le test des juges. Le projet final repose presque entièrement sur Opus 4.6 + Mistral-Large + DeepSeek V4-pro + injection LoRA forcée pour la diversité, pas sur l'effort LoRA propre. À assumer dans la coda BRIEF §8 (cf. principe d'honnêteté méthodologique §10).
+
+**How to apply:** Quand la rédaction de la coda commencera, ouvrir `generations/coda-notes.md` qui contient le tableau complet, le contrôle persona, et une phrase candidate à reformuler littérairement. Ne pas réécrire l'analyse — c'est déjà fait et structuré. Le but est de transformer ce résultat scientifique négatif en matière éditoriale honnête (et possiblement en commentaire sur la nature de la voix : transmissibilité du style superficiel ≠ transmissibilité de la signature).
+
+Related: [[feedback-judge-lineup]] (3-juge lineup et rationale), [[feedback-soft-cap-aggregation]] (règles d'agrégation), [[user_bio]] (auteur du projet).

--- a/projects/-home-haduong-chemin-de-voix/memory/project_milestone2_training.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/project_milestone2_training.md
@@ -1,0 +1,3 @@
+# DELETED 2026-05-20T12:55Z: milestone 2 training weekend sweep
+# Reason: Stale — training completed 2026-05-17; voices deployed and in production manuscript.
+# Original content preserved in git history.

--- a/projects/-home-haduong-chemin-de-voix/memory/project_pilot_v1-8_findings.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/project_pilot_v1-8_findings.md
@@ -1,0 +1,3 @@
+# DELETED 2026-05-20T12:55Z: pilot v.1-8 findings
+# Reason: Stale — pilot conclusions absorbed into the GENERATION.md protocol; sweep matrix finalized.
+# Original content preserved in git history.

--- a/projects/-home-haduong-chemin-de-voix/memory/user_bio.md
+++ b/projects/-home-haduong-chemin-de-voix/memory/user_bio.md
@@ -1,0 +1,10 @@
+---
+name: user-bio
+description: Biographical facts about Minh Hà-Duong — for auteur persona and project context
+metadata: 
+  node_type: memory
+  type: user
+  originSessionId: c6993323-a57f-4a65-b705-7ca0dc0d124f
+---
+
+Minh Hà-Duong : né à Paris en 1969, chercheur franco-vietnamien en énergie et en gouvernance du risque climatique, travaillant entre Paris et Hanoi.

--- a/projects/-home-haduong-fuzzy-corpus/memory/MEMORY.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/MEMORY.md
@@ -1,0 +1,6 @@
+- [Methodology: SWOT, not ranking](methodology_swot.md) — LLM outputs are not ground truth; frame WP7 validation as SWOT characterization of the fuzzy method.
+- [Orchestrator lessons — wave-1](feedback_orchestrator.md) — Execute agents must use their worktree path; use real timestamps; SWOT framing review before first execute wave.
+- [Module boundary rule](feedback_module_boundaries.md) — No cross-script imports; private symbols belong in src/fuzzy_corpus/, not scripts/.
+- [Torch sparse degree computation](feedback_torch_sparse_degrees.md) — Use scatter_add_ on crow/col indices; never .to_dense() or torch.sparse.sum() on CSR.
+- [LaTeX notation conventions and pitfalls](feedback_latex_notation.md) — Operator carousel, no X=X tautologies in notation table, use Edit not sed for renaming, inflationary vs monotone distinction.
+- [Squash merge ticket closure timing](feedback_squash_merge_ticket_closure.md) — Close tickets on main after squash merge lands; closing on the feature branch causes stale-state conflicts.

--- a/projects/-home-haduong-fuzzy-corpus/memory/feedback_latex_notation.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/feedback_latex_notation.md
@@ -1,0 +1,19 @@
+---
+name: LaTeX notation conventions and pitfalls
+description: Procedural rules for LaTeX edits in the fuzzy-corpus paper — notation tables, renaming, and math framing
+type: feedback
+originSessionId: 4976a990-7fcf-42e1-bfe2-baf96c4db9f1
+---
+Never document LaTeX macros as "symbol = expansion" in the notation table — both sides expand to the same rendered letter, producing "W=W, G=G" tautologies.
+**Why:** An agent writing the notation table confused macro documentation with symbol definition.
+**How to apply:** Symbol column = reader-facing math symbol, not `\macro = \expansion`.
+
+Use Edit tool (never sed) for LaTeX renaming. sed backslash escaping corrupts LaTeX commands.
+**Why:** A sed-based G→\Gamma rename produced `\$\\Gamma\` corrupted output.
+**How to apply:** Any rename touching `\command` patterns must use the Edit tool.
+
+"The starting condition is inflationary" is correct in Appendix C's monotone theorem — not "μ₀ is inflationary". Inflationarity (μ₀ ≤ Φ(μ₀,μ₀,Γ)) is a joint condition on (Φ, μ₀), not a property of μ₀ alone.
+
+When body and appendix share a `\label{}`, LaTeX emits `multiply defined` warnings and `\ref{}` resolves to the first definition (body), breaking appendix cross-references. Fix: rename the body label (e.g. `thm:convergence-closed-world`), replace the body proof with "special case of \Cref{thm:...} in \Cref{app:...}", verify the appendix theorem is strictly more general before doing so.
+**Why:** Duplicate labels `thm:monotone-convergence` and `prop:lambda-approx` silently misdirected cross-references for multiple sessions before being caught by a log grep.
+**How to apply:** After adding any theorem to an appendix, grep for its label across all `.tex` files before committing.

--- a/projects/-home-haduong-fuzzy-corpus/memory/feedback_module_boundaries.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/feedback_module_boundaries.md
@@ -1,0 +1,11 @@
+---
+name: Module boundary rule — no cross-script imports
+description: Private symbols in scripts must not be imported by other scripts; promote to src/ instead
+type: feedback
+originSessionId: a7cb726a-d727-46e8-aad7-fe4efa2bc46e
+---
+Keep business logic in `src/fuzzy_corpus/`, not in `scripts/`. Scripts are entry points only.
+
+**Why:** Two review rounds were needed to catch `run_wp7_conditioning.py` importing `_sample_works` from `run_wp7` via `sys.path` manipulation. Private cross-script imports are untestable and break when scripts are refactored independently.
+
+**How to apply:** When a script defines a function another script needs, move it to the appropriate `src/fuzzy_corpus/` module immediately — not "later". LaTeX renderers → `benchmark.py`; data loading helpers → `ingest.py`; seed construction → `seed.py`.

--- a/projects/-home-haduong-fuzzy-corpus/memory/feedback_orchestrator.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/feedback_orchestrator.md
@@ -1,0 +1,15 @@
+---
+name: Orchestrator lessons — wave-1 execution
+description: Process fixes from first orchestrator wave; worktree path, timestamps, MVP-critical classification
+type: feedback
+originSessionId: a1e1fc5e-956b-4f8a-bca4-4e2b976f870b
+---
+Always use `date -u +%Y-%m-%dT%H:%MZ` for ticket log entries — never hardcode a round hour like "17:00Z".
+**Why:** Manual round-hour timestamps caused identical-file conflicts on every rebase in wave-1.
+**How to apply:** Every ticket log line written by an agent must use the shell command for the real UTC time.
+
+Trust the imagine phase's MVP-critical classification. Tickets flagged "nice to have" should be the first to drop when the user changes direction.
+**Why:** Finite-time theory tickets (0001, 0002) were correctly abandoned at low cost because they were pre-flagged as non-critical.
+
+Always do a scientific framing review before the first execute wave. Framing errors are cheapest to fix before any code exists.
+**Why:** The "LLM is not ground truth / SWOT not ranking" correction saved multiple rework rounds.

--- a/projects/-home-haduong-fuzzy-corpus/memory/feedback_squash_merge_ticket_closure.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/feedback_squash_merge_ticket_closure.md
@@ -1,0 +1,11 @@
+---
+name: Squash merge ticket closure timing
+description: Close tickets on main after squash merge, not on the feature branch, to avoid stale-state conflicts
+type: feedback
+originSessionId: 18faeffc-8839-4f7e-8184-52cd59e7419b
+---
+Close the ticket (Status: closed) in a direct commit on main *after* the squash merge lands, not as part of the feature branch. Squash merges erase branch history, so any ticket edits on the branch end up in an older state on main (the squash commit may carry a different Status than what we set on the branch). Closing post-merge avoids the conflict entirely.
+
+**Why:** After PR#57 squash merge, `gh pr merge` failed to fast-forward local main, leaving local main diverged with 3 extra commits. The ticket closure commit then conflicted with the squash merge's version of the ticket. Resolved via `git merge origin/main` + manual conflict resolution, but it was messy.
+
+**How to apply:** After `gh pr merge --squash` succeeds, switch to main, pull, then commit the ticket closure separately as a clean post-merge commit.

--- a/projects/-home-haduong-fuzzy-corpus/memory/feedback_torch_sparse_degrees.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/feedback_torch_sparse_degrees.md
@@ -1,0 +1,23 @@
+---
+name: Torch sparse degree computation
+description: Use scatter_add_ on crow/col indices, never .to_dense() or torch.sparse.sum on CSR
+type: feedback
+originSessionId: 41cb975b-2fcc-4d41-be27-99570b4f02ce
+---
+Computing row/column sums on `torch.sparse_csr_tensor` requires the scatter_add_ pattern — NOT `.to_dense()` or `torch.sparse.sum()`.
+
+**Why:** `.to_dense()` allocates O(N²) memory (OOM on production graphs); `torch.sparse.sum()` raises `NotImplementedError` on CPU for CSR tensors. Both fail silently in tests (small matrices) but explode in production.
+
+**How to apply:** When implementing any degree-based normalization with torch sparse CSR:
+```python
+crow = A.crow_indices()
+col = A.col_indices()
+val = A.values().float()
+row_lengths = torch.diff(crow).to(dtype=torch.int64)
+rows = torch.repeat_interleave(torch.arange(N, device=device, dtype=torch.int64), row_lengths)
+d_out = torch.zeros(N, dtype=torch.float32, device=device)
+d_out.scatter_add_(0, rows, val)
+d_in = torch.zeros(N, dtype=torch.float32, device=device)
+d_in.scatter_add_(0, col, val)
+```
+This is O(nnz) memory and works on both CPU and CUDA.

--- a/projects/-home-haduong-fuzzy-corpus/memory/methodology_swot.md
+++ b/projects/-home-haduong-fuzzy-corpus/memory/methodology_swot.md
@@ -1,0 +1,35 @@
+---
+name: Fuzzy corpus methodology — SWOT, not ranking
+description: In the fuzzy-corpus paper and its Climate_finance application, frame validation as SWOT characterization, never as "method X beats method Y". LLM outputs, reranker scores, PageRank, column-filter membership are all fuzzy signals with their own biases — none is ground truth.
+type: feedback
+originSessionId: a1e1fc5e-956b-4f8a-bca4-4e2b976f870b
+---
+When working on the `fuzzy-corpus` repository's application to
+`Climate_finance`, the validation framing is **SWOT characterization of
+the fuzzy snowballing method**, not comparison against a ground truth.
+
+**Why:** User (the paper's author) stated explicitly: *"Attention le LLM
+c'est pas un ground truth. Dejà faut voir comment il a été prompté, et
+puis c'est vraiment une affaire floue. Il s'agit pas de dire telle
+méthode est mieux mais de comprendre si ca marche, a quelles conditions,
+ses points forts et ses points faibles. SWOT"*. The LLM outputs in
+`llm_relevance_cache.csv` and `llm_audit.csv` were produced under a
+prompt we have not audited, on a specific corpus, with their own biases.
+Treating them as ground truth measures alignment with one particular
+fuzzy signal, not method quality.
+
+**How to apply:**
+
+- Never write "fuzzy beats X" or "recovers Y % of Z" as a headline claim.
+- Never compute "precision / recall / F1" where a non-audited signal is
+  the ground truth.
+- WP7 (and any label-based validation) is a **characterization study**:
+  Strengths, Weaknesses, Opportunities, Threats of the fuzzy method.
+- All signals (fuzzy µ*, personalized PageRank, LLM score, reranker
+  score, HITL labels, column-filter membership, semantic similarity)
+  are treated as **co-equal fuzzy views** on the same corpus.
+- Deliverables are: agreement matrices, correlation structure,
+  population of disagreement (where signals diverge), conditions under
+  which fuzzy behaves well or poorly.
+- Preflight's use of PR/column-F1 ratio (check b) is only a heuristic
+  sanity check on noise floor, not a method-ranking claim.

--- a/projects/-home-haduong-git-erg/memory/feedback_sweep_emitted_vs_gated_surface.md
+++ b/projects/-home-haduong-git-erg/memory/feedback_sweep_emitted_vs_gated_surface.md
@@ -1,0 +1,39 @@
+---
+name: feedback_sweep_emitted_vs_gated_surface
+description: "when sweeping for a fixed anti-pattern's siblings, classify by surface category (emitted-into-adopter & guaranteed-hit vs file-gated dev hint), not the surface string"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 69ab4112-39e6-4a2c-8f8e-f5606bb970a0
+---
+
+When sweeping for siblings of a just-fixed anti-pattern (roar step 3), discriminate by **surface category**, not by the literal string that was wrong.
+
+0242 fixed build-system-specific remediation (`Run 'make build' first`) in the
+pre-commit hook git-erg installs. The grep also hit `src/go/version.go:180`
+(`{"./build/erg", "run: make build"}`). Surface string matched — but it is NOT
+the same defect:
+
+- **0242 (real defect):** text *emitted into the adopter's repo* (the hook),
+  fired on a **guaranteed-hit** condition (`tickets/erg` missing on commit).
+  Every vendored adopter hits it; they can't hand-edit it (re-emitted on every
+  `erg install --hooks`). Must be agnostic. Fix upstream.
+- **version.go hint:** *runtime-printed by the binary itself*, gated behind
+  outdated-detection that only fires in a multi-copy git-erg **dev** tree; the
+  `make build` hint is bound to `./build/erg`, which cannot exist in a vendored
+  tree (EvalSymlinks fails → skipped). Correctly-scoped dev tooling.
+
+The 0242 ticket body said so explicitly: "version.go:180 is a build-provenance
+label, NOT hook text; do not touch." Filing it would be pattern-matching the
+string, not the defect.
+
+**Why:** a class-sweep that keys on the surface string over-files; one that keys
+on surface category (who emits it, is it guaranteed-hit, can the adopter edit
+it) files exactly the real instances. git-erg's emitted-into-adopter surfaces
+are `hookBody`, `pushHookBody`, `agentsBody` (incl. `--create-agents-md`) — all
+must stay build-system-agnostic; that's the complete set to check.
+
+**How to apply:** for each grep hit, ask "is this emitted into the adopter's
+environment and guaranteed to fire?" Yes → same class, file/fix. No (runtime
+dev tooling, file-gated) → not the class, leave it. Confirm against the source
+ticket's "do not touch" notes before filing. See [[feedback_edit_canonical_asset_not_live_copy]].

--- a/projects/-home-haduong-llm-benchmarks/memory/MEMORY.md
+++ b/projects/-home-haduong-llm-benchmarks/memory/MEMORY.md
@@ -1,0 +1,88 @@
+# Project Memory — llm_benchmarks
+
+## Machine: padme (Lenovo ThinkStation P620)
+- CPU: AMD Ryzen Threadripper PRO 3945WX (12 cores)
+- RAM: 128 Go DDR4 RDIMM
+- GPU0: NVIDIA RTX A4000 16 Go (PCI 41:00.0) — power cap 140W, PCIe 4×16, sm_86
+- GPU1: NVIDIA GeForce RTX 3060 12 Go (PCI 61:00.0) — power cap 170W, PCIe 4×16, sm_86
+- Quadro RTX 4000 8 Go (PCI 42:00.0) — removed (confirmed 2026-05-12)
+- Driver: 580.126.09 / CUDA 13.0
+- Fan control: fan2go daemon (remplace nvfd) — GPU fans + 120mm boîtier
+- ODD fan: Alphacool Apex Stealth Metal 120mm — rewired to Front Fan header (canal 3, PWM), intake bas-droite, zip-ties
+- Front fan original: chaîné sur 3-pin pass-through du 120mm (12V permanent)
+- SuperIO: Nuvoton NCT6686D-L at 0x2e:0xa20
+- Thermal: Post-atelier GrosBill 2026-02-22: repasting CPU+3 GPUs, nettoyage ailettes, A4000 57°C max@140W (was 80°C@120W), CPU 72°C (was 79°C idle). Power caps restored to defaults
+
+## GPU index mapping
+- nvidia-smi GPU0 = A4000 (PCI 41:00.0)
+- nvidia-smi GPU1 = RTX 3060 (PCI 61:00.0)
+- NVML GPU0 = nvidia-smi GPU0 = A4000
+- (Quadro RTX 4000 removed — old nvidia-settings ordering note no longer relevant)
+
+## Key files
+- Project docs: ~/nextcloud/CNRS/projets/actifs/padme/llm-models.md
+- Intervention log: ~/nextcloud/CNRS/projets/actifs/padme/intervention-log.txt
+- Thermal report: ~/llm_benchmarks/thermal/rapport-thermique-A4000.md
+- fan2go config: /etc/fan2go/fan2go.yaml
+- fan2go service: /etc/systemd/system/fan2go.service (enabled)
+- fan2go binary: /usr/local/bin/fan2go v0.12.0
+- fan2go db: /var/lib/fan2go/fan2go.db (calibration data, rm to recalibrate)
+- nvfd: purgé (binaire, service, config supprimés 2026-02-23)
+
+## Benchmark conventions
+- Run with: cd src && uv run bench_tps.py
+- Results in: benchmark_history.json (append-only)
+- Thermal profiles: uv run bench_thermal.py
+- Power limits now recorded in hardware.gpus[].power_limit_w and thermal[].power_limit_w
+- Throttle display: 🔥 THERMAL (>90°C) vs ⚡ POWER_CAP (power limit hit)
+
+## User preferences
+- Language: French for conversation, mixed FR/EN for technical docs
+- User is CNRS researcher, project PADME
+- Prefers Mistral > European > others for model selection
+- Located in Bagneux (92), near Paris
+- Does NOT trust courier services (Tech Premium)
+- Uses uv exclusively, no pip/venv
+
+## NCT6686D PWM register map (2026-02-23)
+- PWM READ registers: 0x160+channel (read-only feedback)
+- PWM WRITE registers: 0xA28+channel (actual control!)
+- FAN_CTRL_MODE: 0xA00 (bit per channel: 1=manual, 0=firmware)
+- FAN_CFG_CTRL: 0xA01 (config sequence: write 0x80=request, 0x40=done)
+- FANOUT_CFG: 0x1D0+channel (bit 0x80 = active)
+- FANIN_CFG: 0x1C0+channel (bit 0x80 = active)
+- Config sequence: write 0x80→0xA01, wait, set mode+PWM, write 0x40→0xA01
+
+## NCT6686D channel mapping (confirmed 2026-02-23)
+- Channel 3: Front fan / alim, PWM_WRITE=8, seul canal acceptant les écritures via 0xA2B
+- Channel 6: DIMM FAN 2 (header #9), PWM_WRITE=255 (plein régime)
+- Channels 0,2,4,5: actifs mais écritures rejetées (EC override)
+- Channels 1,7: hidden (FANOUT inactive 0x20), écritures rejetées
+- Tacho 120mm: NON connecté au SuperIO (test doigt confirmé)
+
+## ODD_FAN control — DÉFINITIVEMENT RÉSOLU (2026-02-23)
+- **Conclusion : le header ODD_FAN est un header "bête" — 12V sans signal PWM, fan 4-pin tourne à 100%**
+- Toutes les pistes logicielles épuisées :
+  1. NCT6686D PWM read (0x160+i) → aucun effet
+  2. NCT6686D PWM write (0xA28+i, séquence config) → aucun effet
+  3. NCT6686D canaux cachés (1, 7) → écritures rejetées
+  4. Test tacho (freinage physique) → aucun fan SuperIO ne chute
+  5. ACPI EC → absent (desktop, pas laptop)
+  6. IPMI/BMC → absent
+  7. WMI FanControlStepping → déjà à 1 (min), pas d'effet sur ODD_FAN
+  8. ACPI fan methods → inexistantes
+- WMI BIOS: FanControlStepping=1, QuadM2PCIeCardFanControl=Low Speed (via think_lmi)
+- **Solution finale : rewiring 120mm sur front fan header** (canal 3, PWM contrôlable, 0 €)
+- Aquacomputer QUADRO — commande annulée (rewiring + fan2go suffisent)
+- Modules debug: /scratch/tmp/nct_dump/ (nct_pwm_v2) — survivent aux reboots
+- nct6686d DKMS: /usr/src/nct6686d-1/ (AUTOINSTALL=yes, survit aux reboots+kernel updates)
+- Module name: nct6686 (pas nct6686d!), nécessite force=1 pour customer ID 0x0511
+- Chargement: sudo modprobe nct6686 force=1
+- Auto-load configuré: /etc/modules-load.d/nct6686.conf + /etc/modprobe.d/nct6686.conf
+- GRUB: acpi_enforce_resources=lax ajouté
+- Docs Lenovo HMM: ~/nextcloud/CNRS/projets/actifs/padme/Lenovo Thinkstation P620 30E0/p620_hmm_en-*.pdf
+
+## Known issues
+- Nemotron-Orchestrator-8B ollama modelfile broken: no chat template, no stop tokens → verbose, benchmark not representative
+- Nemotron-Nano-9B-v2: no official ollama quant, only broken community quants
+- nvidia-settings 510 (Ubuntu package) incompatible with driver 580 for fan control writes

--- a/projects/-home-haduong/memory/feedback_beat_padme_ssh.md
+++ b/projects/-home-haduong/memory/feedback_beat_padme_ssh.md
@@ -1,0 +1,13 @@
+---
+name: Beat agent SSH-to-padme blind spot
+description: Beat agents incorrectly exclude tickets that say "SSH to padme" — but beat always runs on padme
+type: feedback
+originSessionId: f66e55c9-026e-404f-b730-645154cd3bf4
+---
+Beat agents have incorrectly excluded tickets citing "Requires SSH to padme" as an external dependency, when beat.py always runs on padme itself.
+
+**Why:** The ticket body was written from the perspective of a developer sitting at doudou who needs to SSH to padme. When the beat agent reads that instruction, it treats SSH as a blocker. But beat.py runs on padme — SSH is already satisfied.
+
+**How to apply:** When pick-ticket or orchestrator sees "SSH to padme" or "run on padme" in a ticket body, treat it as a no-op constraint. The beat always executes on padme. Check whether the data paths exist locally before concluding a ticket is unrunnable.
+
+Also: stale data paths in ticket bodies (e.g. `/home/haduong/CNRS/papiers/actif/...`) may have moved — check the script defaults before rejecting the ticket.

--- a/projects/-home-haduong/memory/project_nightbeat.md
+++ b/projects/-home-haduong/memory/project_nightbeat.md
@@ -1,0 +1,41 @@
+---
+name: Nightbeat deployment
+description: Live nightbeat timer on padme — config values, monitoring commands, timeout chain
+type: project
+originSessionId: f66e55c9-026e-404f-b730-645154cd3bf4
+---
+`claude-nightbeat.timer` is **live on padme** (enabled since 2026-04-25).
+
+Schedule: hourly 22:00–06:00 weeknights; all 24h on weekends. RandomizedDelaySec=300.
+Unit files: `~/.config/systemd/user/claude-nightbeat.{timer,service}`
+Launcher: `~/.claude/scripts/beat.py` — Python orchestrator, rotates across 4 projects per invocation.
+
+**Project rotation:** aedist-technical-report → cadens → Climate_finance → fuzzy-corpus (round-robin via counter at `~/.claude/logs/nightbeat/.run-counter`).
+
+**Timeout chain (beat.py):**
+- `PICK_TICKET_TIMEOUT_S=480` (8 min)
+- `HOUSEKEEPING_TIMEOUT_S=600` (10 min)
+- `ORCHESTRATOR_TIMEOUT_S=1800` (30 min)
+- `systemd TimeoutStartSec=3420` (57 min) — hard last resort; SIGTERM trap writes `aborted` record
+
+**Budget limits:** housekeeping=$0.25, pick-ticket=$0.50, orchestrator=$5.00
+
+**State per project:** `beat-log.jsonl` in project root — one JSON record per line, newest last.
+Fields: `last_run_at`, `ticket_id`, `branch`, `PR`, `outcome`, `diagnostics`, `duration_s`.
+
+**Per-run logs:** `~/.claude/logs/nightbeat/YYYYMMDDTHHMMSSZ.log` (last 60 retained).
+
+**Monitoring:**
+```bash
+# Live journal
+journalctl --user -u claude-nightbeat.service -f
+
+# Last beat result per project
+jq -cs 'last' ~/cadens/beat-log.jsonl ~/aedist-technical-report/beat-log.jsonl \
+  ~/Climate_finance/beat-log.jsonl ~/fuzzy-corpus/beat-log.jsonl
+
+# Today's run summaries from log files
+for f in ~/.claude/logs/nightbeat/$(date -u +%Y%m%d)T*.log; do
+  grep -m1 "project slot\|beat done\|beat aborted" "$f" | head -2
+done
+```

--- a/projects/-home-haduong/memory/project_padme_gpu_power.md
+++ b/projects/-home-haduong/memory/project_padme_gpu_power.md
@@ -1,0 +1,18 @@
+---
+name: project-padme-gpu-power
+description: "padme idle power — RESOLVED. GPU 3060 floor 11W (no D3cold), CPU 70→46W via balanced profile. Both documented in main-logbook §I."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: e33b0ca5-eb5e-4b14-8deb-d91331e0ca78
+---
+
+padme idle-power work, **resolved 2026-06-01**. Full durable docs now in `padme/main-logbook.md` §I (subsections "Affichage et alimentation GPU au repos" + "Profil d'alimentation CPU") and `intervention-log.txt` — commit `a54269d` on branch `add-power-logger`.
+
+**GPU — 11W floor, irreducible.** 3060 (PCI `0000:61:00.0`, idx 1) idles 11W P8, clientless. Reverse-PRIME fixed: display pinned to A4000 via `xorg.conf` `BusID "PCI:65:0:0"` (=0x41) + `AutoAddGPU false`; persistence off. Sub-11W needs D3cold, **unavailable by design**: upstream PCIe port `0000:60:03.1` has no ACPI `_PR3`, and NVIDIA RTD3 is notebook/Intel-Coffeelake-only — P620 is desktop AMD WRX80, off-target. Only <11W levers: pull the card or suspend host.
+
+**CPU — 70→46W, fixed.** `power-profiles-daemon` was in `performance`, pinning all 24 threads to ~4.29 GHz at load 0.1. A/B at the logger: performance ~70W, balanced ~46W, power-saver ~46W (no extra idle gain). Set **`balanced`** (`powerprofilesctl set balanced`, persisted in `/var/lib/power-profiles-daemon/state.ini`) — recovers ~24W idle, full turbo on demand under load. Residual ~45W = Threadripper Pro platform floor (IO die + 8-ch memory + Infinity Fabric).
+
+**Lesson:** on this box both idle floors (GPU 11W, CPU ~45W) are architectural, not tunable; the only real wins were a stuck render GPU and a needlessly-aggressive CPU power profile. RAPL `energy_uj` is 0400 (CVE-2020-8694) → power measurement needs sudo; user runs `tools/padme-power.sh` via `!`.
+
+Related: `[[project-padme-power-logger-pr]]` — the padme-power.sh measurement tool (PR #1).


### PR DESCRIPTION
Ticket: none

End-of-day `/lair` → `/molt` sweep on the harness repo.

## Changes
- **111 durable memory files committed** across 9 projects (Oeconomia-Climate-finance 43, Climate-finance 22, chemin-de-voix 21, aedist-technical-report 10, fuzzy-corpus 7, cadens 3, -home-haduong 3, llm-benchmarks 1, git-erg 1). Written by prior sessions, never staged — the write-commit-atomicity failure this repo's memory index already names.
- **STATE.md status block regenerated** — it still claimed "1 open PR, oldest #666" when #665–#669 had all merged.

## Notes
Staged with an explicit `projects/*/memory/*.md` pathspec. The whitelist gitignore hides memory files from a plain `git add`, but `git add -f -A` sweeps in 600+ gitignored session-transcript `.jsonl` files — caught at 726 staged files and reset before committing.

Blockers and Next actions were re-read and left unchanged; no ticket state moved.

## Gate
`make check`: 765 passed, 97 deselected. `erg check`: PASS (351 tickets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)