### PR TITLE
ticket(0360): counter-analysis on KEYS= precedence; split diagnostics to 0361

### DIFF
--- a/tickets/0360-project-keys-overrides-harness-keys-instead.erg
+++ b/tickets/0360-project-keys-overrides-harness-keys-instead.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-27T19:10Z HDMX-coding-agent created
+2026-07-27T19:30Z HDMX-coding-agent note Counter-analysis added: union makes the harness selection a global floor, so the ranking above is likely inverted. Diagnostics split to 0361.
 
 --- body ---
 ## Context
@@ -61,6 +62,56 @@ over-selection to work at all.
 Whichever is chosen, `HAL_PASSWORD`'s presence in climate-finance-het's `.env`
 should be revisited: under *compose* it can come from the harness selection
 alone and drop out of the project's environment entirely.
+
+## Counter-analysis (2026-07-27, review of #680/#681)
+
+The ranking in step 1 is probably inverted. It rests on an assumption the
+measurement contradicts: that union leaves consequence (2) unchanged.
+
+`~/.claude/.env` is sourced unconditionally, before any cwd is consulted
+(`bash-env.sh:147`). So under **compose**, the harness selection is not a
+fallback — it is a **global floor no project can narrow**. A harness-level
+`KEYS=hal:HAL_PASSWORD` would put that password in every subprocess of every
+project, which is strictly *more* exposure than today, not less. Measured from
+three startup cwds (`env -i`, sentinel values, names only): `$HOME` and a
+project whose `.env` sets no `KEYS=` both resolve the harness selection; only a
+project setting its own `KEYS=` narrows. Compose deletes that last case — the
+only way a project can currently say "in here, just openalex".
+
+**Compose with an opt-out** inherits the same posture by default: union unless
+the project remembers `KEYS_EXCLUSIVE=1`. Default-broad, where the mechanism's
+stated invariant is default-deny.
+
+Read this way, **replace is already the least-privilege-correct rule** — a
+project that declares its needs gets exactly those and nothing else — and the
+two complaints split cleanly:
+
+- Complaint (1), "a project cannot narrow; a miss is silent", is an
+  **ergonomics/diagnostics** defect, not a precedence one. The fix for a silent
+  drop is to make the drop loud (ticket 0361), not to change who wins.
+- Complaint (2), the one with teeth, dissolves without touching precedence.
+  `update-publist` is a harness-level skill the author runs by hand; it has no
+  claim on a science repo's test and build environment. Run it from a directory
+  that selects `hal` — `$HOME` already does — rather than widening that repo's
+  `.env`. This also answers the `HAL_PASSWORD` question above under *replace*,
+  not only under *compose*.
+
+Proposed rule, therefore: **keep replace, and state the doctrine** — the
+harness `KEYS=` is the selection for directories that declare none; a project
+`KEYS=` is that project's complete declaration; a harness-level tool is run
+from a directory that selects what it needs. One sentence of doctrine and a
+warning, against a precedence change that must land atomically in two apply
+mechanisms.
+
+This is an argument, not a verdict: the precedence of a credential mechanism is
+an architecture call for the author (MOA). Recorded here so the decision starts
+from the measurement rather than from the intuition that union is "least
+surprising".
+
+Still open regardless of the choice: `scripts/pipeline_keystore.py` was not
+found at `~/CNRS/projets-actifs/climate-finance-het`, so whether the second
+apply path agrees is **unverified**. Two mechanisms disagreeing stays worse
+than either rule alone.
 
 ## Test
 

--- a/tickets/0361-warn-when-a-project-keys-drops-harness-providers.erg
+++ b/tickets/0361-warn-when-a-project-keys-drops-harness-providers.erg
@@ -1,0 +1,93 @@
+%erg 0.1
+Title: Warn when a project KEYS= silently drops harness-selected providers
+Created: 2026-07-27
+Author: HDMX-coding-agent
+Blocked-by: 0360
+
+--- log ---
+2026-07-27T19:32Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+Split out of ticket 0360, which measured that a project `KEYS=` **replaces**
+the harness `KEYS=` rather than composing with it.
+
+0360's counter-analysis argues replace is the least-privilege-correct rule and
+that the real defect behind its complaint (1) is diagnostic: when a project
+`.env` sets its own `KEYS=`, every provider the harness selected disappears
+with no signal at all. The failure surfaces much later and in the wrong
+vocabulary — a tool reports an ordinary auth error, so the reader debugs the
+credential, the keystore, or the tool, none of which is broken. The
+configuration that caused it is one line in a `.env` the reader was not
+thinking about.
+
+`bash-env.sh` already warns on every *malformed* or *unresolvable* selection
+(`ignoring invalid KEYS entry`, `KEYS var not found`, `KEYS provider not
+found`). The dropped-by-override case is the one silent path left, and it is
+the one that needs no typo to trigger — a correct project `KEYS=` line is
+enough.
+
+Blocked by 0360 because the decision determines whether this work exists: under
+*compose* nothing is ever dropped and the warning is moot. Under *replace*
+(0360's proposal) this warning is the fix.
+
+## Relevant files
+
+- `scripts/bash-env.sh` — the project strict-parse (~line 216, exports each key
+  including `KEYS`) and the provider block (~line 229) that consumes the final
+  `$KEYS`. The harness value must be captured before the strict-parse overwrites
+  it, so the two can be compared.
+- `tests/test_bash_env_keys_selection.sh` and siblings — where the hermetic
+  subprocess pattern already lives.
+
+## Actions
+
+1. Capture the harness `KEYS` into a `_be_*` bookkeeping variable immediately
+   after `~/.claude/.env` is sourced, before the project strict-parse can
+   overwrite it.
+2. After the strict-parse, if both values are non-empty and differ, emit one
+   stderr warning naming **the provider names dropped**, not the values:
+   `bash-env: project KEYS= replaced the harness selection; dropped: hal, zotero`
+3. Stay quiet in every other case: no harness `KEYS=`, no project `KEYS=`,
+   identical selections, or a project selection that is a superset.
+4. `unset` the bookkeeping variable at end of script, as the existing `_be_*`
+   names are, so it does not leak into every subprocess.
+
+## Test
+
+`tests/` — hermetic subprocess per `rules/coding-bash.md`; never source the
+script into the test's own shell. Fixtures: a fake `HOME` whose keystore holds
+**sentinel values only**, plus project dirs exercising each branch.
+
+Assert on stderr, not on the environment:
+
+- harness selects `hal`, project selects `openalex` → warning naming `hal`
+- harness selects `hal`, project `.env` has no `KEYS=` → **no warning**
+- harness and project select the same providers → **no warning**
+- project selects a superset of the harness selection → **no warning**
+- no harness `KEYS=` at all → **no warning**
+
+Red before the change: the first case emits nothing.
+
+## Verification
+
+- [ ] A project `KEYS=` that drops a harness-selected provider names it on stderr
+- [ ] No warning in any of the four quiet cases above
+- [ ] No credential value appears in the warning, any fixture, or any assertion
+- [ ] The bookkeeping variable does not survive into the subprocess environment
+
+## Invariants
+
+- Warning only — the resolved environment is byte-for-byte unchanged by this
+  ticket. Precedence is 0360's to decide, not this one's.
+- `bash-env.sh` keeps no `set -euo pipefail` (it is sourced, not executed).
+- `_be_is_protected_name` stays the single name-policy site (ticket 0352).
+- Sentinel values only: a test that needs a real credential to pass is a test
+  that will one day print one.
+
+## Exit criteria
+
+A project `KEYS=` line that drops a harness-selected provider says so, naming
+the dropped providers and no values, so the failure is read as configuration
+rather than as a broken credential.


### PR DESCRIPTION
Ticket-only diff — one `.erg` edited, one added. `erg check` PASS (354 tickets); 0361 is free on `origin/main` and on every open PR (#678 holds 0359).

## Why

0360 ranked *compose (union)* first, on the grounds that it "fixes (1), leaves (2) as-is". The measurement contradicts that premise. `~/.claude/.env` is sourced before any cwd is consulted (`bash-env.sh:147`), so under union the harness selection is not a fallback but a **global floor no project can narrow** — a harness-level `KEYS=hal:HAL_PASSWORD` would reach every subprocess of every project. Strictly more exposure than today, and it deletes the only case where a project can currently say "in here, just openalex".

Read that way, replace is already the least-privilege-correct rule, and 0360's two complaints split: (1) is diagnostics, not precedence; (2) dissolves by running the harness-level skill from a directory that selects `hal` rather than widening a science repo's `.env`.

## What this PR does

- **0360** — adds a `## Counter-analysis` section to the body and one `note` log line. The filing agent's ranking stays as filed; this is recorded beside it, not in place of it. Per `tickets/AGENTS.md`, a ticket's body is where its own decision record belongs.
- **0361** (new, `Blocked-by: 0360`) — warn when a project `KEYS=` drops harness-selected providers, naming the providers and no values. Blocked because the decision determines whether the work exists: under compose nothing is ever dropped.

Also records what stayed unverified: `scripts/pipeline_keystore.py` was not found at the path 0360 names, so whether the second apply mechanism agrees is still open.

No precedence change is proposed here — that call is the author's.

Ticket-ref: tickets/0360-project-keys-overrides-harness-keys-instead.erg

🤖 Generated with [Claude Code](https://claude.com/claude-code)