### PR TITLE
tickets: hunt/raid economics — test-run budget (0376) and review round-scoping (0377)

### DIFF
--- a/tickets/0376-hunt-executors-re-run-the-full-test-suit.erg
+++ b/tickets/0376-hunt-executors-re-run-the-full-test-suit.erg
@@ -1,0 +1,69 @@
+%erg 0.1
+Title: hunt executors re-run the full test suite mid-loop
+Created: 2026-07-28
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-28T08:57Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The 2026-07-28 trace analysis of 22 hunt/raid kills in climate-finance-het
+(week of 07-21 → 07-28) measured test execution as the single largest active-time
+bucket: 348 of 1,250 agent-minutes (27.8%), ahead of design narration (26.5%)
+and adherence machinery (10.7%). A median code kill ran the check suite 18
+times; roughly 30% of runs failed (legitimate diagnosis), the rest were
+re-confirmation. The pattern behind the excess: executors re-run full
+`make check` after single-file edits mid-loop, and every review-fix or reroll
+cycle re-runs the full suite again, where the hunt contract already prescribes
+`check-fast` during development and one full `check` before the PR.
+
+Full report: https://claude.ai/code/artifact/daa5be2e-0c1b-4ed1-9dba-3ab2416729b3
+
+## Relevant files
+
+- `skills/hunt/SKILL.md` — steps 7–9 name `make check-fast` and `make check`
+  but set no run budget; step 12 ("Fix all comments") is where full-suite
+  re-runs multiply.
+- `skills/gaze/SKILL.md` — reroll path re-validates; same budget question.
+- `skills/raid/SKILL.md` — Phase 6/7 wording inherits whatever the hunt does.
+
+## Actions
+
+1. Add an explicit test-run budget to the hunt contract: `check-fast` (or the
+   affected test file alone) is the loop gate; full `make check` runs exactly
+   once before opening the PR, and once more only when review fixes touched
+   code outside the fast tier — not per fix cycle.
+2. Mirror the same budget in the gaze/reroll path: a reroll re-runs the tests
+   implicated by the defect plus `check-fast`, and one full `check` at the
+   final gate only.
+3. Keep project-specific escape hatches: a repo whose `check` is cheap may say
+   so in its project rules; the budget is the default, not a cap on diagnosis
+   (a failing run is never wasted).
+
+## Test
+
+- Harness skill-text guard (new `tests/test_hunt_test_budget.py`, in the
+  style of `tests/test_skill_descriptions.py`): assert the hunt SKILL.md
+  names a run budget for full-suite invocations (negative guard on the old
+  unbounded wording, per the prose-test polarity rule).
+
+## Verification
+
+- [ ] hunt SKILL.md states the budget; gaze SKILL.md mirrors it
+- [ ] skill-text guard test passes
+- [ ] next trace re-measure (trace-doctor or ad hoc) shows median full-check
+      runs per kill ≤ 3
+
+## Invariants
+
+- TDD red step unchanged (first test must fail; 19/22 kills honored it)
+- `make check` before PR-open remains mandatory — the budget trims
+  *repetition*, not the gate
+
+## Exit criteria
+
+- [ ] Test-run budget wording landed in hunt + gaze skills
+- [ ] Guard test in place and green
+- [ ] Measured baseline recorded in this ticket's log for the next re-measure

--- a/tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
+++ b/tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
@@ -1,0 +1,73 @@
+%erg 0.1
+Title: review rounds re-run the full perspective panel regardless of prior findings
+Created: 2026-07-28
+Author: HDMX-coding-agent
+
+--- log ---
+2026-07-28T08:57Z HDMX-coding-agent created
+
+--- body ---
+## Context
+
+The 2026-07-28 trace analysis of three climate-finance-het raids measured
+review panels at 44–56% of all subagent output tokens — the largest cost
+bucket, ahead of gaze/gates (10–22%) and actual execution (20–30%). PR 1172
+alone received 23 verification agents against 1 execute agent: the
+5-perspective review-pr panel (correctness, consistency, scope, red team, doc
+propagation) was re-run wholesale in 3–4 rounds, plus built-in review,
+adherence, two gate rounds, and four simplify angles. Week-wide, review agents
+emitted 5.8M output tokens — more than all 22 execute kills combined (4.9M).
+
+The spend is not empty ritual — post-review fix edits appeared in 17 of 19
+kills that reached review, and gaze bounced 29% of verdicts — but round
+pricing is flat: round N re-runs every perspective even when round N−1 gave
+most perspectives nothing to say.
+
+Full report: https://claude.ai/code/artifact/daa5be2e-0c1b-4ed1-9dba-3ab2416729b3
+
+## Relevant files
+
+- `skills/review-pr/SKILL.md` — the 5-perspective fan-out; no round-scoping
+  rule today.
+- `skills/gaze/SKILL.md` — orchestrates review + reroll; decides what round 2
+  re-runs.
+- `skills/hunt/SKILL.md` — steps 11–13 loop review up to 3 times.
+
+## Actions
+
+1. Add a round-scoping rule: round 1 runs the full panel; round N>1 re-runs
+   only (a) the perspectives that produced comments in round N−1, and (b) one
+   cheap regression check that the fixes did not break what the silent
+   perspectives had cleared. Model pins per § reviewer decorrelation stay
+   as-is.
+2. Apply the same scoping to the gaze reroll path: a REROLL re-review targets
+   the defects named in the verdict, not the whole battery.
+3. State the exception explicitly: a fix that rewrites the diff substantially
+   (new files touched, >~half the diff changed since the last round) resets to
+   a full panel.
+
+## Test
+
+- Skill-text guard (negative, per prose-test polarity): review-pr SKILL.md
+  must contain a round-scoping section; absence of the old
+  every-round-full-panel wording.
+
+## Verification
+
+- [ ] review-pr and gaze skill texts carry the scoping rule and the reset
+      exception
+- [ ] Guard test green
+- [ ] Next raid's per-PR verification-agent count recorded in this ticket's
+      log (baseline: 23 for PR 1172)
+
+## Invariants
+
+- Round-1 coverage unchanged — all five perspectives still run on every PR
+- Reviewer decorrelation rule untouched (panel models stay below coder tier)
+- Verify-gate evidence contract (per-exit-criterion) unchanged
+
+## Exit criteria
+
+- [ ] Round-scoping wording landed in review-pr + gaze skills
+- [ ] Guard test in place and green
+- [ ] One subsequent raid shows scoped rounds in its transcripts (spot-check)


### PR DESCRIPTION
Files two harness tickets from the 2026-07-28 trace analysis of 22 hunt/raid kills in climate-finance-het (report: https://claude.ai/code/artifact/daa5be2e-0c1b-4ed1-9dba-3ab2416729b3):

- **0376** — hunt executors re-run the full test suite mid-loop. Test execution is the largest active-time bucket (27.8%, median 18 check runs per code kill). Adds a full-suite run budget to the hunt/gaze contracts.
- **0377** — review rounds re-run the full 5-perspective panel regardless of prior findings. Panels are 44–56% of raid subagent tokens; PR 1172 got 23 verification agents vs 1 executor. Round N>1 re-runs only the perspectives that had findings.

Tickets-only diff — filing PR, closes nothing.

Ticket-ref: tickets/0376-hunt-executors-re-run-the-full-test-suit.erg
Ticket-ref: tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)