### PR TITLE
dream: consolidate climate-finance-het memory (91→92)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -1743,7 +1743,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:24Z",
-      "last_confirmed": "2026-07-22T18:30:03Z",
+      "last_confirmed": "2026-07-29T16:46:13Z",
       "promoted": false
     },
     "feedback_agent_prompt_worktree_rooted_paths": {
@@ -1751,7 +1751,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:24Z",
-      "last_confirmed": "2026-07-22T18:30:03Z",
+      "last_confirmed": "2026-07-29T16:46:13Z",
       "promoted": false
     },
     "feedback_atomic_tickets_validation_units": {
@@ -1759,7 +1759,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:24Z",
-      "last_confirmed": "2026-07-22T18:30:03Z",
+      "last_confirmed": "2026-07-29T16:46:14Z",
       "promoted": false
     },
     "feedback_branch_before_edit": {
@@ -1767,7 +1767,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:24Z",
-      "last_confirmed": "2026-07-22T18:30:03Z",
+      "last_confirmed": "2026-07-29T16:46:14Z",
       "promoted": false
     },
     "feedback_bytecheck_old_vs_new_not_golden": {
@@ -1775,7 +1775,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:24Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:14Z",
       "promoted": false
     },
     "feedback_caps_force_pruning_not_compression": {
@@ -1783,7 +1783,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:24Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:14Z",
       "promoted": false
     },
     "feedback_cite_at_existing_locus": {
@@ -1791,7 +1791,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:15Z",
       "promoted": false
     },
     "feedback_cross_repo_ticket_in_owning_repo": {
@@ -1799,7 +1799,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:15Z",
       "promoted": false
     },
     "feedback_data_direction": {
@@ -1807,7 +1807,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:15Z",
       "promoted": false
     },
     "feedback_decide_dont_micromanage": {
@@ -1815,7 +1815,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:15Z",
       "promoted": false
     },
     "feedback_dropna_before_merge": {
@@ -1823,7 +1823,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:16Z",
       "promoted": false
     },
     "feedback_erg_close_archive": {
@@ -1831,7 +1831,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:16Z",
       "promoted": false
     },
     "feedback_evict_to_gitignored_dir_bootstrap": {
@@ -1839,7 +1839,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:17Z",
       "promoted": false
     },
     "feedback_fetch_before_sibling_merge": {
@@ -1847,7 +1847,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:17Z",
       "promoted": false
     },
     "feedback_file_decisions_with_submission": {
@@ -1855,7 +1855,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
       "promoted": false
     },
     "feedback_followup_lets_parent_close": {
@@ -1863,7 +1863,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
       "promoted": false
     },
     "feedback_gate_after_full_review": {
@@ -1871,7 +1871,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
       "promoted": false
     },
     "feedback_gate_execute_on_all_scopers": {
@@ -1879,7 +1879,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:25Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
       "promoted": false
     },
     "feedback_grep_before_commit": {
@@ -1887,7 +1887,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
       "promoted": false
     },
     "feedback_het_register": {
@@ -1895,7 +1895,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:19Z",
       "promoted": false
     },
     "feedback_hitl_decision_cite_evidence": {
@@ -1903,7 +1903,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:20Z",
       "promoted": false
     },
     "feedback_inspect_ref_readonly": {
@@ -1911,7 +1911,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:20Z",
       "promoted": false
     },
     "feedback_isolated_venv_proves_installability": {
@@ -1919,7 +1919,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_letter_voice_flags": {
@@ -1927,7 +1927,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_make_corpus": {
@@ -1935,7 +1935,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_manuscript_number_provenance": {
@@ -1943,7 +1943,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_no_amend_pr": {
@@ -1951,7 +1951,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_apc": {
@@ -1959,7 +1959,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_heavy_deps": {
@@ -1967,7 +1967,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_long_running": {
@@ -1975,7 +1975,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_md_in_md": {
@@ -1983,7 +1983,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:26Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_noverify": {
@@ -1991,7 +1991,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_rebase_dvc": {
@@ -1999,7 +1999,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
       "promoted": false
     },
     "feedback_no_shared_env_sync_during_sibling_agent": {
@@ -2007,7 +2007,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:23Z",
       "promoted": false
     },
     "feedback_no_tool_for_single_use": {
@@ -2015,7 +2015,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:23Z",
       "promoted": false
     },
     "feedback_overnight_exploration": {
@@ -2023,7 +2023,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:23Z",
       "promoted": false
     },
     "feedback_oversell_breaks": {
@@ -2031,7 +2031,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:24Z",
       "promoted": false
     },
     "feedback_parallel_work": {
@@ -2039,7 +2039,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:24Z",
       "promoted": false
     },
     "feedback_phase_separation": {
@@ -2047,7 +2047,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:24Z",
       "promoted": false
     },
     "feedback_pilot_one_instance_critiques_the_ticket": {
@@ -2055,7 +2055,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_pin_test_mutation_teeth": {
@@ -2063,7 +2063,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_prclose_onbranch_ticket_none": {
@@ -2071,7 +2071,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_pr_creates_ticket_no_close": {
@@ -2079,7 +2079,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_propagate_notes_to_tickets": {
@@ -2087,7 +2087,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:27Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_quarto_var_vs_meta": {
@@ -2095,7 +2095,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_ratchet_stale_after_rebuild": {
@@ -2103,7 +2103,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:26Z",
       "promoted": false
     },
     "feedback_read_before_cite": {
@@ -2111,7 +2111,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:26Z",
       "promoted": false
     },
     "feedback_render_bitcompare_is_the_gate": {
@@ -2119,7 +2119,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:26Z",
       "promoted": false
     },
     "feedback_reorg_tracker_first_class_guard": {
@@ -2127,7 +2127,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:26Z",
       "promoted": false
     },
     "feedback_review_agent_worktree": {
@@ -2135,7 +2135,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "feedback_ruff_fix_breaks_reexport_facades": {
@@ -2143,7 +2143,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "feedback_rule9_detector_variable_path_blindspot": {
@@ -2151,7 +2151,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "feedback_settled_debates_to_brief": {
@@ -2159,7 +2159,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "feedback_simplest_fix": {
@@ -2167,7 +2167,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:28Z",
       "promoted": false
     },
     "feedback_ssh_padme": {
@@ -2175,7 +2175,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:28Z",
       "promoted": false
     },
     "feedback_stale_worktree_make": {
@@ -2183,7 +2183,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:28Z",
       "promoted": false
     },
     "feedback_tectonic_next": {
@@ -2191,7 +2191,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:28Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:29Z",
       "promoted": false
     },
     "feedback_verify_active_before_defer_tag": {
@@ -2199,7 +2199,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:29Z",
       "promoted": false
     },
     "feedback_verify_ai_generated_includes": {
@@ -2207,7 +2207,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:29Z",
       "promoted": false
     },
     "feedback_verify_before_advising": {
@@ -2215,7 +2215,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:29Z",
       "promoted": false
     },
     "feedback_verify_datadep_worktree_symlink": {
@@ -2223,7 +2223,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:29Z",
       "promoted": false
     },
     "feedback_verify_deferral_tracker": {
@@ -2231,7 +2231,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_verify_makefile_pathrefactor_with_make_n": {
@@ -2239,7 +2239,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_version_increment_planning": {
@@ -2247,7 +2247,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_visual_verify_citations": {
@@ -2255,7 +2255,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_weekend_boundary": {
@@ -2263,7 +2263,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_worktree_local_hook_commit": {
@@ -2271,7 +2271,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_worktree_search": {
@@ -2279,7 +2279,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "feedback_yaml_quoting": {
@@ -2287,7 +2287,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_0171_conclusion_rebuild": {
@@ -2295,7 +2295,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_deliverables_render_next_to_source": {
@@ -2303,7 +2303,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:29Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_doifetch_sync": {
@@ -2311,7 +2311,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_dvc_integration": {
@@ -2319,7 +2319,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_frozen_manuscript_vs_live_companions": {
@@ -2327,7 +2327,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_gide_conference": {
@@ -2335,7 +2335,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:32Z",
       "promoted": false
     },
     "project_imperial_dragon": {
@@ -2343,7 +2343,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:32Z",
       "promoted": false
     },
     "project_journal_strategy": {
@@ -2351,7 +2351,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:32Z",
       "promoted": false
     },
     "project_oeconomia_rr_pipeline": {
@@ -2359,7 +2359,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:32Z",
       "promoted": false
     },
     "project_ollama_experiment": {
@@ -2367,7 +2367,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:33Z",
       "promoted": false
     },
     "project_paper_ceiling_growth_imaginary": {
@@ -2375,7 +2375,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:33Z",
       "promoted": false
     },
     "project_paper_instrument_circulation": {
@@ -2383,7 +2383,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:33Z",
       "promoted": false
     },
     "project_reorg_0159_relocation": {
@@ -2391,7 +2391,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:34Z",
       "promoted": false
     },
     "project_repo_layout_decision": {
@@ -2399,7 +2399,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:34Z",
       "promoted": false
     },
     "project_rr_traceability_ledger": {
@@ -2407,7 +2407,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:34Z",
       "promoted": false
     },
     "project_techrep_rewrite": {
@@ -2415,7 +2415,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:30Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:34Z",
       "promoted": false
     },
     "project_techrep_split": {
@@ -2423,7 +2423,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "project_uv_path_fix": {
@@ -2431,7 +2431,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "project_worktree_env_data": {
@@ -2439,7 +2439,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "project_writing_build_phase_separation": {
@@ -2447,7 +2447,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "reference_agentic_harness": {
@@ -2455,7 +2455,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "reference_agent_identity": {
@@ -2463,7 +2463,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "reference_bib_fulltext_index": {
@@ -2471,7 +2471,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:35Z",
       "promoted": false
     },
     "reference_cited_works_local_docs_articles": {
@@ -2479,7 +2479,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:36Z",
       "promoted": false
     },
     "reference_paywalled_acquisition": {
@@ -2487,7 +2487,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:36Z",
       "promoted": false
     },
     "reference_publist": {
@@ -2495,7 +2495,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:36Z",
       "promoted": false
     },
     "reference_rdj4hss": {
@@ -2503,7 +2503,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:36Z",
       "promoted": false
     },
     "reference_repo_no_ci": {
@@ -2511,7 +2511,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:36Z",
       "promoted": false
     },
     "reference_stats_cache": {
@@ -2519,7 +2519,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:31Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:37Z",
       "promoted": false
     },
     "reference_trackchange_review_workflow": {
@@ -2527,7 +2527,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:32Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:37Z",
       "promoted": false
     },
     "user_cnrs_section41": {
@@ -2535,7 +2535,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:32Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:37Z",
       "promoted": false
     },
     "user_moa_moe_contract": {
@@ -2543,7 +2543,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:32Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:37Z",
       "promoted": false
     },
     "user_orcid": {
@@ -2551,7 +2551,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-10T21:05:32Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:37Z",
       "promoted": false
     },
     "feedback_supervisor_checkpoint_pattern": {
@@ -2735,7 +2735,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:54Z",
-      "last_confirmed": "2026-07-22T18:30:03Z",
+      "last_confirmed": "2026-07-29T16:46:13Z",
       "promoted": false
     },
     "feedback_background_session_manuscript_pr_workflow": {
@@ -2743,7 +2743,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:54Z",
-      "last_confirmed": "2026-07-22T18:30:03Z",
+      "last_confirmed": "2026-07-29T16:46:14Z",
       "promoted": false
     },
     "feedback_escalate_check_merge_after_note": {
@@ -2751,7 +2751,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:56Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:17Z",
       "promoted": false
     },
     "feedback_fable_second_opinion_prose_structure": {
@@ -2759,7 +2759,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:56Z",
-      "last_confirmed": "2026-07-22T18:30:04Z",
+      "last_confirmed": "2026-07-29T16:46:17Z",
       "promoted": false
     },
     "feedback_gate_verify_branch_not_pr_body": {
@@ -2767,7 +2767,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:56Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
       "promoted": false
     },
     "feedback_hardcoded_secondary_path_survives_input_gate": {
@@ -2775,7 +2775,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:57Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:19Z",
       "promoted": false
     },
     "feedback_interactive_authorization_invisible_to_gates": {
@@ -2783,7 +2783,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:57Z",
-      "last_confirmed": "2026-07-22T18:30:05Z",
+      "last_confirmed": "2026-07-29T16:46:20Z",
       "promoted": false
     },
     "feedback_ln_into_existing_dir_autostage": {
@@ -2791,7 +2791,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:57Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_moving_files_narrows_guard_globs": {
@@ -2799,7 +2799,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:58Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_negative_guard_false_positive_check": {
@@ -2807,7 +2807,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:58Z",
-      "last_confirmed": "2026-07-22T18:30:06Z",
+      "last_confirmed": "2026-07-29T16:46:21Z",
       "promoted": false
     },
     "feedback_pdf_layout_automate_dont_hand_paginate": {
@@ -2815,7 +2815,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:57:59Z",
-      "last_confirmed": "2026-07-22T18:30:07Z",
+      "last_confirmed": "2026-07-29T16:46:24Z",
       "promoted": false
     },
     "feedback_raid_overkill_for_trivial_reference_pattern_fix": {
@@ -2823,7 +2823,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:00Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_raid_scope_triage_before_fanout": {
@@ -2831,7 +2831,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:00Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:25Z",
       "promoted": false
     },
     "feedback_rightsize_agent_model_to_task": {
@@ -2839,7 +2839,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:01Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "feedback_user_pulls_land_in_downloads": {
@@ -2847,7 +2847,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:02Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:29Z",
       "promoted": false
     },
     "feedback_verify_new_citations_against_primary_pdf": {
@@ -2855,7 +2855,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:03Z",
-      "last_confirmed": "2026-07-22T18:30:10Z",
+      "last_confirmed": "2026-07-29T16:46:30Z",
       "promoted": false
     },
     "project_file_relocation_move_surface": {
@@ -2863,7 +2863,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:04Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:31Z",
       "promoted": false
     },
     "project_includes_citation_guard_0244": {
@@ -2871,7 +2871,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:04Z",
-      "last_confirmed": "2026-07-22T18:30:11Z",
+      "last_confirmed": "2026-07-29T16:46:32Z",
       "promoted": false
     },
     "project_rdj26561_rr_round1": {
@@ -2879,7 +2879,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:05Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:33Z",
       "promoted": false
     },
     "reference_hal_sword_update_recipe": {
@@ -2887,7 +2887,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T08:58:06Z",
-      "last_confirmed": "2026-07-22T18:30:13Z",
+      "last_confirmed": "2026-07-29T16:46:36Z",
       "promoted": false
     },
     "feedback_rtk_log_hides_merge_commits": {
@@ -2895,7 +2895,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T18:30:08Z",
-      "last_confirmed": "2026-07-22T18:30:08Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "feedback_sibling_close_collides_on_shared_blocker": {
@@ -2903,7 +2903,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T18:30:09Z",
-      "last_confirmed": "2026-07-22T18:30:09Z",
+      "last_confirmed": "2026-07-29T16:46:27Z",
       "promoted": false
     },
     "project_prior_mappings_overlap_0289": {
@@ -2911,7 +2911,7 @@
         "-home-haduong-CNRS-projets-actifs-climate-finance-het"
       ],
       "first_seen": "2026-07-22T18:30:12Z",
-      "last_confirmed": "2026-07-22T18:30:12Z",
+      "last_confirmed": "2026-07-29T16:46:33Z",
       "promoted": false
     },
     "project-systemd-linked-vs-enabled": {
@@ -3800,6 +3800,70 @@
       ],
       "first_seen": "2026-07-28T21:03:27Z",
       "last_confirmed": "2026-07-28T21:03:27Z",
+      "promoted": false
+    },
+    "feedback_enterworktree_stuck_cwd": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:16Z",
+      "last_confirmed": "2026-07-29T16:46:16Z",
+      "promoted": false
+    },
+    "feedback_erg_close_archive_staging_order": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:17Z",
+      "last_confirmed": "2026-07-29T16:46:17Z",
+      "promoted": false
+    },
+    "feedback_force_push_denied_rebuild_clean": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:18Z",
+      "last_confirmed": "2026-07-29T16:46:18Z",
+      "promoted": false
+    },
+    "feedback_harness_not_here": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:19Z",
+      "last_confirmed": "2026-07-29T16:46:19Z",
+      "promoted": false
+    },
+    "feedback_no_rebase_when_force_push_denied": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:22Z",
+      "last_confirmed": "2026-07-29T16:46:22Z",
+      "promoted": false
+    },
+    "feedback_onstart_trigger": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:23Z",
+      "last_confirmed": "2026-07-29T16:46:23Z",
+      "promoted": false
+    },
+    "feedback_pdftotext_grep_linebreaks": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:24Z",
+      "last_confirmed": "2026-07-29T16:46:24Z",
+      "promoted": false
+    },
+    "feedback_ssh_padme_path": {
+      "projects": [
+        "-home-haduong-CNRS-projets-actifs-climate-finance-het"
+      ],
+      "first_seen": "2026-07-29T16:46:28Z",
+      "last_confirmed": "2026-07-29T16:46:28Z",
       "promoted": false
     }
   }

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/MEMORY.md
@@ -1,7 +1,7 @@
 # Project Memory
 
 ## Key insights
-- 4-paper research programme (`climate-finance-het`); RDJ-26561 data-paper R&R is the active deadline track (tracker 0274, ~2026-10-20). Œconomia v2.0.5 resubmitted 2026-07-21, awaiting editor. Submission records live under `papiers/<state>/<track>/`.
+- 4-paper research programme (`climate-finance-het`); RDJ-26561 revision 1 resubmitted 2026-07-29, awaiting editor. Œconomia v2.0.5 resubmitted 2026-07-21, awaiting editor. Submission records live under `papiers/<state>/<track>/`.
 - **Methodological honesty is a hard norm**: computation *corroborates* history; cite only pipeline numbers traceable to an archived output.
 - **Heavy worktree + parallel-session discipline**: shared uv env on /data, never rebase with dirty DVC symlinks, branch-before-edit, check filesystem before asserting work undone.
 - Author optimizes for **diamond-OA integrity over prestige** (no APC, CNRS Section 41), HET academic register, weekends off.
@@ -30,7 +30,7 @@
 - [project_uv_path_fix.md](project_uv_path_fix.md), [project_worktree_env_data.md](project_worktree_env_data.md), [project_doifetch_sync.md](project_doifetch_sync.md), [project_dvc_integration.md](project_dvc_integration.md).
 
 ## Papers & submission
-- RDJ-26561 R&R round 1: [project_rdj26561_rr_round1.md](project_rdj26561_rr_round1.md) — tracker 0274, deadline ~2026-10-20; 0288 BUILD merged, 0304 harvest (padme) is critical path.
+- RDJ-26561 R&R round 1: [project_rdj26561_rr_round1.md](project_rdj26561_rr_round1.md) — COMPLETE, revision 1 resubmitted 2026-07-29; upload-kit recipe for round 2 inside.
 - [project_prior_mappings_overlap_0289.md](project_prior_mappings_overlap_0289.md) — prior-mappings overlap probe: 89–91% coverage = curation, >99% discovery; artifacts in revision-rdj26561/; feeds 0278/0283.
 - Œconomia R&R: [project_oeconomia_rr_pipeline.md](project_oeconomia_rr_pipeline.md), [project_rr_traceability_ledger.md](project_rr_traceability_ledger.md), [project_0171_conclusion_rebuild.md](project_0171_conclusion_rebuild.md), [feedback_version_increment_planning.md](feedback_version_increment_planning.md).
 - Reports & build: [project_techrep_rewrite.md](project_techrep_rewrite.md), [project_techrep_split.md](project_techrep_split.md), [project_writing_build_phase_separation.md](project_writing_build_phase_separation.md), [project_frozen_manuscript_vs_live_companions.md](project_frozen_manuscript_vs_live_companions.md), [project_repo_layout_decision.md](project_repo_layout_decision.md), [project_deliverables_render_next_to_source.md](project_deliverables_render_next_to_source.md).
@@ -127,3 +127,4 @@
 - [feedback_background_session_manuscript_pr_workflow.md](feedback_background_session_manuscript_pr_workflow.md) — background sessions force worktree+PR even for prose-in-place; reconcile primary checkout's stale uncommitted diff after merge
 - [feedback_pdf_layout_automate_dont_hand_paginate.md](feedback_pdf_layout_automate_dont_hand_paginate.md) — automate pagination (titlesec sectionbreak, widow penalties, dash-ratio col widths); variant builds = transform layer script
 - [feedback_rtk_log_hides_merge_commits.md](feedback_rtk_log_hides_merge_commits.md) — rtk-filtered `git log` omits merge commits; verify tips with rev-parse / `rtk proxy git log`
+- [feedback_pdftotext_grep_linebreaks.md](feedback_pdftotext_grep_linebreaks.md) — line-based grep on pdftotext output false-negatives across line wraps; join text before matching

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_pdftotext_grep_linebreaks.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/feedback_pdftotext_grep_linebreaks.md
@@ -1,0 +1,24 @@
+---
+name: feedback-pdftotext-grep-linebreaks
+description: Never grep pdftotext output line-by-line for a phrase — line wraps split phrases and produce false negatives; join the text first
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d8f1ac34-d65e-4682-8b73-cc98690edfe6
+  modified: 2026-07-29T16:45:52.372Z
+---
+
+A phrase probe against `pdftotext` output with plain `grep` returns a false
+negative whenever the PDF's line wrap falls inside the phrase.
+
+**Why:** on 2026-07-29 this produced a wrong provenance claim ("the release
+PDF was built from the cut branch") that had to be retracted to the author:
+the probe phrase was present but wrapped across two lines, so line-based grep
+missed it, and absence was read as evidence.
+
+**How to apply:** join the extraction before matching —
+`tr -s ' \n' ' ' < out.txt | grep -c "phrase"` (or Python on the joined
+string). Treat any single-phrase absence from an extracted PDF as unverified
+until checked on joined text. Same trap class as [[feedback_rtk_log_hides_merge_commits]]:
+a filter between you and the evidence makes "absent" indistinguishable from
+"not visible through this filter".

--- a/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_rdj26561_rr_round1.md
+++ b/projects/-home-haduong-CNRS-projets-actifs-climate-finance-het/memory/project_rdj26561_rr_round1.md
@@ -1,42 +1,44 @@
 ---
 name: project-rdj26561-rr-round1
-description: "RDJ-26561 data paper R&R round 1 — tracker 0274, deadline ~2026-10-20 (soft, verified); 0288 BUILD merged, 0304 harvest is the critical path"
+description: "RDJ-26561 data paper R&R round 1 COMPLETE — revision 1 resubmitted 2026-07-29, awaiting editor; upload-kit recipe for round 2"
 metadata: 
   node_type: memory
   type: project
   originSessionId: 03c497a7-5c6e-462e-b38e-55b54e94f44a
-  modified: 2026-07-22T18:23:47.238Z
+  modified: 2026-07-29T16:28:58.841Z
 ---
 
-RDJ4HSS data paper (RDJ-26561) got a revise-and-resubmit 2026-07-20 (coeditor
-Cédric Chambru, one referee). Deadline ~2026-10-20 — soft, verified on the
-archived letter ("within three months", received 2026-07-20).
+RDJ4HSS data paper (RDJ-26561): revise-and-resubmit received 2026-07-20
+(coeditor Cédric Chambru, one referee); **revision 1 resubmitted 2026-07-29**
+via the journal platform (author upload), well ahead of the ~2026-10-20
+deadline. Tracker 0274 and release ticket 0283 closed; paper track moved to
+`papiers/sent/RDJ4HSS_Curated_Corpus_Climate_Finance/`. Editor acknowledged
+reception 2026-07-29 and said he would look at it before his summer leave
+the following week — decision window possibly early August 2026.
 
-- Tracker: ticket 0274; remark ledger
-  `deliverables/data-paper/revision-rdj26561/ledger.dedup.jsonl` (15 remarks).
-- **0288 BUILD phase merged 2026-07-22** (PR #1085, after review with 2
-  verified fixes + author decisions on keywords/stems): corpus-v2 curated
-  key-documents layer (unfccc + oecd sources, symbol identifiers, no DOIs,
-  abstract_provenance + keywords_provenance disclosure columns, curated-source
-  protection channel). Starter seeds 47 UNFCCC + 14 OECD in
-  `config/{unfccc,oecd_dac}_sources.yaml`.
-- **Critical path is now 0304** (renumbered from 0293 — seat taken): complete
-  the seed enumeration (UNFCCC ~150–300 via a facet-crawl discovery script on
-  unfccc.int/documents — Topic="Climate finance" facets verified; OECD via
-  manual OLIS export, One returns 403), full `--fetch` harvest **on padme**
-  (coordinate with author), Phase-1 rerun, probe regression (classes A/B must
-  match). Blocks final corpus numbers; prose drafts on v1 numbers, final
-  render waits.
-- Sibling wave merged 2026-07-22: 0284 (dedup run report), 0285, 0289
-  (prior-mappings overlap), 0263 triage. Heavy ticket renumbering that day —
-  fetch before allocating IDs.
-- Still open: 0275/0278/0281 prose (sequence, same file), 0279 variables
-  table (must cover the 4 new columns — note propagated, PR #1089), 0280
-  Zenodo (waits on deferred 0287 CSV decision to avoid double version bump),
-  0286 figure (needs-human), 0283 response letter last (1st person singular).
-- Corpus probe: 310 OECD 10.1787 works already in via OpenAlex — only
-  pre/non-DOI founding documents harvested; DOI polarity is the dedup
-  boundary (seeds must NOT carry DOIs).
-- Sources archived at
-  `~/CNRS/papiers/actif/RDJ4HSS_Curated_Corpus_Climate_Finance/2026-07-20 decision/`
-  (moved from papiers/sent/).
+Frozen state: tag `rdj26561-revision1` (= submission/rdj-data-paper branch),
+Zenodo v2.0.0 (version DOI 10.5281/zenodo.21679237, concept .19236129 —
+concept resolves to latest but lags right after a deposit), HAL
+hal-05570600v2. Corpus v2: 8 sources, 43,179 unified → 33,344 refined.
+
+Upload kit (reuse the recipe at acceptance / round 2), archived in
+`papiers/sent/.../release/2026-07-29-RDJHSS-revision1/`:
+- Journal wants: Word file, 2-8 lowercase keywords below abstract, figures
+  AND tables as separate numbered files, acknowledgements as separate file,
+  APA 7. Guidelines PDF: researchdatajournal.org/libraryFiles/downloadPublic/211.
+- `DataPaper.docx`/`.pdf` render from `deliverables/data-paper/data-paper.qmd`
+  (`quarto render --to docx|pdf`); the two raw-LaTeX tables (sources,
+  variables) carry pipe-table twins behind `content-visible` divs so DOCX
+  keeps them — the variables twin is emitted by `render_markdown_table()`
+  in `scripts/_deposit_variables.py`.
+- Table1-5.md extract from the qmd pipe twin + the self-contained
+  `deliverables/_shared/tables/tab_{corpus_flow,corpus_sources,languages}.md`
+  + the variables pipe twin; Figure1.png = `fig_global_map_direct.png`.
+- Homepage: paper entry (`@techreport`, file→local PDF, HAL eprint, doi slot
+  reserved for the future journal DOI) + separate dataset entry (`@misc`,
+  concept DOI), linked via `relations` — AEDIST pattern.
+
+Word budget note: v1 was trimmed to 2,495 words; the machine cut to 2,497
+(PR #1115) was rejected by the author, and revision 1 shipped at ~3,700+
+prose words with the editor-requested additions — the author's deliberate
+call, not an oversight.


### PR DESCRIPTION
## Decision table

| Decision | Count |
|---|---|
| NOOP | 91 |
| UPDATE | 0 |
| DELETE | 0 |
| ADD | 1 |

before = 91 index lines (main) · after = 92 (working copy). Reconciliation: NOOP+UPDATE+DELETE = 91 = before ✓ · NOOP+UPDATE+ADD = 92 = after ✓.

All 91 existing entries verified against today's session (resubmission wrap-up, register propagation, machine-debt fixes) — none contradicted, none redundant: NOOP with reason "still accurate, no semantic twin". Session-scoped updates to project_rdj26561_rr_round1.md and MEMORY.md headline landed earlier today outside this pass.

**ADD** (git diff --diff-filter=A):

— today's retracted-claim lesson: line-based grep on pdftotext output false-negatives across line wraps; join text before matching.

## Key insights

- Submission events propagate beyond the repo: homepage bib and CNRS secretariat roadmap are registers that silently go stale — now a standing harness rule.
- A link is verified on its landing version, never on HTTP 200 — a DOI can resolve to the previous deposit right after publication.
- Format-conditional twins (content-visible divs) reconcile tuned raw-LaTeX PDF tables with DOCX fidelity; emitting the twin from the generator prevents drift.
- Machine debt bites silently: an expired credential literal in .env disabled the review gate's API queries, denying merges with a misleading count of zero.
- A filter between you and the evidence makes "absent" indistinguishable from "invisible": rtk hides merge commits, pdftotext wraps split phrases — verify through the unfiltered channel.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)