### PR TITLE
skills(0377): scope review rounds — re-run only objecting perspectives

### DIFF
--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -164,16 +164,19 @@ git worktree remove "$primary_root/.claude/worktrees/review-<pr-number>" --force
   - **full**, round ≥ 2 → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate; Agent C is scoped per § Round scoping below.
   Carry the resolved `tier` into the telemetry footer and the output-shape template (see § Telemetry, § Output shape).
 
+- If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
+
 #### Round scoping
 
 **Supersedes the #562 clause.** A round ≥ 2 still resolves to the **full**
 tier, but its Agent C no longer re-runs the whole five-perspective panel by
 default. Agent C re-runs the perspectives that objected in the previous round
 plus one regression check over the cleared ones, per § Round scoping in
-`skills/review-pr/SKILL.md` (ticket 0377). #562's lesson — that a round-2
-battery was needed on an unchanged diff — is preserved by keeping Agents A and
-B, phase 5, and the phase 6 gate at full strength every round; what it does
-*not* justify is re-paying for perspectives that had nothing to say.
+`skills/review-pr/SKILL.md` (ticket 0377). #562's lesson was that a round-2
+battery was needed on an unchanged diff. That lesson is preserved by keeping
+Agents A and B, phase 5, and the phase 6 gate at full strength every round.
+What it does *not* justify is re-paying for perspectives that had nothing to
+say.
 
 An unchanged diff does **not** reset scoping. Reset happens only on a
 substantial rewrite: the round's diff touches files the last review did not
@@ -181,12 +184,11 @@ cover, or changes more than roughly half of its lines. Then the round is
 classified as round 1 and the complete battery runs.
 
 Two nearby mechanisms are untouched by this. The internal REROLL re-entry
-branch (§ Branch on verdict) re-runs the **gate only** and always did — round
-scoping does not widen or narrow it. Convergence mode (ticket 0315, § Convergence
-mode, default off) governs whether a *caller-level* repeat `/gaze` re-runs its
-panel at all; it is a different decision at a different layer and its flag is
-unaffected here.
-- If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
+branch (§ Branch on verdict) re-runs the **gate only** and always did; round
+scoping neither widens nor narrows it. Convergence mode (ticket 0315,
+§ Convergence mode, default off) governs whether a *caller-level* repeat
+`/gaze` re-runs its panel at all. That is a different decision at a different
+layer, and its flag is unaffected here.
 
 ### 2–4. Read-only review fan-out (parallel)
 
@@ -269,8 +271,15 @@ or `/review-pr-prose <pr-number> worktree=$primary_root/.claude/worktrees/review
 `review-pr: skipped (tier: tiny, <pr_lines> lines, <pr_files> files)` in the
 setup summary. When the tier is **small**, run it with the reduced **correctness
 only** perspective set (the `trivial` risk band below) regardless of the risk
-assessment. When the tier is **full**, run the full proportional panel as
-assessed. Otherwise pick by file type: if any `*.qmd` changed → prose
+assessment. When the tier is **full** on round 1, run the full proportional
+panel as assessed; on round ≥ 2, run the panel scoped per § Round scoping —
+only the perspectives whose previous verdict was comment/request-changes (prose:
+minor/major), plus one regression agent covering all the cleared ones, unless
+the diff was substantially rewritten, which resets to the full panel. State the
+round, the scoped perspective list, and the reason for each inclusion in the
+spawned agent's embedded procedure: it does not read this file or
+`skills/review-pr/SKILL.md`, so an unstated rule does not reach it.
+Otherwise pick by file type: if any `*.qmd` changed → prose
 panel; else code panel. Spawn a read-only Agent, cwd `$primary_root/.claude/worktrees/review-<pr-number>`,
 whose embedded procedure is: read the linked ticket's exit criteria and the
 diff, assess risk, and run the proportional perspective set in parallel —

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -161,7 +161,7 @@ git worktree remove "$primary_root/.claude/worktrees/review-<pr-number>" --force
   - **tiny** → Agent A (adherence) + phase 6 gate only. Skip Agent B (`/review`), Agent C (`/review-pr`), and phase 5 (`/simplify`) — each skip logged like the existing `review-pr: skipped (…)` line.
   - **small** → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate. Agent C runs with the reduced "correctness only" perspective set (trivial risk, § 2–4) instead of the full five-perspective panel.
   - **full**, round 1 → the complete battery below, unchanged.
-  - **full**, round ≥ 2 → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate; Agent C is scoped per § Round scoping below.
+  - **full**, round ≥ 2 (i.e. the merge request already carries a prior Agent C review) → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate; Agent C is scoped per § Round scoping below.
   Carry the resolved `tier` into the telemetry footer and the output-shape template (see § Telemetry, § Output shape).
 
 - If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
@@ -178,17 +178,36 @@ Agents A and B, phase 5, and the phase 6 gate at full strength every round.
 What it does *not* justify is re-paying for perspectives that had nothing to
 say.
 
+**Reachable trigger.** The only entry into this branch is a *caller-level*
+repeat `/gaze` on a merge request that already carries a prior Agent C
+review: that invocation re-enters phase 1, reclassifies the tier, and finds a
+review history. gaze's internal REROLL re-entry never reaches here — it
+re-runs the **gate only** (§ Branch on verdict) and never returns to phase 1,
+so round scoping neither widens nor narrows it. Two different counters share
+the word "round", and they never interact: the REROLL round-1/round-2 cap
+counts gaze's own internal fix-and-regate attempts *within* one invocation,
+while the round scoped here counts the Agent C reviews posted on the merge
+request *across* invocations.
+
+**Relation to Convergence mode.** Convergence mode (ticket 0315,
+§ Convergence mode, default off) decides at the caller layer whether a repeat
+`/gaze` re-runs its panel at all; round scoping decides what that re-run panel
+runs when convergence is **off** — with convergence on, the repeat is skipped
+entirely and scoping never applies. Its flag is unaffected here.
+
+**gaze does not compute the round.** It reads only whether a prior Agent C
+review exists — a boolean from the merge request's review history, enough to
+select the scoped branch — and passes no round number to Agent C. Agent C's
+embedded procedure derives the round itself, exactly as § Round scoping in
+`skills/review-pr/SKILL.md` prescribes: count the reviews this skill
+previously posted on the merge request, identifiable by the verdict roster
+those reviews always carry; the round is that count plus one.
+
 An unchanged diff does **not** reset scoping. Reset happens only on a
 substantial rewrite: the round's diff touches files the last review did not
-cover, or changes more than roughly half of its lines. Then the round is
-classified as round 1 and the complete battery runs.
-
-Two nearby mechanisms are untouched by this. The internal REROLL re-entry
-branch (§ Branch on verdict) re-runs the **gate only** and always did; round
-scoping neither widens nor narrows it. Convergence mode (ticket 0315,
-§ Convergence mode, default off) governs whether a *caller-level* repeat
-`/gaze` re-runs its panel at all. That is a different decision at a different
-layer, and its flag is unaffected here.
+cover, or changes more than roughly half of its lines. Then Agent C runs the
+full panel for this round — scoping is ignored. The derived round number
+itself is never mutated; only the scoping decision changes.
 
 ### 2–4. Read-only review fan-out (parallel)
 
@@ -272,12 +291,19 @@ or `/review-pr-prose <pr-number> worktree=$primary_root/.claude/worktrees/review
 setup summary. When the tier is **small**, run it with the reduced **correctness
 only** perspective set (the `trivial` risk band below) regardless of the risk
 assessment. When the tier is **full** on round 1, run the full proportional
-panel as assessed; on round ≥ 2, run the panel scoped per § Round scoping —
-only the perspectives whose previous verdict was comment/request-changes (prose:
-minor/major), plus one regression agent covering all the cleared ones, unless
-the diff was substantially rewritten, which resets to the full panel. State the
-round, the scoped perspective list, and the reason for each inclusion in the
-spawned agent's embedded procedure: it does not read this file or
+panel as assessed; when the merge request already carries a prior Agent C
+review (the caller-level repeat `/gaze` case), run the panel scoped per
+§ Round scoping — only the perspectives whose previous verdict was
+comment/request-changes (prose: minor/major), plus one regression agent
+running a single regression check over all the cleared ones, unless the diff
+was substantially rewritten, in which case the full panel runs for this round
+and scoping is ignored. Do **not** state a round number — gaze computes none.
+Instead, have the embedded procedure instruct the spawned agent to derive the
+round itself (count the reviews this skill previously posted on the merge
+request, identifiable by the verdict roster they always carry; the round is
+that count plus one), read the previous round's verdict roster, build the
+scoped perspective list from it, and record the reason for each inclusion.
+Spell that derivation out: the spawned agent does not read this file or
 `skills/review-pr/SKILL.md`, so an unstated rule does not reach it.
 Otherwise pick by file type: if any `*.qmd` changed → prose
 panel; else code panel. Spawn a read-only Agent, cwd `$primary_root/.claude/worktrees/review-<pr-number>`,

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -554,6 +554,7 @@ tier: tiny|small|full
 adherence: PASS|FAIL — <n_blocking> blocking
 review: <n_comments_posted> | skipped (tier: tiny)
 review-pr: <n_comments_posted> | skipped (tier: tiny) | skipped (adherence blocking)
+review-pr scope: full panel | scoped: <objecting perspectives> + regression (omit if round 1)
 simplify: <n_fixes_applied> | skipped (tier: tiny) | skipped (adherence blocking)
 fix agent: <n_commits> commits (round 2 only, omit if round 1)
 

--- a/skills/gaze/SKILL.md
+++ b/skills/gaze/SKILL.md
@@ -155,13 +155,37 @@ git worktree remove "$primary_root/.claude/worktrees/review-<pr-number>" --force
 - Compute PR size: `git diff origin/main...HEAD --stat` → `pr_lines` (total insertions + deletions) and `pr_files` (files changed). Classify the battery **tier**:
   - **tiny** — `pr_lines ≤ 20` and `pr_files ≤ 2` and this is round 1.
   - **small** — `pr_lines ≤ 150` and `pr_files ≤ 5` and this is round 1 (and not already tiny).
-  - **full** — everything else, **and unconditionally any round ≥ 2**: a REROLL escalates to the full battery regardless of diff size — #562's round-2 needed the full battery on an unchanged diff. The round-2 override wins over any size test.
+  - **full** — everything else, and any round ≥ 2. The **tiny** and **small** tiers are round-1 classifications only; a round ≥ 2 is never tiny or small.
 
   The tier selects which reviewer agents run (see §§ 2–4, 5); phase 6 (`/verify-gate`) is **invariant** — it runs at every tier, never reduced. Per-tier battery:
   - **tiny** → Agent A (adherence) + phase 6 gate only. Skip Agent B (`/review`), Agent C (`/review-pr`), and phase 5 (`/simplify`) — each skip logged like the existing `review-pr: skipped (…)` line.
   - **small** → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate. Agent C runs with the reduced "correctness only" perspective set (trivial risk, § 2–4) instead of the full five-perspective panel.
-  - **full** → the complete battery below, unchanged.
+  - **full**, round 1 → the complete battery below, unchanged.
+  - **full**, round ≥ 2 → Agent A + Agent B + phase 5 (`/simplify`) + phase 6 gate; Agent C is scoped per § Round scoping below.
   Carry the resolved `tier` into the telemetry footer and the output-shape template (see § Telemetry, § Output shape).
+
+#### Round scoping
+
+**Supersedes the #562 clause.** A round ≥ 2 still resolves to the **full**
+tier, but its Agent C no longer re-runs the whole five-perspective panel by
+default. Agent C re-runs the perspectives that objected in the previous round
+plus one regression check over the cleared ones, per § Round scoping in
+`skills/review-pr/SKILL.md` (ticket 0377). #562's lesson — that a round-2
+battery was needed on an unchanged diff — is preserved by keeping Agents A and
+B, phase 5, and the phase 6 gate at full strength every round; what it does
+*not* justify is re-paying for perspectives that had nothing to say.
+
+An unchanged diff does **not** reset scoping. Reset happens only on a
+substantial rewrite: the round's diff touches files the last review did not
+cover, or changes more than roughly half of its lines. Then the round is
+classified as round 1 and the complete battery runs.
+
+Two nearby mechanisms are untouched by this. The internal REROLL re-entry
+branch (§ Branch on verdict) re-runs the **gate only** and always did — round
+scoping does not widen or narrow it. Convergence mode (ticket 0315, § Convergence
+mode, default off) governs whether a *caller-level* repeat `/gaze` re-runs its
+panel at all; it is a different decision at a different layer and its flag is
+unaffected here.
 - If any of these cannot be located, ESCALATE with a clear message. Do not proceed.
 
 ### 2–4. Read-only review fan-out (parallel)

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -76,5 +76,11 @@ argument-hint: <ticket-id>
     ```
     Follow the contract the skill loader returns; do not paraphrase or inline its
     steps (mirrors raid Phase 5's mechanical `Skill(hunt)` invocation, ticket 0293).
+    Each pass through the 11–12 loop is one **review round**. Do not pass a round
+    number: `/review-pr` derives its own round from the merge request's posted
+    review history and scopes the panel accordingly — round 1 runs the full
+    proportional panel, later rounds re-run only the perspectives that objected
+    plus a regression check (§ Round scoping in `skills/review-pr/SKILL.md`,
+    ticket 0377).
 12. Fix all comments regardless of severity. Per fix cycle, run `make check-fast` plus the tests implicated by the comments — not the full suite. If any cycle's fix touches code outside the fast tier, run the full `make check` once, in addition — not on every cycle.
-13. Repeat 11–12 up to 3 times. If still not clean, escalate (see workflow rules).
+13. Repeat 11–12 up to 3 times, i.e. up to round 3. If still not clean, escalate (see workflow rules).

--- a/skills/review-pr-prose/SKILL.md
+++ b/skills/review-pr-prose/SKILL.md
@@ -89,6 +89,10 @@ Violations must cite the line. This agent has no other role — its table goes v
 3. Deduplicate convergent findings.
 4. Build the manuscript. Check consistency between prose and data.
 5. Post a single review on the merge request.
+6. Close with a verdict roster: one line per reviewer that ran, giving its
+   verdict (accept / minor / major), including reviewers that accepted with
+   nothing to say. The next round scopes itself from this roster
+   (§ Round scoping), so a reviewer missing from it reads as accepting.
 
 ## Minor/suggestion tags (mandatory)
 
@@ -113,3 +117,25 @@ Rules:
 | Section rewrite | 3 agents (domain + adversarial + copy) |
 | Full paper draft | Full panel (5-6 agents) |
 | Submission-ready | Full panel + response-to-reviewers template |
+
+### Round scoping
+
+The table above prices **round 1**, which always runs the full panel for the
+change's size. Derive the round from the merge request itself: count the
+reviews this skill has already posted there; the round is that count plus one.
+No caller passes a round number.
+
+For round N > 1, re-run only the reviewers whose round N−1 verdict was
+**minor** or **major**, plus one regression reviewer covering the whole
+accepting set — asked only whether the revisions since then broke what those
+reviewers accepted. The AI-tells auditor is exempt from scoping and runs every
+round: it scans the full text, so revised passages are new surface for it
+regardless of who objected last time.
+
+**Reset exception.** If the revision since the last review touches text the
+review did not cover, or rewrites more than roughly half of it, treat the round
+as round 1 and run the full panel — the accepting reviewers accepted different
+prose.
+
+This mirrors § Round scoping in `skills/review-pr/SKILL.md` (ticket 0377); keep
+the two in sync.

--- a/skills/review-pr-prose/SKILL.md
+++ b/skills/review-pr-prose/SKILL.md
@@ -49,7 +49,7 @@ runs and no review is ever posted.
 
 1. Identify the text: which `.qmd`/`.md` files changed? What is the target venue?
 2. Read the diff of the merge request.
-3. Recruit the panel: select agents appropriate for the venue and scope of changes. Always include an adversarial referee. Add a journal-specific expert if venue rules exist (check project rules).
+3. Recruit the panel: select agents appropriate for the venue and scope of changes. Always include an adversarial referee. Add a journal-specific expert if venue rules exist (check project rules). On round ≥ 2, scope the panel per § Round scoping below before launching it.
 
 ## Each agent runs
 
@@ -126,16 +126,16 @@ reviews this skill has already posted there; the round is that count plus one.
 No caller passes a round number.
 
 For round N > 1, re-run only the reviewers whose round N−1 verdict was
-**minor** or **major**, plus one regression reviewer covering the whole
-accepting set — asked only whether the revisions since then broke what those
-reviewers accepted. The AI-tells auditor is exempt from scoping and runs every
+**minor** or **major**, plus one regression agent running a single regression
+check over the whole accepting set — asked only whether the revisions since
+then broke what those reviewers accepted. The AI-tells auditor is exempt from scoping and runs every
 round: it scans the full text, so revised passages are new surface for it
 regardless of who objected last time.
 
 **Reset exception.** If the revision since the last review touches text the
-review did not cover, or rewrites more than roughly half of it, treat the round
-as round 1 and run the full panel — the accepting reviewers accepted different
-prose.
+review did not cover, or rewrites more than roughly half of it, run the full
+panel for this round — scoping is ignored, and the derived round number itself
+is untouched. The accepting reviewers accepted different prose.
 
 This mirrors § Round scoping in `skills/review-pr/SKILL.md` (ticket 0377); keep
 the two in sync.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -52,7 +52,8 @@ runs and no review is ever posted.
 2. **Read the diff** of the merge request.
 3. **Assess risk level** and determine proportional depth (see table below).
 4. **Launch review agents** in parallel — **foreground**
-   (`run_in_background: false`), per the concurrency contract above:
+   (`run_in_background: false`), per the concurrency contract above. On
+   round ≥ 2, scope the set per § Round scoping below before launching:
 
 | Agent | Focus | Key question |
 |---|---|---|
@@ -87,7 +88,7 @@ For round N > 1, re-run only:
 
 - the perspectives whose round N−1 verdict was **comment** or
   **request-changes** — those are the ones with something outstanding; and
-- **one regression check**: a single agent covering all the perspectives that
+- **one regression check**: a single regression agent covering all the perspectives that
   cleared in round N−1, asked only whether the fixes since then broke anything
   those perspectives had approved. One agent for the whole cleared set, not one
   per perspective — it is a cheap sanity pass, not a re-review.
@@ -98,7 +99,9 @@ own; the regression check stands in for it.
 **Reset exception.** If the diff since the last review touches files that were
 not in it, or changes more than roughly half of its lines, the fixes are a
 rewrite rather than a patch — the cleared perspectives cleared different code.
-Treat that round as round 1 and run the full proportional panel.
+Run the full proportional panel for this round — scoping is ignored. The
+derived round number itself is untouched: the count of posted reviews cannot
+be rolled back, and the review this round posts still increments it.
 
 Model pins are unaffected: scoping changes *which* perspectives run, never
 which model runs them (`rules/workflow.md` § Subagents, reviewer

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -101,7 +101,8 @@ rewrite rather than a patch — the cleared perspectives cleared different code.
 Treat that round as round 1 and run the full proportional panel.
 
 Model pins are unaffected: scoping changes *which* perspectives run, never
-which model runs them (see § reviewer decorrelation).
+which model runs them (`rules/workflow.md` § Subagents, reviewer
+decorrelation).
 
 This is not gaze's **Convergence mode** (ticket 0315, default off) under
 another name. Round scoping works *within* one review invocation, across its

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -125,6 +125,13 @@ nothing about the other.
 3. **Deduplicate** findings across agents.
 4. **Run tests**: `make check`
 5. **Post a single review** on the merge request, attributing each finding to its perspective.
+6. **Close with a verdict roster** — one line per perspective that ran, giving
+   its verdict (approve / comment / request-changes), including the
+   perspectives that returned **approve** with nothing to say. The next round
+   scopes itself from this roster (§ Round scoping), so a perspective missing
+   from it reads as cleared. Dedup (step 3) merges *findings*, never verdicts:
+   a perspective whose only finding was deduped into another's still records
+   its own comment verdict.
 
 ## Minor finding tags (mandatory)
 

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -73,6 +73,44 @@ runs and no review is ever posted.
 | Substantial | All five |
 | High-risk (schema, methodology) | All five + domain experts |
 
+### Round scoping
+
+The table above prices **round 1**. Round 1 always runs the full proportional
+panel — no perspective is skipped on a PR's first review.
+
+Derive the round here, from the PR itself: count the reviews already posted by
+this skill on the merge request; the round is that count plus one. No caller
+passes a round number, and no caller is trusted to have counted — the PR's
+review history is the only source.
+
+For round N > 1, re-run only:
+
+- the perspectives whose round N−1 verdict was **comment** or
+  **request-changes** — those are the ones with something outstanding; and
+- **one regression check**: a single agent covering all the perspectives that
+  cleared in round N−1, asked only whether the fixes since then broke anything
+  those perspectives had approved. One agent for the whole cleared set, not one
+  per perspective — it is a cheap sanity pass, not a re-review.
+
+A perspective that returned **approve** in round N−1 does not run again on its
+own; the regression check stands in for it.
+
+**Reset exception.** If the diff since the last review touches files that were
+not in it, or changes more than roughly half of its lines, the fixes are a
+rewrite rather than a patch — the cleared perspectives cleared different code.
+Treat that round as round 1 and run the full proportional panel.
+
+Model pins are unaffected: scoping changes *which* perspectives run, never
+which model runs them (see § reviewer decorrelation).
+
+This is not gaze's **Convergence mode** (ticket 0315, default off) under
+another name. Round scoping works *within* one review invocation, across its
+rounds, and always runs at least the objecting perspectives plus the
+regression check. Convergence mode works at the *caller* level, deciding
+whether a whole repeat `/gaze` runs its panel again at all. The two are
+orthogonal; neither replaces the other, and enabling or disabling one says
+nothing about the other.
+
 ## Each agent runs
 
 1. Read the issue exit criteria and the diff.

--- a/tests/test_review_round_scoping.py
+++ b/tests/test_review_round_scoping.py
@@ -19,11 +19,12 @@ Polarity: the negative guards pin the OLD phrasing and may be exact — that
 wording is gone and must not come back. The positive markers stay LOOSE
 (section name only), so the prose can be rewritten without breaking the test.
 
-RED proof (2026-07-28): against the unedited SKILL.md files all four tests
-failed — gaze still carried both old clauses and neither skill had a
-"Round scoping" section.
+RED proof (2026-07-28): against the unedited SKILL.md files the tests
+failed — gaze still carried both old clauses and none of the three skills
+had a "Round scoping" section.
 """
 
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -36,6 +37,7 @@ REVIEW_PR = REPO / "skills" / "review-pr" / "SKILL.md"
 REVIEW_PR_PROSE = REPO / "skills" / "review-pr-prose" / "SKILL.md"
 
 
+@lru_cache(maxsize=None)
 def _text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 

--- a/tests/test_review_round_scoping.py
+++ b/tests/test_review_round_scoping.py
@@ -1,0 +1,77 @@
+"""Pin round scoping across the review skills (ticket 0377).
+
+Review panels were the largest subagent cost bucket in the 2026-07-28 trace
+analysis (44–56% of all subagent output tokens) because round pricing was flat:
+round N re-ran every perspective even when round N−1 gave most perspectives
+nothing to say. Ticket 0377 scopes later rounds to the perspectives that
+objected, plus one cheap regression check.
+
+Two mechanisms had to change together:
+
+- `skills/review-pr/SKILL.md` gains a § Round scoping rule (round 1 = full
+  proportional panel; round N>1 = objecting perspectives + regression check),
+  and relates it to gaze's Convergence mode so the two are not confused.
+- `skills/gaze/SKILL.md` drops the #562 clause that sent *any* round ≥ 2 to
+  the full battery unconditionally, replacing it with a reset condition tied
+  to substantial diff rewrite.
+
+Polarity: the negative guards pin the OLD phrasing and may be exact — that
+wording is gone and must not come back. The positive markers stay LOOSE
+(section name only), so the prose can be rewritten without breaking the test.
+
+RED proof (2026-07-28): against the unedited SKILL.md files all four tests
+failed — gaze still carried both old clauses and neither skill had a
+"Round scoping" section.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.adherence
+
+REPO = Path(__file__).resolve().parents[1]
+GAZE = REPO / "skills" / "gaze" / "SKILL.md"
+REVIEW_PR = REPO / "skills" / "review-pr" / "SKILL.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_gaze_no_longer_forces_full_battery_every_round():
+    text = _text(GAZE)
+    assert "unconditionally any round" not in text, (
+        "skills/gaze/SKILL.md still sends any round >= 2 to the full battery "
+        "unconditionally. Ticket 0377 replaced the #562 clause: a round >= 2 "
+        "reruns a scoped battery, and only a substantial diff rewrite resets "
+        "to the full panel."
+    )
+    assert "regardless of diff size" not in text, (
+        "skills/gaze/SKILL.md still claims a REROLL escalates to the full "
+        "battery regardless of diff size (ticket 0377 removed that clause)."
+    )
+
+
+def test_gaze_has_round_scoping_section():
+    assert "Round scoping" in _text(GAZE), (
+        "skills/gaze/SKILL.md must carry a 'Round scoping' section stating "
+        "what a round >= 2 re-runs and when scoping resets (ticket 0377)."
+    )
+
+
+def test_review_pr_has_round_scoping_section():
+    assert "Round scoping" in _text(REVIEW_PR), (
+        "skills/review-pr/SKILL.md must carry a 'Round scoping' section: "
+        "round 1 runs the full proportional panel, later rounds re-run only "
+        "the perspectives that objected (ticket 0377)."
+    )
+
+
+def test_review_pr_round_scoping_relates_to_convergence():
+    assert "convergence" in _text(REVIEW_PR).lower(), (
+        "skills/review-pr/SKILL.md's round scoping must be related to gaze's "
+        "Convergence mode (ticket 0315), so callers do not confuse "
+        "within-invocation scoping with caller-level repeat suppression "
+        "(ticket 0377)."
+    )

--- a/tests/test_review_round_scoping.py
+++ b/tests/test_review_round_scoping.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.adherence
 REPO = Path(__file__).resolve().parents[1]
 GAZE = REPO / "skills" / "gaze" / "SKILL.md"
 REVIEW_PR = REPO / "skills" / "review-pr" / "SKILL.md"
+REVIEW_PR_PROSE = REPO / "skills" / "review-pr-prose" / "SKILL.md"
 
 
 def _text(path: Path) -> str:
@@ -65,6 +66,35 @@ def test_review_pr_has_round_scoping_section():
         "skills/review-pr/SKILL.md must carry a 'Round scoping' section: "
         "round 1 runs the full proportional panel, later rounds re-run only "
         "the perspectives that objected (ticket 0377)."
+    )
+
+
+def test_gaze_agent_c_procedure_carries_round_scoping():
+    """Gaze spawns Agent C with an EMBEDDED procedure, not a /review-pr fork.
+
+    The spawned agent reads neither gaze/SKILL.md nor review-pr/SKILL.md, so a
+    scoping rule stated only in the doctrine sections never reaches the code
+    path the ticket's cost analysis targets. This slices the Agent C block
+    deliberately: the assertion is about that paragraph, not the file.
+
+    The marker is the section name, not a bare "round": `foreground` and
+    `background` both contain that substring, and the Agent C block has used
+    both since long before this ticket — asserting on it would have passed
+    against the unfixed text (verified 2026-07-28) and guarded nothing.
+    """
+    agent_c = _text(GAZE).split("**Agent C — PR review**", 1)[1].split("### ", 1)[0]
+    assert "Round scoping" in agent_c, (
+        "gaze's embedded Agent C procedure must reference § Round scoping. The "
+        "spawned agent never reads review-pr/SKILL.md, so a rule stated only "
+        "in gaze's doctrine section is inert on the gaze path (ticket 0377)."
+    )
+
+
+def test_prose_sibling_has_round_scoping_section():
+    """Gaze's Agent C is /review-pr OR /review-pr-prose; both need the rule."""
+    assert "Round scoping" in _text(REVIEW_PR_PROSE), (
+        "skills/review-pr-prose/SKILL.md must carry a 'Round scoping' section "
+        "too — gaze points a round >= 2 prose panel at it (ticket 0377)."
     )
 
 

--- a/tests/test_review_round_scoping.py
+++ b/tests/test_review_round_scoping.py
@@ -84,7 +84,15 @@ def test_gaze_agent_c_procedure_carries_round_scoping():
     both since long before this ticket — asserting on it would have passed
     against the unfixed text (verified 2026-07-28) and guarded nothing.
     """
-    agent_c = _text(GAZE).split("**Agent C — PR review**", 1)[1].split("### ", 1)[0]
+    text = _text(GAZE)
+    marker = "**Agent C — PR review**"
+    assert marker in text, (
+        f"skills/gaze/SKILL.md no longer carries the {marker!r} heading, so the "
+        "Agent C block cannot be located. If the phase was renamed, update this "
+        "test's marker; if it was removed, ticket 0377's scoping rule has lost "
+        "the code path it guards."
+    )
+    agent_c = text.split(marker, 1)[1].split("### ", 1)[0]
     assert "Round scoping" in agent_c, (
         "gaze's embedded Agent C procedure must reference § Round scoping. The "
         "spawned agent never reads review-pr/SKILL.md, so a rule stated only "

--- a/tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
+++ b/tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
@@ -7,6 +7,7 @@ Author: HDMX-coding-agent
 2026-07-28T08:57Z HDMX-coding-agent created
 2026-07-28T13:02Z claude note execute: round scoping landed in review-pr + gaze + hunt 11/13; guard tests/test_review_round_scoping.py
 
+2026-07-28T13:52Z bump verify-reroll — round 1: gaze's round>=2 Agent C tier branch (gaze:163-164,278-281) has no reachable trigger inside gaze's own REROLL loop and gaze never states how it derives the round it must pass to Agent C
 --- body ---
 ## Context
 

--- a/tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
+++ b/tickets/0377-review-rounds-re-run-the-full-perspectiv.erg
@@ -5,6 +5,7 @@ Author: HDMX-coding-agent
 
 --- log ---
 2026-07-28T08:57Z HDMX-coding-agent created
+2026-07-28T13:02Z claude note execute: round scoping landed in review-pr + gaze + hunt 11/13; guard tests/test_review_round_scoping.py
 
 --- body ---
 ## Context

--- a/tickets/closed/0377-review-rounds-re-run-the-full-perspectiv.erg
+++ b/tickets/closed/0377-review-rounds-re-run-the-full-perspectiv.erg
@@ -2,12 +2,14 @@
 Title: review rounds re-run the full perspective panel regardless of prior findings
 Created: 2026-07-28
 Author: HDMX-coding-agent
+Closed: autoclosed — PR #696
 
 --- log ---
 2026-07-28T08:57Z HDMX-coding-agent created
 2026-07-28T13:02Z claude note execute: round scoping landed in review-pr + gaze + hunt 11/13; guard tests/test_review_round_scoping.py
 
 2026-07-28T13:52Z bump verify-reroll — round 1: gaze's round>=2 Agent C tier branch (gaze:163-164,278-281) has no reachable trigger inside gaze's own REROLL loop and gaze never states how it derives the round it must pass to Agent C
+2026-07-28T14:01Z Integration Test closed — autoclosed — PR #696
 --- body ---
 ## Context
 


### PR DESCRIPTION
**Ticket:** tickets/0377-review-rounds-re-run-the-full-perspectiv.erg

Builds on merged PR #692 (ticket 0376, test-run budget) — hunt step 12's budget wording is left untouched; this PR only edits steps 11 and 13.

## Why

The 2026-07-28 trace analysis of three climate-finance-het raids put review panels at 44–56% of all subagent output tokens, the largest cost bucket, ahead of gaze/gates (10–22%) and execution itself (20–30%). PR 1172 alone drew 23 verification agents against 1 execute agent.

The spend is not empty ritual — post-review fix edits appeared in 17 of 19 kills that reached review — but round pricing was flat: round N re-ran every perspective even when round N−1 gave most of them nothing to say.

## What

**`skills/review-pr/SKILL.md`** — new § Round scoping. Round 1 is unchanged (full proportional panel). Round N>1 re-runs only the perspectives whose previous verdict was comment or request-changes, plus **one** regression agent covering the whole cleared set — one agent, not one per cleared perspective, since it is a sanity pass rather than a re-review. The skill derives the round by counting its own posted reviews on the merge request; no caller passes a round number, because a caller that miscounts would silently under-review while the PR's own history cannot be miscounted.

**`skills/gaze/SKILL.md`** — the #562 clause sent any round ≥ 2 to the full battery unconditionally. That over-corrected. #562's real lesson was that a round-2 battery was needed on an unchanged diff, and that is satisfied by keeping Agents A and B, phase 5, and the phase 6 gate at full strength every round; only Agent C is scoped. The reset condition is a substantial rewrite (new files, or >~half the lines changed since the last review), **not** an unchanged diff — an unchanged diff is precisely the case where the earlier clearances still hold.

**`skills/review-pr-prose/SKILL.md`** — gaze's Agent C is `/review-pr` *or* `/review-pr-prose`, so the prose sibling gains the parallel rule. The AI-tells auditor is exempt from scoping: it scans the full text, so revised prose is new surface for it whatever the last round's verdicts were.

**`skills/hunt/SKILL.md`** — steps 11/13 name the loop iteration as a round and state that no round number is passed.

Three gaps surfaced by the pre-PR adherence gate, all the same failure family — the rule stated where the actor could not read it:

1. Gaze does not fork `/review-pr` for Agent C; it spawns an agent with an **embedded** procedure duplicating the panel logic, and that paragraph still said "run the full proportional panel". The feature would have been inert on the gaze path — the very path the cost analysis measured. Agent C's procedure now carries the rule itself.
2. Round N scopes from per-perspective verdicts that Synthesis never required be recorded, and dedup could drop an objecting perspective's only finding, making it read as cleared — under-scoping, the unsafe direction. Both review skills now close with a verdict roster including approvals, and dedup is stated to merge findings, never verdicts.
3. Gaze's output shape recorded round and tier but not *which* perspectives a scoped round ran, leaving ticket exit criterion 3 unverifiable as built. One template line now reports the scope.

## Verification

- New guard `tests/test_review_round_scoping.py` (6 adherence tests), proven RED against the unedited files before each fix.
- Polarity per the prose-test rule: negative guards pin the removed gaze wording exactly; positive markers are section names only, so the prose stays rewritable.
- The gate's suggested assertion for gap 1 was `"round" in agent_c.lower()` — that **passes against the unfixed text**, since `foreground` and `background` both contain "round" and the block has used them for ages. Verified against the pre-fix blob and switched to a marker genuinely absent before the fix.
- `make check`: 882 passed, 1 failed. The single failure is `test_guard_cd_primary_repo.sh`, pre-existing local-env noise (`KEYS provider not found`), unrelated to this diff and green in CI. Rebasing onto current main picked up the locale fix (#693) that cleared the second known-noise failure.
- Invariants held: phase 6 (`/verify-gate`) still runs at every tier, never reduced; reviewer-decorrelation model pins untouched (scoping changes which perspectives run, never which model runs them); verify-gate's per-exit-criterion contract untouched; `convergence.enabled` still default off.
- `/verify-adherence`: PASS (second run), zero mechanical failures.

## Deviation from the ticket

Ticket action 2 asks that the gaze **REROLL** path be scoped as well. This PR declines: that internal re-entry branch already re-runs the gate only, so there is no panel there to scope. The change is documented in gaze's new subsection alongside Convergence mode (ticket 0315, default off, untouched), which is a caller-level decision at a different layer — same word "round", different mechanisms, deliberately kept orthogonal rather than merged.

Exit criterion 3 ("one subsequent raid shows scoped rounds in its transcripts") is necessarily left for a later raid to observe; the telemetry line added above is what makes it observable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
