### PR TITLE
dream: consolidate Climate_finance memory (21→22)

### DIFF
--- a/memory/.provenance.json
+++ b/memory/.provenance.json
@@ -3167,7 +3167,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_lean_methods": {
@@ -3175,7 +3175,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_verify_contract": {
@@ -3183,7 +3183,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_agent_timeout_refactor": {
@@ -3191,7 +3191,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_reimagine_catches_stale_deps": {
@@ -3199,7 +3199,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_null_df_slicing": {
@@ -3207,7 +3207,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "project_companion_paper_design": {
@@ -3215,7 +3215,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_vars_file_provenance": {
@@ -3223,7 +3223,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:41Z",
-      "last_confirmed": "2026-07-24T20:27:41Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "reference_machine_padme": {
@@ -3231,7 +3231,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:05Z",
       "promoted": false
     },
     "feedback_a4paper": {
@@ -3239,7 +3239,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_analytical_null_overlay": {
@@ -3247,7 +3247,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_verify_agent_worktree": {
@@ -3255,7 +3255,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_worktree_deletion": {
@@ -3263,7 +3263,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_gh_projects_classic_error": {
@@ -3271,7 +3271,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_autodiscovery_class_guard": {
@@ -3279,7 +3279,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_merge_conflict_all_hunks": {
@@ -3287,7 +3287,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "reference_padme_downloads_dir": {
@@ -3295,7 +3295,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:05Z",
       "promoted": false
     },
     "reference_riomarkers_dataset_book": {
@@ -3303,7 +3303,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:05Z",
       "promoted": false
     },
     "feedback_telechargements_scratch": {
@@ -3311,7 +3311,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "reference_cookie_replay_fetch": {
@@ -3319,7 +3319,7 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     },
     "feedback_env_file_no_override": {
@@ -3327,7 +3327,31 @@
         "-home-haduong-Climate-finance"
       ],
       "first_seen": "2026-07-24T20:27:42Z",
-      "last_confirmed": "2026-07-24T20:27:42Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
+      "promoted": false
+    },
+    "feedback_date_generated_texts": {
+      "projects": [
+        "-home-haduong-Climate-finance"
+      ],
+      "first_seen": "2026-07-29T17:50:04Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
+      "promoted": false
+    },
+    "feedback_pipe_masks_exit_code": {
+      "projects": [
+        "-home-haduong-Climate-finance"
+      ],
+      "first_seen": "2026-07-29T17:50:04Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
+      "promoted": false
+    },
+    "project_conferences_2026": {
+      "projects": [
+        "-home-haduong-Climate-finance"
+      ],
+      "first_seen": "2026-07-29T17:50:04Z",
+      "last_confirmed": "2026-07-29T17:50:04Z",
       "promoted": false
     }
   }

--- a/projects/-home-haduong-Climate-finance/memory/MEMORY.md
+++ b/projects/-home-haduong-Climate-finance/memory/MEMORY.md
@@ -29,3 +29,4 @@
 - [Téléchargements is scratch](feedback_telechargements_scratch.md) — move+checksum+delete downloads to durable homes asap
 - [Cookie-replay fetch](reference_cookie_replay_fetch.md) — author's Firefox cookies unlock oecd.org/one.oecd.org; tabs via recovery.jsonlz4
 - [uv --env-file no override](feedback_env_file_no_override.md) — ambient shell vars shadow refreshed .env keys; pass rotated creds explicitly
+- [Pipe masks exit code](feedback_pipe_masks_exit_code.md) — `cmd | tail` in a background task reports exit 0 on failure; run bare or pipefail

--- a/projects/-home-haduong-Climate-finance/memory/feedback_pipe_masks_exit_code.md
+++ b/projects/-home-haduong-Climate-finance/memory/feedback_pipe_masks_exit_code.md
@@ -1,0 +1,15 @@
+---
+name: pipe-masks-exit-code
+description: "Piping a build/test command through `| tail` reports the pipe's exit code, not the command's — background tasks then notify \"completed (exit 0)\" on failure"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 565b2902-f291-41d1-9605-a19fdbe15894
+  modified: 2026-07-29T17:49:47.581Z
+---
+
+Running `make corpus 2>&1 | tail -100` or `make check | tail -25` in a background task makes the harness report tail's exit code (0), so a failed pipeline or test suite notifies as "completed". Bit twice on 2026-07-29: a CUDA-OOM `dvc repro` failure and a 1-failed `make check` both arrived as exit 0.
+
+**Why:** the shell returns the last pipe stage's status unless `set -o pipefail` is active; background-task notifications key on that status.
+
+**How to apply:** run the command bare (the output file already captures everything) or prefix with `set -o pipefail;`. Verify outcomes from the log tail, never from the exit-0 notification alone. Related: [[This machine is padme]].

--- a/projects/-home-haduong-Climate-finance/memory/reference_machine_padme.md
+++ b/projects/-home-haduong-Climate-finance/memory/reference_machine_padme.md
@@ -3,5 +3,6 @@ name: This machine is padme
 description: The current working machine hostname is padme — the GPU server where corpus data lives
 type: reference
 originSessionId: ffb7544c-0aee-4a39-b094-7dcb6ec24e41
+modified: 2026-07-29T17:49:37.659Z
 ---
-The machine running these sessions IS padme — the GPU server. Claude Code runs directly on padme; there is no remote SSH needed. `refined_works.csv` and all Phase 1 corpus data live here at `$CLIMATE_FINANCE_DATA/catalogs/`. A failing `test_corpus_acceptance.py::test_refined_works_exists` on padme is a real problem, not an expected data-missing failure.
+The machine running these sessions IS padme — the GPU server. Claude Code runs directly on padme; there is no remote SSH needed. `refined_works.csv` and all Phase 1 corpus data live here at `$CLIMATE_FINANCE_DATA/catalogs/`. A failing `test_corpus_acceptance.py::test_refined_works_exists` on padme is a real problem, not an expected data-missing failure. Exception (2026-07-29): `test_reranker_cache_exists` fails in a *worktree* because `llm_relevance_cache.csv` is DVC-untracked and never reaches worktrees (ticket 0592) — check the primary checkout before declaring the data missing.


### PR DESCRIPTION
## Decision table

| File | Decision | Reason |
|------|----------|--------|
| reference_machine_padme.md | UPDATE | added worktree caveat: test_reranker_cache_exists fails in worktrees (DVC-untracked file, ticket 0592) |
| feedback_pipe_masks_exit_code.md | ADD | new lesson — `cmd | tail` in background tasks reports exit 0 on failure (bit twice 2026-07-29) |
| 20 remaining entries | NOOP | accurate, non-redundant (gh Projects-classic and cookie-replay entries re-confirmed today) |

Counts: before 21 (NOOP 20 + UPDATE 1 + DELETE 0) · after 22 (NOOP 20 + UPDATE 1 + ADD 1).

ADD list (git diff --diff-filter=A): projects/-home-haduong-Climate-finance/memory/feedback_pipe_masks_exit_code.md

Key insights: unchanged. Promotion candidates: none. Decay flags: none.

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)