### PR TITLE
ticket(0375): consolidate project writing rules into the harness axis model (deferred)

### DIFF
--- a/tickets/0375-consolidate-project-writing-rules-into-harness.erg
+++ b/tickets/0375-consolidate-project-writing-rules-into-harness.erg
@@ -1,0 +1,63 @@
+%erg 0.1
+Title: Consolidate project writing rules into the harness axis model
+Created: 2026-07-28
+Author: haduong
+Label: deferred
+
+--- log ---
+2026-07-28T08:30Z haduong created
+
+--- body ---
+## Context
+Writing rules have accreted per-project instead of composing from the harness
+axis model (`rules/prose/_all.md`, `rules/doctype/`, `rules/lang/`, project
+manifests holding mappings only). Climate_finance carries a local
+`.claude/rules/writing.md` that mixes two layers: project-specific content
+(core argument, periodization, corpus, citation practices, voice) and
+generalizable doctrine that belongs harness-level. Found while tracing where
+the "prose adherence tests pin negative guards only" rule lives (2026-07-28).
+Other projects likely carry similar local files. Author: "We need to import
+and consolidate the writing rules harness level, this project and others,
+someday."
+
+## Relevant files
+- `rules/prose/_all.md` — universal prose layer; receives generalizable guards
+- `rules/README.md` — axis-model index; update if new rule files appear
+- `~/Climate_finance/.claude/rules/writing.md` — the known mixed-layer case;
+  its "CI test polarity rule" (negative guards + mechanical checks only, no
+  positive phrasing pins) and its editorial-brief pattern (positive intent in
+  `docs/editorial-brief.md`, checked at review time) are the candidates to
+  promote
+- `~/Climate_finance/.claude/rules/oeconomia-style.md`,
+  `review-checklist.md` — same inventory pass
+- `tickets/AGENTS.md` § pure-prose-ticket test polarity — landed with this
+  ticket's PR; the harness-level statement of the polarity asymmetry
+
+## Actions
+1. Inventory writing/prose rules across projects (Climate_finance first, then
+   the other paper repos under `~/CNRS/papiers/` and active project repos).
+2. Classify each rule by layer: universal prose, doctype, lang, or genuinely
+   project-local (argument, corpus, voice).
+3. Promote the generalizable rules into the harness axis files; leave
+   project-local content in place, trimmed of what moved up.
+4. Keep the axis-model invariant: project manifests (`rules-map.toml`) hold
+   path-to-axis mappings only, never rule text.
+5. Update `rules/README.md` index for any new or grown rule file.
+
+## Verification
+- [ ] Each promoted rule appears once, harness-level; no duplicate statement
+      survives in a project-local file
+- [ ] Project-local files retain only content that names the project's own
+      argument, corpus, venue, or voice
+- [ ] `make check` passes in the harness repo
+
+## Invariants
+- Per-file rule injection (`inject_rule_on_edit.py`) keeps working; injected
+  bodies stay small (scope note in `prose/_all.md`)
+- Consumer projects keep rendering/CI green after their local files shrink
+
+## Exit criteria
+- [ ] Inventory note listing every project-local writing rule and its layer
+      verdict
+- [ ] Generalizable rules merged into harness `rules/`; project files trimmed
+- [ ] Rules index updated

--- a/tickets/0375-consolidate-project-writing-rules-into-harness.erg
+++ b/tickets/0375-consolidate-project-writing-rules-into-harness.erg
@@ -6,6 +6,7 @@ Label: deferred
 
 --- log ---
 2026-07-28T08:30Z haduong created
+2026-07-28T08:50Z haduong note Author: sweep ALL sibling project rule files at reimagine time, not only writing.md; prose-ticket TDD clause relocated to Climate_finance writing.md
 
 --- body ---
 ## Context
@@ -30,12 +31,15 @@ someday."
   promote
 - `~/Climate_finance/.claude/rules/oeconomia-style.md`,
   `review-checklist.md` — same inventory pass
-- `tickets/AGENTS.md` § pure-prose-ticket test polarity — landed with this
-  ticket's PR; the harness-level statement of the polarity asymmetry
+- `~/Climate_finance/.claude/rules/writing.md` § prose tickets — the
+  pure-prose-tickets-skip-TDD clause (added 2026-07-28, per author); a
+  promotion candidate for this sweep
 
 ## Actions
-1. Inventory writing/prose rules across projects (Climate_finance first, then
-   the other paper repos under `~/CNRS/papiers/` and active project repos).
+1. At reimagine time, sweep ALL sibling rule files: every project-local
+   `.claude/rules/*` across Climate_finance, the other paper repos under
+   `~/CNRS/papiers/`, and active project repos — not only files named
+   `writing.md`.
 2. Classify each rule by layer: universal prose, doctype, lang, or genuinely
    project-local (argument, corpus, voice).
 3. Promote the generalizable rules into the harness axis files; leave

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -82,3 +82,13 @@ What problem or need this addresses. Why now.
 ## Exit criteria
 - Definition of done — when is this ticket complete?
 ```
+
+**Pure prose tickets omit the `## Test` section: TDD's red step does not
+apply.** A red-first test assumes a machine-checkable positive outcome, and
+prose has none — a test asserting that a specific positive phrasing appears
+breaks on every legitimate rewrite. Verification for prose is review-based:
+the recompiled artifact and the prose review panel. Prose adherence tests
+stay negative-polarity (forbidden phrasings) or mechanical (density ratchets,
+structural presence), and a ticket extends them only when it pins a
+newly-observed defect class, never pro forma to satisfy the template. The
+asymmetry behind the rule: defects are lexically stable, good prose is not.

--- a/tickets/AGENTS.md
+++ b/tickets/AGENTS.md
@@ -82,13 +82,3 @@ What problem or need this addresses. Why now.
 ## Exit criteria
 - Definition of done — when is this ticket complete?
 ```
-
-**Pure prose tickets omit the `## Test` section: TDD's red step does not
-apply.** A red-first test assumes a machine-checkable positive outcome, and
-prose has none — a test asserting that a specific positive phrasing appears
-breaks on every legitimate rewrite. Verification for prose is review-based:
-the recompiled artifact and the prose review panel. Prose adherence tests
-stay negative-polarity (forbidden phrasings) or mechanical (density ratchets,
-structural presence), and a ticket extends them only when it pins a
-newly-observed defect class, never pro forma to satisfy the template. The
-asymmetry behind the rule: defects are lexically stable, good prose is not.


### PR DESCRIPTION
## Summary
New ticket `0375` (label: deferred): at reimagine time, sweep ALL project-local `.claude/rules/*` files (Climate_finance and other paper/project repos), promote the generalizable writing-rule layer into the harness axis model, and leave argument/corpus/voice content project-local.

The pure-prose-tickets-skip-TDD clause initially bundled here was relocated to Climate_finance's `.claude/rules/writing.md` per author — it lands via that repo's own PR.

ID 0375 allocated twelve clear of the 0361 frontier; open-PR collision scan (per-PR `gh pr view --json files`) shows 0359–0361 in flight, no conflict.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)