### PR TITLE
Count a forked session's inherited turns once in the compaction audit

### DIFF
--- a/scripts/trace-compact-audit.py
+++ b/scripts/trace-compact-audit.py
@@ -78,6 +78,7 @@ def parse_trajectory(path: Path) -> dict:
     awaiting_post_read = False
     entry_skill = None
     last_ts = None
+    first_ts = None
 
     with open(path, encoding="utf-8", errors="replace") as fh:
         for line in fh:
@@ -94,6 +95,8 @@ def parse_trajectory(path: Path) -> dict:
             tstamp = ts._parse_ts(rec.get("timestamp", ""))
             if tstamp is not None:
                 last_ts = tstamp
+                if first_ts is None:
+                    first_ts = tstamp
 
             rec_type = rec.get("type")
             if rec_type == "system" and rec.get("subtype") == "compact_boundary":
@@ -122,7 +125,12 @@ def parse_trajectory(path: Path) -> dict:
                     seen_ids.add(msg_id)
                     cache_read = usage.get("cache_read_input_tokens", 0) or 0
                     events.append(
-                        {"kind": "turn", "cache_read": cache_read, "model": model}
+                        {
+                            "kind": "turn",
+                            "cache_read": cache_read,
+                            "model": model,
+                            "msg_id": msg_id,
+                        }
                     )
                     if awaiting_post_read:
                         post_compact_reads.append(cache_read)
@@ -145,7 +153,47 @@ def parse_trajectory(path: Path) -> dict:
         "post_compact_tokens": post_compact_tokens,
         "entry_skill": entry_skill,
         "last_ts": last_ts,
+        "first_ts": first_ts,
     }
+
+
+def drop_inherited_turns(trajectories: list[tuple]) -> int:
+    """Strip turns a trajectory inherited from an earlier one, corpus-wide.
+
+    `parse_trajectory` dedups turns by message id within a single file. A fork
+    or resume starts a NEW file that replays the parent's records verbatim —
+    same message ids — so the per-file set never sees them and every inherited
+    turn is counted a second time. On the 2026-07-27 census that inflated the
+    recoverable-compaction figure by ~28% ($278.68 -> ~$201): two session pairs
+    contributed byte-identical runs.
+
+    Trajectories are processed oldest-first so the originating session keeps its
+    turns and the fork contributes only what it actually added. Turns are
+    dropped in place; compact/clear events are left alone, since a fork
+    genuinely re-enters that state. Returns the number of turns dropped.
+    """
+    from datetime import datetime, timezone
+
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
+    ordered = sorted(
+        trajectories,
+        key=lambda item: (item[3]["first_ts"] or epoch, item[1], item[2]),
+    )
+    claimed: set[str] = set()
+    dropped = 0
+    for _, _, _, traj in ordered:
+        kept = []
+        for ev in traj["events"]:
+            if ev["kind"] == "turn":
+                mid = ev.get("msg_id")
+                if mid is not None:
+                    if mid in claimed:
+                        dropped += 1
+                        continue
+                    claimed.add(mid)
+            kept.append(ev)
+        traj["events"] = kept
+    return dropped
 
 
 def find_missed_runs(events: list[dict], min_run: int, threshold: int) -> list[dict]:
@@ -198,6 +246,12 @@ def audit_corpus(projects_dir: Path, days: int, min_run: int, threshold: int) ->
         if traj["last_ts"] is None or traj["last_ts"] < cutoff:
             continue
         trajectories.append((project, session_id, agent_id, traj))
+
+    duplicate_turns = drop_inherited_turns(trajectories)
+    if duplicate_turns:
+        log.info(
+            "dropped %d turns inherited by forked/resumed sessions", duplicate_turns
+        )
 
     post_reads = [r for _, _, _, t in trajectories for r in t["post_compact_reads"]]
     post_tokens = [r for _, _, _, t in trajectories for r in t["post_compact_tokens"]]
@@ -267,6 +321,7 @@ def audit_corpus(projects_dir: Path, days: int, min_run: int, threshold: int) ->
         "threshold_tokens": threshold,
         "files_seen": files_seen,
         "agents_in_window": len(trajectories),
+        "inherited_turns_dropped": duplicate_turns,
         "compactions_observed": compactions,
         "clears_observed": clears,
         "post_compact_median_tokens": median_post,

--- a/skills/trace-doctor/SKILL.md
+++ b/skills/trace-doctor/SKILL.md
@@ -92,6 +92,14 @@ a third), which is what a monthly re-measure is for. The compaction advisory
 (H8, from the wired compact-audit input) is reported as an advisory count of
 missed compact/clear runs, not an A/B.
 
+Report `inherited_turns_dropped` from the compact-audit summary alongside H8.
+It counts turns a forked or resumed session replayed from its parent, which the
+audit attributes to the parent only. A non-zero count is normal; a *large* one
+means the window is fork-heavy, so H8's run count reflects fewer distinct
+sessions than `agents_in_window` suggests. Comparing an H8 figure against any
+census taken before 2026-07-27 compares against an inflated number — that run
+overstated recoverable spend by 27% on the same corpus.
+
 ## 3. Cross-reference existing tickets
 
 For each actionable finding, decide whether it is already owned. Search open

--- a/tests/test_trace_compact_audit.py
+++ b/tests/test_trace_compact_audit.py
@@ -174,3 +174,93 @@ def test_cli_flags_present():
     for flag in ("--projects-dir", "--days", "--threshold", "--min-run", "--output", "--json"):
         assert flag in src, f"missing CLI flag {flag}"
     assert "ArgumentParser" in src
+
+
+# --- corpus-wide dedup of forked/resumed sessions ----------------------------
+# parse_trajectory dedups turns by message id within ONE file. A fork or resume
+# replays the parent's records verbatim into a NEW file, so the per-file set
+# never sees them and every inherited turn is counted twice. On the 2026-07-27
+# census this overstated recoverable compaction by 27% ($285.33 -> $208.99,
+# same corpus, 12 missed runs -> 8).
+
+from datetime import datetime, timezone  # noqa: E402
+
+
+def _ts(minute):
+    return datetime(2026, 6, 9, 10, minute, tzinfo=timezone.utc)
+
+
+def _traj(events, first_ts):
+    return {"events": events, "first_ts": first_ts}
+
+
+def _turn(msg_id, cache_read=400_000):
+    return {
+        "kind": "turn",
+        "cache_read": cache_read,
+        "model": "claude-opus-4-8",
+        "msg_id": msg_id,
+    }
+
+
+def test_fork_inherited_turns_counted_once():
+    """The child replays the parent's turns; only the parent keeps them."""
+    parent = _traj([_turn("a"), _turn("b")], _ts(0))
+    child = _traj([_turn("a"), _turn("b"), _turn("c")], _ts(5))
+    trajectories = [("p", "parent", "main", parent), ("p", "child", "main", child)]
+
+    dropped = tca.drop_inherited_turns(trajectories)
+
+    assert dropped == 2
+    assert [e["msg_id"] for e in parent["events"]] == ["a", "b"]
+    assert [e["msg_id"] for e in child["events"]] == ["c"], (
+        "child must keep only the turns it actually added"
+    )
+
+
+def test_dedup_is_oldest_first_regardless_of_input_order():
+    """Attribution must follow session start time, not iteration order — the
+    trace-file walk gives no ordering guarantee, so a child listed first would
+    otherwise steal the parent's turns and leave the parent empty."""
+    parent = _traj([_turn("a"), _turn("b")], _ts(0))
+    child = _traj([_turn("a"), _turn("b"), _turn("c")], _ts(5))
+    trajectories = [("p", "child", "main", child), ("p", "parent", "main", parent)]
+
+    tca.drop_inherited_turns(trajectories)
+
+    assert [e["msg_id"] for e in parent["events"]] == ["a", "b"]
+    assert [e["msg_id"] for e in child["events"]] == ["c"]
+
+
+def test_dedup_preserves_compact_and_clear_events():
+    """A fork genuinely re-enters compact/clear state — those events are not
+    inherited spend and must survive, or run detection silently re-merges runs
+    that were really broken."""
+    parent = _traj([_turn("a"), {"kind": "compact"}], _ts(0))
+    child = _traj([_turn("a"), {"kind": "clear"}, _turn("z")], _ts(5))
+    trajectories = [("p", "parent", "main", parent), ("p", "child", "main", child)]
+
+    tca.drop_inherited_turns(trajectories)
+
+    assert [e["kind"] for e in child["events"]] == ["clear", "turn"]
+    assert [e["kind"] for e in parent["events"]] == ["turn", "compact"]
+
+
+def test_turns_without_message_id_are_never_dropped():
+    """Defensive: an unidentifiable turn cannot be proven inherited, so keep it
+    rather than silently under-report."""
+    a = _traj([{"kind": "turn", "cache_read": 1, "model": "m"}], _ts(0))
+    b = _traj([{"kind": "turn", "cache_read": 1, "model": "m"}], _ts(5))
+    trajectories = [("p", "a", "main", a), ("p", "b", "main", b)]
+
+    assert tca.drop_inherited_turns(trajectories) == 0
+    assert len(a["events"]) == 1 and len(b["events"]) == 1
+
+
+def test_distinct_sessions_are_not_deduped():
+    """Two unrelated sessions share no message ids — nothing may be dropped."""
+    a = _traj([_turn("a1"), _turn("a2")], _ts(0))
+    b = _traj([_turn("b1"), _turn("b2")], _ts(5))
+    trajectories = [("p", "a", "main", a), ("p", "b", "main", b)]
+
+    assert tca.drop_inherited_turns(trajectories) == 0


### PR DESCRIPTION
Fixes the compaction measurement that `trace-doctor` reports, following the
2026-07-27 census.

## The defect

`parse_trajectory` dedups turns by message id **within a single trace file**. A
fork or resume opens a *new* file that replays the parent's records verbatim,
message ids included, so the per-file set never sees them. The audit finds the
same physical run in both sessions and bills it twice.

The tell was two session pairs contributing byte-identical run rows
(same `run_start_event`, `run_turns`, `mean_cache_read`, `max_cache_read`,
`recoverable_usd`).

## Measured effect

Controlled — the pre-fix script re-run on the *same* corpus as the fixed one, so
neither number moves with corpus growth:

| | pre-fix | post-fix |
|---|---|---|
| agents_in_window | 136 | 136 |
| missed_runs | 12 | 8 |
| recoverable_usd_upper_bound | $285.33 | $208.99 |

**27% of the headline was double-counted.** 892 inherited turns dropped.

## Design choices

- **Corpus-wide and oldest-first**, so the originating session keeps its turns
  and the fork contributes only what it added. Ordering is load-bearing: the
  trace-file walk gives no ordering guarantee, and a child processed first would
  strip the parent instead. Tested explicitly.
- **compact/clear events survive dedup.** A fork genuinely re-enters that state;
  dropping them would silently re-merge runs that were really broken — trading
  one measurement error for another.
- **Turns with no message id are kept.** Unidentifiable is not the same as
  inherited, and under-reporting is not a safer failure than over-reporting,
  only a quieter one.
- **Surfaced, not silent**: `inherited_turns_dropped` lands in the summary, and
  `trace-doctor` now warns that comparing H8 against any pre-2026-07-27 census
  compares against the inflated figure.

## Verification

- `make check-fast` — 776 passed (771 on base, +5 new)
- controlled before/after on the live corpus, table above
- mutation-checked: making the dedup a no-op fails 3 of the 5 new tests

## Explicitly not in scope

Whether the 300k absolute threshold still means the same thing on large-context
models, where auto-compact never fires because the window is never approached.
That is a semantics question rather than a double-count, and it needs its own
decision — the observed sessions ran at 240k–630k per-turn cache read on
models whose window they never came close to filling.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
