### PR TITLE
ticket(0358): confirm ambient-env leakage; the leak reached disk off-repo

### DIFF
--- a/tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg
+++ b/tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg
@@ -6,6 +6,7 @@ Author: Integration Test
 --- log ---
 2026-07-24T20:19Z Integration Test created
 2026-07-24T20:20Z Integration Test note found during /lair step 9 full-suite run on main (36873aa); 3 suites red, 9 assertions
+2026-07-27T12:40Z HDMX-coding-agent note hypothesis 1 (ambient-env leakage) CONFIRMED by source inspection; and the leak has escaped the repo — a live sk-or- key was found in plaintext on disk in a climate-finance job scratch dir. Severity raised. See the two sections appended to the body.
 
 --- body ---
 ## Context
@@ -100,3 +101,71 @@ hypothesis holds.
       with the discriminating evidence
 - [ ] If containment: a note in `rules/coding-bash.md` or memory recording
       the defect class
+- [ ] Every helper that spawns a subprocess in the three suites uses `env -i`
+- [ ] `_assert_eq` / `_assert_contains` never print a captured value that could
+      be a credential (print a length or a hash, or scrub before printing)
+- [ ] `tests/test_bash_env_tested_via_subprocess.sh` (or a sibling) fails when a
+      helper spawns without `env -i`
+
+## 2026-07-27 — hypothesis 1 confirmed, by source inspection
+
+Hypothesis 1 (ambient-env leakage) holds. No re-run on a key-less machine was
+needed; the source settles it.
+
+`tests/test_bash_env_keys_selection_explicit.sh` defines four subprocess
+helpers — `_load_var`, `_load_rc`, `_load_stderr`, `_load_exports` — and every
+one spawns as:
+
+    HOME="$home" bash -c '...' _ "$projdir" "$SCRIPT" ...
+
+`HOME` is overridden; the rest of the environment is **inherited**. So the
+machine's own exported `OPENROUTER_API_KEY` is visible inside the subprocess,
+the destination variable is non-empty where the fixture intended it empty, and
+5a/5c/5d fail. That is exactly the trap `rules/coding-bash.md` § BASH_ENV
+documents, in the suite that documents it.
+
+Two aggravating details:
+
+- The file uses `env -i` **exactly once**, so this is inconsistency, not a
+  deliberate design. `tests/test_seat_runner.sh` uses it **zero** times;
+  `tests/test_bash_env_tested_via_subprocess.sh` uses it three times.
+- `tests/test_seat_runner.sh:204` has a podman stub that runs
+  `env > "$PODMAN_ENV_CAP"` — dumping the entire inherited environment,
+  credentials included, to a file the test then prints.
+
+So this is a test bug, not a containment regression in `scripts/bash-env.sh`.
+But it has a security consequence that hypothesis 2 would not have had, below.
+
+## 2026-07-27 — the leak reached disk outside this repo
+
+The failure messages print the captured value:
+
+    FAIL: (5a) invalid SRC: DST not set — got [sk-or-v1-…], want []
+
+so each spurious failure writes a **live** OpenRouter credential to stdout.
+Anything capturing that output persists it. A climate-finance session did
+exactly that, redirecting the suites into its job scratch dir. Found on
+2026-07-27 in `~/.claude/jobs/bccc95ab/tmp/`:
+
+- 5 `sk-or-` tokens across 3 files (`base_test_seat_runner.sh.log`,
+  `base_test_bash_env_keys_selection_explicit.sh.log`, `old.log`)
+- 4 were an already-rotated key; **1 was the key live in the ambient
+  environment at the time of discovery**
+- the seat-runner log carried a full `env` dump (PATH, DBUS_SESSION_BUS_ADDRESS,
+  `OPENROUTER_API_KEY=…`) from the `PODMAN_ENV_CAP` capture above
+
+All five were redacted in place on 2026-07-27; a search for the live value now
+returns zero files. The same rotated key also sits in three session-transcript
+`.jsonl` files, deliberately left alone: the key is dead, and rewriting harness
+session records risks more than the residual exposure.
+
+This raises the severity. The ticket was filed on the ground that `make check`
+is red and blocks merges. It also **bit a science project**: a live credential
+was written in plaintext into a directory belonging to another repo's session.
+Both limbs of the tooling-repo severity floor are now met, not just the first.
+
+Consequence for the fix: adding `env -i` turns the suites green *and* closes the
+leak, but the two are separable and both are required. A green suite that still
+prints captured values on failure would re-leak the next time an assertion
+fails for an unrelated reason — which is why the value-printing assertion
+helpers get their own exit criterion above.


### PR DESCRIPTION
Updates ticket 0358 only. No test or production code changed — the fix itself
is left for whoever picks the ticket up.

## What this settles

0358 named two hypotheses and asked which held. Source inspection decides it,
no key-less machine needed.

All four subprocess helpers in `tests/test_bash_env_keys_selection_explicit.sh`
— `_load_var`, `_load_rc`, `_load_stderr`, `_load_exports` — spawn as:

```bash
HOME="$home" bash -c '...' _ "$projdir" "$SCRIPT" ...
```

`HOME` is overridden; everything else is **inherited**. The machine's exported
`OPENROUTER_API_KEY` is thus visible where the fixture intended an empty
environment, which is exactly why `(5a)`, `(5c)` and `(5d)` see a value and
fail. **Hypothesis 1 — ambient-env leakage.** In the suite whose own rule
(`rules/coding-bash.md` § BASH_ENV) documents this trap.

Two aggravating details:

| File | `env -i` uses |
|---|---|
| `tests/test_bash_env_tested_via_subprocess.sh` | 3 |
| `tests/test_bash_env_keys_selection_explicit.sh` | **1** (inconsistent, not by design) |
| `tests/test_seat_runner.sh` | **0** |

and `tests/test_seat_runner.sh:204` runs `env > "$PODMAN_ENV_CAP"` — dumping the
entire inherited environment to a file the test then prints.

So: a test bug, not a containment regression in `scripts/bash-env.sh`.

## Why the severity goes up anyway

The assertion helpers print the captured value:

```
FAIL: (5a) invalid SRC: DST not set — got [sk-or-v1-…], want []
```

Every spurious failure therefore writes a live credential to stdout. A
climate-finance session redirected these suites into its job scratch dir, and on
2026-07-27 that directory held **5 `sk-or-` tokens across 3 files** — 4 of an
already-rotated key, and **one of the key live in the ambient environment at the
time of discovery**. The seat-runner log carried a full `env` dump from the
`PODMAN_ENV_CAP` capture.

All five were redacted in place; a search for the live value now returns zero
files. The same rotated key remains in three session-transcript `.jsonl` files,
deliberately untouched — the key is dead, and rewriting harness session records
risks more than the residual exposure.

0358 was filed on the ground that `make check` is red and blocks merges. It has
now also **bitten a science project**, writing a plaintext credential into
another repo's session directory. Both limbs of the tooling-repo severity floor
are met, not just the first.

## Three exit criteria added

- every spawning helper in the three suites uses `env -i`
- `_assert_eq` / `_assert_contains` never print a captured value that could be a
  credential (length, hash, or scrub first)
- a guard fails when a helper spawns without `env -i`

The second is separable and load-bearing: `env -i` alone greens the suites and
closes *this* leak, but a helper that still prints captured values re-leaks the
next time an assertion fails for an unrelated reason.

## Verification

- `erg check tickets/` — PASS, 352 tickets
- no real `sk-or-` token appears in the ticket text (checked mechanically)

**Ticket-ref:** tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)