### PR TITLE
ticket(0391): close wontfix — mid-raid re-screen is a fenced corner case

### DIFF
--- a/tickets/closed/0391-re-screen-skip-labels-at-raid-phase-5-la.erg
+++ b/tickets/closed/0391-re-screen-skip-labels-at-raid-phase-5-la.erg
@@ -2,10 +2,12 @@
 Title: re-screen skip labels at raid Phase 5 launch, not only Phase 1
 Created: 2026-07-28
 Author: Integration Test
+Closed: wontfix: author is the labelling actor and is in the loop by definition; the window is hours wide and 0390's Phase 1 screen covers the measured failure mode (0334/0338); growing raid skill text for this corner case contradicts the harness cool-down directive
 
 --- log ---
 2026-07-28T14:58Z Integration Test created
 
+2026-07-28T15:22Z Integration Test closed — wontfix: author is the labelling actor and is in the loop by definition; the window is hours wide and 0390's Phase 1 screen covers the measured failure mode (0334/0338); growing raid skill text for this corner case contradicts the harness cool-down directive
 --- body ---
 ## Context
 


### PR DESCRIPTION
Author-directed wontfix (both follow-ups from PR #698 killed the same way): the author is the only actor applying needs-human, so the mid-raid labelling race has a human in the loop by construction; 0390's Phase 1 screen covers the measured failure mode. Sibling git-erg#325 closed wontfix — erg validate already fences case-variant labels.

The close is performed in this diff (manual chore-close recipe), so no close claim:

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)