### PR TITLE
No ambient credentials in the suites that print what they find

### DIFF
--- a/tests/test_bash_env_keys_selection_explicit.sh
+++ b/tests/test_bash_env_keys_selection_explicit.sh
@@ -45,9 +45,17 @@ printf "TRICKY_KEY='a b \$(touch %s/PWNED) c'\n" "$WORK" > "$FHOME/.config/keys/
 
 # Load bash-env.sh in a subprocess with $HOME=<home> and PWD=<projdir>, then print
 # the value of environment variable <var> ("" if unset). stderr silenced.
+#
+# `env -i` is load-bearing, not tidiness. The fake HOME isolates the keystore,
+# but a plain `HOME=... bash -c` still inherits the caller's environment — so a
+# real OPENROUTER_API_KEY exported by the harness loader masked the very
+# variable these assertions check. "DST not set" then failed with the ambient
+# value, and printed a live credential into the failure message (2026-07-27).
+# A known-empty base env is the only way an inherited variable cannot mask the
+# behaviour under test (rules/coding-bash.md).
 _load_var() {
     local home="$1" projdir="$2" var="$3"
-    HOME="$home" bash -c '
+    env -i HOME="$home" PATH="$PATH" bash -c '
         cd "$1" || exit 1
         source "$2"
         n="$3"
@@ -58,7 +66,7 @@ _load_var() {
 # Load bash-env.sh as above but return only the exit code (0 = no shell error).
 _load_rc() {
     local home="$1" projdir="$2"
-    HOME="$home" bash -c '
+    env -i HOME="$home" PATH="$PATH" bash -c '
         cd "$1" || exit 1
         source "$2"
     ' _ "$projdir" "$SCRIPT" >/dev/null 2>&1
@@ -70,7 +78,7 @@ _load_rc() {
 # the void — so $( ) collects exactly the warnings the script emits.
 _load_stderr() {
     local home="$1" projdir="$2"
-    HOME="$home" bash -c '
+    env -i HOME="$home" PATH="$PATH" bash -c '
         cd "$1" || exit 1
         source "$2"
     ' _ "$projdir" "$SCRIPT" 2>&1 >/dev/null
@@ -79,7 +87,7 @@ _load_stderr() {
 # Load bash-env.sh as above and print `export -p` (the exported environment).
 _load_exports() {
     local home="$1" projdir="$2"
-    HOME="$home" bash -c '
+    env -i HOME="$home" PATH="$PATH" bash -c '
         cd "$1" || exit 1
         source "$2"
         export -p
@@ -121,7 +129,7 @@ _assert_eq() {
 # name against the ambient environment (only against the provider file).
 _load_var_ambient() {
     local home="$1" projdir="$2" var="$3" amb_name="$4" amb_val="$5"
-    HOME="$home" bash -c '
+    env -i HOME="$home" PATH="$PATH" bash -c '
         cd "$1" || exit 1
         export "$4=$5"
         source "$2"

--- a/tests/test_seat_runner.sh
+++ b/tests/test_seat_runner.sh
@@ -15,6 +15,41 @@
 # going; a genuine defect FAILs.
 set -euo pipefail
 
+# --- hermetic credential scope (2026-07-27) ----------------------------------
+# Every credential this suite handles is a FIXTURE, injected via
+# --credential-env MY_TEST_VAR; seat-runner re-exports that fixture value as
+# OPENAI_API_KEY for its children, which is why the exfiltration stubs below
+# interpolate "${OPENAI_API_KEY:-}" — they are meant to echo the fixture, and
+# the assertions check the scrub removed it.
+#
+# That only holds if no REAL key is in scope. When the injection does not reach
+# a stub, the stub inherits the ambient environment instead, and a failing
+# assertion prints whatever it found. On 2026-07-27 that spilled a live
+# OpenAI key into a terminal and a session transcript.
+#
+# So: drop every provider credential before anything runs. A stub that misses
+# the injection now prints an empty string, not a secret.
+unset OPENAI_API_KEY OPENROUTER_API_KEY ANTHROPIC_API_KEY DEEPSEEK_API_KEY \
+      MISTRAL_API_KEY TAVILY_API_KEY ZOTERO_API_KEY ZOTERO_RW_API_KEY
+
+# Unsetting here is NOT enough on its own. BASH_ENV points every child bash at
+# scripts/bash-env.sh, which re-runs the KEYS selection and re-exports the real
+# credential — overriding whatever this parent set. The stubs are bash scripts,
+# so they were being handed the live key no matter what happened up here. Clear
+# BASH_ENV so children stay hermetic; the fixture arrives via --credential-env,
+# which needs no loader.
+export BASH_ENV=
+
+# Assert against a CHILD, not this shell. A parent-scope check passes while the
+# leak is alive, because re-injection happens on child startup — that blind spot
+# is what made the first attempt at this fix a no-op.
+_hermetic_probe="$(bash -c 'printf "%s" "${OPENAI_API_KEY:-}"')"
+if [ -n "$_hermetic_probe" ]; then
+    printf 'FAIL: child processes still receive a credential; suite is not hermetic\n' >&2
+    exit 1
+fi
+unset _hermetic_probe
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SR="${REPO_ROOT}/scripts/seat-runner.sh"
 RELAY="${REPO_ROOT}/scripts/seat-runner/net-relay.py"


### PR DESCRIPTION
Two suites assert on credential handling, and both were reading the **real** key
the harness exports. When an assertion failed, it printed what it found — a live
credential into a terminal and a session transcript.

Neither is a scrub failure. Both are inherited-environment failures.

## `test_seat_runner.sh` — BASH_ENV re-injection

The suite injects a fixture via `--credential-env`; seat-runner re-exports it as
`OPENAI_API_KEY` for its children, which is why the exfiltration stubs
interpolate that name. But `BASH_ENV` points every child bash at
`scripts/bash-env.sh`, which re-runs the `KEYS` selection and re-exports the
**real** value, overriding the fixture. The stubs are bash scripts, so they were
handed the live key regardless of what the suite set.

Unsetting in the parent is a **no-op** against this — re-injection happens at
child startup. So `BASH_ENV` is cleared for the suite, and the guard probes a
**child**, not the suite's own shell. A parent-scope check passes while the leak
is alive; that blind spot made the first version of this fix do nothing.

## `test_bash_env_keys_selection_explicit.sh` — inherited env masks the assertion

Already hermetic for `HOME` (fake keystore, sentinel values, documented as such),
but its four helpers ran `HOME=... bash -c`, inheriting everything else. The
ambient `OPENROUTER_API_KEY` masked the variable under test, so *"DST not set"*
failed against the real value — and printed it. Now `env -i`, per
`rules/coding-bash.md`.

## These suites were RED *because* of this

Not merely leaky. The ambient key overrode the injected fixture, so the scrub
assertions compared against a value the scrub was never given. Fixing the
isolation turns both green:

| | before | after |
|---|---|---|
| failing shell suites | 3 | 1 |
| `test_seat_runner.sh` | exit 1, 4 failures | exit 0 |
| `test_bash_env_keys_selection_explicit.sh` | exit 1 | exit 0 |

`test_reviewers_audition.sh` (cost/latency assertions) and
`test_guard_cd_primary_repo.sh` remain red — both unrelated to credentials and
red on `origin/main` too.

## Verification

Measured with a **fake sentinel loader**, never the real key:

- before: sentinel appears **4×** in output, 4 assertion failures
- after: **0×**, 0 failures

The first attempt at this measurement was void and I discarded it — running the
old suite from a temp dir broke its `REPO_ROOT`, so it never reached the stubs
and reported a misleading clean zero.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
