### PR TITLE
edm: check docs/ and Zotero before declaring a source inaccessible

### DIFF
--- a/rules/edm.md
+++ b/rules/edm.md
@@ -12,6 +12,14 @@ projects. Zotero is the system of record; git holds neither the sources nor the
   `*.md` research notes are staged in a project-local `docs/`, then stored in
   Zotero. `docs/` is git-ignored in full (`*.pdf`, `*.html`, `*.md`) — never
   tracked. Neither binaries nor notes belong in the repo.
+- **Check `docs/` staging *and* Zotero before declaring a source
+  inaccessible.** A source-verification agent lists `docs/` (author-name
+  variants included) and queries the Zotero library before any web search,
+  and every "remained inaccessible" sentence in a note is re-read against
+  both. A scan without a text layer is not inaccessible — `ocrmypdf` is
+  installed. (Eight false "inaccessible" verdicts in one session, HET
+  2026-08-10, including a fake showstopper and three fictitious "human
+  action required" items.)
 - **Project `.bib` files are also staging**, git-ignored, synced to Zotero. The
   `.bib` is provenance scaffolding, not the source of truth.
 - **Periodic sync + purge.** Reconcile staging to Zotero periodically (correct


### PR DESCRIPTION
Adds the mandatory local-first check to the EDM rule: a source-verification agent lists `docs/` staging and queries the Zotero library **before** any web search, and every « resté inaccessible » sentence is re-read against both. Textless scans are not inaccessible (`ocrmypdf`).

Motivation: eight false « inaccessible » verdicts in one HET session (polycentric_activity, 2026-08-10), including a fake showstopper and three fictitious human-action items. Author directive 2026-08-11: « Ajoute la règle. L'agent vérifie docs et le zotero. »

Ticket: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)