### PR TITLE
memory: fr_FR locale breaks test-guarded float output

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -86,3 +86,4 @@
 - [Raid worktrees miss same-session main commits](feedback_raid_worktree_rebase.md) — rebase the PR branch onto main before merging
 - [CLI verb belongs in the sub-command](feedback_cli_verb_in_subcommand.md) — the script name is the noun; avoid `install-deps.sh uninstall`
 - [Paper idea — harnesses vs. human psychology](project_paper_harnesses_psychology.md) — AI coding harnesses evaluated against what psychology says about how humans work
+- [fr_FR locale breaks float guards](feedback_locale_fr_floats_in_guarded_scripts.md) — awk/printf emit `70,0` under fr_FR; export LC_ALL=C after set -euo pipefail in any test-guarded script

--- a/projects/-home-haduong--claude/memory/feedback_locale_fr_floats_in_guarded_scripts.md
+++ b/projects/-home-haduong--claude/memory/feedback_locale_fr_floats_in_guarded_scripts.md
@@ -1,0 +1,23 @@
+---
+name: locale-fr-floats-in-guarded-scripts
+description: awk/printf float output is locale-dependent — this machine's fr_FR emits decimal commas that break test guards; pin LC_ALL=C at script top
+metadata:
+  type: feedback
+---
+
+`awk 'BEGIN{printf "%.1f", …}'` and shell `printf %f` honor `LC_NUMERIC`, and
+this machine runs `fr_FR`, so they emit `70,0` where a test guard expects
+`70.0`. Ticket 0358 sat misdiagnosed as three broken credential suites when
+the surviving failure was this artifact (fixed in PR #693 by `export LC_ALL=C`
+at the top of `skills/reviewers/reviewers.sh`).
+
+**Why:** a locale-dependent failure reproduces on the author's machines but not
+in CI (C locale), so it reads as flaky or as a logic bug, and the ticket
+inflates. A partial in-script patch is a tell — reviewers.sh already had a
+per-call `LC_ALL=C` on one awk while three siblings were unprotected.
+
+**How to apply:** any script whose numeric output is parsed or test-guarded
+gets one `export LC_ALL=C` right after `set -euo pipefail`, never per-call
+prefixes. When a guard reports a missing expected number, diff the actual
+output for `,` vs `.` before suspecting the logic. Related: [[rtk-rewrites-git-output]]
+for the other class of "output not what the parser expects".


### PR DESCRIPTION
Ticket: none

Roar step-6 lesson from PR #693 (ticket 0358): awk/printf float output honors LC_NUMERIC, so fr_FR decimal commas break test guards and read as logic bugs. One memory entry + index line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)