### PR TITLE
docs(update-publist): credentials come from the keystore, not .env

### DIFF
--- a/skills/update-publist/SKILL.md
+++ b/skills/update-publist/SKILL.md
@@ -111,9 +111,18 @@ curl -s 'https://api.archives-ouvertes.fr/search/hal/?q=authIdHal_s:minh-ha-duon
 ```
 
 Standard values for this author:
-- Structure: `#struct-1380080` (CIRED)
+- Structure: `#struct-1380080` (CIRED). **Verified against the HAL ref API,
+  2026-07-27** — a fork of this skill carried `struct-1002424`, which
+  resolves to ECOSYS, an unrelated laboratory. Do not "correct" this id
+  from another document; re-verify it instead:
+  `curl -s 'https://api.archives-ouvertes.fr/ref/structure/?q=docid:1380080&fl=docid,name_s,acronym_s&wt=json'`
+- ORCID: `0000-0001-9988-2100`
 - idhal: `minh-ha-duong`
 - Typology: `COMM` for a conference talk (adjust per doctype)
+- Stamps: CIRED, CNRS
+- Domains: `shs.eco`, `shs.hisphilso` (adjust per paper)
+- File reference in the TEI:
+  `<ref type="file" target="paper.pdf" subtype="author" n="1"/>`
 
 For a journal article, resolve the journal's HAL id rather than typing
 the title into the TEI:
@@ -154,6 +163,15 @@ so it is deleted even on error or interruption. Contents:
 ```
 user = "HAL_ID_VALUE:HAL_PASSWORD_VALUE"
 ```
+
+**Dry run first.** The same request with `-H "X-test: 1"` validates the
+package without creating a record. Run it, read the response, and only
+then repeat without the header.
+
+**Updating an existing deposit** is the same request as a `PUT` to
+`https://api.archives-ouvertes.fr/sword/hal/{hal-id}`. Use it rather
+than a second POST — a second POST creates a duplicate record, and
+duplicates need moderator action to merge.
 
 The SWORD acknowledgement means "stored in workspace" — moderation
 status is confirmed by HAL's email, not the API response.

--- a/skills/update-publist/SKILL.md
+++ b/skills/update-publist/SKILL.md
@@ -73,9 +73,16 @@ This directory is NOT a git repo. It deploys over FTP.
 
 Credentials: `HAL_ID` and `HAL_PASSWORD` live in `~/.config/keys/hal.env` and
 reach the environment because a `KEYS=` line selects them — no `.env` holds a
-credential value. Selection is default-deny, so the shell must start in a
-directory whose `.env` names `hal:HAL_ID,hal:HAL_PASSWORD`; `~/.claude/.env`
-does, which covers a run from anywhere.
+credential value. Selection is default-deny, so the selection in force must
+name `hal:HAL_ID,hal:HAL_PASSWORD`; `~/.claude/.env` does, which covers any
+startup directory that sets no `KEYS=` of its own.
+
+A project `KEYS=` **replaces** the harness one rather than adding to it
+(ticket 0360), so from a project whose `.env` carries its own `KEYS=` line the
+deposit fails as an ordinary auth error unless that line also names `hal:`.
+Run from a directory with no `KEYS=` of its own, or check first —
+names only, never values:
+`bash -c ': "${HAL_ID:?not selected from this cwd}"'`.
 **Never echo, display, log, or commit credential values.** Pass them
 to curl via a chmod-600 temporary config file (`curl -K`), never on the
 command line. Mask `<hal:password>` in any displayed API response.

--- a/skills/update-publist/SKILL.md
+++ b/skills/update-publist/SKILL.md
@@ -53,7 +53,11 @@ This directory is NOT a git repo. It deploys over FTP.
 
 ## Step 2: HAL deposit via SWORD
 
-Credentials: `HAL_ID` and `HAL_PASSWORD` from the project `.env`.
+Credentials: `HAL_ID` and `HAL_PASSWORD` live in `~/.config/keys/hal.env` and
+reach the environment because a `KEYS=` line selects them — no `.env` holds a
+credential value. Selection is default-deny, so the shell must start in a
+directory whose `.env` names `hal:HAL_ID,hal:HAL_PASSWORD`; `~/.claude/.env`
+does, which covers a run from anywhere.
 **Never echo, display, log, or commit credential values.** Pass them
 to curl via a chmod-600 temporary config file (`curl -K`), never on the
 command line. Mask `<hal:password>` in any displayed API response.

--- a/skills/update-publist/SKILL.md
+++ b/skills/update-publist/SKILL.md
@@ -28,6 +28,24 @@ This directory is NOT a git repo. It deploys over FTP.
    Required fields: `file = {files/HaDuong-YYYY-Topic.pdf}`. Add
    `eprint = {https://hal.science/hal-XXXXXXXvN}` after HAL deposit.
 
+   Pick the type from the publication's *status*, not its venue:
+
+   | Status | Type | Notes |
+   |--------|------|-------|
+   | Peer-reviewed and accepted | `@article` | `journaltitle`, `doi` |
+   | Under review / preprint | `@techreport` | `type` = "Preprint, under review at {Journal}". **No** `institution` field |
+   | CIRED Working Paper series | `@techreport` | The only case that gets `institution = {CIRED}` |
+   | Conference presentation | `@inproceedings` | `booktitle`, `location`, `date` |
+   | Dataset | `@misc` | `howpublished = {Zenodo}`, `doi` |
+   | Book | `@book` | `publisher`, `isbn` |
+
+   The preprint/CIRED-WP split is the one that gets fixed wrong: an
+   `institution` field on a preprint makes the page render it as
+   CIRED-published work it is not.
+
+   Field conventions: `doi` bare, no URL prefix (`10.5281/zenodo.19097045`);
+   `date` in ISO form (`2026-03-18`); `eprint` the full HAL URL.
+
 3. **Translation pairs.** For a translated work:
    - The translation key gets an `:EN` suffix.
    - On the translation: `related = {OriginalKey}`,
@@ -62,6 +80,25 @@ does, which covers a run from anywhere.
 to curl via a chmod-600 temporary config file (`curl -K`), never on the
 command line. Mask `<hal:password>` in any displayed API response.
 
+### Pre-upload PDF review (GATE)
+
+Read **every page** of the PDF with vision before building any metadata.
+This checks the *document*; the 2b gate checks the *payload*, and neither
+substitutes for the other — a well-formed TEI can wrap an anonymized draft.
+
+- The author's name appears in the document (no "[Anonymous]", no
+  anonymized review version).
+- Affiliations are present and will match the HAL metadata.
+- No placeholder text and no draft watermark contradicting the deposit
+  status.
+- The file is complete: all pages, figures and tables render.
+- Nothing sensitive is embedded — API keys, personal addresses beyond
+  the correspondence one.
+
+Guidelines: https://doc.hal.science/en/deposit/
+
+Only proceed once the review passes.
+
 ### 2a. Prepare the TEI metadata
 
 Use the AOfr TEI format (template reference:
@@ -77,6 +114,14 @@ Standard values for this author:
 - Structure: `#struct-1380080` (CIRED)
 - idhal: `minh-ha-duong`
 - Typology: `COMM` for a conference talk (adjust per doctype)
+
+For a journal article, resolve the journal's HAL id rather than typing
+the title into the TEI:
+```
+curl -s 'https://api.archives-ouvertes.fr/ref/journal/?q=title_t:{name}&fl=docid,title_s,valid_s&wt=json'
+```
+Use the `docid` as `halJournalId`, and prefer an entry whose `valid_s`
+is `VALID`.
 
 ### 2b. Assemble and review the payload
 
@@ -118,6 +163,11 @@ status is confirmed by HAL's email, not the API response.
 After a successful deposit, update the BibTeX entry in
 `src/Ha-Duong.bib` with the `eprint` field pointing to the new HAL
 record, then rebuild the personal page (Step 1.4-1.5).
+
+If the run happened inside a project that tracks HAL ids in its
+`STATE.md`, update them there too — a stale HAL id in project state is
+the usual way a second deposit gets made for a record that already
+exists.
 
 ## Credential safety rules
 


### PR DESCRIPTION
The HAL deposit step of `update-publist` said its credentials come "from the
project `.env`". That was true before the keystore migration. It is now false
in the worst direction: a reader who believes it edits `.env` — the one file
whose invariant is that it holds no credential value.

This names the real source (`~/.config/keys/hal.env`), the real mechanism
(a default-deny `KEYS=` selection), and the part that actually bites: the
loader reads the `.env` of the directory the shell *starts* in, so a run
launched from an unselected cwd fails as an ordinary auth error. `~/.claude/.env`
now carries `hal:HAL_ID,hal:HAL_PASSWORD` (machine-local, no value written), which
covers every startup directory that does not declare a `KEYS=` line of its own.
A directory whose `.env` *does* carry one replaces the harness selection wholesale —
measured, and tracked as ticket 0360 in #681. The original wording here said "a run
from any cwd resolves", which is false in exactly the case 0360 documents.

Verified by hash from three startup cwds (`$HOME`, the project root, a project
worktree): both names present and matching `~/.config/keys/hal.env`. No value
was printed at any point.

Found while fixing the same stale claim in the climate-finance project, which
turned out to carry a stale *fork* of this skill that shadowed this one — two
documents disagreeing on fact. The fork is deleted there in favour of this
document (project ticket 0364).

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
