### PR TITLE
memory: child-agent notifications bubble to the top session

### DIFF
--- a/projects/-home-haduong--claude/memory/MEMORY.md
+++ b/projects/-home-haduong--claude/memory/MEMORY.md
@@ -46,6 +46,7 @@
 - [Don't codify hard rules for judgment calls](feedback_dont_codify_hard_rules.md) — hard rules for "do the sensible thing" conventions make agents lazy
 - [Paper release/ subdir layout](user_paper_release_subdir_layout.md) — one dir per paper under `~/CNRS/papiers/{actif,sent,published}`; immutable append-only `release/<date desc>/` per
 - [Workflow agents are session-bound](feedback_workflow_agents_session_bound.md) — Workflow agent() runs in the SESSION checkout unless isolation:'worktree'
+- [Child-agent notifications bubble to the session](feedback_child_agent_notifications_bubble.md) — a delegate's own background children complete-notify the top session; don't act, wait for the delegate
 - [Subagent model/effort levers](feedback_subagent_model_effort_levers.md) — skill frontmatter model: does NOT propagate to spawned children; per-invocation `model` enum is the only
 - [Trace usage dedupe by message.id](feedback_trace_usage_dedupe_by_message_id.md) — session-trace JSONL repeats message.usage on every content-block row
 - [Cross-repo tickets live at the destination](feedback_cross_repo_tickets_live_at_destination.md) — a ticket for work in repo X goes in X's own store; trackers reference cross-repo work

--- a/projects/-home-haduong--claude/memory/feedback_child_agent_notifications_bubble.md
+++ b/projects/-home-haduong--claude/memory/feedback_child_agent_notifications_bubble.md
@@ -1,0 +1,30 @@
+---
+name: feedback_child_agent_notifications_bubble
+description: A background subagent's OWN background children can complete-notify the top-level session; treat such notifications as the delegate's internal traffic — don't act on them, wait for the delegate's own completion
+metadata:
+  type: feedback
+---
+
+During raid 376/377 (2026-07-28), the wave-2 execute agent (launched via
+Agent, background) spawned its own background reviewer for its pre-PR
+self-gate. When that grandchild finished, its completion notification —
+full findings payload included — arrived in the *top-level session*, not
+(only) in the delegating agent. The delegate was still mid-run; its own
+completion notification arrived later with the findings already handled.
+
+**Why:** a task-notification fires whenever an agent stops with no live
+background children of its own; the routing surfaces grandchild
+completions at the session level. Acting on one from the interface
+session duplicates the delegate's in-flight work — the findings belong
+to *its* loop (here: step-9 self-gate findings the executor proceeded to
+fix itself). Intervening or "helpfully" fixing would have collided with
+the delegate inside its own worktree.
+
+**How to apply:** on receiving a completion notification, check whether
+the task-id matches an agent *you* launched. If not, it is a delegate's
+internal traffic: note anything strategically useful (scope extensions,
+blocking findings), take no action, and wait for the delegate's own
+task-id to complete. Judge the delegate on its final report — which may
+already incorporate the grandchild's findings. Related:
+[[feedback_supervisor_checkpoint_pattern]],
+[[feedback_workflow_agents_session_bound]].


### PR DESCRIPTION
Ticket: none

Roar step-6 memory from raid 376/377: a background delegate's own background children complete-notify the top-level session; the supervisor must treat those as the delegate's internal traffic and wait for the delegate's own completion. One new memory file + index line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)