### PR TITLE
ticket(0358): file the three red credential-path test suites

### DIFF
--- a/tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg
+++ b/tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg
@@ -1,0 +1,102 @@
+%erg 0.1
+Title: fix-tests: credential scrubbing and key-selection suites fail on make check
+Created: 2026-07-24
+Author: Integration Test
+
+--- log ---
+2026-07-24T20:19Z Integration Test created
+2026-07-24T20:20Z Integration Test note found during /lair step 9 full-suite run on main (36873aa); 3 suites red, 9 assertions
+
+--- body ---
+## Context
+
+`make check` on main (36873aa) ends `3 failed, 858 passed, 1 skipped`. The
+three red suites all belong to the reviewer-seat credential path:
+
+- `tests/test_bash_env_keys_selection_explicit.sh`
+- `tests/test_reviewers_audition.sh`
+- `tests/test_seat_runner.sh`
+
+PR #667 already observed these as pre-existing and reproducing on its base,
+so they predate the 0357 work and are not a regression from it. They have
+sat unticketed since.
+
+These clear the tooling-repo severity floor (`rules/workflow.md`
+§ Autonomous Action Rules) on two counts: `make check` is the pre-PR gate,
+so a red suite blocks every merge; and the failing assertions are the
+credential-containment guards themselves, not cosmetics.
+
+## The nine failing assertions
+
+Key selection — the guard expects the destination variable to be **unset**,
+but it carries a live OpenRouter key (value withheld; it is a real
+`sk-or-v1-…` credential from the aedist config, which is itself part of the
+finding):
+
+- `(5a) invalid SRC: DST not set`
+- `(5c) SRC=DST=extra: aedist value not smuggled anywhere`
+- `(5d) absent SRC: DST not set`
+
+Redaction — the scrubber's marker never appears:
+
+- `scrub: findings carry the redaction marker` (missing `[REDACTED-CREDENTIAL]`)
+- `scrub: failure-path stderr carries the redaction marker`
+- `scrub: WARN-cat stderr carries the redaction marker`
+
+Seat runner / audition:
+
+- `credential-env: secret reaches podman via process env` (missing probe value)
+- `audition: cost from token counts` (missing `cost=$0.0021`)
+- `0353: existing running-sum latency preserved` (missing `latency=70.0s`)
+
+## Diagnosis discipline
+
+Observation only — cause not yet established. Two hypotheses worth
+discriminating before any fix:
+
+1. **Ambient-env leakage.** The 5a/5c/5d failures show a real key where the
+   test crafted an empty env. If the suite does not spawn through
+   `env -i`, the machine's own `~/.config/keys/` export would satisfy the
+   variable and the assertion would fail only on a machine that has the key
+   — i.e. the test is environment-dependent, not the code broken. This is
+   the exact trap `rules/coding-bash.md` § BASH_ENV documents.
+2. **Genuine containment regression.** If the suite *is* hermetic, the key
+   is reaching the destination through the code path under test, and the
+   scrub-marker failures are the same defect seen from the output side.
+
+Hypothesis 1 predicts the suite passes on a machine without the aedist key;
+hypothesis 2 predicts it fails everywhere. Check that first — it costs one
+`env -i` run and decides whether this is a test bug or a security bug.
+
+The audition/latency failures (`cost=$0.0021`, `latency=70.0s`) look like a
+separate, more mundane fixture-drift problem and may split off.
+
+## Relevant files
+- `tests/test_bash_env_keys_selection_explicit.sh` — key-selection guard
+- `tests/test_reviewers_audition.sh` — cost/latency assertions
+- `tests/test_seat_runner.sh` — podman credential-env + scrub markers
+- `scripts/bash-env.sh` — the export boundary under test
+- `skills/reviewers/` — seat runner and audition machinery
+
+## Test
+The suites are the test; they are already RED. Before changing any
+production code, re-run each under a hermetic base env
+(`env -i HOME=<fixture> BASH_ENV=… bash -c …`) to establish which
+hypothesis holds.
+
+## Verification
+- [ ] Each of the three suites exits 0
+- [ ] Rerun proves the key-selection assertions fail on the pre-fix state
+      for the established cause (not merely because the machine lacks a key)
+- [ ] No credential value appears in any test output or log
+
+## Invariants
+- No real credential is ever printed, committed, or asserted on by value
+- `make check` green on main
+
+## Exit criteria
+- [ ] `make check` on main reports 0 failures
+- [ ] The cause is stated in the log as test-hermeticity or containment,
+      with the discriminating evidence
+- [ ] If containment: a note in `rules/coding-bash.md` or memory recording
+      the defect class


### PR DESCRIPTION
Ticket-ref: tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg

Files ticket 0358. No code change — ticket only.

`make check` on main (36873aa) ends `3 failed, 858 passed, 1 skipped`. The three red suites (`test_bash_env_keys_selection_explicit.sh`, `test_reviewers_audition.sh`, `test_seat_runner.sh`) were already noted as pre-existing by PR #667 and have sat unticketed since.

Filed rather than reported-only: `make check` is the pre-PR gate, so a red suite blocks every merge, and the failing assertions are the credential-containment guards themselves — both sides of the tooling severity floor.

The body states the observation and holds the cause, per the diagnosis-discipline rule. Two hypotheses with a cheap discriminator: a non-hermetic suite picking up the machine's ambient key (fails only where the key exists) versus a real containment regression (fails everywhere). One `env -i` run decides it. No credential value appears in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)