### PR TITLE
skills(0376): give hunt and gaze a test-run budget

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -382,6 +382,7 @@ The subagent spawned on REROLL receives:
   violations, per-exit-criterion gaps).
 - Strict rule: **only** the listed items. No scope creep. No "while I'm here" edits.
 - TDD discipline still applies: add a failing test for any behavioural fix before coding.
+- Test-run budget: `make check-fast` plus the tests implicated by the unresolved-items list during the fix; one full `make check` before the final push — not per fix.
 
 Push commits to the PR branch; do not open new PRs. Trigger re-entry into phase 6.
 

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -61,14 +61,14 @@ argument-hint: <ticket-id>
 5. Read the files listed in **Relevant files**.
 6. Write the first test from the **Test** section of the ticket.
 7. Run `make check-fast` — confirm the test fails.
-8. Announce `[Plan → Execute]`, then implement until `make check` passes.
+8. Announce `[Plan → Execute]`, then implement until `make check-fast` (or the affected test file alone) passes — that is the loop gate. Full `make check` runs once, immediately before step 10 opens the PR — not per edit.
 9. Pre-PR self-gate: run `/verify-adherence <branch>` (the branch created in step 4).
    - Clean → proceed to step 10. Note adherence passed in the merge-request description so `/gaze` can skip the mechanical phase on its next pass.
    - Blockers → decide per blocker:
-     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check` and `/verify-adherence`, then proceed only once clean. Up to 3 fix-and-recheck cycles; if still not clean after 3 rounds, escalate.
+     - Cheap and mechanical (obvious fix, no design judgement) → fix in place, re-run `make check-fast` and `/verify-adherence`, then proceed only once clean. Up to 3 fix-and-recheck cycles; if still not clean after 3 rounds, escalate.
      - Otherwise → STOP. Do not open the PR. Escalate with the adherence report and the blocker list.
    - Circuit breaker: if `/verify-adherence` itself errors, times out, or returns an unparseable result → ESCALATE. Do not open the PR and do not silently skip the gate.
-10. Push the branch and open a merge request.
+10. Run the full `make check` once, then push the branch and open a merge request.
 11. Review the merge request. This action is mechanical — invoke the review-pr
     skill with the PR number:
     ```
@@ -76,5 +76,5 @@ argument-hint: <ticket-id>
     ```
     Follow the contract the skill loader returns; do not paraphrase or inline its
     steps (mirrors raid Phase 5's mechanical `Skill(hunt)` invocation, ticket 0293).
-12. Fix all comments regardless of severity.
+12. Fix all comments regardless of severity. Per fix cycle, run `make check-fast` plus the tests implicated by the comments — not the full suite. If any cycle's fix touches code outside the fast tier, run the full `make check` once, in addition — not on every cycle.
 13. Repeat 11–12 up to 3 times. If still not clean, escalate (see workflow rules).

--- a/tests/test_hunt_test_budget.py
+++ b/tests/test_hunt_test_budget.py
@@ -21,6 +21,7 @@ text block (not "anywhere in the file") so a fix that mentions check-fast
 in an unrelated step does not satisfy these tests.
 """
 
+import functools
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -28,6 +29,12 @@ HUNT = REPO / "skills" / "hunt" / "SKILL.md"
 GAZE = REPO / "skills" / "gaze" / "SKILL.md"
 
 BUDGET_KEYWORDS = ("once", "budget")
+
+
+@functools.cache
+def _hunt_text() -> str:
+    """Read hunt/SKILL.md once for the three tests that slice it."""
+    return HUNT.read_text()
 
 
 def _block(text: str, start_marker: str, end_marker: str) -> str:
@@ -39,7 +46,7 @@ def _block(text: str, start_marker: str, end_marker: str) -> str:
 
 def test_hunt_step8_drops_unbounded_full_check_wording():
     """The old 'implement until `make check` passes' loop gate must be gone."""
-    text = HUNT.read_text()
+    text = _hunt_text()
     assert "implement until `make check` passes" not in text, (
         "hunt step 8 still tells the executor to loop on full `make check` — "
         "the loop gate should be `make check-fast` (or the affected test "
@@ -49,7 +56,7 @@ def test_hunt_step8_drops_unbounded_full_check_wording():
 
 def test_hunt_step8_names_check_fast_as_loop_gate():
     """Step 8's replacement wording names check-fast as the loop gate."""
-    text = HUNT.read_text()
+    text = _hunt_text()
     block = _block(text, "8. Announce", "9. Pre-PR self-gate")
     assert "check-fast" in block, (
         "hunt step 8 must name `make check-fast` (or the affected test "
@@ -59,7 +66,7 @@ def test_hunt_step8_names_check_fast_as_loop_gate():
 
 def test_hunt_review_fix_loop_names_a_test_budget():
     """Steps 12-13 must name check-fast and bound full-check re-runs."""
-    text = HUNT.read_text()
+    text = _hunt_text()
     block = _block(text, "12. Fix all comments", "escalate (see workflow rules)")
     assert "check-fast" in block, (
         "hunt's review-fix loop (steps 12-13) must name `make check-fast` "

--- a/tests/test_hunt_test_budget.py
+++ b/tests/test_hunt_test_budget.py
@@ -1,0 +1,85 @@
+"""Guard: hunt/gaze name a test-run budget; the old unbounded wording is gone.
+
+Ticket 0376. Trace analysis (2026-07-28, climate-finance-het) measured full
+`make check` re-runs as the single largest active-time bucket across 22
+hunt/raid kills (27.8%): executors re-ran the full suite after single-file
+edits mid-loop, and every review-fix cycle re-ran it again. Fix: `make
+check-fast` (or the affected test file) is the loop gate everywhere except
+the one-time full `make check` immediately before PR-open / before the fix
+agent's final push.
+
+RED proof: on the pre-fix hunt/SKILL.md, step 8 reads "implement until
+`make check` passes" (no `-fast`) — this trips
+test_hunt_step8_drops_unbounded_full_check_wording. The three positive-marker
+tests also fail pre-fix: step 8's block carries no `check-fast` mention, the
+steps 12-13 block carries neither `check-fast` nor a budget word ("once"/
+"budget"), and gaze's Fix-agent contract carries none of them either.
+
+Loose positive markers only (prose-test polarity rule): this file never
+pins the new sentence verbatim. Markers are scoped to the specific step's
+text block (not "anywhere in the file") so a fix that mentions check-fast
+in an unrelated step does not satisfy these tests.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HUNT = REPO / "skills" / "hunt" / "SKILL.md"
+GAZE = REPO / "skills" / "gaze" / "SKILL.md"
+
+BUDGET_KEYWORDS = ("once", "budget")
+
+
+def _block(text: str, start_marker: str, end_marker: str) -> str:
+    """Return the slice of `text` between two literal markers."""
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    return text[start:end]
+
+
+def test_hunt_step8_drops_unbounded_full_check_wording():
+    """The old 'implement until `make check` passes' loop gate must be gone."""
+    text = HUNT.read_text()
+    assert "implement until `make check` passes" not in text, (
+        "hunt step 8 still tells the executor to loop on full `make check` — "
+        "the loop gate should be `make check-fast` (or the affected test "
+        "file), per ticket 0376's test-run budget"
+    )
+
+
+def test_hunt_step8_names_check_fast_as_loop_gate():
+    """Step 8's replacement wording names check-fast as the loop gate."""
+    text = HUNT.read_text()
+    block = _block(text, "8. Announce", "9. Pre-PR self-gate")
+    assert "check-fast" in block, (
+        "hunt step 8 must name `make check-fast` (or the affected test "
+        "file) as the implementation loop gate"
+    )
+
+
+def test_hunt_review_fix_loop_names_a_test_budget():
+    """Steps 12-13 must name check-fast and bound full-check re-runs."""
+    text = HUNT.read_text()
+    block = _block(text, "12. Fix all comments", "escalate (see workflow rules)")
+    assert "check-fast" in block, (
+        "hunt's review-fix loop (steps 12-13) must name `make check-fast` "
+        "as the per-cycle test gate, not the full suite"
+    )
+    assert any(kw in block for kw in BUDGET_KEYWORDS), (
+        "hunt's review-fix loop must bound full `make check` re-runs to a "
+        "one-time/budgeted case, not per fix cycle"
+    )
+
+
+def test_gaze_fix_agent_contract_names_a_test_budget():
+    """The Fix-agent contract must name check-fast and bound full-check reruns."""
+    text = GAZE.read_text(encoding="utf-8")
+    block = _block(text, "## Fix-agent contract", "Push commits to the PR branch")
+    assert "check-fast" in block, (
+        "gaze's Fix-agent contract must name `make check-fast` as the fix "
+        "agent's test gate"
+    )
+    assert any(kw in block for kw in BUDGET_KEYWORDS), (
+        "gaze's Fix-agent contract must bound full `make check` to a "
+        "one-time/budgeted case before push, not per fix"
+    )

--- a/tickets/0376-hunt-executors-re-run-the-full-test-suit.erg
+++ b/tickets/0376-hunt-executors-re-run-the-full-test-suit.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-28T08:57Z HDMX-coding-agent created
+2026-07-28T09:18Z claude note baseline: median 18 full-check runs per kill, 27.8% of active agent-minutes (2026-07-28 trace analysis) — target ≤ 3 after budget
 
 --- body ---
 ## Context

--- a/tickets/closed/0376-hunt-executors-re-run-the-full-test-suit.erg
+++ b/tickets/closed/0376-hunt-executors-re-run-the-full-test-suit.erg
@@ -2,11 +2,13 @@
 Title: hunt executors re-run the full test suite mid-loop
 Created: 2026-07-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #692
 
 --- log ---
 2026-07-28T08:57Z HDMX-coding-agent created
 2026-07-28T09:18Z claude note baseline: median 18 full-check runs per kill, 27.8% of active agent-minutes (2026-07-28 trace analysis) — target ≤ 3 after budget
 
+2026-07-28T12:58Z Integration Test closed — autoclosed — PR #692
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0376-hunt-executors-re-run-the-full-test-suit.erg

## Why

The 2026-07-28 trace analysis of 22 hunt/raid kills measured full `make check` re-runs as the largest active-time bucket: 348 of 1,250 agent-minutes (27.8%), median 18 full-suite runs per kill. The hunt contract already prescribed `check-fast` during development, but step 8 said "implement until `make check` passes" and the review-fix loop (step 12) set no budget at all.

## What

- hunt step 8: `make check-fast` (or the affected test file alone) is the loop gate.
- hunt step 9 mechanical-fix bullet: same swap.
- hunt step 10: the one mandatory full `make check`, moved into the PR-opening step so it reads as a gate, not a loop exit.
- hunt steps 12–13: per-cycle `check-fast` plus the implicated tests; one additional full check only when a fix leaves the fast tier.
- gaze Fix-agent contract: mirrors the same budget.
- New guard `tests/test_hunt_test_budget.py`: negative guard on the old unbounded step-8 wording, loose positive markers scoped to each step's text block (prose-test polarity rule).

Rejected alternative: a numeric cap ("at most 3 full runs") — a failing diagnostic run is never waste, and a cap invites gaming the counter; the budget names *which gate applies where*, which is checkable from the text.

## Verification

- `tests/test_hunt_test_budget.py`, `tests/test_hunt_invokes_review_pr.py`, `tests/test_skill_descriptions.py`: 9/9 green.
- Full `make check`: 872 passed; 4 local failures shown pre-existing/environmental (2 rtk output-rewrite artifacts that pass under `rtk proxy`, 2 bash suites failing identically on a worktree without this change — "KEYS provider not found", local env only).

## Notes

- Wave 1 of raid 376/377; ticket 0377 (round scoping) lands next and rewrites hunt steps 12–13 on top of this wording — sequential by design.
- Report-only finding (severity floor): `review-pr:88` and `gaze:260` run a full `make check` per synthesis invocation; candidate for the same budget treatment, not ticketed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)