### PR TITLE
memory: force-push guard misfires on dash-f flags across a compound

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -9,6 +9,7 @@
 
 ## Entries
 
+- [Guard flags match across compounds](feedback_guard_flags_match_across_compound.md) — `git push && gh api -f x=y` trips the force-push guard; split the calls or use --field
 - [Verify sibling PRs jointly, not just individually](feedback_verify_sibling_prs_jointly.md) — two PRs each 9/9 green landed a claim and its refutation the same day (#680/#681); per-PR gates pass both by construction
 - [erg ready reads the current branch's tree](feedback_erg_ready_reads_current_branch_tree.md) — a stale branch lists tickets already merged and archived on main
 - [CLAUDE.md is a thin loader in IDH](feedback_claude_md_is_thin_loader_idh.md) — proposing to add doctrine/posture prose to CLAUDE.md is a red flag

--- a/projects/-home-haduong--claude/memory/feedback_guard_flags_match_across_compound.md
+++ b/projects/-home-haduong--claude/memory/feedback_guard_flags_match_across_compound.md
@@ -1,0 +1,22 @@
+---
+name: guard-flags-match-across-compound
+description: guard-destructive-bash.sh blocks `git push && gh api … -f x=y` as a force push — the -f belongs to gh api; split the compound or use --field
+metadata:
+  type: feedback
+---
+
+`scripts/guard-destructive-bash.sh` blocked `git push && gh api -X PATCH -f
+title=… -f body=…` with "BLOCKED: force push can destroy remote history"
+(2026-07-28). No force push was present: the `-f` flags belonged to `gh api`
+(shorthand for `--field`), but the guard pattern-matches `push` and `-f`
+within the whole command string, not per-subcommand.
+
+**Why:** a denied call means adjusting, not retrying verbatim — and the wrong
+adjustment here (adding `--force-with-lease` to satisfy the guard's
+suggestion) would turn a false positive into a real force push.
+
+**How to apply:** when a compound mixes `git push` with another tool that
+takes `-f`/`--force`-looking flags (`gh api -f`, `rm -f`, `curl -f`), split
+into separate Bash calls, or use the long form (`--field`). Per
+[[dont-codify-hard-rules]]'s sibling doctrine on guards (workflow § severity
+floor): a misfire this cheap to route around is reported, not patched.


### PR DESCRIPTION
## Summary
Roar step-6 memory from today's session: `guard-destructive-bash.sh` blocked a compound of a plain push with `gh api` field flags as a force push. The memory records the route-around (split the compound, or use the long `--field` form) and warns against the trap of satisfying the guard by actually force-pushing. It fired a second time on the memory commit itself, whose message quoted the trigger tokens. Below the severity floor: no guard patch, no ticket.

**Ticket:** none

🤖 Generated with [Claude Code](https://claude.com/claude-code)