### PR TITLE
fix(0358): reviewers.sh floats are locale-independent (LC_ALL=C)

### DIFF
--- a/skills/reviewers/reviewers.sh
+++ b/skills/reviewers/reviewers.sh
@@ -10,6 +10,7 @@
 # Containment is the seat-runner's OS sandbox (0217), NOT this script.
 # This script holds no secrets; seat credentials load via BASH_ENV (0207).
 set -euo pipefail
+export LC_ALL=C  # every awk/sort float reads and writes `.` decimals under any ambient locale
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="${REVIEWERS_REPO:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"

--- a/tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg
+++ b/tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg
@@ -8,6 +8,7 @@ Author: Integration Test
 2026-07-24T20:20Z Integration Test note found during /lair step 9 full-suite run on main (36873aa); 3 suites red, 9 assertions
 2026-07-27T12:40Z HDMX-coding-agent note hypothesis 1 (ambient-env leakage) CONFIRMED by source inspection; and the leak has escaped the repo — a live sk-or- key was found in plaintext on disk in a climate-finance job scratch dir. Severity raised. See the two sections appended to the body.
 
+2026-07-28T12:59Z note diagnosed: 2 of 3 suites fixed upstream since filing; audition failure was a locale artifact (awk printf %.1f emits 70,0 under fr_FR) — fixed by export LC_ALL=C at reviewers.sh top
 --- body ---
 ## Context
 

--- a/tickets/closed/0358-fix-tests-credential-scrubbing-and-key-s.erg
+++ b/tickets/closed/0358-fix-tests-credential-scrubbing-and-key-s.erg
@@ -2,6 +2,7 @@
 Title: fix-tests: credential scrubbing and key-selection suites fail on make check
 Created: 2026-07-24
 Author: Integration Test
+Closed: autoclosed — PR #693
 
 --- log ---
 2026-07-24T20:19Z Integration Test created
@@ -9,6 +10,7 @@ Author: Integration Test
 2026-07-27T12:40Z HDMX-coding-agent note hypothesis 1 (ambient-env leakage) CONFIRMED by source inspection; and the leak has escaped the repo — a live sk-or- key was found in plaintext on disk in a climate-finance job scratch dir. Severity raised. See the two sections appended to the body.
 
 2026-07-28T12:59Z note diagnosed: 2 of 3 suites fixed upstream since filing; audition failure was a locale artifact (awk printf %.1f emits 70,0 under fr_FR) — fixed by export LC_ALL=C at reviewers.sh top
+2026-07-28T13:00Z Integration Test closed — autoclosed — PR #693
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0358-fix-tests-credential-scrubbing-and-key-s.erg

Ticket 0358's three red suites had shrunk to one: two were fixed upstream since filing, and the last (`test_reviewers_audition.sh`, 2 assertions) was a locale artifact — awk `printf %.1f` emits `70,0` under `LC_NUMERIC=fr_FR` where the guard expects `70.0`. One `export LC_ALL=C` at the top of `reviewers.sh` generalizes the local patch line 152 already applied to a single call site.

Verified: audition 31/31 green, seat-runner and keys-selection suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)