### PR TITLE
rules: submission events propagate to homepage bib and CNRS roadmap

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -13,6 +13,7 @@ files on demand when their scope signal applies to your task.
 | [coding-python.md](./coding-python.md) | edit of `*.py` (alias: `format/python`) | Python 3.10+ style, testing markers, Make rules, `uv` workflow. |
 | [coding-bash.md](./coding-bash.md) | edit of `*.sh` (alias: `format/bash`) | Bash `set -euo pipefail` discipline: arithmetic-zero abort, unbound associative-array key. |
 | [pdf-finishing.md](./pdf-finishing.md) | finishing pass of any PDF deliverable (submission, deposit, personal page) | Automate pagination (titlesec, widow penalties, dash-ratio widths); scripted pdftotext checklist; variants as archived transform layers. |
+| [submission-events.md](./submission-events.md) | a manuscript's submission state changes (submitted, resubmitted, accepted, published) | Propagate the event to the external registers: homepage `Ha-Duong.bib` (rebuild + deploy) and CNRS secretariat `Feuille de route <year>.odt` (+ PDF). |
 | [prose/_all.md](./prose/_all.md) | edit of any prose file (`*.tex` `*.qmd` `*.md` `*.txt`) | Universal prose rules: LLMism guards, Elements of Style. |
 | [prose/cutting.md](./prose/cutting.md) | a pass cutting prose to a word/page budget | Remove whole passages before condensing; displaced ≠ deleted; a cut plan starts with the whole-removal pass. |
 | [doctype/techreport.md](./doctype/techreport.md) | edit of a `techreport` file (`\documentclass{report}` or manifest) | Report conventions: standalone abstract, numbered floats with takeaway captions, label cross-references. |

--- a/rules/submission-events.md
+++ b/rules/submission-events.md
@@ -1,0 +1,21 @@
+<!-- last-reviewed: 2026-07-29 -->
+# Submission events — propagate to the external registers
+
+When a manuscript's submission state changes — initial submission, revision
+resubmitted, accepted, published — the repo side (STATE, tickets, tags,
+submission branch) is not the whole bookkeeping. Two registers live outside
+git and go silently stale unless updated in the same session:
+
+1. **Homepage publications list** — `~/CNRS/html/Ha-Duong.bib`: update the
+   entry (title, date, status note in `type`, DOI — concept DOI for
+   datasets), rebuild (`make` in `~/CNRS/html/src/`), deploy
+   (`make sync` in `~/CNRS/html/`, which validates first).
+2. **CNRS secretariat roadmap** — `~/CNRS/secretariat/Feuille de route
+   <year>.odt`: update the paper's row (état accompli, prochaine action) in
+   the style of the neighbouring rows, then regenerate the companion PDF
+   (`libreoffice --headless --convert-to pdf`).
+
+Propose both as part of the submission-event wrap-up; they are author-visible
+deliverables, not chores to defer. (Author directive, 2026-07-29, at the
+RDJ-26561 revision-1 resubmission — the homepage and roadmap updates had to
+be asked for after the fact.)


### PR DESCRIPTION
Adds `rules/submission-events.md` + index row: on any manuscript submission-state change, update the homepage publications list (`Ha-Duong.bib`, rebuild + deploy) and the CNRS secretariat `Feuille de route <year>.odt` (+ PDF) in the same session. Author directive 2026-07-29, after both registers went stale at the RDJ-26561 revision-1 resubmission.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)